### PR TITLE
#14: grow the kernel heap on demand

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -56,3 +56,7 @@ harness = false
 [[test]]
 name = "tasks"
 harness = false
+
+[[test]]
+name = "heap_grow"
+harness = false

--- a/kernel/src/mem/heap.rs
+++ b/kernel/src/mem/heap.rs
@@ -57,9 +57,14 @@ impl GrowingHeap {
 
     /// Map the next `GROW_CHUNK_BYTES` (or less if we're bumping the
     /// cap) past the current top and call `Heap::extend`. Returns false
-    /// if we're already at the cap or the map failed.
-    fn grow(&self) -> bool {
-        let _g = self.grow_lock.lock();
+    /// if we're already at the cap or no pages could be mapped.
+    ///
+    /// Must be called with `grow_lock` held. Maps page-by-page so that
+    /// if the frame allocator fails partway through we still extend the
+    /// heap by the successful prefix rather than leaking those frames
+    /// and leaving the heap permanently stuck (`paging::map_range`
+    /// documents that earlier pages stay mapped on partial failure).
+    fn grow_locked(&self) -> bool {
         let mapped = self.mapped.load(Ordering::Acquire);
         if mapped >= HEAP_MAX_SIZE {
             return false;
@@ -68,19 +73,26 @@ impl GrowingHeap {
         let chunk = GROW_CHUNK_BYTES.min(remaining);
         let start = VirtAddr::new((HEAP_BASE + mapped) as u64);
         let frames = (chunk as u64) / FRAME_SIZE;
-        if paging::map_range(
-            start,
-            frames,
-            PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
-        )
-        .is_err()
-        {
+        let mut grown: usize = 0;
+        for i in 0..frames {
+            if paging::map_range(
+                start + i * FRAME_SIZE,
+                1,
+                PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
+            )
+            .is_err()
+            {
+                break;
+            }
+            grown += FRAME_SIZE as usize;
+        }
+        if grown == 0 {
             return false;
         }
-        // SAFETY: just mapped `chunk` bytes contiguous with the current
+        // SAFETY: `grown` bytes were mapped contiguously at the current
         // heap top; they're owned by the heap from here on.
-        unsafe { self.inner.lock().extend(chunk) };
-        self.mapped.fetch_add(chunk, Ordering::Release);
+        unsafe { self.inner.lock().extend(grown) };
+        self.mapped.fetch_add(grown, Ordering::Release);
         true
     }
 }
@@ -92,7 +104,16 @@ unsafe impl GlobalAlloc for GrowingHeap {
             if !p.is_null() {
                 return p;
             }
-            if !self.grow() {
+            // Double-checked: take the grow lock, then re-try the alloc
+            // before growing. Without this, two threads that both see
+            // null can each call `grow_locked` serially and burn two
+            // chunks of the 16 MiB cap when one would have sufficed.
+            let _g = self.grow_lock.lock();
+            let p = self.inner.alloc(layout);
+            if !p.is_null() {
+                return p;
+            }
+            if !self.grow_locked() {
                 return ptr::null_mut();
             }
         }

--- a/kernel/src/mem/heap.rs
+++ b/kernel/src/mem/heap.rs
@@ -1,43 +1,141 @@
-//! Kernel heap: carve a contiguous 1 MiB slab from physical memory via
-//! the global bump frame allocator, then hand it to `linked_list_allocator`.
+//! Kernel heap with grow-on-demand. Reserves a 16 MiB virtual range
+//! inside the higher half, backs the first 1 MiB with frames at init,
+//! and maps more 64 KiB chunks on allocator OOM until the cap.
 //!
-//! The slab is addressed through Limine's HHDM (Higher-Half Direct Map),
-//! which already covers all physical memory in the virtual address space
-//! Limine sets up.
+//! The allocator wraps `linked_list_allocator::LockedHeap` with a
+//! `GlobalAlloc` impl that, on null, takes a grow lock, maps the next
+//! chunk via [`paging::map_range`], calls `Heap::extend`, and retries.
+
+use core::alloc::{GlobalAlloc, Layout};
+use core::ptr;
+use core::sync::atomic::{AtomicUsize, Ordering};
 
 use linked_list_allocator::LockedHeap;
+use spin::Mutex;
+use x86_64::structures::paging::PageTableFlags;
+use x86_64::VirtAddr;
 
-use super::frame;
-use super::FRAME_SIZE;
-use crate::boot::HHDM_REQUEST;
+use super::{paging, FRAME_SIZE};
 use crate::serial_println;
 
-#[global_allocator]
-static ALLOCATOR: LockedHeap = LockedHeap::empty();
+/// Base of the reserved heap VA window. Lives in the higher half above
+/// Limine's HHDM (Limine puts HHDM at 0xFFFF_8000_… typically); the
+/// paging integration test also uses `0xFFFF_C000_…` addresses outside
+/// our cap, so no collision.
+pub const HEAP_BASE: usize = 0xFFFF_C000_0000_0000;
+/// Boot-time backed portion of the heap. Kept at 1 MiB so the smoke
+/// marker `"heap: 1024 KiB"` stays unchanged.
+pub const INITIAL_HEAP_SIZE: usize = 1024 * 1024;
+/// Hard cap. Growth stops here and the allocator returns null.
+pub const HEAP_MAX_SIZE: usize = 16 * 1024 * 1024;
+/// Frames mapped per grow step — 64 KiB picked so we amortize the
+/// map + extend cost without wasting much when demand is light.
+pub const GROW_CHUNK_FRAMES: u64 = 16;
+const GROW_CHUNK_BYTES: usize = (GROW_CHUNK_FRAMES * FRAME_SIZE) as usize;
 
-/// 256 × 4 KiB = 1 MiB. Room for early `Vec`/`Box` usage; grows later.
-pub const HEAP_FRAMES: u64 = 256;
-pub const HEAP_SIZE: usize = (HEAP_FRAMES * FRAME_SIZE) as usize;
+pub struct GrowingHeap {
+    inner: LockedHeap,
+    mapped: AtomicUsize,
+    grow_lock: Mutex<()>,
+}
 
-pub fn init() {
-    let hhdm = HHDM_REQUEST
-        .get_response()
-        .expect("Limine HHDM response missing");
-
-    let heap_phys = frame::global()
-        .lock()
-        .allocate_contiguous(HEAP_FRAMES)
-        .expect("no contiguous USABLE region large enough for the kernel heap");
-    let heap_virt = heap_phys + hhdm.offset();
-
-    unsafe {
-        ALLOCATOR.lock().init(heap_virt as *mut u8, HEAP_SIZE);
+impl GrowingHeap {
+    const fn new() -> Self {
+        Self {
+            inner: LockedHeap::empty(),
+            mapped: AtomicUsize::new(0),
+            grow_lock: Mutex::new(()),
+        }
     }
 
+    /// Bytes of VA currently backed by frames and handed to the
+    /// underlying heap. Starts at `INITIAL_HEAP_SIZE`; monotonically
+    /// increases up to `HEAP_MAX_SIZE`.
+    pub fn mapped_size(&self) -> usize {
+        self.mapped.load(Ordering::Acquire)
+    }
+
+    /// Map the next `GROW_CHUNK_BYTES` (or less if we're bumping the
+    /// cap) past the current top and call `Heap::extend`. Returns false
+    /// if we're already at the cap or the map failed.
+    fn grow(&self) -> bool {
+        let _g = self.grow_lock.lock();
+        let mapped = self.mapped.load(Ordering::Acquire);
+        if mapped >= HEAP_MAX_SIZE {
+            return false;
+        }
+        let remaining = HEAP_MAX_SIZE - mapped;
+        let chunk = GROW_CHUNK_BYTES.min(remaining);
+        let start = VirtAddr::new((HEAP_BASE + mapped) as u64);
+        let frames = (chunk as u64) / FRAME_SIZE;
+        if paging::map_range(
+            start,
+            frames,
+            PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
+        )
+        .is_err()
+        {
+            return false;
+        }
+        // SAFETY: just mapped `chunk` bytes contiguous with the current
+        // heap top; they're owned by the heap from here on.
+        unsafe { self.inner.lock().extend(chunk) };
+        self.mapped.fetch_add(chunk, Ordering::Release);
+        true
+    }
+}
+
+unsafe impl GlobalAlloc for GrowingHeap {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        loop {
+            let p = self.inner.alloc(layout);
+            if !p.is_null() {
+                return p;
+            }
+            if !self.grow() {
+                return ptr::null_mut();
+            }
+        }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        self.inner.dealloc(ptr, layout);
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: GrowingHeap = GrowingHeap::new();
+
+/// Bytes of VA currently backed by the heap. Exposed for tests and
+/// diagnostics.
+pub fn mapped_size() -> usize {
+    ALLOCATOR.mapped_size()
+}
+
+/// Map the initial slab and hand it to the inner heap. Requires
+/// `paging::init` to have run so `map_range` is live.
+pub fn init() {
+    let frames = (INITIAL_HEAP_SIZE as u64) / FRAME_SIZE;
+    paging::map_range(
+        VirtAddr::new(HEAP_BASE as u64),
+        frames,
+        PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
+    )
+    .expect("failed to map initial heap range");
+
+    unsafe {
+        ALLOCATOR
+            .inner
+            .lock()
+            .init(HEAP_BASE as *mut u8, INITIAL_HEAP_SIZE);
+    }
+    ALLOCATOR.mapped.store(INITIAL_HEAP_SIZE, Ordering::Release);
+
     serial_println!(
-        "heap: {} KiB @ {:#x} (phys {:#x})",
-        HEAP_SIZE / 1024,
-        heap_virt,
-        heap_phys
+        "heap: {} KiB @ {:#x} (reserved {} KiB, grows in {} KiB chunks)",
+        INITIAL_HEAP_SIZE / 1024,
+        HEAP_BASE,
+        HEAP_MAX_SIZE / 1024,
+        GROW_CHUNK_BYTES / 1024,
     );
 }

--- a/kernel/src/mem/mod.rs
+++ b/kernel/src/mem/mod.rs
@@ -39,11 +39,15 @@ impl Region {
 #[cfg(target_os = "none")]
 pub fn init() {
     frame::init();
-    heap::init();
 
+    // Paging comes up before the heap now — `heap::init` maps its
+    // initial slab through `paging::map_range` instead of carving
+    // HHDM-addressed frames directly.
     let hhdm = crate::boot::HHDM_REQUEST
         .get_response()
         .expect("Limine HHDM response missing");
     paging::init(x86_64::VirtAddr::new(hhdm.offset()));
+
+    heap::init();
     crate::arch::x86_64::ist_guard::install();
 }

--- a/kernel/tests/heap_grow.rs
+++ b/kernel/tests/heap_grow.rs
@@ -1,0 +1,63 @@
+//! Integration test: the heap grows past its initial 1 MiB slab on
+//! demand.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::vec;
+use alloc::vec::Vec;
+use core::panic::PanicInfo;
+
+use vibix::{
+    exit_qemu,
+    mem::heap::{self, INITIAL_HEAP_SIZE},
+    serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("starts_at_initial_size", &(starts_at_initial_size as fn())),
+        ("grows_past_initial", &(grows_past_initial as fn())),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+fn starts_at_initial_size() {
+    assert_eq!(heap::mapped_size(), INITIAL_HEAP_SIZE);
+}
+
+fn grows_past_initial() {
+    // 2 MiB overshoots the 1 MiB initial slab enough to require at
+    // least one grow step. Touch both ends so a silent half-mapping
+    // would page-fault the test.
+    const N: usize = 2 * 1024 * 1024;
+    let v: Vec<u8> = vec![0xAB; N];
+    assert_eq!(v.len(), N);
+    assert_eq!(v[0], 0xAB);
+    assert_eq!(v[N - 1], 0xAB);
+    let after = heap::mapped_size();
+    assert!(
+        after > INITIAL_HEAP_SIZE,
+        "heap did not grow: mapped_size={after}, INITIAL={INITIAL_HEAP_SIZE}"
+    );
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -342,6 +342,7 @@ fn test_all() -> R<()> {
     for t in [
         "basic_boot",
         "heap_alloc",
+        "heap_grow",
         "should_panic",
         "timer_tick",
         "paging",


### PR DESCRIPTION
## Summary
- Reserves a 16 MiB higher-half VA window (`HEAP_BASE = 0xFFFF_C000_0000_0000`) at init; backs the first 1 MiB with frames.
- Introduces `GrowingHeap`: a `GlobalAlloc` shim around `linked_list_allocator::LockedHeap` that, on null, takes a grow lock, maps the next 64 KiB chunk via `paging::map_range`, calls `Heap::extend`, and retries — capped at 16 MiB.
- Reorders `mem::init` so paging comes up before the heap (`heap::init` now goes through `paging::map_range` instead of carving HHDM-addressed frames directly).
- Adds `heap::mapped_size()` for tests/diagnostics.

Smoke marker `"heap: 1024 KiB"` is preserved: boot-time backed size stays 1 MiB; growth happens only in response to demand.

Closes #14.

## Test plan
- [x] `cargo xtask build` — clean.
- [x] `cargo xtask test` — new `heap_grow` (2 cases) passes; existing `heap_alloc`, `paging`, `tasks`, `timer_tick`, `basic_boot`, `should_panic` all still pass.
- [x] `cargo xtask smoke` — all 12 markers present, including unchanged `"heap: 1024 KiB"`.
