### PR TITLE
M4: paging foundation (OffsetPageTable + map/unmap)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -43,3 +43,7 @@ harness = false
 [[test]]
 name = "timer_tick"
 harness = false
+
+[[test]]
+name = "paging"
+harness = false

--- a/kernel/src/mem/frame.rs
+++ b/kernel/src/mem/frame.rs
@@ -3,7 +3,8 @@
 //! Walks an ordered slice of USABLE `Region`s, handing out 4 KiB frames
 //! in ascending physical order. Frames are never returned — this is a
 //! one-way allocator, appropriate for one-shot boot allocations (e.g.
-//! the kernel heap). A reclaiming allocator is a later milestone.
+//! the kernel heap and page-table pages). A reclaiming allocator is a
+//! later milestone.
 //!
 //! Kept free of `limine` and `x86_64` types so its bookkeeping can be
 //! unit-tested on the host.
@@ -80,6 +81,53 @@ impl<'a> BumpFrameAllocator<'a> {
 fn align_up(x: u64, a: u64) -> u64 {
     (x + a - 1) & !(a - 1)
 }
+
+// --- Global allocator, populated at boot --------------------------------
+
+/// Maximum distinct USABLE regions we snapshot from the Limine memmap.
+/// QEMU's `q35` machine reports ~16 entries with a handful of USABLE —
+/// 64 is comfortable headroom for real hardware.
+pub const MAX_REGIONS: usize = 64;
+
+#[cfg(target_os = "none")]
+mod global {
+    use super::{BumpFrameAllocator, Region, MAX_REGIONS};
+    use crate::boot::MEMMAP_REQUEST;
+    use spin::{Mutex, Once};
+
+    /// Snapshot of USABLE regions taken once at boot. The trailing
+    /// `usize` is the number of populated entries.
+    static REGIONS: Once<([Region; MAX_REGIONS], usize)> = Once::new();
+    static ALLOCATOR: Once<Mutex<BumpFrameAllocator<'static>>> = Once::new();
+
+    pub fn init() {
+        let memmap = MEMMAP_REQUEST
+            .get_response()
+            .expect("Limine memory-map response missing");
+
+        let regions = REGIONS.call_once(|| {
+            let mut buf = [Region::new(0, 0); MAX_REGIONS];
+            let mut n = 0;
+            for entry in memmap.entries() {
+                if entry.entry_type == limine::memory_map::EntryType::USABLE {
+                    assert!(n < MAX_REGIONS, "more USABLE regions than MAX_REGIONS");
+                    buf[n] = Region::new(entry.base, entry.length);
+                    n += 1;
+                }
+            }
+            (buf, n)
+        });
+        let slice: &'static [Region] = &regions.0[..regions.1];
+        ALLOCATOR.call_once(|| Mutex::new(BumpFrameAllocator::new(slice)));
+    }
+
+    pub fn global() -> &'static Mutex<BumpFrameAllocator<'static>> {
+        ALLOCATOR.get().expect("frame::init not called")
+    }
+}
+
+#[cfg(target_os = "none")]
+pub use global::{global, init};
 
 #[cfg(test)]
 mod tests {

--- a/kernel/src/mem/heap.rs
+++ b/kernel/src/mem/heap.rs
@@ -1,16 +1,15 @@
 //! Kernel heap: carve a contiguous 1 MiB slab from physical memory via
-//! our bump frame allocator, then hand it to `linked_list_allocator`.
+//! the global bump frame allocator, then hand it to `linked_list_allocator`.
 //!
 //! The slab is addressed through Limine's HHDM (Higher-Half Direct Map),
 //! which already covers all physical memory in the virtual address space
-//! Limine sets up. No paging work needed at this stage — that's the job
-//! of milestone 3 when we take over the page tables ourselves.
+//! Limine sets up.
 
 use linked_list_allocator::LockedHeap;
 
-use super::frame::BumpFrameAllocator;
-use super::{Region, FRAME_SIZE};
-use crate::boot::{HHDM_REQUEST, MEMMAP_REQUEST};
+use super::frame;
+use super::FRAME_SIZE;
+use crate::boot::HHDM_REQUEST;
 use crate::serial_println;
 
 #[global_allocator]
@@ -20,32 +19,13 @@ static ALLOCATOR: LockedHeap = LockedHeap::empty();
 pub const HEAP_FRAMES: u64 = 256;
 pub const HEAP_SIZE: usize = (HEAP_FRAMES * FRAME_SIZE) as usize;
 
-/// Maximum distinct USABLE regions we snapshot from the Limine memmap.
-/// QEMU's `q35` machine reports ~16 entries with a handful of USABLE —
-/// 64 is comfortable headroom for real hardware without heap help.
-const MAX_REGIONS: usize = 64;
-
 pub fn init() {
-    let memmap = MEMMAP_REQUEST
-        .get_response()
-        .expect("Limine memory-map response missing");
     let hhdm = HHDM_REQUEST
         .get_response()
         .expect("Limine HHDM response missing");
 
-    let mut regions_buf = [Region::new(0, 0); MAX_REGIONS];
-    let mut n = 0;
-    for entry in memmap.entries() {
-        if entry.entry_type == limine::memory_map::EntryType::USABLE {
-            assert!(n < MAX_REGIONS, "more USABLE regions than MAX_REGIONS");
-            regions_buf[n] = Region::new(entry.base, entry.length);
-            n += 1;
-        }
-    }
-    let regions = &regions_buf[..n];
-
-    let mut allocator = BumpFrameAllocator::new(regions);
-    let heap_phys = allocator
+    let heap_phys = frame::global()
+        .lock()
         .allocate_contiguous(HEAP_FRAMES)
         .expect("no contiguous USABLE region large enough for the kernel heap");
     let heap_virt = heap_phys + hhdm.offset();

--- a/kernel/src/mem/mod.rs
+++ b/kernel/src/mem/mod.rs
@@ -1,16 +1,20 @@
-//! Physical-frame allocator + kernel heap.
+//! Physical-frame allocator, kernel heap, and paging.
 //!
-//! Milestone 2 keeps things deliberately minimal:
 //!  - `frame::BumpFrameAllocator` bumps through Limine's USABLE regions.
 //!    Pure logic, no `limine`/`x86_64` dependencies → host-testable.
-//!  - `heap` pulls one contiguous 1 MiB slice of frames and hands it to
-//!    `linked_list_allocator::LockedHeap`, which becomes the kernel's
-//!    global allocator. Heap memory is addressed through Limine's HHDM.
+//!    A global instance is installed by `frame::init` and shared by
+//!    the heap and the paging layer.
+//!  - `heap` pulls one contiguous 1 MiB slice of frames from the global
+//!    allocator and hands it to `linked_list_allocator::LockedHeap`.
+//!  - `paging` wraps Limine's active PML4 in an `OffsetPageTable` so
+//!    the kernel can own its own `map`/`unmap`/`translate` API.
 
 pub mod frame;
 
 #[cfg(target_os = "none")]
 pub mod heap;
+#[cfg(target_os = "none")]
+pub mod paging;
 
 /// 4 KiB. The only page size we care about right now.
 pub const FRAME_SIZE: u64 = 4096;
@@ -29,9 +33,16 @@ impl Region {
     }
 }
 
-/// Initialize memory subsystems in-kernel: build the frame allocator
-/// from Limine's memory map, then bring up the heap.
+/// Initialize memory subsystems in-kernel: snapshot Limine's memory map
+/// into the global frame allocator, bring up the heap, then wrap the
+/// active page tables in our own mapper.
 #[cfg(target_os = "none")]
 pub fn init() {
+    frame::init();
     heap::init();
+
+    let hhdm = crate::boot::HHDM_REQUEST
+        .get_response()
+        .expect("Limine HHDM response missing");
+    paging::init(x86_64::VirtAddr::new(hhdm.offset()));
 }

--- a/kernel/src/mem/paging.rs
+++ b/kernel/src/mem/paging.rs
@@ -1,0 +1,116 @@
+//! Kernel paging: wrap Limine's active page tables in an
+//! [`OffsetPageTable`] and expose typed `map`/`unmap`/`translate`.
+//!
+//! Limine hands us a PML4 with the kernel image identity-ish-mapped at
+//! −2 GiB and all of physical RAM HHDM-mapped. We keep that tree
+//! (no CR3 switch here) and just take ownership of it through the
+//! `x86_64` crate's mapper abstraction. Future milestones that need to
+//! install mappings of their own — heap growth, IST guard pages, user
+//! address spaces — go through this module instead of relying on
+//! whatever Limine happened to set up.
+
+use spin::{Mutex, Once};
+use x86_64::registers::control::Cr3;
+use x86_64::structures::paging::mapper::{MapToError, TranslateResult, UnmapError};
+use x86_64::structures::paging::{
+    FrameAllocator, Mapper, OffsetPageTable, Page, PageTable, PageTableFlags, PhysFrame, Size4KiB,
+    Translate,
+};
+use x86_64::{PhysAddr, VirtAddr};
+
+use super::frame;
+use crate::serial_println;
+
+/// Frame allocator adapter: pulls 4 KiB frames from the global
+/// `BumpFrameAllocator`. Zero-sized; construct ad-hoc wherever you need
+/// to hand the mapper a `FrameAllocator`.
+pub struct KernelFrameAllocator;
+
+unsafe impl FrameAllocator<Size4KiB> for KernelFrameAllocator {
+    fn allocate_frame(&mut self) -> Option<PhysFrame<Size4KiB>> {
+        let phys = frame::global().lock().allocate_frame()?;
+        Some(PhysFrame::containing_address(PhysAddr::new(phys)))
+    }
+}
+
+static MAPPER: Once<Mutex<OffsetPageTable<'static>>> = Once::new();
+
+/// Install the kernel mapper. Must be called after `frame::init` (page
+/// tables allocated for new mappings come from the global allocator)
+/// and before any caller tries to `map`/`unmap`.
+pub fn init(hhdm_offset: VirtAddr) {
+    let (cr3_frame, _) = Cr3::read();
+    // Physical → virtual via HHDM. Limine guarantees the active PML4
+    // is covered by the HHDM mapping it installed.
+    let l4_virt = hhdm_offset + cr3_frame.start_address().as_u64();
+    // SAFETY: Limine's PML4 lives for the life of the kernel, is
+    // exclusively ours from this point on, and the HHDM mapping makes
+    // the cast a valid `&mut PageTable`.
+    let l4: &'static mut PageTable = unsafe { &mut *(l4_virt.as_mut_ptr::<PageTable>()) };
+    let mapper = unsafe { OffsetPageTable::new(l4, hhdm_offset) };
+    MAPPER.call_once(|| Mutex::new(mapper));
+    serial_println!("paging: mapper online");
+}
+
+/// Run a closure with exclusive access to the kernel mapper. Acquires
+/// the mapper lock for the duration of the call.
+pub fn with_mapper<R>(f: impl FnOnce(&mut OffsetPageTable<'static>) -> R) -> R {
+    let mapper = MAPPER.get().expect("paging::init not called");
+    let mut guard = mapper.lock();
+    f(&mut guard)
+}
+
+/// Map `page` to a freshly-allocated physical frame with `flags`.
+/// Returns the frame so callers that care can recover its physical
+/// address.
+pub fn map(
+    page: Page<Size4KiB>,
+    flags: PageTableFlags,
+) -> Result<PhysFrame<Size4KiB>, MapToError<Size4KiB>> {
+    let mut alloc = KernelFrameAllocator;
+    let frame = alloc
+        .allocate_frame()
+        .ok_or(MapToError::FrameAllocationFailed)?;
+    with_mapper(|m| {
+        // SAFETY: caller owns the virtual address; we allocated the
+        // physical frame, so no aliasing. Flushing the TLB entry below.
+        let flush = unsafe { m.map_to(page, frame, flags, &mut alloc)? };
+        flush.flush();
+        Ok(frame)
+    })
+}
+
+/// Map `count` contiguous 4 KiB pages starting at `start`. Each page
+/// gets an independent physical frame (frames are not guaranteed
+/// contiguous). On partial failure earlier pages remain mapped.
+pub fn map_range(
+    start: VirtAddr,
+    count: u64,
+    flags: PageTableFlags,
+) -> Result<(), MapToError<Size4KiB>> {
+    for i in 0..count {
+        let page = Page::<Size4KiB>::containing_address(start + i * 4096);
+        map(page, flags)?;
+    }
+    Ok(())
+}
+
+/// Unmap `page` and flush the TLB. The backing frame is leaked — we
+/// don't have a reclaiming frame allocator yet.
+pub fn unmap(page: Page<Size4KiB>) -> Result<PhysFrame<Size4KiB>, UnmapError> {
+    with_mapper(|m| {
+        let (frame, flush) = m.unmap(page)?;
+        flush.flush();
+        Ok(frame)
+    })
+}
+
+/// Translate a virtual address to its backing physical address, if any.
+pub fn translate(addr: VirtAddr) -> Option<PhysAddr> {
+    with_mapper(|m| match m.translate(addr) {
+        TranslateResult::Mapped { frame, offset, .. } => {
+            Some(frame.start_address() + offset)
+        }
+        TranslateResult::NotMapped | TranslateResult::InvalidFrameAddress(_) => None,
+    })
+}

--- a/kernel/tests/paging.rs
+++ b/kernel/tests/paging.rs
@@ -1,0 +1,73 @@
+//! Integration test: the kernel mapper can map a fresh frame at a
+//! chosen virtual address, survive a read/write round-trip, and unmap
+//! cleanly.
+
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+use x86_64::structures::paging::{Page, PageTableFlags, Size4KiB};
+use x86_64::VirtAddr;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("map_roundtrip_unmap", &(map_roundtrip_unmap as fn())),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+/// Pick a virt address well above HHDM and below the kernel's −2 GiB
+/// load region. With 256 MiB of RAM in QEMU, HHDM tops out near
+/// 0xFFFF_8000_1000_0000; the kernel sits at 0xFFFF_FFFF_8000_0000.
+/// This address lives comfortably between them.
+const TEST_VA: u64 = 0xFFFF_C000_DEAD_B000;
+
+fn map_roundtrip_unmap() {
+    use vibix::mem::paging;
+
+    let va = VirtAddr::new(TEST_VA);
+    assert!(
+        paging::translate(va).is_none(),
+        "picked test VA {va:?} is already mapped — pick another"
+    );
+
+    let page: Page<Size4KiB> = Page::containing_address(va);
+    let flags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE;
+    let _frame = paging::map(page, flags).expect("map failed");
+
+    let phys = paging::translate(va).expect("translate after map returned None");
+    serial_println!("  mapped {va:?} -> {phys:?}");
+
+    let ptr = va.as_u64() as *mut u64;
+    unsafe {
+        ptr.write_volatile(0xCAFE_F00D_DEAD_BEEF);
+        assert_eq!(ptr.read_volatile(), 0xCAFE_F00D_DEAD_BEEF);
+    }
+
+    paging::unmap(page).expect("unmap failed");
+    assert!(
+        paging::translate(va).is_none(),
+        "translate after unmap still returned Some"
+    );
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -40,6 +40,7 @@ const SMOKE_MARKERS: &[&str] = &[
     "hhdm offset:",
     "GDT + IDT loaded",
     "heap: 1024 KiB",
+    "paging: mapper online",
     "PIC remapped",
     "timer: 100 Hz",
     "vibix online.",
@@ -275,7 +276,7 @@ fn test_all() -> R<()> {
             "-Z", "build-std=core,compiler_builtins,alloc",
             "-Z", "build-std-features=compiler-builtins-mem",
         ]);
-    for t in ["basic_boot", "heap_alloc", "should_panic", "timer_tick"] {
+    for t in ["basic_boot", "heap_alloc", "should_panic", "timer_tick", "paging"] {
         cmd.arg("--test").arg(t);
     }
     check(cmd.status()?)?;


### PR DESCRIPTION
## Summary
- **paging:** new `kernel/src/mem/paging.rs` wraps Limine's active PML4 in an `OffsetPageTable` anchored at the HHDM offset, accessed through a `spin::Once<Mutex<...>>` global. Exposes `map`, `map_range`, `unmap`, `translate`, and a `with_mapper` escape hatch.
- **frame allocator:** `BumpFrameAllocator` is promoted to a global `Once<Mutex<...>>` so both the heap and the paging layer pull frames from the same cursor. `heap::init` no longer builds its own local allocator. Host unit tests unchanged.
- **init order:** `mem::init` now runs `frame::init → heap::init → paging::init`.
- **test:** new `kernel/tests/paging.rs` maps a page at `0xFFFF_C000_DEAD_B000`, round-trips a `u64`, unmaps, and asserts `translate` returns `None` on both sides.
- **xtask:** new smoke marker `"paging: mapper online"`; `paging` added to the integration-test list.

Out of scope (see issue body): fresh PML4 + CR3 switch, heap growth, user/kernel split, large pages, IST guard page (#6 builds on this).

Closes #5.

## Test plan
- [x] `cargo xtask build` — clean.
- [x] `cargo xtask test` — 12 host unit tests + 5 QEMU integration tests (basic_boot, heap_alloc, paging, should_panic, timer_tick) all pass.
- [x] `cargo xtask smoke` — all 10 markers present (including the new `paging: mapper online`).
- [x] Eyeball a `cargo xtask run` serial log to confirm no regressions in the interactive boot path.
