### PR TITLE
ci(claude): allow gh pr and gh issue create in claude-code-action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,5 +46,5 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          claude_args: '--allowed-tools "Bash(gh pr:*)" "Bash(gh issue create:*)"'
 


### PR DESCRIPTION
## Summary
- Activates the commented-out `claude_args` line in `.github/workflows/claude.yml`.
- Sets `--allowed-tools "Bash(gh pr:*)" "Bash(gh issue create:*)"` so the action can both operate on PRs and open new issues from @claude comments.

Closes #27.

## Test plan
- [x] YAML parses (`python3 -c 'import yaml; yaml.safe_load(open(...))'`)
- [ ] Verified end-to-end by tagging `@claude` on an issue/comment and confirming the action can run `gh issue create` when asked
