### PR TITLE
M5: cooperative kernel tasks + round-robin scheduler

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -52,3 +52,7 @@ harness = false
 [[test]]
 name = "paging"
 harness = false
+
+[[test]]
+name = "tasks"
+harness = false

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -23,6 +23,8 @@ pub mod framebuffer;
 #[cfg(target_os = "none")]
 pub mod serial;
 #[cfg(target_os = "none")]
+pub mod task;
+#[cfg(target_os = "none")]
 pub mod test_harness;
 #[cfg(target_os = "none")]
 pub mod time;

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -93,11 +93,22 @@ pub extern "C" fn _start() -> ! {
     x86_64::instructions::interrupts::enable();
     serial_println!("interrupts enabled");
 
+    vibix::task::init();
+    vibix::task::spawn(idle_task);
+
     loop {
+        vibix::task::yield_now();
         match vibix::input::read_key() {
             pc_keyboard::DecodedKey::Unicode(c) => serial_print!("{}", c),
             pc_keyboard::DecodedKey::RawKey(key) => serial_print!("[{:?}]", key),
         }
+    }
+}
+
+fn idle_task() -> ! {
+    loop {
+        x86_64::instructions::hlt();
+        vibix::task::yield_now();
     }
 }
 

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -75,9 +75,14 @@ pub fn yield_now() {
     };
 
     // SAFETY: `prev_rsp_ptr` points at the `rsp` field of a Box<Task>
-    // inside the ready queue. On a single CPU with cooperative
-    // scheduling, nothing else runs between here and the write inside
-    // `context_switch`, and the VecDeque isn't resized by that write.
+    // in the ready queue. The Box indirection pins the Task's address
+    // — a VecDeque reallocation would move the Box, not the Task
+    // itself — so the pointer stays valid even if an IRQ fires before
+    // `context_switch` reaches its write. The Task can't be dropped
+    // until someone re-acquires SCHED and pops it, which can't happen
+    // between this lock drop and that write on a single CPU. This
+    // relies on no IRQ handler calling `spawn`/`yield_now`; the
+    // current timer + keyboard handlers don't.
     unsafe {
         context_switch(prev_rsp_ptr, next_rsp);
     }

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -1,0 +1,84 @@
+//! Cooperative kernel tasks.
+//!
+//! A minimal round-robin scheduler with a single ready queue and no
+//! preemption — tasks hand control back only by calling [`yield_now`].
+//! Each task owns a heap-allocated kernel stack and a saved register
+//! context; the hand-written switch in [`switch`] is the one place
+//! that touches `rsp`.
+//!
+//! ## Ordering
+//!
+//! [`init`] must be called after `mem::init()` (we allocate on the
+//! heap) and after interrupts are enabled in `main` — `vibix::init()`
+//! deliberately stays single-threaded so integration tests that don't
+//! care about tasks keep their simple `_start` flow.
+//!
+//! ## What's *not* here (yet)
+//!
+//! - Preemption (M6 lands a timer-driven switch).
+//! - Blocking primitives — cooperative code polls + yields.
+//! - Per-task address spaces or guard pages.
+
+mod scheduler;
+mod switch;
+mod task;
+
+use alloc::boxed::Box;
+use spin::{Lazy, Mutex};
+
+use scheduler::Scheduler;
+use switch::context_switch;
+use task::Task;
+
+use crate::serial_println;
+
+static SCHED: Lazy<Mutex<Scheduler>> = Lazy::new(|| Mutex::new(Scheduler::new()));
+
+/// Install the bootstrap task wrapping the currently-running thread.
+/// Must be called exactly once, before any [`spawn`] or [`yield_now`].
+pub fn init() {
+    let mut sched = SCHED.lock();
+    assert!(sched.current.is_none(), "task::init called twice");
+    sched.current = Some(Box::new(Task::bootstrap()));
+    drop(sched);
+    serial_println!("tasks: scheduler online");
+}
+
+/// Queue a new task running `entry`. The task starts at the back of
+/// the ready queue and will run when scheduling reaches it.
+pub fn spawn(entry: fn() -> !) {
+    let mut sched = SCHED.lock();
+    sched.ready.push_back(Box::new(Task::new(entry)));
+}
+
+/// Yield the CPU to the next runnable task. If no other task is
+/// ready, returns immediately. Safe to call from any task (including
+/// the bootstrap task after [`init`]).
+pub fn yield_now() {
+    // Carve out the switch parameters under the lock, then drop the
+    // lock BEFORE the context switch. Holding it across would
+    // deadlock the incoming task's own call to `yield_now`.
+    let (prev_rsp_ptr, next_rsp) = {
+        let mut sched = SCHED.lock();
+        let Some(next) = sched.ready.pop_front() else {
+            return;
+        };
+        let prev = sched.current.take().expect("yield_now before task::init");
+
+        let next_rsp = next.rsp;
+        sched.current = Some(next);
+        sched.ready.push_back(prev);
+        let prev_ref = sched.ready.back_mut().expect("just pushed");
+        let prev_rsp_ptr: *mut usize = &mut prev_ref.rsp as *mut usize;
+
+        (prev_rsp_ptr, next_rsp)
+    };
+
+    // SAFETY: `prev_rsp_ptr` points at the `rsp` field of a Box<Task>
+    // inside the ready queue. On a single CPU with cooperative
+    // scheduling, nothing else runs between here and the write inside
+    // `context_switch`, and the VecDeque isn't resized by that write.
+    unsafe {
+        context_switch(prev_rsp_ptr, next_rsp);
+    }
+}

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -1,0 +1,23 @@
+//! Round-robin scheduler state. Holds the currently-running task and
+//! a FIFO ready queue. Cooperative only — `yield_now()` is the sole
+//! rescheduling point, so we don't need to worry about IRQs mutating
+//! the queue mid-switch.
+
+use alloc::boxed::Box;
+use alloc::collections::VecDeque;
+
+use super::task::Task;
+
+pub(super) struct Scheduler {
+    pub current: Option<Box<Task>>,
+    pub ready: VecDeque<Box<Task>>,
+}
+
+impl Scheduler {
+    pub const fn new() -> Self {
+        Self {
+            current: None,
+            ready: VecDeque::new(),
+        }
+    }
+}

