### PR TITLE
M6: preemptive scheduling via the PIT tick

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -56,3 +56,7 @@ harness = false
 [[test]]
 name = "tasks"
 harness = false
+
+[[test]]
+name = "preempt"
+harness = false

--- a/kernel/src/arch/x86_64/interrupts.rs
+++ b/kernel/src/arch/x86_64/interrupts.rs
@@ -25,7 +25,12 @@ impl InterruptIndex {
 
 pub extern "x86-interrupt" fn timer_interrupt(_frame: InterruptStackFrame) {
     crate::time::on_tick();
+    // EOI before any attempt to preempt. If we switched to another
+    // task first and *that* task ever re-entered this ISR, the PIC
+    // would be carrying an un-acked IRQ and subsequent ticks would
+    // stall.
     notify_eoi(InterruptIndex::Timer.as_u8());
+    crate::task::preempt_tick();
 }
 
 pub extern "x86-interrupt" fn keyboard_interrupt(_frame: InterruptStackFrame) {

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -1,10 +1,10 @@
-//! Cooperative kernel tasks.
+//! Round-robin kernel tasks, cooperative + PIT-driven preemption.
 //!
-//! A minimal round-robin scheduler with a single ready queue and no
-//! preemption — tasks hand control back only by calling [`yield_now`].
-//! Each task owns a heap-allocated kernel stack and a saved register
-//! context; the hand-written switch in [`switch`] is the one place
-//! that touches `rsp`.
+//! Tasks can hand control back explicitly with [`yield_now`], and the
+//! timer ISR calls [`preempt_tick`] every PIT interrupt to rotate tasks
+//! that never yield. Each task owns a heap-allocated kernel stack and a
+//! saved register context; the hand-written switch in [`switch`] is the
+//! one place that touches `rsp`.
 //!
 //! ## Ordering
 //!
@@ -15,7 +15,7 @@
 //!
 //! ## What's *not* here (yet)
 //!
-//! - Preemption (M6 lands a timer-driven switch).
+//! - Priorities, per-CPU queues, tickless idle.
 //! - Blocking primitives — cooperative code polls + yields.
 //! - Per-task address spaces or guard pages.
 
@@ -25,12 +25,18 @@ mod task;
 
 use alloc::boxed::Box;
 use spin::{Lazy, Mutex};
+use x86_64::instructions::interrupts;
 
 use scheduler::Scheduler;
 use switch::context_switch;
 use task::Task;
 
 use crate::serial_println;
+use crate::time::TICK_MS;
+
+/// Default time slice, in milliseconds. At 100 Hz this lines up with a
+/// single PIT tick — every tick is a rescheduling opportunity.
+pub(crate) const DEFAULT_SLICE_MS: u32 = 10;
 
 static SCHED: Lazy<Mutex<Scheduler>> = Lazy::new(|| Mutex::new(Scheduler::new()));
 
@@ -55,18 +61,32 @@ pub fn spawn(entry: fn() -> !) {
 /// ready, returns immediately. Safe to call from any task (including
 /// the bootstrap task after [`init`]).
 pub fn yield_now() {
+    // Mask IRQs across the lock + switch so the timer ISR's preempt
+    // path can't mutate the ready queue between our lock drop and the
+    // context_switch (which would invalidate `prev_rsp_ptr`). `was_on`
+    // lives on this task's stack — when we're eventually switched back
+    // in, it'll be restored and we re-enable iff this task was running
+    // with IRQs on. Tasks first entered via the trampoline always come
+    // back here with IRQs on, regardless of our caller's state.
+    let was_on = interrupts::are_enabled();
+    interrupts::disable();
+
     // Carve out the switch parameters under the lock, then drop the
     // lock BEFORE the context switch. Holding it across would
     // deadlock the incoming task's own call to `yield_now`.
     let (prev_rsp_ptr, next_rsp) = {
         let mut sched = SCHED.lock();
         let Some(next) = sched.ready.pop_front() else {
+            if was_on {
+                interrupts::enable();
+            }
             return;
         };
         let prev = sched.current.take().expect("yield_now before task::init");
 
         let next_rsp = next.rsp;
         sched.current = Some(next);
+        sched.current.as_mut().unwrap().slice_remaining_ms = DEFAULT_SLICE_MS;
         sched.ready.push_back(prev);
         let prev_ref = sched.ready.back_mut().expect("just pushed");
         let prev_rsp_ptr: *mut usize = &mut prev_ref.rsp as *mut usize;
@@ -80,9 +100,69 @@ pub fn yield_now() {
     // itself — so the pointer stays valid even if an IRQ fires before
     // `context_switch` reaches its write. The Task can't be dropped
     // until someone re-acquires SCHED and pops it, which can't happen
-    // between this lock drop and that write on a single CPU. This
-    // relies on no IRQ handler calling `spawn`/`yield_now`; the
-    // current timer + keyboard handlers don't.
+    // between this lock drop and that write on a single CPU. We've
+    // also masked IRQs for the duration, so the preempt tick can't
+    // fire and re-enter the scheduler while the switch is in flight.
+    unsafe {
+        context_switch(prev_rsp_ptr, next_rsp);
+    }
+
+    if was_on {
+        interrupts::enable();
+    }
+}
+
+/// Called from the timer ISR after `notify_eoi`. Decrements the
+/// current task's slice; if it's exhausted and there's another task
+/// ready, rotates and context-switches. Bails on lock contention so
+/// the ISR never blocks on a task that's in the middle of its own
+/// cooperative switch.
+///
+/// Runs with IRQs masked (interrupt gate). The switched-in task
+/// resumes either via IRET (if it was last preempted) or through
+/// `yield_now`'s tail (if it was last suspended cooperatively) — both
+/// paths restore a correct IF on return to task code.
+pub fn preempt_tick() {
+    // `try_lock` + bail: yield_now (or another preempt tick mid-switch)
+    // may already hold SCHED. We'll get another tick in 10 ms.
+    let Some(mut sched) = SCHED.try_lock() else {
+        return;
+    };
+
+    // No task::init yet (or a non-task integration test) — nothing to
+    // preempt. Forces Lazy init, but that's allocation-free.
+    if sched.current.is_none() {
+        return;
+    }
+
+    {
+        let current = sched.current.as_mut().unwrap();
+        current.slice_remaining_ms = current.slice_remaining_ms.saturating_sub(TICK_MS as u32);
+        if current.slice_remaining_ms > 0 {
+            return;
+        }
+    }
+
+    let Some(next) = sched.ready.pop_front() else {
+        // Slice expired but nobody else is ready. Reload and keep
+        // running — prevents repeated try_lock churn on every tick.
+        sched.current.as_mut().unwrap().slice_remaining_ms = DEFAULT_SLICE_MS;
+        return;
+    };
+
+    let prev = sched.current.take().unwrap();
+    let next_rsp = next.rsp;
+    sched.current = Some(next);
+    sched.current.as_mut().unwrap().slice_remaining_ms = DEFAULT_SLICE_MS;
+    sched.ready.push_back(prev);
+    let prev_ref = sched.ready.back_mut().expect("just pushed");
+    let prev_rsp_ptr: *mut usize = &mut prev_ref.rsp as *mut usize;
+    drop(sched);
+
+    // SAFETY: same invariant as `yield_now` — `prev_rsp_ptr` stays
+    // valid because Box pins the Task's address, and IRQs are masked
+    // inside the ISR so no other scheduler path can race us between
+    // lock drop and the context switch.
     unsafe {
         context_switch(prev_rsp_ptr, next_rsp);
     }

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -1,7 +1,8 @@
 //! Round-robin scheduler state. Holds the currently-running task and
-//! a FIFO ready queue. Cooperative only — `yield_now()` is the sole
-//! rescheduling point, so we don't need to worry about IRQs mutating
-//! the queue mid-switch.
+//! a FIFO ready queue. Rescheduling happens from either `yield_now()`
+//! (cooperative) or `preempt_tick()` (PIT ISR); `yield_now` masks IRQs
+//! across the lock/switch window so the two paths can't race on the
+//! queue.
 
 use alloc::boxed::Box;
 use alloc::collections::VecDeque;

--- a/kernel/src/task/switch.rs
+++ b/kernel/src/task/switch.rs
@@ -55,7 +55,13 @@ context_switch:
 
 task_entry_trampoline:
     // Entry fn pointer was primed into r12. It's `fn() -> !`, so a
-    // return here is a bug; `ud2` makes that loud.
+    // return here is a bug; `ud2` makes that loud. `sti` first so a
+    // task entered for the first time from the preempt ISR (which
+    // runs with IF=0 under an interrupt gate) still receives future
+    // timer IRQs and can itself be preempted. `sti` when IF is
+    // already set is a no-op, so the cooperative-yield path is
+    // unaffected.
+    sti
     call r12
     ud2
 "#

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -7,6 +7,7 @@ use alloc::alloc::{alloc_zeroed, handle_alloc_error, Layout};
 use alloc::boxed::Box;
 
 use super::switch::task_entry_trampoline;
+use super::DEFAULT_SLICE_MS;
 
 /// 16 KiB per task — plenty for the handful of kernel frames
 /// cooperative tasks build up between `yield_now()` calls. Aligned to
@@ -24,6 +25,11 @@ pub(super) struct Task {
     /// `0` is a sentinel meaning "not yet saved" — legal only for the
     /// bootstrap task before its first yield.
     pub rsp: usize,
+    /// Milliseconds left in this task's current CPU slice. The PIT ISR
+    /// decrements this by `TICK_MS`; when it hits zero the task rotates
+    /// to the back of the ready queue and the counter is reloaded from
+    /// `DEFAULT_SLICE_MS`.
+    pub slice_remaining_ms: u32,
 }
 
 impl Task {
@@ -34,6 +40,7 @@ impl Task {
         Self {
             _stack: None,
             rsp: 0,
+            slice_remaining_ms: DEFAULT_SLICE_MS,
         }
     }
 
@@ -81,6 +88,7 @@ impl Task {
         Self {
             _stack: Some(stack),
             rsp,
+            slice_remaining_ms: DEFAULT_SLICE_MS,
         }
     }
 }

--- a/kernel/tests/preempt.rs
+++ b/kernel/tests/preempt.rs
@@ -14,9 +14,9 @@ use core::panic::PanicInfo;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 use vibix::{
-    exit_qemu, serial_println, task, time,
+    exit_qemu, serial_println, task,
     test_harness::{test_panic_handler, Testable},
-    QemuExitCode,
+    time, QemuExitCode,
 };
 
 #[no_mangle]

--- a/kernel/tests/preempt.rs
+++ b/kernel/tests/preempt.rs
@@ -1,0 +1,84 @@
+//! Integration test: the PIT preempts tasks that never yield.
+//!
+//! Spawns two workers that spin on a counter with no cooperative
+//! `yield_now`, then the driver sleeps on `hlt` watching `uptime_ms()`
+//! until the deadline passes. Both workers must have made progress —
+//! if either counter is still zero, preemption didn't rotate through.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use vibix::{
+    exit_qemu, serial_println, task, time,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[(
+        "preempts_never_yielding_tasks",
+        &(preempts_never_yielding_tasks as fn()),
+    )];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+static A: AtomicUsize = AtomicUsize::new(0);
+static B: AtomicUsize = AtomicUsize::new(0);
+
+fn spin_a() -> ! {
+    loop {
+        A.fetch_add(1, Ordering::Relaxed);
+        core::hint::spin_loop();
+    }
+}
+
+fn spin_b() -> ! {
+    loop {
+        B.fetch_add(1, Ordering::Relaxed);
+        core::hint::spin_loop();
+    }
+}
+
+fn preempts_never_yielding_tasks() {
+    A.store(0, Ordering::SeqCst);
+    B.store(0, Ordering::SeqCst);
+
+    task::spawn(spin_a);
+    task::spawn(spin_b);
+
+    // 100 ms window = 10 PIT ticks at 100 Hz. With a 10 ms slice each
+    // worker should land at least one full slice; hlt parks the driver
+    // between ticks so the workers get the CPU.
+    let start = time::uptime_ms();
+    while time::uptime_ms() < start + 100 {
+        x86_64::instructions::hlt();
+    }
+
+    let a = A.load(Ordering::Relaxed);
+    let b = B.load(Ordering::Relaxed);
+    assert!(a > 0, "spin_a never ran under preemption (a={a})");
+    assert!(b > 0, "spin_b never ran under preemption (b={b})");
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -346,6 +346,7 @@ fn test_all() -> R<()> {
         "timer_tick",
         "paging",
         "tasks",
+        "preempt",
     ] {
         cmd.arg("--test").arg(t);
     }


### PR DESCRIPTION
## Summary

Closes the M6 milestone from #18: the PIT tick now drives preemption so tasks that never call `yield_now` still get rotated.

- `Task::slice_remaining_ms` holds remaining CPU time; refreshed to `DEFAULT_SLICE_MS` (10 ms) on every switch-in.
- `task::preempt_tick()` runs from the timer ISR **after** `notify_eoi` — PIC is acked before any switch attempt. Uses `try_lock` + bail so it can't deadlock against a task mid-`yield_now`.
- `yield_now` masks IRQs across its lock + switch window so the preempt ISR can't mutate the ready queue between the lock drop and the context switch. A task-local `was_on` flag restores the caller's IF on resume.
- `task_entry_trampoline` issues `sti` before calling the entry fn. A task first entered from the preempt ISR is otherwise running with IF=0 (interrupt gate) and would never see another tick.

Out of scope, per the issue: priorities, per-CPU queues, tickless idle.

Refs #18.

## Test plan

- [x] `cargo xtask build` — clean.
- [x] `cargo xtask test` — all integration tests pass, including:
  - new `kernel/tests/preempt.rs` — spawns two never-yielding spinners; driver parks on `hlt` for 100 ms; both counters must be > 0.
  - existing `tasks` (cooperative) and `timer_tick` tests still pass.
- [x] `cargo xtask smoke` — all 12 serial markers present.