### PR TITLE
ci: run fmt, clippy, tests, smoke, and release build on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,11 @@ jobs:
       - name: cargo fmt --check
         run: cargo fmt --all -- --check
 
-      - name: cargo clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+      # Kernel clippy requires --target x86_64-unknown-none + -Z build-std,
+      # which isn't wired through xtask yet. Scope clippy to the host-crate
+      # (xtask) for now; kernel clippy is a follow-up.
+      - name: cargo clippy (xtask)
+        run: cargo clippy -p xtask --all-targets -- -D warnings
 
       - name: cargo xtask test
         run: cargo xtask test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y --no-install-recommends \
+            qemu-system-x86 xorriso build-essential
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+          components: rust-src, llvm-tools, rustfmt, clippy
+          targets: x86_64-unknown-none
+
+      - name: Cache cargo + limine
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+            build/limine
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: cargo fmt --check
+        run: cargo fmt --all -- --check
+
+      - name: cargo clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: cargo xtask test
+        run: cargo xtask test
+
+      - name: cargo xtask smoke
+        run: cargo xtask smoke
+
+      - name: cargo xtask build --release
+        run: cargo xtask build --release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
@@ -12,8 +15,9 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install system dependencies
         run: |
@@ -22,14 +26,14 @@ jobs:
             qemu-system-x86 xorriso build-essential
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: nightly
           components: rust-src, llvm-tools, rustfmt, clippy
           targets: x86_64-unknown-none
 
       - name: Cache cargo + limine
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -13,7 +13,8 @@ static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
     let mut idt = InterruptDescriptorTable::new();
     idt.divide_error.set_handler_fn(divide_error);
     idt.invalid_opcode.set_handler_fn(invalid_opcode);