--- a/kernel/src/task/switch.rs
+++ b/kernel/src/task/switch.rs
@@ -1,0 +1,62 @@
+//! Low-level context switch and the trampoline that bootstraps a fresh
+//! task's first run.
+//!
+//! `context_switch` saves the six System-V AMD64 callee-saved registers
+//! (`rbx`, `rbp`, `r12`-`r15`) plus `rsp` of the outgoing task, then
+//! loads the incoming task's state symmetrically. That's the entire
+//! saved context — caller-saved registers belong to whichever function
+//! called `yield_now()` and Rust/LLVM handle them for us.
+//!
+//! A new task's stack is primed so that the first `context_switch`
+//! into it returns into `task_entry_trampoline`, which reads the entry
+//! function pointer out of `r12` and calls it.
+
+use core::arch::global_asm;
+
+unsafe extern "C" {
+    /// Save the outgoing task's callee-saved regs + rsp into
+    /// `*prev_rsp`, then load `next_rsp` and the incoming task's regs.
+    ///
+    /// # Safety
+    /// - `prev_rsp` must be a valid, aligned, writable `*mut usize`
+    ///   pointing at stable storage that outlives this call.
+    /// - `next_rsp` must be a valid saved rsp produced either by a
+    ///   prior `context_switch` or by `Task::new`'s stack priming.
+    pub fn context_switch(prev_rsp: *mut usize, next_rsp: usize);
+}
+
+global_asm!(
+    r#"
+    .section .text
+    .global context_switch
+    .global task_entry_trampoline
+
+context_switch:
+    // rdi = prev_rsp (*mut usize), rsi = next_rsp (usize)
+    push rbx
+    push rbp
+    push r12
+    push r13
+    push r14
+    push r15
+    mov [rdi], rsp
+    mov rsp, rsi
+    pop r15
+    pop r14
+    pop r13
+    pop r12
+    pop rbp
+    pop rbx
+    ret
+
+task_entry_trampoline:
+    // Entry fn pointer was primed into r12. It's `fn() -> !`, so a
+    // return here is a bug; `ud2` makes that loud.
+    call r12
+    ud2
+"#
+);
+
+unsafe extern "C" {
+    pub fn task_entry_trampoline();
+}

--- a/kernel/src/task/switch.rs
+++ b/kernel/src/task/switch.rs
@@ -23,6 +23,10 @@ unsafe extern "C" {
     /// - `next_rsp` must be a valid saved rsp produced either by a
     ///   prior `context_switch` or by `Task::new`'s stack priming.
     pub fn context_switch(prev_rsp: *mut usize, next_rsp: usize);
+
+    /// First-entry trampoline for a freshly primed task. The entry fn
+    /// pointer is passed in `r12`; the trampoline just `call`s it.
+    pub fn task_entry_trampoline();
 }
 
 global_asm!(
@@ -56,7 +60,3 @@ task_entry_trampoline:
     ud2
 "#
 );
