### PR TITLE
xtask: add lint subcommand for host + kernel clippy

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -7,6 +7,7 @@
 //!   test          — run host unit tests + QEMU integration tests
 //!   test-runner   — (internal) boot a pre-built test kernel ELF in QEMU
 //!   smoke         — boot the kernel and assert on expected serial markers
+//!   lint          — run clippy on xtask (host) and vibix (kernel, no_std)
 //!   clean         — remove build artifacts
 //!
 //! Flags (apply where sensible): --release, --fault-test
@@ -80,11 +81,12 @@ fn main() -> R<()> {
             test_runner(Path::new(kernel))?;
         }
         "smoke" => smoke(&opts)?,
+        "lint" => lint()?,
         "clean" => clean()?,
         other => {
             eprintln!("unknown subcommand: {other}");
             eprintln!(
-                "usage: cargo xtask [build|iso|run|test|smoke|clean] [--release] [--fault-test]"
+                "usage: cargo xtask [build|iso|run|test|smoke|lint|clean] [--release] [--fault-test]"
             );
             std::process::exit(2);
         }
@@ -414,6 +416,48 @@ fn smoke(opts: &BuildOpts) -> R<()> {
         eprintln!("--- captured serial ---\n{output}\n-----------------------");
         Err(format!("smoke: missing markers {:?}", missing).into())
     }
+}
+
+fn lint() -> R<()> {
+    println!("→ clippy: xtask (host)");
+    check(
+        Command::new("cargo")
+            .current_dir(workspace_root())
+            .args([
+                "clippy",
+                "--package",
+                "xtask",
+                "--all-targets",
+                "--",
+                "-D",
+                "warnings",
+            ])
+            .status()?,
+    )?;
+
+    println!("→ clippy: vibix (kernel, x86_64-unknown-none)");
+    check(
+        Command::new("cargo")
+            .current_dir(workspace_root())
+            .args([
+                "clippy",
+                "--package",
+                "vibix",
+                "--target",
+                "x86_64-unknown-none",
+                "-Z",
+                "build-std=core,compiler_builtins,alloc",
+                "-Z",
+                "build-std-features=compiler-builtins-mem",
+                "--all-targets",
+                "--",
+                "-D",
+                "warnings",
+            ])
+            .status()?,
+    )?;
+
+    Ok(())
 }
 
 fn clean() -> R<()> {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -24,6 +24,16 @@ type R<T> = Result<T, Box<dyn Error>>;
 const LIMINE_TAG: &str = "v8.x-binary";
 const LIMINE_REPO: &str = "https://github.com/limine-bootloader/limine.git";
 
+const KERNEL_TARGET: &str = "x86_64-unknown-none";
+const KERNEL_BUILD_STD_ARGS: &[&str] = &[
+    "--target",
+    KERNEL_TARGET,
+    "-Z",
+    "build-std=core,compiler_builtins,alloc",
+    "-Z",
+    "build-std-features=compiler-builtins-mem",
+];
+
 // QEMU process exit codes produced by `isa-debug-exit` writing our
 // QemuExitCode values. See kernel/src/test_harness.rs.
 const QEMU_EXIT_SUCCESS: i32 = 65; // (0x20 << 1) | 1
@@ -119,7 +129,7 @@ fn kernel_binary(opts: &BuildOpts) -> PathBuf {
     let profile = if opts.release { "release" } else { "debug" };
     workspace_root()
         .join("target")
-        .join("x86_64-unknown-none")
+        .join(KERNEL_TARGET)
         .join(profile)
         .join("vibix")
 }
@@ -127,17 +137,8 @@ fn kernel_binary(opts: &BuildOpts) -> PathBuf {
 fn build(opts: &BuildOpts) -> R<PathBuf> {
     let mut cmd = Command::new("cargo");
     cmd.current_dir(workspace_root())
-        .arg("build")
-        .arg("--package")
-        .arg("vibix")
-        .arg("--bin")
-        .arg("vibix")
-        .arg("--target")
-        .arg("x86_64-unknown-none")
-        .arg("-Z")
-        .arg("build-std=core,compiler_builtins,alloc")
-        .arg("-Z")
-        .arg("build-std-features=compiler-builtins-mem");
+        .args(["build", "--package", "vibix", "--bin", "vibix"])
+        .args(KERNEL_BUILD_STD_ARGS);
     if opts.release {
         cmd.arg("--release");
     }
@@ -334,17 +335,9 @@ fn test_all() -> R<()> {
     // `test-runner <binary>` per compiled test.
     println!("→ integration tests under QEMU");
     let mut cmd = Command::new("cargo");
-    cmd.current_dir(workspace_root()).args([
-        "test",
-        "--package",
-        "vibix",
-        "--target",
-        "x86_64-unknown-none",
-        "-Z",
-        "build-std=core,compiler_builtins,alloc",
-        "-Z",
-        "build-std-features=compiler-builtins-mem",
-    ]);
+    cmd.current_dir(workspace_root())
+        .args(["test", "--package", "vibix"])
+        .args(KERNEL_BUILD_STD_ARGS);
     for t in [
         "basic_boot",
         "heap_alloc",
@@ -439,21 +432,9 @@ fn lint() -> R<()> {
     check(
         Command::new("cargo")
             .current_dir(workspace_root())
-            .args([
-                "clippy",
-                "--package",
-                "vibix",
-                "--target",
-                "x86_64-unknown-none",
-                "-Z",
-                "build-std=core,compiler_builtins,alloc",
-                "-Z",
-                "build-std-features=compiler-builtins-mem",
-                "--all-targets",
-                "--",
-                "-D",
-                "warnings",
-            ])
+            .args(["clippy", "--package", "vibix"])
+            .args(KERNEL_BUILD_STD_ARGS)
+            .args(["--all-targets", "--", "-D", "warnings"])
             .status()?,
     )?;
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -428,7 +428,7 @@ fn lint() -> R<()> {
             .status()?,
     )?;
 
-    println!("→ clippy: vibix (kernel, x86_64-unknown-none)");
+    println!("→ clippy: vibix (kernel, {KERNEL_TARGET})");
     check(
         Command::new("cargo")
             .current_dir(workspace_root())


### PR DESCRIPTION
Adds `cargo xtask lint` which runs clippy on both the host crate (xtask) and the kernel crate (vibix, no_std/baremetal) with the correct flags.

The kernel invocation mirrors the build flags used by `cargo xtask test`:
`--target x86_64-unknown-none -Z build-std=core,compiler_builtins,alloc -Z build-std-features=compiler-builtins-mem`

> [!NOTE]
> The CI workflow step in `.github/workflows/ci.yml` also needs updating: replace `cargo clippy -p xtask --all-targets -- -D warnings` with `cargo xtask lint`.

Closes #22

Generated with [Claude Code](https://claude.ai/code)