-    idt.general_protection_fault.set_handler_fn(general_protection);
+    idt.general_protection_fault
+        .set_handler_fn(general_protection);
     idt.page_fault.set_handler_fn(page_fault);
     unsafe {
         idt.double_fault

--- a/kernel/src/framebuffer.rs
+++ b/kernel/src/framebuffer.rs
@@ -16,9 +16,9 @@ const BG: u32 = 0x0000_0000;
 
 pub struct Console {
     buffer: *mut u32,
-    width: usize,   // pixels
-    height: usize,  // pixels
-    pitch: usize,   // u32s per row
+    width: usize,  // pixels
+    height: usize, // pixels
+    pitch: usize,  // u32s per row
     cols: usize,
     rows: usize,
     cx: usize,

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -13,7 +13,10 @@ pub extern "C" fn _start() -> ! {
     vibix::serial::init();
     serial_println!("vibix booting…");
 
-    assert!(BASE_REVISION.is_supported(), "Limine base revision unsupported");
+    assert!(
+        BASE_REVISION.is_supported(),
+        "Limine base revision unsupported"
+    );
 
     if let Some(fb_response) = FRAMEBUFFER_REQUEST.get_response() {
         if let Some(fb) = fb_response.framebuffers().next() {
@@ -103,4 +106,3 @@ fn panic(info: &PanicInfo) -> ! {
     serial_println!("KERNEL PANIC: {}", info);
     exit_qemu(QemuExitCode::Failure)
 }
-

--- a/kernel/src/mem/frame.rs
+++ b/kernel/src/mem/frame.rs
@@ -24,7 +24,11 @@ impl<'a> BumpFrameAllocator<'a> {
     /// should be non-overlapping; ordering is not required but starting
     /// at the lowest `start` gives deterministic output.
     pub fn new(regions: &'a [Region]) -> Self {
-        let mut me = Self { regions, cursor: 0, region_idx: 0 };
+        let mut me = Self {
+            regions,
+            cursor: 0,
+            region_idx: 0,
+        };
         me.advance_to_next_region();
         me
     }
@@ -167,7 +171,7 @@ mod tests {
     #[test]
     fn walks_across_multiple_regions() {
         let regions = [
-            Region::new(0x1000, 0x2000), // 2 frames
+            Region::new(0x1000, 0x2000),  // 2 frames
             Region::new(0x10000, 0x1000), // 1 frame
         ];
         let mut a = BumpFrameAllocator::new(&regions);
@@ -189,7 +193,7 @@ mod tests {
     #[test]
     fn allocate_contiguous_stays_within_a_region() {
         let regions = [
-            Region::new(0x1000, 0x2000), // 2 frames — too small
+            Region::new(0x1000, 0x2000),   // 2 frames — too small
             Region::new(0x10000, 0x10000), // 16 frames
         ];
         let mut a = BumpFrameAllocator::new(&regions);

--- a/kernel/src/mem/paging.rs
+++ b/kernel/src/mem/paging.rs
@@ -108,9 +108,7 @@ pub fn unmap(page: Page<Size4KiB>) -> Result<PhysFrame<Size4KiB>, UnmapError> {
 /// Translate a virtual address to its backing physical address, if any.
 pub fn translate(addr: VirtAddr) -> Option<PhysAddr> {
     with_mapper(|m| match m.translate(addr) {
-        TranslateResult::Mapped { frame, offset, .. } => {
-            Some(frame.start_address() + offset)
-        }
+        TranslateResult::Mapped { frame, offset, .. } => Some(frame.start_address() + offset),
         TranslateResult::NotMapped | TranslateResult::InvalidFrameAddress(_) => None,
     })
 }

--- a/kernel/tests/heap_alloc.rs
+++ b/kernel/tests/heap_alloc.rs
@@ -31,7 +31,10 @@ fn run_tests() {
     let tests: &[(&str, &dyn Testable)] = &[
         ("simple_box", &(simple_box as fn())),
         ("large_vec", &(large_vec as fn())),
-        ("many_allocations_reclaim", &(many_allocations_reclaim as fn())),
+        (
+            "many_allocations_reclaim",
+            &(many_allocations_reclaim as fn()),
+        ),
     ];
     serial_println!("running {} tests", tests.len());
     for (name, t) in tests {

--- a/kernel/tests/paging.rs
+++ b/kernel/tests/paging.rs
@@ -27,9 +27,8 @@ fn panic(info: &PanicInfo) -> ! {
 }
 
 fn run_tests() {
-    let tests: &[(&str, &dyn Testable)] = &[
-        ("map_roundtrip_unmap", &(map_roundtrip_unmap as fn())),
-    ];
+    let tests: &[(&str, &dyn Testable)] =
+        &[("map_roundtrip_unmap", &(map_roundtrip_unmap as fn()))];
     serial_println!("running {} tests", tests.len());
     for (name, t) in tests {
         serial_println!("test {name}");

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -53,26 +53,39 @@ fn main() -> R<()> {
     let release = take_flag(&mut args, "--release");
     let fault_test = take_flag(&mut args, "--fault-test");
 
-    let cmd = args.get(0).map(String::as_str).unwrap_or("run").to_string();
+    let cmd = args
+        .first()
+        .map(String::as_str)
+        .unwrap_or("run")
+        .to_string();
     let rest: Vec<String> = args.into_iter().skip(1).collect();
-    let opts = BuildOpts { release, fault_test };
+    let opts = BuildOpts {
+        release,
+        fault_test,
+    };
 
     match cmd.as_str() {
-        "build" => { build(&opts)?; }
-        "iso" => { iso(&opts)?; }
-        "run" => { run(&opts)?; }
+        "build" => {
+            build(&opts)?;
+        }
+        "iso" => {
+            iso(&opts)?;
+        }
+        "run" => {
+            run(&opts)?;
+        }
         "test" => test_all()?,
         "test-runner" => {
-            let kernel = rest
-                .first()
-                .ok_or("test-runner: missing kernel ELF path")?;
+            let kernel = rest.first().ok_or("test-runner: missing kernel ELF path")?;
             test_runner(Path::new(kernel))?;
         }
         "smoke" => smoke(&opts)?,
         "clean" => clean()?,
         other => {
             eprintln!("unknown subcommand: {other}");
-            eprintln!("usage: cargo xtask [build|iso|run|test|smoke|clean] [--release] [--fault-test]");
+            eprintln!(
+                "usage: cargo xtask [build|iso|run|test|smoke|clean] [--release] [--fault-test]"
+            );
             std::process::exit(2);
         }
     }
@@ -113,11 +126,16 @@ fn build(opts: &BuildOpts) -> R<PathBuf> {
     let mut cmd = Command::new("cargo");
     cmd.current_dir(workspace_root())
         .arg("build")
-        .arg("--package").arg("vibix")
-        .arg("--bin").arg("vibix")
-        .arg("--target").arg("x86_64-unknown-none")
-        .arg("-Z").arg("build-std=core,compiler_builtins,alloc")
-        .arg("-Z").arg("build-std-features=compiler-builtins-mem");
+        .arg("--package")
+        .arg("vibix")
+        .arg("--bin")
+        .arg("vibix")
+        .arg("--target")
+        .arg("x86_64-unknown-none")
+        .arg("-Z")
+        .arg("build-std=core,compiler_builtins,alloc")
+        .arg("-Z")
+        .arg("build-std-features=compiler-builtins-mem");
     if opts.release {
         cmd.arg("--release");
     }
@@ -139,10 +157,12 @@ fn ensure_limine() -> R<PathBuf> {
     }
     fs::create_dir_all(root.parent().unwrap())?;
     println!("→ cloning limine {LIMINE_TAG}");
-    check(Command::new("git")
-        .args(["clone", "--depth=1", "--branch", LIMINE_TAG, LIMINE_REPO])
-        .arg(&root)
-        .status()?)?;
+    check(
+        Command::new("git")
+            .args(["clone", "--depth=1", "--branch", LIMINE_TAG, LIMINE_REPO])
+            .arg(&root)
+            .status()?,
+    )?;
     check(Command::new("make").arg("-C").arg(&root).status()?)?;
     Ok(root)
 }
@@ -162,26 +182,52 @@ fn make_iso(kernel: &Path, iso_out: &Path, staging: &str) -> R<()> {
         workspace_root().join("kernel/limine.conf"),
         iso_root.join("boot/limine/limine.conf"),
     )?;
-    for f in ["limine-bios.sys", "limine-bios-cd.bin", "limine-uefi-cd.bin"] {
+    for f in [
+        "limine-bios.sys",
+        "limine-bios-cd.bin",
+        "limine-uefi-cd.bin",
+    ] {
         fs::copy(limine.join(f), iso_root.join("boot/limine").join(f))?;
     }
-    fs::copy(limine.join("BOOTX64.EFI"), iso_root.join("EFI/BOOT/BOOTX64.EFI"))?;
+    fs::copy(
+        limine.join("BOOTX64.EFI"),
+        iso_root.join("EFI/BOOT/BOOTX64.EFI"),
+    )?;
 
     fs::create_dir_all(iso_out.parent().unwrap())?;
-    check(Command::new("xorriso")
-        .args(["-as", "mkisofs", "-b", "boot/limine/limine-bios-cd.bin",
-               "-no-emul-boot", "-boot-load-size", "4", "-boot-info-table",
-               "--efi-boot", "boot/limine/limine-uefi-cd.bin",
-               "-efi-boot-part", "--efi-boot-image", "--protective-msdos-label"])
-        .arg(&iso_root)
-        .arg("-o").arg(iso_out)
-        .stdout(Stdio::null()).stderr(Stdio::null())
-        .status()?)?;
+    check(
+        Command::new("xorriso")
+            .args([
+                "-as",
+                "mkisofs",
+                "-b",
+                "boot/limine/limine-bios-cd.bin",
+                "-no-emul-boot",
+                "-boot-load-size",
+                "4",
+                "-boot-info-table",
+                "--efi-boot",
+                "boot/limine/limine-uefi-cd.bin",
+                "-efi-boot-part",
+                "--efi-boot-image",
+                "--protective-msdos-label",
+            ])
+            .arg(&iso_root)
+            .arg("-o")
+            .arg(iso_out)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()?,
+    )?;
 
-    check(Command::new(limine.join("limine"))
-        .arg("bios-install").arg(iso_out)
-        .stdout(Stdio::null()).stderr(Stdio::null())
-        .status()?)?;
+    check(
+        Command::new(limine.join("limine"))
+            .arg("bios-install")
+            .arg(iso_out)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()?,
+    )?;
 
     Ok(())
 }
@@ -197,11 +243,20 @@ fn iso(opts: &BuildOpts) -> R<PathBuf> {
 fn run(opts: &BuildOpts) -> R<()> {
     let iso = iso(opts)?;
     let status = Command::new("qemu-system-x86_64")
-        .args(["-M", "q35", "-m", "256M",
-               "-serial", "stdio",
-               "-no-reboot", "-no-shutdown",
-               "-device", "isa-debug-exit,iobase=0xf4,iosize=0x04"])
-        .arg("-cdrom").arg(&iso)
+        .args([
+            "-M",
+            "q35",
+            "-m",
+            "256M",
+            "-serial",
+            "stdio",
+            "-no-reboot",
+            "-no-shutdown",
+            "-device",
+            "isa-debug-exit,iobase=0xf4,iosize=0x04",
+        ])
+        .arg("-cdrom")
+        .arg(&iso)
         .status()?;
     match status.code() {
         Some(c) if c == QEMU_EXIT_FAILURE => Err("kernel panic — see serial log above".into()),
@@ -218,21 +273,28 @@ fn run(opts: &BuildOpts) -> R<()> {
 /// the exit-code protocol (Success=65, Failure=33).
 fn test_runner(kernel: &Path) -> R<()> {
     let name = kernel.file_name().unwrap().to_string_lossy();
-    let iso = workspace_root()
-        .join("target")
-        .join(format!("{name}.iso"));
+    let iso = workspace_root().join("target").join(format!("{name}.iso"));
     make_iso(kernel, &iso, &format!("iso_{name}"))?;
 
     eprintln!("▶ {}", name);
     // Note: no `-no-shutdown` here — it would prevent `isa-debug-exit`
     // from actually terminating QEMU, defeating the exit-code protocol.
     let mut child = Command::new("qemu-system-x86_64")
-        .args(["-M", "q35", "-m", "256M",
-               "-serial", "stdio",
-               "-display", "none",
-               "-no-reboot",
-               "-device", "isa-debug-exit,iobase=0xf4,iosize=0x04"])
-        .arg("-cdrom").arg(&iso)
+        .args([
+            "-M",
+            "q35",
+            "-m",
+            "256M",
+            "-serial",
+            "stdio",
+            "-display",
+            "none",
+            "-no-reboot",
+            "-device",
+            "isa-debug-exit,iobase=0xf4,iosize=0x04",
+        ])
+        .arg("-cdrom")
+        .arg(&iso)
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
         .spawn()?;
@@ -242,9 +304,7 @@ fn test_runner(kernel: &Path) -> R<()> {
         if let Some(status) = child.try_wait()? {
             return match status.code() {
                 Some(c) if c == QEMU_EXIT_SUCCESS => Ok(()),
-                Some(c) if c == QEMU_EXIT_FAILURE => {
-                    Err(format!("test {name} failed").into())
-                }
+                Some(c) if c == QEMU_EXIT_FAILURE => Err(format!("test {name} failed").into()),
                 other => Err(format!("test {name}: unexpected qemu exit {other:?}").into()),
             };
         }
@@ -259,10 +319,12 @@ fn test_runner(kernel: &Path) -> R<()> {
 fn test_all() -> R<()> {
     // Host unit tests (--lib only; pure-logic modules).
     println!("→ host unit tests");
-    check(Command::new("cargo")
-        .current_dir(workspace_root())
-        .args(["test", "--package", "vibix", "--lib"])
-        .status()?)?;
+    check(
+        Command::new("cargo")
+            .current_dir(workspace_root())
+            .args(["test", "--package", "vibix", "--lib"])
+            .status()?,
+    )?;
 
     // QEMU integration tests. Each is invoked by name so cargo doesn't
     // also try to build the lib's no_std test harness (which would
@@ -270,14 +332,24 @@ fn test_all() -> R<()> {
     // `test-runner <binary>` per compiled test.
     println!("→ integration tests under QEMU");
     let mut cmd = Command::new("cargo");
-    cmd.current_dir(workspace_root())
-        .args([
-            "test", "--package", "vibix",
-            "--target", "x86_64-unknown-none",
-            "-Z", "build-std=core,compiler_builtins,alloc",
-            "-Z", "build-std-features=compiler-builtins-mem",
-        ]);
-    for t in ["basic_boot", "heap_alloc", "should_panic", "timer_tick", "paging"] {
+    cmd.current_dir(workspace_root()).args([
+        "test",
+        "--package",
+        "vibix",
+        "--target",
+        "x86_64-unknown-none",
+        "-Z",
+        "build-std=core,compiler_builtins,alloc",
+        "-Z",
+        "build-std-features=compiler-builtins-mem",
+    ]);
+    for t in [
+        "basic_boot",
+        "heap_alloc",
+        "should_panic",
+        "timer_tick",
+        "paging",
+    ] {
         cmd.arg("--test").arg(t);
     }
     check(cmd.status()?)?;
@@ -291,12 +363,22 @@ fn smoke(opts: &BuildOpts) -> R<()> {
     // We run QEMU with serial to stdio, capture output, then kill after
     // a short delay — the kernel halts in hlt_loop forever.
     let child = Command::new("qemu-system-x86_64")
-        .args(["-M", "q35", "-m", "256M",
-               "-serial", "stdio",
-               "-display", "none",
-               "-no-reboot", "-no-shutdown",
-               "-device", "isa-debug-exit,iobase=0xf4,iosize=0x04"])
-        .arg("-cdrom").arg(&iso)
+        .args([
+            "-M",
+            "q35",
+            "-m",
+            "256M",
+            "-serial",
+            "stdio",
+            "-display",
+            "none",
+            "-no-reboot",
+            "-no-shutdown",
+            "-device",
+            "isa-debug-exit,iobase=0xf4,iosize=0x04",
+        ])
+        .arg("-cdrom")
+        .arg(&iso)
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .spawn()?;
@@ -305,7 +387,9 @@ fn smoke(opts: &BuildOpts) -> R<()> {
     let reader_handle = std::thread::spawn(move || -> std::io::Result<String> {
         use std::io::Read;
         let mut out = String::new();
-        if let Some(mut s) = child.stdout { s.read_to_string(&mut out)?; }
+        if let Some(mut s) = child.stdout {
+            s.read_to_string(&mut out)?;
+        }
         Ok(out)
     });
 
@@ -313,7 +397,9 @@ fn smoke(opts: &BuildOpts) -> R<()> {
     // Kill QEMU so the reader thread can drain and return.
     let _ = Command::new("kill").arg(pid.to_string()).status();
 
-    let output = reader_handle.join().map_err(|_| "reader thread panicked")??;
+    let output = reader_handle
+        .join()
+        .map_err(|_| "reader thread panicked")??;
 
     let mut missing = Vec::new();
     for m in SMOKE_MARKERS {
@@ -333,7 +419,12 @@ fn smoke(opts: &BuildOpts) -> R<()> {
 fn clean() -> R<()> {
     let _ = fs::remove_dir_all(workspace_root().join("target"));
     let _ = fs::remove_dir_all(workspace_root().join("build"));
-    check(Command::new("cargo").current_dir(workspace_root()).arg("clean").status()?)?;
+    check(
+        Command::new("cargo")
+            .current_dir(workspace_root())
+            .arg("clean")
+            .status()?,
+    )?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` — a single `test` job on `ubuntu-latest` that guards `main` and every PR.
- Installs `qemu-system-x86`, `xorriso`, `build-essential`; sets up the nightly toolchain from `rust-toolchain.toml`; caches cargo registry/git, `target/`, and `build/limine/` (so the one-time Limine clone is paid once).
- Runs cheap checks first (`cargo fmt --check`, `cargo clippy -D warnings`) then the full kernel flow: `cargo xtask test` (host unit + in-kernel QEMU integration under TCG), `cargo xtask smoke`, `cargo xtask build --release`.
- `concurrency` cancels superseded PR runs.

Closes #4.

Out of scope: self-hosted/KVM runners, stable/beta matrix, release-artifact uploads.

## Test plan
- [ ] CI run on this PR is green end-to-end.
- [ ] Watch for clippy `-D warnings` failures on the existing code; fix inline or relax here if needed.
- [ ] Confirm the QEMU integration tests complete well inside the 30 s per-test timeout under TCG.
- [ ] Note: could not pre-run locally — cargo isn't on PATH on this host; relying on CI to self-verify.
