### PR TITLE
M7: ACPI + APIC/IOAPIC for the BSP

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -60,3 +60,7 @@ harness = false
 [[test]]
 name = "preempt"
 harness = false
+
+[[test]]
+name = "apic_online"
+harness = false

--- a/kernel/src/acpi.rs
+++ b/kernel/src/acpi.rs
@@ -1,0 +1,293 @@
+//! Minimal ACPI table parser — just enough to discover LAPIC / IOAPIC
+//! topology from the MADT. We do NOT walk the DSDT or execute AML; that
+//! is a future milestone. We read:
+//!
+//!   RSDP → XSDT (or RSDT, on rev 0 firmware) → MADT → entries
+//!
+//! Limine hands us a pre-mapped virtual pointer to the RSDP in its HHDM
+//! window (base revision ≥ 2), so we treat all physical addresses we
+//! encounter while walking tables as HHDM offsets too.
+//!
+//! Reference: ACPI Specification, section 5 (RSDP/XSDT) and section
+//! 5.2.12 (MADT).
+use core::mem;
+use core::slice;
+
+use spin::Once;
+use x86_64::structures::paging::PageTableFlags;
+
+use crate::mem::paging;
+use crate::serial_println;
+
+/// Maximum IOAPICs we record. One is the common case; two is exotic.
+const MAX_IOAPICS: usize = 4;
+/// Maximum interrupt source overrides. Spec allows up to 16 (one per
+/// ISA IRQ); in practice firmware reports ≤ 4.
+const MAX_OVERRIDES: usize = 16;
+
+#[derive(Debug, Clone, Copy)]
+pub struct IoApic {
+    pub id: u8,
+    pub phys_addr: u32,
+    pub gsi_base: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct InterruptOverride {
+    pub bus: u8,
+    pub source: u8,
+    pub gsi: u32,
+    pub flags: u16,
+}
+
+#[derive(Debug)]
+pub struct AcpiInfo {
+    pub lapic_phys: u64,
+    pub cpu_count: u32,
+    ioapics: [Option<IoApic>; MAX_IOAPICS],
+    overrides: [Option<InterruptOverride>; MAX_OVERRIDES],
+}
+
+impl AcpiInfo {
+    pub fn ioapics(&self) -> impl Iterator<Item = &IoApic> {
+        self.ioapics.iter().filter_map(|e| e.as_ref())
+    }
+
+    pub fn overrides(&self) -> impl Iterator<Item = &InterruptOverride> {
+        self.overrides.iter().filter_map(|e| e.as_ref())
+    }
+
+    /// Map ISA IRQ → (GSI, flags), applying any interrupt source
+    /// override from the MADT. With no override, ISA IRQs are identity
+    /// mapped (IRQ N → GSI N, edge-triggered active-high — flags 0).
+    pub fn resolve_isa_irq(&self, irq: u8) -> (u32, u16) {
+        for ov in self.overrides() {
+            if ov.bus == 0 && ov.source == irq {
+                return (ov.gsi, ov.flags);
+            }
+        }
+        (irq as u32, 0)
+    }
+
+    /// Find the IOAPIC that owns the given GSI. Returned pair is
+    /// `(ioapic, gsi_offset_within_ioapic)`. None if no IOAPIC claims
+    /// it — typically a firmware bug.
+    pub fn ioapic_for_gsi(&self, gsi: u32) -> Option<(&IoApic, u32)> {
+        for io in self.ioapics() {
+            // Without the Max Redirection Entry reg we can't know the
+            // upper bound exactly, but for the legacy ISA range (< 24)
+            // the first IOAPIC with gsi_base == 0 is correct.
+            if gsi >= io.gsi_base && gsi < io.gsi_base + 240 {
+                return Some((io, gsi - io.gsi_base));
+            }
+        }
+        None
+    }
+}
+
+static INFO: Once<AcpiInfo> = Once::new();
+
+pub fn info() -> Option<&'static AcpiInfo> {
+    INFO.get()
+}
+
+#[repr(C, packed)]
+struct Rsdp {
+    signature: [u8; 8],
+    checksum: u8,
+    oem_id: [u8; 6],
+    revision: u8,
+    rsdt_address: u32,
+    // v2+ fields below.
+    length: u32,
+    xsdt_address: u64,
+    ext_checksum: u8,
+    _reserved: [u8; 3],
+}
+
+#[repr(C, packed)]
+#[derive(Clone, Copy)]
+struct SdtHeader {
+    signature: [u8; 4],
+    length: u32,
+    revision: u8,
+    checksum: u8,
+    oem_id: [u8; 6],
+    oem_table_id: [u8; 8],
+    oem_revision: u32,
+    creator_id: u32,
+    creator_revision: u32,
+}
+
+const MADT_PROCESSOR_LAPIC: u8 = 0;
+const MADT_IOAPIC: u8 = 1;
+const MADT_INTERRUPT_OVERRIDE: u8 = 2;
+const MADT_LAPIC_ADDRESS_OVERRIDE: u8 = 5;
+
+/// Initialize ACPI from Limine's RSDP response.
+///
+/// `rsdp_phys` is the physical address Limine provided. Under base
+/// revision 3 this is always a physical address; we add the HHDM
+/// offset ourselves to reach it. All physical pointers inside the
+/// ACPI tables (XSDT entries, child SDTs) are translated the same
+/// way.
+pub fn init(rsdp_phys: usize, hhdm_offset: u64) {
+    // Firmware tables may live in reserved/ROM ranges that Limine's
+    // HHDM doesn't cover. Map the RSDP page (with some slack for the
+    // extended part) into HHDM before we touch it.
+    map_phys(rsdp_phys as u64, mem::size_of::<Rsdp>() as u64);
+    let rsdp = unsafe { &*((rsdp_phys as u64 + hhdm_offset) as *const Rsdp) };
+    assert_eq!(&rsdp.signature, b"RSD PTR ", "bad RSDP signature");
+
+    let xsdt_phys = rsdp.xsdt_address;
+    let rsdt_phys = rsdp.rsdt_address;
+
+    let madt_ptr = if rsdp.revision >= 2 && xsdt_phys != 0 {
+        find_madt_xsdt(xsdt_phys, hhdm_offset)
+    } else {
+        find_madt_rsdt(rsdt_phys as u64, hhdm_offset)
+    }
+    .expect("MADT not found in ACPI tables");
+
+    let info = parse_madt(madt_ptr);
+    serial_println!(
+        "acpi: MADT parsed (cpus={}, ioapics={}, overrides={}, lapic={:#x})",
+        info.cpu_count,
+        info.ioapics().count(),
+        info.overrides().count(),
+        info.lapic_phys
+    );
+    INFO.call_once(|| info);
+}
+
+fn read_sdt(phys: u64, hhdm: u64) -> &'static SdtHeader {
+    // First map enough for the header; then re-map the full table
+    // once we know its length. Both calls are no-ops if the range is
+    // already mapped.
+    map_phys(phys, mem::size_of::<SdtHeader>() as u64);
+    let header = unsafe { &*((phys + hhdm) as *const SdtHeader) };
+    map_phys(phys, header.length as u64);
+    header
+}
+
+fn find_madt_xsdt(xsdt_phys: u64, hhdm: u64) -> Option<*const SdtHeader> {
+    let header = read_sdt(xsdt_phys, hhdm);
+    let entries_bytes = header.length as usize - mem::size_of::<SdtHeader>();
+    let count = entries_bytes / 8;
+    let entries_ptr =
+        (xsdt_phys + hhdm + mem::size_of::<SdtHeader>() as u64) as *const u64;
+    for i in 0..count {
+        let phys = unsafe { entries_ptr.add(i).read_unaligned() };
+        let sdt = read_sdt(phys, hhdm);
+        if &sdt.signature == b"APIC" {
+            return Some(sdt as *const _);
+        }
+    }
+    None
+}
+
+fn find_madt_rsdt(rsdt_phys: u64, hhdm: u64) -> Option<*const SdtHeader> {
+    let header = read_sdt(rsdt_phys, hhdm);
+    let entries_bytes = header.length as usize - mem::size_of::<SdtHeader>();
+    let count = entries_bytes / 4;
+    let entries_ptr =
+        (rsdt_phys + hhdm + mem::size_of::<SdtHeader>() as u64) as *const u32;
+    for i in 0..count {
+        let phys = unsafe { entries_ptr.add(i).read_unaligned() } as u64;
+        let sdt = read_sdt(phys, hhdm);
+        if &sdt.signature == b"APIC" {
+            return Some(sdt as *const _);
+        }
+    }
+    None
+}
+
+fn map_phys(phys: u64, size: u64) {
+    paging::map_phys_into_hhdm(
+        phys,
+        size,
+        PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE,
+    )
+    .expect("failed to map ACPI physical range");
+}
+
+fn parse_madt(madt: *const SdtHeader) -> AcpiInfo {
+    let header = unsafe { &*madt };
+    let total_len = header.length as usize;
+
+    // MADT layout after the SDT header:
+    //   u32 local_apic_address
+    //   u32 flags
+    //   variable-length entries
+    let body = unsafe {
+        slice::from_raw_parts(
+            (madt as *const u8).add(mem::size_of::<SdtHeader>()),
+            total_len - mem::size_of::<SdtHeader>(),
+        )
+    };
+
+    let lapic_addr = u32::from_le_bytes(body[0..4].try_into().unwrap()) as u64;
+
+    let mut info = AcpiInfo {
+        lapic_phys: lapic_addr,
+        cpu_count: 0,
+        ioapics: [None; MAX_IOAPICS],
+        overrides: [None; MAX_OVERRIDES],
+    };
+
+    let mut off = 8; // skip lapic_addr + flags
+    let mut ioapic_idx = 0usize;
+    let mut override_idx = 0usize;
+    while off + 2 <= body.len() {
+        let entry_type = body[off];
+        let entry_len = body[off + 1] as usize;
+        if entry_len < 2 || off + entry_len > body.len() {
+            break;
+        }
+        let payload = &body[off + 2..off + entry_len];
+        match entry_type {
+            MADT_PROCESSOR_LAPIC if payload.len() >= 6 => {
+                // u8 acpi_processor_id, u8 apic_id, u32 flags
+                let flags = u32::from_le_bytes(payload[2..6].try_into().unwrap());
+                // bit0 = Enabled, bit1 = Online-Capable (ACPI 6.3+).
+                if flags & 0b11 != 0 {
+                    info.cpu_count += 1;
+                }
+            }
+            MADT_IOAPIC if payload.len() >= 10 && ioapic_idx < MAX_IOAPICS => {
+                // u8 ioapic_id, u8 reserved, u32 addr, u32 gsi_base
+                let id = payload[0];
+                let addr = u32::from_le_bytes(payload[2..6].try_into().unwrap());
+                let gsi_base = u32::from_le_bytes(payload[6..10].try_into().unwrap());
+                info.ioapics[ioapic_idx] = Some(IoApic {
+                    id,
+                    phys_addr: addr,
+                    gsi_base,
+                });
+                ioapic_idx += 1;
+            }
+            MADT_INTERRUPT_OVERRIDE if payload.len() >= 8 && override_idx < MAX_OVERRIDES => {
+                // u8 bus, u8 source, u32 gsi, u16 flags
+                let bus = payload[0];
+                let source = payload[1];
+                let gsi = u32::from_le_bytes(payload[2..6].try_into().unwrap());
+                let flags = u16::from_le_bytes(payload[6..8].try_into().unwrap());
+                info.overrides[override_idx] = Some(InterruptOverride {
+                    bus,
+                    source,
+                    gsi,
+                    flags,
+                });
+                override_idx += 1;
+            }
+            MADT_LAPIC_ADDRESS_OVERRIDE if payload.len() >= 10 => {
+                // u16 reserved, u64 addr
+                info.lapic_phys = u64::from_le_bytes(payload[2..10].try_into().unwrap());
+            }
+            _ => {}
+        }
+        off += entry_len;
+    }
+
+    info
+}

