### PR TITLE
M4: guard page under the #DF IST stack

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -27,6 +27,11 @@ pc-keyboard = "0.8"
 default = []
 # Enable to trigger a UD2 after init; verifies the invalid-opcode handler path.
 fault-test = []
+# Enable to deliberately overflow the #DF IST stack after init; verifies
+# that the guard page below the stack catches overflow as a #PF instead
+# of letting it silently corrupt .bss. Manual verification only —
+# successful overflow is indistinguishable from other crashes in CI.
+ist-overflow-test = []
 
 [[test]]
 name = "basic_boot"

--- a/kernel/src/arch/x86_64/gdt.rs
+++ b/kernel/src/arch/x86_64/gdt.rs
@@ -1,5 +1,10 @@
 //! GDT + TSS. A dedicated IST stack for #DF keeps double-faults from
 //! triple-faulting when the current kernel stack is the thing on fire.
+//!
+//! The IST stack is page-aligned so that `ist_guard` can unmap the
+//! lowest page as a guard: an overflow walks down past that boundary
+//! and takes a #PF whose fault address pinpoints the overflow, rather
+//! than silently scribbling through whatever `.bss` sits below.
 
 use spin::Lazy;
 use x86_64::instructions::segmentation::{Segment, CS, DS, ES, FS, GS, SS};
@@ -11,15 +16,26 @@ use x86_64::VirtAddr;
 
 pub const DOUBLE_FAULT_IST_INDEX: u16 = 0;
 
+/// 20 KiB total. The lowest 4 KiB becomes the guard page once paging
+/// is up, leaving 16 KiB of usable stack — comfortable for the
+/// handful of instructions a #DF handler needs to run.
 const STACK_SIZE: usize = 4096 * 5;
