### PR TITLE
Milestone 3: 8259 PIC, PIT timer, and PS/2 keyboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /limine
 Cargo.lock
 *.iso
+.env
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -2,28 +2,28 @@
 
 A hobby x86_64 kernel, vibe-coded in Rust. Boots under the Limine boot
 protocol, prints to serial + a framebuffer console, installs a minimal
-GDT/TSS + IDT with CPU exception handlers, and has a physical frame
-allocator backing a 1 MiB kernel heap.
+GDT/TSS + IDT with CPU exception handlers, owns a 1 MiB kernel heap,
+and drives a PIT-backed timer + PS/2 keyboard through the legacy 8259
+PIC.
 
 ## Status
 
 Milestones complete:
 
-- **M1 — hello-kernel:**
-  - Limine boot (BIOS + UEFI via a hybrid ISO)
-  - COM1 16550 serial logging
-  - Linear-framebuffer text console (font8x8 glyphs)
-  - GDT + TSS with a dedicated IST stack for `#DF`
-  - IDT handlers for `#DE`, `#UD`, `#GP`, `#PF`, `#DF`
-  - Panic handler that logs + exits QEMU via `isa-debug-exit`
-- **M2 — memory + testing:**
-  - Bump frame allocator over Limine's USABLE memory-map entries
-  - `linked_list_allocator`-backed `#[global_allocator]` (1 MiB heap,
-    mapped via HHDM — no custom paging yet)
-  - Three-layer automated testing story (see below)
+- **M1 — hello-kernel:** Limine boot (BIOS + UEFI), COM1 serial,
+  framebuffer text console (font8x8), GDT/TSS + `#DF` IST, IDT for
+  `#DE`/`#UD`/`#GP`/`#PF`/`#DF`.
+- **M2 — memory + testing:** bump frame allocator over Limine's
+  USABLE map, `linked_list_allocator`-backed `#[global_allocator]`
+  (1 MiB via HHDM — no custom paging yet), three-layer automated
+  testing story (see below).
+- **M3 — interrupts:** 8259 PIC remapped to 0x20/0x28, PIT at 100 Hz
+  driving `time::uptime_ms()`, PS/2 keyboard ISR feeding a ring
+  buffer decoded by `pc-keyboard` on the consumer side. Keystrokes
+  in QEMU echo over serial.
 
 Out of scope for now: paging beyond Limine's defaults, a reclaiming
-frame allocator, PIC/APIC + timer IRQs, keyboard, scheduling, userspace.
+frame allocator, APIC, preemptive scheduling, userspace.
 
 ## Requirements
 

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -20,6 +20,8 @@ x86_64 = "0.15"
 uart_16550 = "0.3"
 font8x8 = { version = "0.3", default-features = false, features = ["unicode"] }
 linked_list_allocator = "0.10"
+pic8259 = "0.11"
+pc-keyboard = "0.8"
 
 [features]
 default = []
@@ -36,4 +38,8 @@ harness = false
 
 [[test]]
 name = "should_panic"
+harness = false
+
+[[test]]
+name = "timer_tick"
 harness = false

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -5,7 +5,9 @@
 use spin::Lazy;
 use x86_64::structures::idt::{InterruptDescriptorTable, InterruptStackFrame, PageFaultErrorCode};
 
-use crate::{arch::x86_64::gdt::DOUBLE_FAULT_IST_INDEX, serial_println};
+use crate::arch::x86_64::gdt::DOUBLE_FAULT_IST_INDEX;
+use crate::arch::x86_64::interrupts::{keyboard_interrupt, timer_interrupt, InterruptIndex};
+use crate::serial_println;
 
 static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
     let mut idt = InterruptDescriptorTable::new();
@@ -18,6 +20,8 @@ static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
             .set_handler_fn(double_fault)
             .set_stack_index(DOUBLE_FAULT_IST_INDEX);
     }
+    idt[InterruptIndex::Timer.as_u8()].set_handler_fn(timer_interrupt);
+    idt[InterruptIndex::Keyboard.as_u8()].set_handler_fn(keyboard_interrupt);
     idt
 });
 