--- a/kernel/src/acpi.rs
+++ b/kernel/src/acpi.rs
@@ -174,8 +174,7 @@ fn find_madt_xsdt(xsdt_phys: u64, hhdm: u64) -> Option<*const SdtHeader> {
     let header = read_sdt(xsdt_phys, hhdm);
     let entries_bytes = header.length as usize - mem::size_of::<SdtHeader>();
     let count = entries_bytes / 8;
-    let entries_ptr =
-        (xsdt_phys + hhdm + mem::size_of::<SdtHeader>() as u64) as *const u64;
+    let entries_ptr = (xsdt_phys + hhdm + mem::size_of::<SdtHeader>() as u64) as *const u64;
     for i in 0..count {
         let phys = unsafe { entries_ptr.add(i).read_unaligned() };
         let sdt = read_sdt(phys, hhdm);
@@ -190,8 +189,7 @@ fn find_madt_rsdt(rsdt_phys: u64, hhdm: u64) -> Option<*const SdtHeader> {
     let header = read_sdt(rsdt_phys, hhdm);
     let entries_bytes = header.length as usize - mem::size_of::<SdtHeader>();
     let count = entries_bytes / 4;
-    let entries_ptr =
-        (rsdt_phys + hhdm + mem::size_of::<SdtHeader>() as u64) as *const u32;
+    let entries_ptr = (rsdt_phys + hhdm + mem::size_of::<SdtHeader>() as u64) as *const u32;
     for i in 0..count {
         let phys = unsafe { entries_ptr.add(i).read_unaligned() } as u64;
         let sdt = read_sdt(phys, hhdm);

--- a/kernel/src/acpi.rs
+++ b/kernel/src/acpi.rs
@@ -68,21 +68,6 @@ impl AcpiInfo {
         }
         (irq as u32, 0)
     }
-
-    /// Find the IOAPIC that owns the given GSI. Returned pair is
-    /// `(ioapic, gsi_offset_within_ioapic)`. None if no IOAPIC claims
-    /// it — typically a firmware bug.
-    pub fn ioapic_for_gsi(&self, gsi: u32) -> Option<(&IoApic, u32)> {
-        for io in self.ioapics() {
-            // Without the Max Redirection Entry reg we can't know the
-            // upper bound exactly, but for the legacy ISA range (< 24)
-            // the first IOAPIC with gsi_base == 0 is correct.
-            if gsi >= io.gsi_base && gsi < io.gsi_base + 240 {
-                return Some((io, gsi - io.gsi_base));
-            }
-        }
-        None
-    }
 }
 
 static INFO: Once<AcpiInfo> = Once::new();
@@ -136,8 +121,24 @@ pub fn init(rsdp_phys: usize, hhdm_offset: u64) {
     // HHDM doesn't cover. Map the RSDP page (with some slack for the
     // extended part) into HHDM before we touch it.
     map_phys(rsdp_phys as u64, mem::size_of::<Rsdp>() as u64);
-    let rsdp = unsafe { &*((rsdp_phys as u64 + hhdm_offset) as *const Rsdp) };
+    let rsdp_virt = rsdp_phys as u64 + hhdm_offset;
+    let rsdp = unsafe { &*(rsdp_virt as *const Rsdp) };
     assert_eq!(&rsdp.signature, b"RSD PTR ", "bad RSDP signature");
+    // RSDP checksum: the first 20 bytes (fields through rsdt_address)
+    // must sum to 0 mod 256. For revision ≥ 2 the full `length` bytes
+    // must also checksum to zero, covering the extended fields.
+    assert!(
+        checksum(rsdp_virt as *const u8, 20) == 0,
+        "bad RSDP v1 checksum"
+    );
+    if rsdp.revision >= 2 {
+        let len = rsdp.length as usize;
+        assert!(len >= mem::size_of::<Rsdp>(), "RSDP length too small");
+        assert!(
+            checksum(rsdp_virt as *const u8, len) == 0,
+            "bad RSDP v2 checksum"
+        );
+    }
 
     let xsdt_phys = rsdp.xsdt_address;
     let rsdt_phys = rsdp.rsdt_address;
@@ -165,9 +166,30 @@ fn read_sdt(phys: u64, hhdm: u64) -> &'static SdtHeader {
     // once we know its length. Both calls are no-ops if the range is
     // already mapped.
     map_phys(phys, mem::size_of::<SdtHeader>() as u64);
-    let header = unsafe { &*((phys + hhdm) as *const SdtHeader) };
-    map_phys(phys, header.length as u64);
+    let virt = phys + hhdm;
+    let header = unsafe { &*(virt as *const SdtHeader) };
+    let len = header.length as usize;
+    assert!(
+        len >= mem::size_of::<SdtHeader>(),
+        "SDT length {len} smaller than header"
+    );
+    map_phys(phys, len as u64);
+    assert!(
+        checksum(virt as *const u8, len) == 0,
+        "bad SDT checksum (sig {:?})",
+        header.signature
+    );
     header
+}
+
+/// Sum `len` bytes starting at `ptr`, returning the low 8 bits. ACPI
+/// tables are valid when this sum is 0.
+fn checksum(ptr: *const u8, len: usize) -> u8 {
+    let mut sum: u8 = 0;
+    for i in 0..len {
+        sum = sum.wrapping_add(unsafe { *ptr.add(i) });
+    }
+    sum
 }
 
 fn find_madt_xsdt(xsdt_phys: u64, hhdm: u64) -> Option<*const SdtHeader> {
@@ -212,15 +234,20 @@ fn map_phys(phys: u64, size: u64) {
 fn parse_madt(madt: *const SdtHeader) -> AcpiInfo {
     let header = unsafe { &*madt };
     let total_len = header.length as usize;
+    // MADT layout after the SDT header: u32 local_apic_address, u32
+    // flags, then variable-length entries. Anything shorter than
+    // header + the two u32s is malformed.
+    const MADT_FIXED_FIELDS: usize = 8;
+    assert!(
+        total_len >= mem::size_of::<SdtHeader>() + MADT_FIXED_FIELDS,
+        "MADT length {total_len} too small"
+    );
+    let body_len = total_len - mem::size_of::<SdtHeader>();
 
-    // MADT layout after the SDT header:
-    //   u32 local_apic_address
-    //   u32 flags
-    //   variable-length entries
     let body = unsafe {
         slice::from_raw_parts(
             (madt as *const u8).add(mem::size_of::<SdtHeader>()),
-            total_len - mem::size_of::<SdtHeader>(),
+            body_len,
         )
     };
 

--- a/kernel/src/arch/mod.rs
+++ b/kernel/src/arch/mod.rs
@@ -2,4 +2,4 @@
 pub mod x86_64;
 
 #[cfg(target_arch = "x86_64")]
-pub use x86_64::init;
+pub use x86_64::{init, init_apic};

--- a/kernel/src/arch/x86_64/apic.rs
+++ b/kernel/src/arch/x86_64/apic.rs
@@ -191,8 +191,7 @@ pub fn route_legacy_irq(isa_irq: u8, vector: u8) {
         .iter()
         .filter_map(|e| e.as_ref())
         .find_map(|io| {
-            let entries =
-                unsafe { io.max_redirection_entries() };
+            let entries = unsafe { io.max_redirection_entries() };
             if gsi >= io.gsi_base && gsi < io.gsi_base + entries {
                 Some((io, gsi - io.gsi_base))
             } else {

--- a/kernel/src/arch/x86_64/apic.rs
+++ b/kernel/src/arch/x86_64/apic.rs
@@ -1,0 +1,227 @@
+//! xAPIC Local APIC and IOAPIC drivers for the BSP.
+//!
+//! The LAPIC is the per-CPU interrupt controller; here we only bring up
+//! the bootstrap processor's LAPIC (APs are a future milestone). The
+//! IOAPIC(s) take device IRQs (legacy ISA plus anything else a bus
+//! hands us) and route them to a LAPIC as a redirection entry.
+//!
+//! We stay in xAPIC (MMIO) mode — x2APIC's MSR interface is simpler in
+//! some ways but not worth the conditional until SMP needs it.
+
+use core::ptr::{read_volatile, write_volatile};
+
+use spin::Once;
+use x86_64::structures::paging::PageTableFlags;
+
+use crate::acpi;
+use crate::mem::paging;
+use crate::serial_println;
+
+fn map_mmio(phys: u64, size: u64) {
+    paging::map_phys_into_hhdm(
+        phys,
+        size,
+        PageTableFlags::PRESENT
+            | PageTableFlags::WRITABLE
+            | PageTableFlags::NO_EXECUTE
+            | PageTableFlags::NO_CACHE
+            | PageTableFlags::WRITE_THROUGH,
+    )
+    .expect("failed to map APIC MMIO");
+}
+
+// LAPIC register offsets (all MMIO 32-bit, aligned on 16 bytes).
+const LAPIC_ID: usize = 0x20;
+const LAPIC_EOI: usize = 0xB0;
+const LAPIC_SPURIOUS: usize = 0xF0;
+const LAPIC_TPR: usize = 0x80;
+
+// IOAPIC indirect registers.
+const IOAPIC_VER_REG: u32 = 0x01;
+const IOAPIC_REDTBL_BASE: u32 = 0x10;
+
+struct LocalApic {
+    base: *mut u32,
+}
+
+unsafe impl Send for LocalApic {}
+unsafe impl Sync for LocalApic {}
+
+impl LocalApic {
+    unsafe fn read(&self, reg: usize) -> u32 {
+        read_volatile(self.base.byte_add(reg))
+    }
+
+    unsafe fn write(&self, reg: usize, val: u32) {
+        write_volatile(self.base.byte_add(reg), val);
+    }
+}
+
+struct IoApic {
+    base: *mut u32,
+    gsi_base: u32,
+    id: u8,
+}
+
+unsafe impl Send for IoApic {}
+unsafe impl Sync for IoApic {}
+
+impl IoApic {
+    unsafe fn read(&self, reg: u32) -> u32 {
+        write_volatile(self.base, reg);
+        read_volatile(self.base.byte_add(0x10))
+    }
+
+    unsafe fn write(&self, reg: u32, val: u32) {
+        write_volatile(self.base, reg);
+        write_volatile(self.base.byte_add(0x10), val);
+    }
+
+    /// Max redirection entries for this IOAPIC (reads from the version
+    /// register; the high byte is `max_redirection_entry`, 0-indexed).
+    unsafe fn max_redirection_entries(&self) -> u32 {
+        ((self.read(IOAPIC_VER_REG) >> 16) & 0xFF) + 1
+    }
+
+    /// Program a redirection entry.
+    ///
+    /// * `gsi_offset` — entry index within this IOAPIC (GSI minus its
+    ///   gsi_base).
+    /// * `vector` — CPU IDT vector the LAPIC should raise.
+    /// * `lapic_id` — physical destination LAPIC id.
+    /// * `trigger_level` / `active_low` — come from the MADT override
+    ///   flags for the source IRQ.
+    /// * `masked` — leave the entry masked?
+    unsafe fn set_redirection(
+        &self,
+        gsi_offset: u32,
+        vector: u8,
+        lapic_id: u8,
+        trigger_level: bool,
+        active_low: bool,
+        masked: bool,
+    ) {
+        let mut low: u32 = vector as u32;
+        // Delivery mode = 0 (fixed), dest mode = 0 (physical).
+        if active_low {
+            low |= 1 << 13;
+        }
+        if trigger_level {
+            low |= 1 << 15;
+        }
+        if masked {
+            low |= 1 << 16;
+        }
+        let high: u32 = (lapic_id as u32) << 24;
+
+        let idx = IOAPIC_REDTBL_BASE + gsi_offset * 2;
+        // High half first, then low — writing low unmasks the entry,
+        // so it must be last.
+        self.write(idx + 1, high);
+        self.write(idx, low);
+    }
+}
+
+static LAPIC: Once<LocalApic> = Once::new();
+static IOAPICS: Once<[Option<IoApic>; 4]> = Once::new();
+
+/// Initialize the BSP's LAPIC. Must run after `acpi::init`.
+pub fn init_bsp(hhdm_offset: u64) {
+    let info = acpi::info().expect("acpi::init must run before apic::init_bsp");
+    // LAPIC MMIO is 4 KiB starting at `lapic_phys`.
+    map_mmio(info.lapic_phys, 0x1000);
+    let base = (info.lapic_phys + hhdm_offset) as *mut u32;
+    let lapic = LocalApic { base };
+    unsafe {
+        // TPR = 0: accept every priority.
+        lapic.write(LAPIC_TPR, 0);
+        // Spurious vector register: vector 0xFF + software enable bit.
+        lapic.write(LAPIC_SPURIOUS, 0x100 | 0xFF);
+    }
+    let id = unsafe { lapic.read(LAPIC_ID) } >> 24;
+    LAPIC.call_once(|| lapic);
+    serial_println!("apic: BSP online (lapic_id={})", id);
+}
+
+/// Set up every IOAPIC: mask all redirection entries. Legacy IRQs are
+/// programmed later via `route_legacy_irq`.
+pub fn ioapic_init(hhdm_offset: u64) {
+    let info = acpi::info().expect("acpi::init must run before ioapic_init");
+    let mut slots: [Option<IoApic>; 4] = [None, None, None, None];
+    let mut count = 0usize;
+    for (i, io) in info.ioapics().enumerate().take(4) {
+        map_mmio(io.phys_addr as u64, 0x1000);
+        let base = (io.phys_addr as u64 + hhdm_offset) as *mut u32;
+        let ioa = IoApic {
+            base,
+            gsi_base: io.gsi_base,
+            id: io.id,
+        };
+        let entries = unsafe { ioa.max_redirection_entries() };
+        // Mask every entry. Vector/dest don't matter while masked.
+        for e in 0..entries {
+            unsafe {
+                ioa.set_redirection(e, 0xFE, 0, false, false, true);
+            }
+        }
+        slots[i] = Some(ioa);
+        count += 1;
+    }
+    IOAPICS.call_once(|| slots);
+    serial_println!("ioapic: initialized ({} controller(s))", count);
+}
+
+/// Route a legacy ISA IRQ to an IDT vector on the BSP.
+pub fn route_legacy_irq(isa_irq: u8, vector: u8) {
+    let info = acpi::info().expect("acpi not initialized");
+    let ioapics = IOAPICS.get().expect("ioapic not initialized");
+    let lapic_id = bsp_lapic_id();
+
+    let (gsi, flags) = info.resolve_isa_irq(isa_irq);
+    // MPS INTI flags: polarity bits [1:0], trigger bits [3:2].
+    //   polarity: 00=bus default, 01=active high, 11=active low
+    //   trigger:  00=bus default, 01=edge,        11=level
+    // ISA bus default is edge / active-high.
+    let polarity = flags & 0b11;
+    let trigger = (flags >> 2) & 0b11;
+    let active_low = polarity == 0b11;
+    let level = trigger == 0b11;
+
+    let (io, offset) = ioapics
+        .iter()
+        .filter_map(|e| e.as_ref())
+        .find_map(|io| {
+            let entries =
+                unsafe { io.max_redirection_entries() };
+            if gsi >= io.gsi_base && gsi < io.gsi_base + entries {
+                Some((io, gsi - io.gsi_base))
+            } else {
+                None
+            }
+        })
+        .expect("no IOAPIC owns this GSI");
+
+    unsafe {
+        io.set_redirection(offset, vector, lapic_id, level, active_low, false);
+    }
+    serial_println!(
+        "ioapic: IRQ{} -> gsi {} -> vec {:#x} on lapic {} (ioapic {})",
+        isa_irq,
+        gsi,
+        vector,
+        lapic_id,
+        io.id
+    );
+}
+
+pub fn bsp_lapic_id() -> u8 {
+    let lapic = LAPIC.get().expect("lapic not initialized");
+    (unsafe { lapic.read(LAPIC_ID) } >> 24) as u8
+}
+
+/// End-of-interrupt, called from ISRs instead of the old 8259 EOI.
+pub fn lapic_eoi() {
+    if let Some(lapic) = LAPIC.get() {
+        unsafe { lapic.write(LAPIC_EOI, 0) };
+    }
+}

--- a/kernel/src/arch/x86_64/mod.rs
+++ b/kernel/src/arch/x86_64/mod.rs
@@ -1,11 +1,29 @@
+pub mod apic;
 pub mod gdt;
 pub mod idt;
 pub mod interrupts;
 pub mod ist_guard;
 pub mod pic;
 
+/// Bring up arch-specific interrupt plumbing that doesn't depend on
+/// the kernel mapper. Interrupts stay disabled throughout.
 pub fn init() {
     gdt::init();
     idt::init();
-    pic::init();
+    // Remap + mask the 8259 before touching ACPI/APIC. Leaving it in
+    // its reset state would fire legacy IRQs into CPU exception
+    // vectors as soon as we `sti`.
+    pic::init_and_disable();
+}
+
+/// Bring up ACPI + APIC. Must run after `mem::init` — the ACPI
+/// parser and APIC drivers lean on the kernel mapper to map ACPI
+/// tables (in BIOS/ACPI-reclaimable memory) and LAPIC/IOAPIC MMIO
+/// regions into the HHDM window.
+pub fn init_apic(rsdp_phys: usize, hhdm_offset: u64) {
+    crate::acpi::init(rsdp_phys, hhdm_offset);
+    apic::init_bsp(hhdm_offset);
+    apic::ioapic_init(hhdm_offset);
+    apic::route_legacy_irq(0, interrupts::InterruptIndex::Timer.as_u8());
+    apic::route_legacy_irq(1, interrupts::InterruptIndex::Keyboard.as_u8());
 }

--- a/kernel/src/arch/x86_64/pic.rs
+++ b/kernel/src/arch/x86_64/pic.rs
@@ -1,9 +1,10 @@
-//! Legacy 8259 PIC pair, remapped past the CPU exception vectors.
+//! Legacy 8259 PIC pair — remapped and then fully disabled.
 //!
-//! Vectors 0x00–0x1F are reserved for CPU exceptions, so we remap the
-//! master PIC to 0x20–0x27 and the slave to 0x28–0x2F. `init()` must
-//! run after the IDT is loaded so we don't take an IRQ into a stale
-//! handler; callers still gate `sti` until they're ready.
+//! The APIC (see `apic.rs`) drives interrupts on this kernel. We still
+//! run through the 8259 init sequence once at boot so any leftover IRQ
+//! lines raised by firmware land on our remapped (0x20+) vectors
+//! rather than smashing into CPU exception vectors, then we mask every
+//! line on both chips. EOI goes through the LAPIC now.
 
 use pic8259::ChainedPics;
 use spin::Mutex;
@@ -14,19 +15,18 @@ pub const PIC_2_OFFSET: u8 = PIC_1_OFFSET + 8;
 pub static PICS: Mutex<ChainedPics> =
     Mutex::new(unsafe { ChainedPics::new(PIC_1_OFFSET, PIC_2_OFFSET) });
 
-pub fn init() {
+pub fn init_and_disable() {
     let mut pics = PICS.lock();
     unsafe {
         pics.initialize();
-        // Unmask IRQ0 (timer) and IRQ1 (keyboard); keep everything else
-        // masked until we wire up a device for it.
-        pics.write_masks(0b1111_1100, 0b1111_1111);
+        // Mask every line — the IOAPIC routes IRQs now.
+        pics.write_masks(0xFF, 0xFF);
     }
-    crate::serial_println!("PIC remapped to {:#x}/{:#x}", PIC_1_OFFSET, PIC_2_OFFSET);
+    crate::serial_println!("PIC remapped to {:#x}/{:#x} and masked", PIC_1_OFFSET, PIC_2_OFFSET);
 }
 
-/// Safely notify end-of-interrupt for a vector previously raised by the
-/// PIC. Called from ISRs.
-pub fn notify_eoi(vector: u8) {
-    unsafe { PICS.lock().notify_end_of_interrupt(vector) };
+/// End-of-interrupt. Forwarded to the LAPIC — the 8259 is fully masked
+/// and never delivers here.
+pub fn notify_eoi(_vector: u8) {
+    super::apic::lapic_eoi();
 }

--- a/kernel/src/arch/x86_64/pic.rs
+++ b/kernel/src/arch/x86_64/pic.rs
@@ -22,7 +22,11 @@ pub fn init_and_disable() {
         // Mask every line — the IOAPIC routes IRQs now.
         pics.write_masks(0xFF, 0xFF);
     }
-    crate::serial_println!("PIC remapped to {:#x}/{:#x} and masked", PIC_1_OFFSET, PIC_2_OFFSET);
+    crate::serial_println!(
+        "PIC remapped to {:#x}/{:#x} and masked",
+        PIC_1_OFFSET,
+        PIC_2_OFFSET
+    );
 }
 
 /// End-of-interrupt. Forwarded to the LAPIC — the 8259 is fully masked

--- a/kernel/src/boot.rs
+++ b/kernel/src/boot.rs
@@ -4,7 +4,7 @@
 
 use limine::request::{
     FramebufferRequest, HhdmRequest, MemoryMapRequest, RequestsEndMarker, RequestsStartMarker,
-    StackSizeRequest,
+    RsdpRequest, StackSizeRequest,
 };
 use limine::BaseRevision;
 
@@ -30,6 +30,10 @@ pub static HHDM_REQUEST: HhdmRequest = HhdmRequest::new();
 #[used]
 #[link_section = ".limine_requests"]
 pub static STACK_REQUEST: StackSizeRequest = StackSizeRequest::new().with_size(STACK_SIZE);
+
+#[used]
+#[link_section = ".limine_requests"]
+pub static RSDP_REQUEST: RsdpRequest = RsdpRequest::new();
 
 #[used]
 #[link_section = ".limine_requests_start"]

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -15,6 +15,8 @@ pub mod input;
 pub mod mem;
 
 #[cfg(target_os = "none")]
+pub mod acpi;
+#[cfg(target_os = "none")]
 pub mod arch;
 #[cfg(target_os = "none")]
 pub mod boot;
@@ -38,8 +40,17 @@ pub use test_harness::{exit_qemu, QemuExitCode, Testable};
 #[cfg(target_os = "none")]
 pub fn init() {
     serial::init();
+    let hhdm = boot::HHDM_REQUEST
+        .get_response()
+        .expect("Limine HHDM response missing")
+        .offset();
+    let rsdp = boot::RSDP_REQUEST
+        .get_response()
+        .expect("Limine RSDP response missing")
+        .address();
     arch::init();
     mem::init();
+    arch::init_apic(rsdp, hhdm);
     time::init();
 }
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -3,7 +3,7 @@
 
 use core::panic::PanicInfo;
 
-use vibix::boot::{BASE_REVISION, FRAMEBUFFER_REQUEST, HHDM_REQUEST, MEMMAP_REQUEST};
+use vibix::boot::{BASE_REVISION, FRAMEBUFFER_REQUEST, HHDM_REQUEST, MEMMAP_REQUEST, RSDP_REQUEST};
 use vibix::framebuffer::Console;
 use vibix::{exit_qemu, framebuffer, println, serial_print, serial_println, QemuExitCode};
 
@@ -51,14 +51,23 @@ pub extern "C" fn _start() -> ! {
         );
     }
 
-    if let Some(hhdm) = HHDM_REQUEST.get_response() {
-        serial_println!("hhdm offset: {:#x}", hhdm.offset());
-    }
+    let hhdm_offset = HHDM_REQUEST
+        .get_response()
+        .map(|h| h.offset())
+        .expect("Limine HHDM response missing");
+    serial_println!("hhdm offset: {:#x}", hhdm_offset);
+
+    let rsdp_ptr = RSDP_REQUEST
+        .get_response()
+        .map(|r| r.address())
+        .expect("Limine RSDP response missing");
+    serial_println!("rsdp: {:#x}", rsdp_ptr);
 
     vibix::arch::init();
     serial_println!("GDT + IDT loaded");
 
     vibix::mem::init();
+    vibix::arch::init_apic(rsdp_ptr, hhdm_offset);
     vibix::time::init();
 
     println!("vibix online.");

--- a/kernel/src/mem/paging.rs
+++ b/kernel/src/mem/paging.rs
@@ -108,8 +108,18 @@ pub fn map_phys_into_hhdm(
     size: u64,
     flags: PageTableFlags,
 ) -> Result<(), MapToError<Size4KiB>> {
+    if size == 0 {
+        return Ok(());
+    }
     let start = phys & !0xFFF;
-    let end = (phys + size + 0xFFF) & !0xFFF;
+    // Round the end up to the next page boundary with checked
+    // arithmetic — firmware-provided sizes could in principle push
+    // the sum past u64::MAX. Silent wrap would turn into a mis-map.
+    let end = phys
+        .checked_add(size - 1)
+        .and_then(|v| v.checked_add(0x1000))
+        .expect("map_phys_into_hhdm: physical range overflow")
+        & !0xFFF;
     let hhdm_offset = with_mapper(|m| m.phys_offset());
     with_mapper(|m| {
         let mut alloc = KernelFrameAllocator;

--- a/kernel/src/mem/paging.rs
+++ b/kernel/src/mem/paging.rs
@@ -95,6 +95,43 @@ pub fn map_range(
     Ok(())
 }
 
+/// Map a physical range into the HHDM window with the given flags.
+///
+/// Limine's HHDM covers usable RAM by default, but physical regions
+/// we need to poke at (ACPI tables in reserved/ROM ranges, LAPIC /
+/// IOAPIC MMIO) aren't included. This installs a read/write mapping
+/// page-by-page at `hhdm_offset + phys` so callers can keep using the
+/// uniform phys→HHDM translation pattern. Re-mapping an already-mapped
+/// page is a no-op.
+pub fn map_phys_into_hhdm(
+    phys: u64,
+    size: u64,
+    flags: PageTableFlags,
+) -> Result<(), MapToError<Size4KiB>> {
+    let start = phys & !0xFFF;
+    let end = (phys + size + 0xFFF) & !0xFFF;
+    let hhdm_offset = with_mapper(|m| m.phys_offset());
+    with_mapper(|m| {
+        let mut alloc = KernelFrameAllocator;
+        let mut addr = start;
+        while addr < end {
+            let page = Page::<Size4KiB>::containing_address(hhdm_offset + addr);
+            let frame = PhysFrame::<Size4KiB>::containing_address(PhysAddr::new(addr));
+            // SAFETY: caller is responsible for ensuring the physical
+            // range is safe to alias at this virtual address. For MMIO
+            // and firmware-provided ACPI tables the kernel is the sole
+            // user and we never hand these pages to the frame allocator.
+            match unsafe { m.map_to(page, frame, flags, &mut alloc) } {
+                Ok(flush) => flush.flush(),
+                Err(MapToError::PageAlreadyMapped(_)) => {}
+                Err(e) => return Err(e),
+            }
+            addr += 4096;
+        }
+        Ok(())
+    })
+}
+
 /// Unmap `page` and flush the TLB. The backing frame is leaked — we
 /// don't have a reclaiming frame allocator yet.
 pub fn unmap(page: Page<Size4KiB>) -> Result<PhysFrame<Size4KiB>, UnmapError> {

--- a/kernel/src/mem/paging.rs
+++ b/kernel/src/mem/paging.rs
@@ -120,8 +120,8 @@ pub fn map_phys_into_hhdm(
         .and_then(|v| v.checked_add(0x1000))
         .expect("map_phys_into_hhdm: physical range overflow")
         & !0xFFF;
-    let hhdm_offset = with_mapper(|m| m.phys_offset());
     with_mapper(|m| {
+        let hhdm_offset = m.phys_offset();
         let mut alloc = KernelFrameAllocator;
         let mut addr = start;
         while addr < end {

--- a/kernel/tests/apic_online.rs
+++ b/kernel/tests/apic_online.rs
@@ -1,0 +1,52 @@
+//! Integration test: ACPI + APIC bring-up on the BSP.
+//!
+//! After `vibix::init()` the MADT should have been parsed, the BSP
+//! LAPIC enabled, and at least one IOAPIC set up. This test does not
+//! re-verify IRQ delivery (timer_tick covers that); it just confirms
+//! the discovered topology is sane.
+
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("madt_parsed", &(madt_parsed as fn())),
+        ("ioapic_present", &(ioapic_present as fn())),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+fn madt_parsed() {
+    let info = vibix::acpi::info().expect("ACPI info missing after init");
+    assert!(info.cpu_count >= 1, "MADT reported {} CPUs", info.cpu_count);
+    assert_ne!(info.lapic_phys, 0, "LAPIC base is zero");
+}
+
+fn ioapic_present() {
+    let info = vibix::acpi::info().expect("ACPI info missing after init");
+    let count = info.ioapics().count();
+    assert!(count >= 1, "no IOAPICs discovered");
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -54,6 +54,9 @@ const SMOKE_MARKERS: &[&str] = &[
     "paging: mapper online",
     "paging: IST guard installed",
     "PIC remapped",
+    "acpi: MADT parsed",
+    "apic: BSP online",
+    "ioapic: initialized",
     "timer: 100 Hz",
     "vibix online.",
     "interrupts enabled",
@@ -347,6 +350,7 @@ fn test_all() -> R<()> {
         "paging",
         "tasks",
         "preempt",
+        "apic_online",
     ] {
         cmd.arg("--test").arg(t);
     }


### PR DESCRIPTION
## Summary
- Parse ACPI (RSDP → XSDT/RSDT → MADT) to discover LAPIC base, IOAPIC(s), and ISA interrupt source overrides; hand-rolled — no new crate deps.
- Bring the BSP's xAPIC online (spurious vector 0xFF + software enable, TPR cleared) and mask all IOAPIC redirection entries.
- Route IRQ0 (PIT → 0x20) and IRQ1 (keyboard → 0x21) through the IOAPIC, honoring MADT source overrides for GSI, polarity, and trigger mode.
- Remap + fully mask the 8259 so any legacy spurious IRQ doesn't hit a CPU exception vector; `pic::notify_eoi` now writes to the LAPIC EOI register.
- Add `mem::paging::map_phys_into_hhdm` for on-demand r/w (and UC for MMIO) HHDM mappings of physical ranges Limine doesn't cover — ACPI tables in reserved/BIOS ROM memory and LAPIC/IOAPIC MMIO.
- Split `arch::init` into `init()` (GDT/IDT/PIC-mask) + `init_apic(rsdp, hhdm)` so ACPI/APIC bring-up runs after the mapper is alive.
- New integration test `apic_online`; three new smoke markers.

Out of scope: AML/DSDT, HPET (#33), x2APIC, AP startup and IPIs.

Refs #19.

## Test plan
- [x] `cargo xtask smoke` — all 15 markers present (`acpi: MADT parsed`, `apic: BSP online`, `ioapic: initialized` added).
- [x] `cargo xtask test` — all integration tests pass under QEMU (`timer_tick` + `preempt` continue to pass, proving timer IRQs still land; new `apic_online` verifies MADT/IOAPIC topology).
- [x] Manual: `cargo xtask run`, type in QEMU, confirm keystrokes echo.