-static mut DOUBLE_FAULT_STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
+
+#[repr(C, align(4096))]
+struct PageAligned<const N: usize>([u8; N]);
+
+static mut DOUBLE_FAULT_STACK: PageAligned<STACK_SIZE> = PageAligned([0; STACK_SIZE]);
+
+/// Virtual address of the first byte of `DOUBLE_FAULT_STACK`. This is
+/// the start of the 4 KiB page that `ist_guard` unmaps.
+pub fn df_stack_guard_addr() -> VirtAddr {
+    VirtAddr::from_ptr(&raw const DOUBLE_FAULT_STACK)
+}
 
 static TSS: Lazy<TaskStateSegment> = Lazy::new(|| {
     let mut tss = TaskStateSegment::new();
-    tss.interrupt_stack_table[DOUBLE_FAULT_IST_INDEX as usize] = {
-        let start = VirtAddr::from_ptr(&raw const DOUBLE_FAULT_STACK);
-        start + STACK_SIZE as u64
-    };
+    tss.interrupt_stack_table[DOUBLE_FAULT_IST_INDEX as usize] =
+        df_stack_guard_addr() + STACK_SIZE as u64;
     tss
 });
 

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -63,5 +63,22 @@ extern "x86-interrupt" fn page_fault(frame: InterruptStackFrame, code: PageFault
 
 extern "x86-interrupt" fn double_fault(frame: InterruptStackFrame, _code: u64) -> ! {
     serial_println!("EXCEPTION: #DF (double fault)\n{:#?}", frame);
+    #[cfg(feature = "ist-overflow-test")]
+    {
+        // We're running on the IST stack now — the whole point. Burn
+        // through it so overflow walks into the guard page below and
+        // surfaces as a #PF with a fault address inside the guard.
+        serial_println!("ist-overflow-test: recursing inside #DF handler");
+        df_recurse(core::hint::black_box(0));
+    }
     hang();
+}
+
+#[cfg(feature = "ist-overflow-test")]
+#[inline(never)]
+#[allow(unconditional_recursion)]
+fn df_recurse(depth: u64) -> u64 {
+    let buf = [depth; 64];
+    let next = core::hint::black_box(depth).wrapping_add(1);
+    df_recurse(next).wrapping_add(core::hint::black_box(buf[0]))
 }

--- a/kernel/src/arch/x86_64/ist_guard.rs
+++ b/kernel/src/arch/x86_64/ist_guard.rs
@@ -1,0 +1,25 @@
+//! Guard page at the low end of the #DF IST stack.
+//!
+//! The double-fault handler runs on a dedicated 20 KiB stack carved
+//! out of `.bss` (see `gdt.rs`). If the handler overflows that stack,
+//! there is no next-level fault to catch us — we'd silently corrupt
+//! whatever came before it in `.bss`. We fix that by unmapping the
+//! lowest 4 KiB of the stack once paging is up: an overflow past that
+//! boundary now takes a #PF with a fault address that pinpoints the
+//! overflow, instead of turning into memory corruption.
+//!
+//! The TSS still points at the *high* end of the stack. Usable stack
+//! shrinks from 20 KiB to 16 KiB — plenty for the handler.
+
+use x86_64::structures::paging::{Page, Size4KiB};
+
+use super::gdt;
+use crate::mem::paging;
+use crate::serial_println;
+
+pub fn install() {
+    let guard = gdt::df_stack_guard_addr();
+    let page: Page<Size4KiB> = Page::containing_address(guard);
+    paging::unmap(page).expect("failed to unmap IST guard page");
+    serial_println!("paging: IST guard installed @ {:#x}", guard.as_u64());
+}

--- a/kernel/src/arch/x86_64/ist_guard.rs
+++ b/kernel/src/arch/x86_64/ist_guard.rs
@@ -19,7 +19,11 @@ use crate::serial_println;
 
 pub fn install() {
     let guard = gdt::df_stack_guard_addr();
-    let page: Page<Size4KiB> = Page::containing_address(guard);
+    // `from_start_address` instead of `containing_address`: the guard VA
+    // must be exactly page-aligned — otherwise we'd silently round down
+    // and unmap something that isn't the guard.
+    let page: Page<Size4KiB> =
+        Page::from_start_address(guard).expect("IST guard address must be page-aligned");
     paging::unmap(page).expect("failed to unmap IST guard page");
     serial_println!("paging: IST guard installed @ {:#x}", guard.as_u64());
 }

--- a/kernel/src/arch/x86_64/mod.rs
+++ b/kernel/src/arch/x86_64/mod.rs
@@ -1,6 +1,7 @@
 pub mod gdt;
 pub mod idt;
 pub mod interrupts;
+pub mod ist_guard;
 pub mod pic;
 
 pub fn init() {

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -8,6 +8,7 @@ use vibix::framebuffer::Console;
 use vibix::{exit_qemu, framebuffer, println, serial_print, serial_println, QemuExitCode};
 
 #[no_mangle]
+#[cfg_attr(feature = "ist-overflow-test", allow(unreachable_code))]
 pub extern "C" fn _start() -> ! {
     vibix::serial::init();
     serial_println!("vibix booting…");
@@ -68,8 +69,22 @@ pub extern "C" fn _start() -> ! {
 
     #[cfg(feature = "ist-overflow-test")]
     {
-        serial_println!("ist-overflow-test: recursing to blow the IST guard");
-        recurse(core::hint::black_box(0));
+        // Trigger a real #DF so the CPU switches to the IST stack before
+        // we recurse (recursion happens in the #DF handler itself, in
+        // idt.rs, under the same feature). The cascade: bad RSP → ud2
+        // raises #UD → the #UD handler preamble can't push its frame on
+        // the invalid RSP → #PF → same — push fails again → #DF. The
+        // #DF vector has an IST index, so the CPU finally switches to a
+        // good stack and enters our handler, which then blows it.
+        serial_println!("ist-overflow-test: forcing #DF via bad RSP + ud2");
+        unsafe {
+            core::arch::asm!(
+                "mov rsp, {bad}",
+                "ud2",
+                bad = in(reg) 0xFFFF_FFFF_FFFE_F000u64,
+                options(noreturn),
+            );
+        }
     }
 
     x86_64::instructions::interrupts::enable();
@@ -89,14 +104,3 @@ fn panic(info: &PanicInfo) -> ! {
     exit_qemu(QemuExitCode::Failure)
 }
 
-/// Recurse forever, consuming stack on each frame. Used by
-/// `ist-overflow-test` to force the #DF handler to chew through its
-/// IST stack and run into the guard page below.
-#[cfg(feature = "ist-overflow-test")]
-#[inline(never)]
-#[allow(unconditional_recursion)]
-fn recurse(depth: u64) -> u64 {
-    let buf = [depth; 64];
-    let next = core::hint::black_box(depth).wrapping_add(1);
-    recurse(next).wrapping_add(core::hint::black_box(buf[0]))
-}

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -66,6 +66,12 @@ pub extern "C" fn _start() -> ! {
         unsafe { core::arch::asm!("ud2") };
     }
 
+    #[cfg(feature = "ist-overflow-test")]
+    {
+        serial_println!("ist-overflow-test: recursing to blow the IST guard");
+        recurse(core::hint::black_box(0));
+    }
+
     x86_64::instructions::interrupts::enable();
     serial_println!("interrupts enabled");
 
@@ -81,4 +87,16 @@ pub extern "C" fn _start() -> ! {
 fn panic(info: &PanicInfo) -> ! {
     serial_println!("KERNEL PANIC: {}", info);
     exit_qemu(QemuExitCode::Failure)
+}
+
+/// Recurse forever, consuming stack on each frame. Used by
+/// `ist-overflow-test` to force the #DF handler to chew through its
+/// IST stack and run into the guard page below.
+#[cfg(feature = "ist-overflow-test")]
+#[inline(never)]
+#[allow(unconditional_recursion)]
+fn recurse(depth: u64) -> u64 {
+    let buf = [depth; 64];
+    let next = core::hint::black_box(depth).wrapping_add(1);
+    recurse(next).wrapping_add(core::hint::black_box(buf[0]))
 }

--- a/kernel/src/mem/mod.rs
+++ b/kernel/src/mem/mod.rs
@@ -45,4 +45,5 @@ pub fn init() {
         .get_response()
         .expect("Limine HHDM response missing");
     paging::init(x86_64::VirtAddr::new(hhdm.offset()));
+    crate::arch::x86_64::ist_guard::install();
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -41,6 +41,7 @@ const SMOKE_MARKERS: &[&str] = &[
     "GDT + IDT loaded",
     "heap: 1024 KiB",
     "paging: mapper online",
+    "paging: IST guard installed",
     "PIC remapped",
     "timer: 100 Hz",
     "vibix online.",


### PR DESCRIPTION
## Summary
- **gdt:** wrap `DOUBLE_FAULT_STACK` in a `#[repr(C, align(4096))]` shim so the low end lands on a page boundary; expose `df_stack_guard_addr()`.
- **arch::ist_guard:** new module, `install()` unmaps the 4 KiB page at the low end of the IST stack via `paging::unmap`. Called from the tail of `mem::init` once paging is up.
- **usable stack:** shrinks from 20 KiB to 16 KiB — the lowest page becomes the guard. TSS still points at the high end; overflow walks *down* into the unmapped page and surfaces as a #PF instead of silently corrupting `.bss`.
- **xtask:** new smoke marker `"paging: IST guard installed"`.
- **fault gating:** new `ist-overflow-test` feature flips on a `recurse()` in `_start` that deliberately blows the IST stack. Deliberately a separate feature from `fault-test` — manual verification only, since a successful overflow is indistinguishable from any other crash to CI.

Out of scope (see issue body): per-task stack guard pages, moving the IST stack off a static, catching #DF recursively.

Closes #6.

## Test plan
- [x] `cargo xtask build` — clean.
- [x] `cargo xtask test` — all 12 host + 5 QEMU integration tests pass (serial shows `paging: IST guard installed @ 0xffffffff8000e000`).
- [x] `cargo xtask smoke` — all 11 markers present.
- [ ] Manual: `cargo build --features ist-overflow-test ...` + boot under QEMU, confirm serial shows a #PF print with the fault address inside the guard page.
- [ ] Eyeball a `cargo xtask run` serial log for no regressions.