--- a/kernel/src/arch/x86_64/interrupts.rs
+++ b/kernel/src/arch/x86_64/interrupts.rs
@@ -1,0 +1,35 @@
+//! Hardware-IRQ vector numbers and ISRs for the devices we care about.
+//!
+//! ISRs are kept deliberately tiny: update shared state, EOI, return.
+//! Any decoding or IO (serial logging, pc-keyboard state machine) is
+//! deferred to the consumer side — a keyboard burst of ~10 scancodes
+//! at boot should never block inside an interrupt handler.
+
+use x86_64::instructions::port::Port;
+use x86_64::structures::idt::InterruptStackFrame;
+
+use crate::arch::x86_64::pic::{notify_eoi, PIC_1_OFFSET};
+
+#[derive(Debug, Clone, Copy)]
+#[repr(u8)]
+pub enum InterruptIndex {
+    Timer = PIC_1_OFFSET,
+    Keyboard = PIC_1_OFFSET + 1,
+}
+
+impl InterruptIndex {
+    pub const fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+pub extern "x86-interrupt" fn timer_interrupt(_frame: InterruptStackFrame) {
+    crate::time::on_tick();
+    notify_eoi(InterruptIndex::Timer.as_u8());
+}
+
+pub extern "x86-interrupt" fn keyboard_interrupt(_frame: InterruptStackFrame) {
+    let code: u8 = unsafe { Port::new(0x60).read() };
+    crate::input::push_scancode_from_isr(code);
+    notify_eoi(InterruptIndex::Keyboard.as_u8());
+}

--- a/kernel/src/arch/x86_64/mod.rs
+++ b/kernel/src/arch/x86_64/mod.rs
@@ -1,7 +1,10 @@
 pub mod gdt;
 pub mod idt;
+pub mod interrupts;
+pub mod pic;
 
 pub fn init() {
     gdt::init();
     idt::init();
+    pic::init();
 }

--- a/kernel/src/arch/x86_64/pic.rs
+++ b/kernel/src/arch/x86_64/pic.rs
@@ -1,0 +1,32 @@
+//! Legacy 8259 PIC pair, remapped past the CPU exception vectors.
+//!
+//! Vectors 0x00–0x1F are reserved for CPU exceptions, so we remap the
+//! master PIC to 0x20–0x27 and the slave to 0x28–0x2F. `init()` must
+//! run after the IDT is loaded so we don't take an IRQ into a stale
+//! handler; callers still gate `sti` until they're ready.
+
+use pic8259::ChainedPics;
+use spin::Mutex;
+
+pub const PIC_1_OFFSET: u8 = 0x20;
+pub const PIC_2_OFFSET: u8 = PIC_1_OFFSET + 8;
+
+pub static PICS: Mutex<ChainedPics> =
+    Mutex::new(unsafe { ChainedPics::new(PIC_1_OFFSET, PIC_2_OFFSET) });
+
+pub fn init() {
+    let mut pics = PICS.lock();
+    unsafe {
+        pics.initialize();
+        // Unmask IRQ0 (timer) and IRQ1 (keyboard); keep everything else
+        // masked until we wire up a device for it.
+        pics.write_masks(0b1111_1100, 0b1111_1111);
+    }
+    crate::serial_println!("PIC remapped to {:#x}/{:#x}", PIC_1_OFFSET, PIC_2_OFFSET);
+}
+
+/// Safely notify end-of-interrupt for a vector previously raised by the
+/// PIC. Called from ISRs.
+pub fn notify_eoi(vector: u8) {
+    unsafe { PICS.lock().notify_end_of_interrupt(vector) };
+}

--- a/kernel/src/input.rs
+++ b/kernel/src/input.rs
@@ -1,0 +1,169 @@
+//! Keyboard input path: an interrupt-safe scancode ring fed by the
+//! keyboard ISR and drained on the consumer side, plus a `pc-keyboard`
+//! state machine that turns scancodes into `DecodedKey`s.
+//!
+//! The `RingBuffer` primitive is generic and kept free of kernel-only
+//! dependencies so it's host-unit-testable.
+
+use core::mem::MaybeUninit;
+
+pub struct RingBuffer<T, const N: usize> {
+    buf: [MaybeUninit<T>; N],
+    head: usize,
+    tail: usize,
+    len: usize,
+}
+
+impl<T: Copy, const N: usize> RingBuffer<T, N> {
+    pub const fn new() -> Self {
+        Self {
+            buf: [MaybeUninit::uninit(); N],
+            head: 0,
+            tail: 0,
+            len: 0,
+        }
+    }
+
+    /// Push `v`. Returns `false` and drops the value if the ring is full.
+    pub fn push(&mut self, v: T) -> bool {
+        if self.len == N {
+            return false;
+        }
+        self.buf[self.tail] = MaybeUninit::new(v);
+        self.tail = (self.tail + 1) % N;
+        self.len += 1;
+        true
+    }
+
+    pub fn pop(&mut self) -> Option<T> {
+        if self.len == 0 {
+            return None;
+        }
+        let v = unsafe { self.buf[self.head].assume_init() };
+        self.head = (self.head + 1) % N;
+        self.len -= 1;
+        Some(v)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+}
+
+impl<T: Copy, const N: usize> Default for RingBuffer<T, N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(target_os = "none")]
+pub use kernel_side::*;
+
+#[cfg(target_os = "none")]
+mod kernel_side {
+    use super::RingBuffer;
+    use pc_keyboard::{layouts::Us104Key, DecodedKey, HandleControl, Keyboard, ScancodeSet1};
+    use spin::{Lazy, Mutex};
+    use x86_64::instructions::interrupts::without_interrupts;
+
+    /// Scancodes land here from the keyboard ISR. Sized at 128: a human
+    /// typist can't overflow it, and firmware key-repeat bursts are well
+    /// under that between consumer polls.
+    static SCANCODES: Mutex<RingBuffer<u8, 128>> = Mutex::new(RingBuffer::new());
+
+    static KEYBOARD: Lazy<Mutex<Keyboard<Us104Key, ScancodeSet1>>> = Lazy::new(|| {
+        Mutex::new(Keyboard::new(
+            ScancodeSet1::new(),
+            Us104Key,
+            HandleControl::Ignore,
+        ))
+    });
+
+    /// Called from the keyboard ISR. Interrupts are already disabled.
+    pub fn push_scancode_from_isr(code: u8) {
+        SCANCODES.lock().push(code);
+    }
+
+    pub fn try_read_scancode() -> Option<u8> {
+        without_interrupts(|| SCANCODES.lock().pop())
+    }
+
+    /// Block (via `hlt`) until a decoded key is available.
+    pub fn read_key() -> DecodedKey {
+        loop {
+            while let Some(code) = try_read_scancode() {
+                let mut kbd = KEYBOARD.lock();
+                if let Ok(Some(event)) = kbd.add_byte(code) {
+                    if let Some(key) = kbd.process_keyevent(event) {
+                        return key;
+                    }
+                }
+            }
+            x86_64::instructions::interrupts::enable_and_hlt();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn push_pop_fifo_order() {
+        let mut r: RingBuffer<u8, 4> = RingBuffer::new();
+        assert!(r.push(1));
+        assert!(r.push(2));
+        assert!(r.push(3));
+        assert_eq!(r.pop(), Some(1));
+        assert_eq!(r.pop(), Some(2));
+        assert_eq!(r.pop(), Some(3));
+        assert_eq!(r.pop(), None);
+    }
+
+    #[test]
+    fn pop_on_empty_returns_none() {
+        let mut r: RingBuffer<u8, 4> = RingBuffer::new();
+        assert_eq!(r.pop(), None);
+        assert!(r.is_empty());
+    }
+
+    #[test]
+    fn overflow_drops_new_value_and_preserves_old() {
+        let mut r: RingBuffer<u8, 2> = RingBuffer::new();
+        assert!(r.push(1));
+        assert!(r.push(2));
+        assert!(!r.push(3)); // dropped
+        assert_eq!(r.pop(), Some(1));
+        assert_eq!(r.pop(), Some(2));
+        assert_eq!(r.pop(), None);
+    }
+
+    #[test]
+    fn wraps_around() {
+        let mut r: RingBuffer<u8, 3> = RingBuffer::new();
+        r.push(1);
+        r.push(2);
+        assert_eq!(r.pop(), Some(1));
+        r.push(3);
+        r.push(4); // wraps tail to 1
+        assert_eq!(r.pop(), Some(2));
+        assert_eq!(r.pop(), Some(3));
+        assert_eq!(r.pop(), Some(4));
+        assert_eq!(r.pop(), None);
+    }
+
+    #[test]
+    fn len_tracks_occupancy() {
+        let mut r: RingBuffer<u8, 4> = RingBuffer::new();
+        assert_eq!(r.len(), 0);
+        r.push(1);
+        r.push(2);
+        assert_eq!(r.len(), 2);
+        r.pop();
+        assert_eq!(r.len(), 1);
+    }
+}

--- a/kernel/src/input.rs
+++ b/kernel/src/input.rs
@@ -66,14 +66,21 @@ pub use kernel_side::*;
 #[cfg(target_os = "none")]
 mod kernel_side {
     use super::RingBuffer;
+    use core::sync::atomic::{AtomicU64, Ordering};
     use pc_keyboard::{layouts::Us104Key, DecodedKey, HandleControl, Keyboard, ScancodeSet1};
     use spin::{Lazy, Mutex};
-    use x86_64::instructions::interrupts::without_interrupts;
+    use x86_64::instructions::interrupts::{self, without_interrupts};
 
     /// Scancodes land here from the keyboard ISR. Sized at 128: a human
     /// typist can't overflow it, and firmware key-repeat bursts are well
     /// under that between consumer polls.
     static SCANCODES: Mutex<RingBuffer<u8, 128>> = Mutex::new(RingBuffer::new());
+
+    /// Count of scancodes dropped because the ring was full when the ISR
+    /// tried to push. Surface via `scancode_overflows()`; a non-zero
+    /// reading means the consumer isn't keeping up and modifier tracking
+    /// may be desynced.
+    static OVERFLOWS: AtomicU64 = AtomicU64::new(0);
 
     static KEYBOARD: Lazy<Mutex<Keyboard<Us104Key, ScancodeSet1>>> = Lazy::new(|| {
         Mutex::new(Keyboard::new(
@@ -85,14 +92,24 @@ mod kernel_side {
 
     /// Called from the keyboard ISR. Interrupts are already disabled.
     pub fn push_scancode_from_isr(code: u8) {
-        SCANCODES.lock().push(code);
+        if !SCANCODES.lock().push(code) {
+            OVERFLOWS.fetch_add(1, Ordering::Relaxed);
+        }
     }
 
     pub fn try_read_scancode() -> Option<u8> {
         without_interrupts(|| SCANCODES.lock().pop())
     }
 
+    pub fn scancode_overflows() -> u64 {
+        OVERFLOWS.load(Ordering::Relaxed)
+    }
+
     /// Block (via `hlt`) until a decoded key is available.
+    ///
+    /// Disabling interrupts before the final empty-check plugs the race
+    /// where an IRQ could enqueue between the drain and `hlt`, parking
+    /// us until some unrelated interrupt arrived.
     pub fn read_key() -> DecodedKey {
         loop {
             while let Some(code) = try_read_scancode() {
@@ -103,7 +120,14 @@ mod kernel_side {
                     }
                 }
             }
-            x86_64::instructions::interrupts::enable_and_hlt();
+            interrupts::disable();
+            if SCANCODES.lock().is_empty() {
+                // enable_and_hlt is atomic: IF=1 and hlt execute with no
+                // window for a pending IRQ to be missed.
+                interrupts::enable_and_hlt();
+            } else {
+                interrupts::enable();
+            }
         }
     }
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -11,6 +11,7 @@
 
 extern crate alloc;
 
+pub mod input;
 pub mod mem;
 
 #[cfg(target_os = "none")]
@@ -23,17 +24,21 @@ pub mod framebuffer;
 pub mod serial;
 #[cfg(target_os = "none")]
 pub mod test_harness;
+#[cfg(target_os = "none")]
+pub mod time;
 
 #[cfg(target_os = "none")]
 pub use test_harness::{exit_qemu, QemuExitCode, Testable};
 
 /// Bring up core kernel subsystems in the right order. Callable from
-/// both the main bin and from integration-test `_start`s.
+/// both the main bin and from integration-test `_start`s. Interrupts
+/// remain **disabled** on return — callers `sti` when they're ready.
 #[cfg(target_os = "none")]
 pub fn init() {
     serial::init();
     arch::init();
     mem::init();
+    time::init();
 }
 
 /// Halt forever. Handy in panic paths and as a terminal call in tests.

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -5,7 +5,7 @@ use core::panic::PanicInfo;
 
 use vibix::boot::{BASE_REVISION, FRAMEBUFFER_REQUEST, HHDM_REQUEST, MEMMAP_REQUEST};
 use vibix::framebuffer::Console;
-use vibix::{exit_qemu, framebuffer, hlt_loop, println, serial_println, QemuExitCode};
+use vibix::{exit_qemu, framebuffer, println, serial_print, serial_println, QemuExitCode};
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
@@ -55,6 +55,7 @@ pub extern "C" fn _start() -> ! {
     serial_println!("GDT + IDT loaded");
 
     vibix::mem::init();
+    vibix::time::init();
 
     println!("vibix online.");
     serial_println!("vibix online.");
@@ -65,7 +66,15 @@ pub extern "C" fn _start() -> ! {
         unsafe { core::arch::asm!("ud2") };
     }
 
-    hlt_loop();
+    x86_64::instructions::interrupts::enable();
+    serial_println!("interrupts enabled");
+
+    loop {
+        match vibix::input::read_key() {
+            pc_keyboard::DecodedKey::Unicode(c) => serial_print!("{}", c),
+            pc_keyboard::DecodedKey::RawKey(key) => serial_print!("[{:?}]", key),
+        }
+    }
 }
 
 #[panic_handler]

--- a/kernel/src/time.rs
+++ b/kernel/src/time.rs
@@ -1,0 +1,47 @@
+//! Monotonic time, driven by the PIT.
+//!
+//! The PIT (channel 0) is programmed to fire IRQ0 at ~100 Hz; the timer
+//! ISR calls `on_tick` which bumps a global counter. `uptime_ms` is a
+//! cheap read of that counter.
+
+use core::sync::atomic::{AtomicU64, Ordering};
+
+/// PIT oscillator frequency, in Hz. Divisor = this / desired Hz.
+const PIT_FREQ_HZ: u32 = 1_193_182;
+/// Desired tick rate. 100 Hz → 10 ms per tick — coarse, but cheap and
+/// plenty for a toy kernel.
+pub const TICK_HZ: u32 = 100;
+pub const TICK_MS: u64 = 1000 / TICK_HZ as u64;
+
+static TICKS: AtomicU64 = AtomicU64::new(0);
+
+/// Program PIT channel 0 in rate-generator mode at `TICK_HZ` and log a
+/// marker.
+#[cfg(target_os = "none")]
+pub fn init() {
+    use x86_64::instructions::port::Port;
+
+    let divisor: u16 = (PIT_FREQ_HZ / TICK_HZ) as u16;
+    unsafe {
+        // Command: channel 0, access lobyte/hibyte, mode 2 (rate gen),
+        // binary counting = 0b00_11_010_0 = 0x34.
+        Port::<u8>::new(0x43).write(0x34);
+        let mut data: Port<u8> = Port::new(0x40);
+        data.write((divisor & 0xff) as u8);
+        data.write((divisor >> 8) as u8);
+    }
+    crate::serial_println!("timer: {} Hz", TICK_HZ);
+}
+
+/// Called from the timer ISR.
+pub fn on_tick() {
+    TICKS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn ticks() -> u64 {
+    TICKS.load(Ordering::Relaxed)
+}
+
+pub fn uptime_ms() -> u64 {
+    ticks() * TICK_MS
+}

--- a/kernel/tests/timer_tick.rs
+++ b/kernel/tests/timer_tick.rs
@@ -1,0 +1,60 @@
+//! Integration test: PIT → IDT → tick counter.
+//!
+//! After full init and `sti`, `time::uptime_ms()` should advance
+//! monotonically. The PIT ticks at 100 Hz (10 ms), so waiting for a
+//! handful of ticks is cheap even under QEMU.
+
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("ticks_advance", &(ticks_advance as fn())),
+        ("uptime_monotonic", &(uptime_monotonic as fn())),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+fn ticks_advance() {
+    let start = vibix::time::ticks();
+    // Wait for at least ~50 ms worth of ticks (5 @ 100 Hz). Use hlt
+    // so the CPU actually sleeps between interrupts — a busy loop
+    // under QEMU can race the first tick.
+    while vibix::time::ticks() < start + 5 {
+        x86_64::instructions::hlt();
+    }
+    assert!(vibix::time::ticks() >= start + 5);
+}
+
+fn uptime_monotonic() {
+    let a = vibix::time::uptime_ms();
+    for _ in 0..3 {
+        x86_64::instructions::hlt();
+    }
+    let b = vibix::time::uptime_ms();
+    assert!(b >= a, "uptime went backwards: {a} -> {b}");
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -40,7 +40,10 @@ const SMOKE_MARKERS: &[&str] = &[
     "hhdm offset:",
     "GDT + IDT loaded",
     "heap: 1024 KiB",
+    "PIC remapped",
+    "timer: 100 Hz",
     "vibix online.",
+    "interrupts enabled",
 ];
 
 fn main() -> R<()> {
@@ -272,7 +275,7 @@ fn test_all() -> R<()> {
             "-Z", "build-std=core,compiler_builtins,alloc",
             "-Z", "build-std-features=compiler-builtins-mem",
         ]);
-    for t in ["basic_boot", "heap_alloc", "should_panic"] {
+    for t in ["basic_boot", "heap_alloc", "should_panic", "timer_tick"] {
         cmd.arg("--test").arg(t);
     }
     check(cmd.status()?)?;


### PR DESCRIPTION
## Summary

Wires up the legacy 8259 PIC, a PIT-driven timer tick, and PS/2 keyboard input so the kernel has a heartbeat and reacts to keystrokes.

- **PIC (`arch::pic`)** — `ChainedPics` remapped to `0x20` / `0x28`, IRQ0 + IRQ1 unmasked, everything else masked.
- **PIT (`time`)** — channel 0 at 100 Hz (10 ms/tick); `time::uptime_ms()` reads an `AtomicU64` tick counter updated by the timer ISR.
- **PS/2 keyboard (`input`)** — ISR reads port `0x60`, pushes into a generic `RingBuffer<u8, 128>`. Consumer drains via `read_key()` using `pc-keyboard`'s state machine, blocking on `enable_and_hlt` between polls.
- **`_start`** — `sti` after `mem::init` + `time::init`; echo loop prints decoded keys over serial.

Tests added:
- Host unit tests for `RingBuffer` (FIFO, overflow, wrap, empty-pop).
- `kernel/tests/timer_tick.rs` — boots under QEMU, enables interrupts, asserts the tick counter advances.
- Three new smoke markers (`PIC remapped`, `timer: 100 Hz`, `interrupts enabled`) guard init-phase regressions.

Explicitly out of scope: APIC, preemptive scheduling, full modifier/layout handling, mouse, other PIC lines.

## Test plan

- [x] `cargo xtask test` — 12 host unit tests + 8 integration tests across `basic_boot`, `heap_alloc`, `should_panic`, `timer_tick` all green
- [x] `cargo xtask smoke` — all 9 markers present
- [x] `cargo xtask run --fault-test` — `#UD` still caught (regression)
- [x] `cargo xtask run` — manually type in the QEMU window and confirm keys echo on serial

🤖 Generated with [Claude Code](https://claude.com/claude-code)