-
-unsafe extern "C" {
-    pub fn task_entry_trampoline();
-}

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -42,9 +42,10 @@ impl Task {
     ///
     /// Primed layout (low → high):
     /// ```text
-    ///   r15=0  r14=0  r13=0  r12=entry  rbp=0  rbx=0  ret=trampoline
-    ///   ^ saved rsp                                    ^ stack top
+    ///   r15=0  r14=0  r13=0  r12=entry  rbp=0  rbx=0  ret=trampoline  <top>
+    ///   ^ saved rsp (initial)                          ^ rsp after 6 pops
     /// ```
+    /// `ret` then consumes the last slot and lands rsp on `<top>`.
     pub fn new(entry: fn() -> !) -> Self {
         let layout = Layout::new::<Stack>();
         // SAFETY: Stack has non-zero size and align 16; alloc_zeroed

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -1,0 +1,85 @@
+//! Per-task state: a heap-allocated kernel stack and a saved stack
+//! pointer. The stack is primed on construction so the first context
+//! switch into a new task lands in `task_entry_trampoline`, which then
+//! calls the entry function.
+
+use alloc::alloc::{alloc_zeroed, handle_alloc_error, Layout};
+use alloc::boxed::Box;
+
+use super::switch::task_entry_trampoline;
+
+/// 16 KiB per task — plenty for the handful of kernel frames
+/// cooperative tasks build up between `yield_now()` calls. Aligned to
+/// 16 so the primed `rsp` is ABI-legal at the trampoline's `call`.
+const STACK_SIZE: usize = 16 * 1024;
+
+#[repr(C, align(16))]
+pub(super) struct Stack([u8; STACK_SIZE]);
+
+pub(super) struct Task {
+    /// Holder for the heap-allocated stack. `None` only for the
+    /// bootstrap task, which inherits the boot-time kernel stack.
+    _stack: Option<Box<Stack>>,
+    /// Saved `rsp`. Updated on every `context_switch` out of the task.
+    /// `0` is a sentinel meaning "not yet saved" — legal only for the
+    /// bootstrap task before its first yield.
+    pub rsp: usize,
+}
+
+impl Task {
+    /// Bootstrap task for the currently-running thread of control. Its
+    /// `rsp` is filled in by the first `context_switch` that yields
+    /// away from this thread.
+    pub fn bootstrap() -> Self {
+        Self {
+            _stack: None,
+            rsp: 0,
+        }
+    }
+
+    /// Allocate a fresh stack and prime it so the first switch into
+    /// this task runs `entry` via the trampoline.
+    ///
+    /// Primed layout (low → high):
+    /// ```text
+    ///   r15=0  r14=0  r13=0  r12=entry  rbp=0  rbx=0  ret=trampoline
+    ///   ^ saved rsp                                    ^ stack top
+    /// ```
+    pub fn new(entry: fn() -> !) -> Self {
+        let layout = Layout::new::<Stack>();
+        // SAFETY: Stack has non-zero size and align 16; alloc_zeroed
+        // either returns a valid ptr of that layout or null (handled).
+        let stack = unsafe {
+            let ptr = alloc_zeroed(layout) as *mut Stack;
+            if ptr.is_null() {
+                handle_alloc_error(layout);
+            }
+            Box::from_raw(ptr)
+        };
+
+        let base = Box::as_ref(&stack) as *const Stack as *const u8 as usize;
+        let top = base + STACK_SIZE;
+
+        // Seven 8-byte slots: [r15, r14, r13, r12, rbp, rbx, ret].
+        let rsp = top - 7 * 8;
+        let slots = rsp as *mut usize;
+        // SAFETY: the 56 bytes at `rsp` sit inside the freshly
+        // allocated, zeroed Stack and are exclusively owned here.
+        unsafe {
+            slots.add(0).write(0); // r15
+            slots.add(1).write(0); // r14
+            slots.add(2).write(0); // r13
+            slots.add(3).write(entry as *const () as usize); // r12 ← entry
+            slots.add(4).write(0); // rbp
+            slots.add(5).write(0); // rbx
+            slots
+                .add(6)
+                .write(task_entry_trampoline as *const () as usize); // ret
+        }
+
+        Self {
+            _stack: Some(stack),
+            rsp,
+        }
+    }
+}

--- a/kernel/tests/tasks.rs
+++ b/kernel/tests/tasks.rs
@@ -1,0 +1,112 @@
+//! Integration test: cooperative kernel tasks actually interleave, and
+//! a spawned task can flip a flag the driver task polls.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use vibix::{
+    exit_qemu, serial_println, task,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    task::init();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("two_tasks_interleave", &(two_tasks_interleave as fn())),
+        (
+            "spawn_then_join_via_flag",
+            &(spawn_then_join_via_flag as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+static A: AtomicUsize = AtomicUsize::new(0);
+static B: AtomicUsize = AtomicUsize::new(0);
+const ROUNDS: usize = 50;
+
+fn task_a() -> ! {
+    for _ in 0..ROUNDS {
+        A.fetch_add(1, Ordering::SeqCst);
+        task::yield_now();
+    }
+    loop {
+        task::yield_now();
+    }
+}
+
+fn task_b() -> ! {
+    for _ in 0..ROUNDS {
+        B.fetch_add(1, Ordering::SeqCst);
+        task::yield_now();
+    }
+    loop {
+        task::yield_now();
+    }
+}
+
+fn two_tasks_interleave() {
+    A.store(0, Ordering::SeqCst);
+    B.store(0, Ordering::SeqCst);
+
+    task::spawn(task_a);
+    task::spawn(task_b);
+
+    // Drive the scheduler from the driver (bootstrap) task. ROUNDS*3
+    // yields is comfortably enough for both workers to finish their
+    // ROUNDS bumps under round-robin.
+    for _ in 0..(ROUNDS * 3) {
+        task::yield_now();
+    }
+
+    let a = A.load(Ordering::SeqCst);
+    let b = B.load(Ordering::SeqCst);
+    assert_eq!(a, ROUNDS, "task_a didn't run to completion (a={a})");
+    assert_eq!(b, ROUNDS, "task_b didn't run to completion (b={b})");
+}
+
+static FLAG: AtomicBool = AtomicBool::new(false);
+
+fn flag_setter() -> ! {
+    FLAG.store(true, Ordering::SeqCst);
+    loop {
+        task::yield_now();
+    }
+}
+
+fn spawn_then_join_via_flag() {
+    FLAG.store(false, Ordering::SeqCst);
+    task::spawn(flag_setter);
+
+    // Poll + yield until the flag flips. Bound the loop so a
+    // scheduler bug fails the test fast instead of hanging CI.
+    for _ in 0..1_000 {
+        if FLAG.load(Ordering::SeqCst) {
+            return;
+        }
+        task::yield_now();
+    }
+    panic!("flag never flipped — scheduler didn't run the spawned task");
+}

--- a/kernel/tests/tasks.rs
+++ b/kernel/tests/tasks.rs
@@ -47,6 +47,10 @@ static A: AtomicUsize = AtomicUsize::new(0);
 static B: AtomicUsize = AtomicUsize::new(0);
 const ROUNDS: usize = 50;
 
+// M5 has no task-exit primitive, so worker tasks that finish their
+// real work park in a yield loop. They stay in the ready queue for
+// subsequent tests in this binary — safe because later tests only
+// assert on counters/flags of their own, not on queue shape.
 fn task_a() -> ! {
     for _ in 0..ROUNDS {
         A.fetch_add(1, Ordering::SeqCst);

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -46,6 +46,7 @@ const SMOKE_MARKERS: &[&str] = &[
     "timer: 100 Hz",
     "vibix online.",
     "interrupts enabled",
+    "tasks: scheduler online",
 ];
 
 fn main() -> R<()> {
@@ -349,6 +350,7 @@ fn test_all() -> R<()> {
         "should_panic",
         "timer_tick",
         "paging",
+        "tasks",
     ] {
         cmd.arg("--test").arg(t);
     }


### PR DESCRIPTION
## Summary
- New `kernel/src/task/` module: `Task` with a 16 KiB heap-allocated, 16-aligned kernel stack, `Scheduler` with a `VecDeque` run queue under `spin::Mutex`, and a hand-written `context_switch` (saves `rbx`/`rbp`/`r12`–`r15` + `rsp`). Fresh tasks start via a trampoline that reads the entry fn pointer from `r12`.
- `task::init()` runs at the end of `main` (not inside `vibix::init()`) so integration tests that don't care about tasks keep their simple `_start` flow. Idle task (`hlt; yield_now`) spawned; input loop now calls `yield_now()` each iteration.
- Adds `kernel/tests/tasks.rs` with `two_tasks_interleave` (round-robin correctness) and `spawn_then_join_via_flag` (driver polls a flag a spawned task flips), and the `"tasks: scheduler online"` smoke marker.

Closes #16.

## Test plan
- [x] `cargo xtask test` — host unit tests + all integration tests (including the new `tasks` binary) pass.
- [x] `cargo xtask smoke` — all 12 markers present, including the new `tasks: scheduler online`.
- [x] `cargo xtask build --release` — clean release build.
- [x] `cargo fmt --all -- --check` and `cargo clippy -p xtask --all-targets -- -D warnings` clean.