### PR TITLE
#12: own a fresh kernel PML4 + switch CR3

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -64,3 +64,7 @@ harness = false
 [[test]]
 name = "preempt"
 harness = false
+
+[[test]]
+name = "pml4_switch"
+harness = false

--- a/kernel/linker.ld
+++ b/kernel/linker.ld
@@ -19,32 +19,40 @@ SECTIONS
     . = 0xffffffff80000000;
 
     .limine_requests : {
+        PROVIDE(__limine_requests_start = .);
         KEEP(*(.limine_requests_start))
         KEEP(*(.limine_requests))
         KEEP(*(.limine_requests_end))
+        PROVIDE(__limine_requests_end = .);
     } :limine_requests
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
 
     .text : {
+        PROVIDE(__text_start = .);
         *(.text .text.*)
+        PROVIDE(__text_end = .);
     } :text
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
 
     .rodata : {
+        PROVIDE(__rodata_start = .);
         *(.rodata .rodata.*)
+        PROVIDE(__rodata_end = .);
     } :rodata
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
 
     .data : {
+        PROVIDE(__data_start = .);
         *(.data .data.*)
     } :data
 
     .bss : {
         *(.bss .bss.*)
         *(COMMON)
+        PROVIDE(__data_end = .);
     } :data
 
     .dynamic : {

--- a/kernel/src/boot.rs
+++ b/kernel/src/boot.rs
@@ -3,8 +3,8 @@
 //! take control.
 
 use limine::request::{
-    ExecutableAddressRequest, FramebufferRequest, HhdmRequest, MemoryMapRequest,
-    RequestsEndMarker, RequestsStartMarker, RsdpRequest, StackSizeRequest,
+    ExecutableAddressRequest, FramebufferRequest, HhdmRequest, MemoryMapRequest, RequestsEndMarker,
+    RequestsStartMarker, RsdpRequest, StackSizeRequest,
 };
 use limine::BaseRevision;
 

--- a/kernel/src/boot.rs
+++ b/kernel/src/boot.rs
@@ -3,8 +3,8 @@
 //! take control.
 
 use limine::request::{
-    FramebufferRequest, HhdmRequest, MemoryMapRequest, RequestsEndMarker, RequestsStartMarker,
-    StackSizeRequest,
+    ExecutableAddressRequest, FramebufferRequest, HhdmRequest, MemoryMapRequest,
+    RequestsEndMarker, RequestsStartMarker, StackSizeRequest,
 };
 use limine::BaseRevision;
 
@@ -30,6 +30,10 @@ pub static HHDM_REQUEST: HhdmRequest = HhdmRequest::new();
 #[used]
 #[link_section = ".limine_requests"]
 pub static STACK_REQUEST: StackSizeRequest = StackSizeRequest::new().with_size(STACK_SIZE);
+
+#[used]
+#[link_section = ".limine_requests"]
+pub static KERNEL_ADDRESS_REQUEST: ExecutableAddressRequest = ExecutableAddressRequest::new();
 
 #[used]
 #[link_section = ".limine_requests_start"]

--- a/kernel/src/mem/mod.rs
+++ b/kernel/src/mem/mod.rs
@@ -50,4 +50,9 @@ pub fn init() {
 
     heap::init();
     crate::arch::x86_64::ist_guard::install();
+
+    // Build a clean kernel-owned PML4 from the now-populated mapper
+    // state and swap CR3 to it. After this point, Limine's original
+    // page-table tree is no longer reachable.
+    paging::build_and_switch_kernel_pml4();
 }

--- a/kernel/src/mem/paging.rs
+++ b/kernel/src/mem/paging.rs
@@ -133,13 +133,21 @@ pub fn map_phys_into_hhdm(
                 Ok(flush) => flush.flush(),
                 // Already mapped via a 4 KiB PTE — no-op.
                 Err(MapToError::PageAlreadyMapped(_)) => {}
-                // Already covered by a 2 MiB HHDM huge page (see
-                // `populate_hhdm` in the kernel-PML4 build). The
-                // physical address is already reachable at
-                // `hhdm + phys`, which is what the caller wanted; we
-                // accept the coarser flags rather than split the
-                // huge page back into 4 KiB PTEs.
-                Err(MapToError::ParentEntryHugePage) => {}
+                // A 2 MiB HHDM huge page already covers this address
+                // with write-back cacheable flags. That's fine for RAM
+                // (ACPI tables, reclaimable regions), but wrong for
+                // device MMIO — caching LAPIC/IOAPIC reads silently
+                // corrupts interrupt handling. Accept the collision
+                // only when the caller isn't demanding a specific
+                // memory type; otherwise treat it as a bug (a caller
+                // wanting NO_CACHE means populate_hhdm should have
+                // skipped this physical range).
+                Err(e @ MapToError::ParentEntryHugePage) => {
+                    let mmio_bits = PageTableFlags::NO_CACHE | PageTableFlags::WRITE_THROUGH;
+                    if flags.intersects(mmio_bits) {
+                        return Err(e);
+                    }
+                }
                 Err(e) => return Err(e),
             }
             addr += 4096;
@@ -195,6 +203,7 @@ pub fn build_and_switch_kernel_pml4() {
         populate_kernel_image(&mut new_mapper, &mut alloc);
         clone_heap(&mut new_mapper, &mut alloc);
         clone_ist_stack(&mut new_mapper, &mut alloc);
+        clone_boot_stack(&mut new_mapper, &mut alloc);
         map_framebuffer(&mut new_mapper, &mut alloc);
     }
 
@@ -251,32 +260,41 @@ fn populate_hhdm(
         .get_response()
         .expect("Limine memory-map response missing");
 
-    // Cover [0, top) where `top` is the max end across *all* entries —
-    // that pulls in framebuffer MMIO, ACPI tables, and reclaimable
-    // regions, matching what Limine's HHDM did for us.
-    let mut top: u64 = 0;
-    for entry in memmap.entries() {
-        let end = entry.base + entry.length;
-        if end > top {
-            top = end;
-        }
-    }
-    let top = (top + TWO_MIB - 1) & !(TWO_MIB - 1);
-
     let flags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE;
-    let mut phys: u64 = 0;
-    while phys < top {
-        let page = Page::<Size2MiB>::containing_address(hhdm + phys);
-        let frame = PhysFrame::<Size2MiB>::containing_address(PhysAddr::new(phys));
-        // SAFETY: HHDM is a fresh mapping into an empty tree; we own
-        // it; flushing isn't required because this PML4 isn't live.
-        unsafe {
-            mapper
-                .map_to(page, frame, flags, alloc)
-                .expect("HHDM 2 MiB map failed")
-                .ignore();
+
+    // Iterate the memory-map entries and HHDM-map only ranges that
+    // hold real RAM or firmware data. Skipping RESERVED and BAD_MEMORY
+    // leaves MMIO holes (LAPIC/IOAPIC) uncovered so `map_phys_into_hhdm`
+    // can install 4 KiB PTEs with the correct NO_CACHE/WRITE_THROUGH
+    // attributes for device MMIO. Sparse high-address entries on real
+    // hardware also don't force us to densely map every 2 MiB below them.
+    use limine::memory_map::EntryType;
+    for entry in memmap.entries() {
+        match entry.entry_type {
+            EntryType::USABLE
+            | EntryType::BOOTLOADER_RECLAIMABLE
+            | EntryType::EXECUTABLE_AND_MODULES
+            | EntryType::FRAMEBUFFER
+            | EntryType::ACPI_RECLAIMABLE
+            | EntryType::ACPI_NVS => {}
+            _ => continue,
         }
-        phys += TWO_MIB;
+        let start = entry.base & !(TWO_MIB - 1);
+        let end = (entry.base + entry.length + TWO_MIB - 1) & !(TWO_MIB - 1);
+        let mut phys = start;
+        while phys < end {
+            let page = Page::<Size2MiB>::containing_address(hhdm + phys);
+            let frame = PhysFrame::<Size2MiB>::containing_address(PhysAddr::new(phys));
+            // SAFETY: HHDM into a fresh tree we own; flush unneeded
+            // since this PML4 isn't live yet.
+            match unsafe { mapper.map_to(page, frame, flags, alloc) } {
+                Ok(f) => f.ignore(),
+                // Adjacent entries may share a rounded-up 2 MiB page.
+                Err(MapToError::PageAlreadyMapped(_)) => {}
+                Err(e) => panic!("HHDM 2 MiB map {:#x} failed: {:?}", phys, e),
+            }
+            phys += TWO_MIB;
+        }
     }
 }
 
@@ -357,6 +375,12 @@ fn clone_range(
                 match mapper.map_to(page, frame, flags, alloc) {
                     Ok(f) => f.ignore(),
                     Err(MapToError::PageAlreadyMapped(_)) => {}
+                    // Already covered by a 2 MiB HHDM huge page — e.g.
+                    // Limine's boot stack lives in HHDM-mapped RAM, so
+                    // its virtual address is reachable via the same
+                    // backing frame through the huge page. Safe to
+                    // skip; the translation is already correct.
+                    Err(MapToError::ParentEntryHugePage) => {}
                     Err(e) => panic!("clone_range map_to {:#x} failed: {:?}", addr.as_u64(), e),
                 }
             }
@@ -377,6 +401,31 @@ fn clone_ist_stack(mapper: &mut OffsetPageTable<'static>, alloc: &mut KernelFram
     // populate_kernel_image. Nothing extra to do here; kept as a seam
     // for when IST stacks move out of .bss into dedicated allocations.
     let _ = (mapper, alloc);
+}
+
+/// Preserve the current (Limine-provided) boot stack across the CR3
+/// switch. Limine's `StackSizeRequest` stack is allocated from
+/// bootloader-reclaimable memory and is NOT guaranteed to live in the
+/// HHDM window — we must explicitly clone its virtual mapping into the
+/// new tree or the CPU will fault on the very next push after CR3
+/// reloads.
+fn clone_boot_stack(mapper: &mut OffsetPageTable<'static>, alloc: &mut KernelFrameAllocator) {
+    // Read RSP at this exact frame — we know the stack lives somewhere
+    // that contains this address. Limine gave us STACK_SIZE bytes; clone
+    // a generous window of 2× on either side so we cover the whole
+    // stack regardless of where RSP currently sits inside it. `clone_range`
+    // skips pages that aren't mapped in the old tree, so over-covering
+    // is harmless.
+    let rsp: u64;
+    // SAFETY: reading RSP is always defined.
+    unsafe {
+        core::arch::asm!("mov {}, rsp", out(reg) rsp, options(nomem, nostack, preserves_flags));
+    }
+    let window = 2 * crate::boot::STACK_REQUEST.size();
+    let base = VirtAddr::new(rsp.saturating_sub(window));
+    let top = VirtAddr::new(rsp.saturating_add(window));
+    let flags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE;
+    clone_range(mapper, alloc, base, top, flags);
 }
 
 fn map_framebuffer(mapper: &mut OffsetPageTable<'static>, alloc: &mut KernelFrameAllocator) {

--- a/kernel/src/mem/paging.rs
+++ b/kernel/src/mem/paging.rs
@@ -15,8 +15,8 @@ use spin::Mutex;
 use x86_64::registers::control::Cr3;
 use x86_64::structures::paging::mapper::{MapToError, TranslateResult, UnmapError};
 use x86_64::structures::paging::{
-    FrameAllocator, Mapper, OffsetPageTable, Page, PageTable, PageTableFlags, PhysFrame,
-    Size2MiB, Size4KiB, Translate,
+    FrameAllocator, Mapper, OffsetPageTable, Page, PageTable, PageTableFlags, PhysFrame, Size2MiB,
+    Size4KiB, Translate,
 };
 use x86_64::{PhysAddr, VirtAddr};
 
@@ -131,7 +131,15 @@ pub fn map_phys_into_hhdm(
             // user and we never hand these pages to the frame allocator.
             match unsafe { m.map_to(page, frame, flags, &mut alloc) } {
                 Ok(flush) => flush.flush(),
+                // Already mapped via a 4 KiB PTE — no-op.
                 Err(MapToError::PageAlreadyMapped(_)) => {}
+                // Already covered by a 2 MiB HHDM huge page (see
+                // `populate_hhdm` in the kernel-PML4 build). The
+                // physical address is already reachable at
+                // `hhdm + phys`, which is what the caller wanted; we
+                // accept the coarser flags rather than split the
+                // huge page back into 4 KiB PTEs.
+                Err(MapToError::ParentEntryHugePage) => {}
                 Err(e) => return Err(e),
             }
             addr += 4096;
@@ -275,10 +283,7 @@ fn populate_hhdm(
 /// Map the kernel image section-by-section with tight permissions.
 /// Pages that are unmapped in the *current* (old) tree are skipped so
 /// that the IST guard unmap survives the switch.
-fn populate_kernel_image(
-    mapper: &mut OffsetPageTable<'static>,
-    alloc: &mut KernelFrameAllocator,
-) {
+fn populate_kernel_image(mapper: &mut OffsetPageTable<'static>, alloc: &mut KernelFrameAllocator) {
     extern "C" {
         static __limine_requests_start: u8;
         static __limine_requests_end: u8;

--- a/kernel/src/mem/paging.rs
+++ b/kernel/src/mem/paging.rs
@@ -1,20 +1,22 @@
-//! Kernel paging: wrap Limine's active page tables in an
-//! [`OffsetPageTable`] and expose typed `map`/`unmap`/`translate`.
+//! Kernel paging: wrap Limine's page tables in an [`OffsetPageTable`],
+//! then build a fresh kernel-owned PML4 and atomically switch CR3 to it.
 //!
-//! Limine hands us a PML4 with the kernel image identity-ish-mapped at
-//! −2 GiB and all of physical RAM HHDM-mapped. We keep that tree
-//! (no CR3 switch here) and just take ownership of it through the
-//! `x86_64` crate's mapper abstraction. Future milestones that need to
-//! install mappings of their own — heap growth, IST guard pages, user
-//! address spaces — go through this module instead of relying on
-//! whatever Limine happened to set up.
+//! Boot flow: [`init`] wraps Limine's active tree so early subsystems
+//! (heap, IST guard) can install mappings through the normal API. Once
+//! those are in place, [`build_and_switch_kernel_pml4`] constructs a
+//! clean tree that maps only what the kernel actually needs — kernel
+//! image per section with tight flags, HHDM via 2 MiB pages, heap, IST
+//! stack sans guard, framebuffer — and swaps CR3 to it. From that point
+//! on Limine's original tree is unreachable; it (and
+//! `BOOTLOADER_RECLAIMABLE` frames) will be freed once a reclaiming
+//! allocator lands (issue #13).
 
-use spin::{Mutex, Once};
+use spin::Mutex;
 use x86_64::registers::control::Cr3;
 use x86_64::structures::paging::mapper::{MapToError, TranslateResult, UnmapError};
 use x86_64::structures::paging::{
-    FrameAllocator, Mapper, OffsetPageTable, Page, PageTable, PageTableFlags, PhysFrame, Size4KiB,
-    Translate,
+    FrameAllocator, Mapper, OffsetPageTable, Page, PageTable, PageTableFlags, PhysFrame,
+    Size2MiB, Size4KiB, Translate,
 };
 use x86_64::{PhysAddr, VirtAddr};
 
@@ -33,36 +35,36 @@ unsafe impl FrameAllocator<Size4KiB> for KernelFrameAllocator {
     }
 }
 
-static MAPPER: Once<Mutex<OffsetPageTable<'static>>> = Once::new();
+/// The active kernel mapper. `None` before [`init`] runs; replaced
+/// wholesale by [`build_and_switch_kernel_pml4`] when we swap CR3. A
+/// plain `Mutex<Option<...>>` (instead of `Once`) so the switch can
+/// install a fresh `OffsetPageTable` rooted at the new PML4.
+static MAPPER: Mutex<Option<OffsetPageTable<'static>>> = Mutex::new(None);
 
-/// Install the kernel mapper. Must be called after `frame::init` (page
-/// tables allocated for new mappings come from the global allocator)
-/// and before any caller tries to `map`/`unmap`.
+/// HHDM offset, stashed at [`init`] so the switch code and the
+/// per-frame zero helper can re-use it without re-reading the Limine
+/// response.
+static HHDM_OFFSET: Mutex<Option<VirtAddr>> = Mutex::new(None);
+
+/// Install the kernel mapper over Limine's active PML4. Must be called
+/// after `frame::init` and before any caller tries to `map`/`unmap`.
 pub fn init(hhdm_offset: VirtAddr) {
     let (cr3_frame, _) = Cr3::read();
-    // Physical → virtual via HHDM. Limine guarantees the active PML4
-    // is covered by the HHDM mapping it installed.
-    let l4_virt = hhdm_offset + cr3_frame.start_address().as_u64();
-    // SAFETY: Limine's PML4 lives for the life of the kernel, is
-    // exclusively ours from this point on, and the HHDM mapping makes
-    // the cast a valid `&mut PageTable`.
-    let l4: &'static mut PageTable = unsafe { &mut *(l4_virt.as_mut_ptr::<PageTable>()) };
+    let l4 = unsafe { pml4_as_mut(cr3_frame, hhdm_offset) };
     let mapper = unsafe { OffsetPageTable::new(l4, hhdm_offset) };
-    MAPPER.call_once(|| Mutex::new(mapper));
+    *MAPPER.lock() = Some(mapper);
+    *HHDM_OFFSET.lock() = Some(hhdm_offset);
     serial_println!("paging: mapper online");
 }
 
-/// Run a closure with exclusive access to the kernel mapper. Acquires
-/// the mapper lock for the duration of the call.
+/// Run a closure with exclusive access to the kernel mapper.
 pub fn with_mapper<R>(f: impl FnOnce(&mut OffsetPageTable<'static>) -> R) -> R {
-    let mapper = MAPPER.get().expect("paging::init not called");
-    let mut guard = mapper.lock();
-    f(&mut guard)
+    let mut guard = MAPPER.lock();
+    let m = guard.as_mut().expect("paging::init not called");
+    f(m)
 }
 
 /// Map `page` to a freshly-allocated physical frame with `flags`.
-/// Returns the frame so callers that care can recover its physical
-/// address.
 pub fn map(
     page: Page<Size4KiB>,
     flags: PageTableFlags,
@@ -72,17 +74,13 @@ pub fn map(
         .allocate_frame()
         .ok_or(MapToError::FrameAllocationFailed)?;
     with_mapper(|m| {
-        // SAFETY: caller owns the virtual address; we allocated the
-        // physical frame, so no aliasing. Flushing the TLB entry below.
         let flush = unsafe { m.map_to(page, frame, flags, &mut alloc)? };
         flush.flush();
         Ok(frame)
     })
 }
 
-/// Map `count` contiguous 4 KiB pages starting at `start`. Each page
-/// gets an independent physical frame (frames are not guaranteed
-/// contiguous). On partial failure earlier pages remain mapped.
+/// Map `count` contiguous 4 KiB pages starting at `start`.
 pub fn map_range(
     start: VirtAddr,
     count: u64,
@@ -95,8 +93,7 @@ pub fn map_range(
     Ok(())
 }
 
-/// Unmap `page` and flush the TLB. The backing frame is leaked — we
-/// don't have a reclaiming frame allocator yet.
+/// Unmap `page` and flush the TLB. Backing frame is leaked.
 pub fn unmap(page: Page<Size4KiB>) -> Result<PhysFrame<Size4KiB>, UnmapError> {
     with_mapper(|m| {
         let (frame, flush) = m.unmap(page)?;
@@ -111,4 +108,230 @@ pub fn translate(addr: VirtAddr) -> Option<PhysAddr> {
         TranslateResult::Mapped { frame, offset, .. } => Some(frame.start_address() + offset),
         TranslateResult::NotMapped | TranslateResult::InvalidFrameAddress(_) => None,
     })
+}
+
+/// Physical address of the currently-active PML4 (i.e. CR3).
+pub fn active_pml4_phys() -> PhysAddr {
+    Cr3::read().0.start_address()
+}
+
+// -- PML4 construction + CR3 swap ---------------------------------------
+
+/// Build a fresh kernel PML4 and switch CR3 to it. Drops Limine's
+/// original tree (leaks its intermediate tables until a reclaiming
+/// allocator lands).
+pub fn build_and_switch_kernel_pml4() {
+    let hhdm = HHDM_OFFSET
+        .lock()
+        .expect("paging::init must run before the CR3 switch");
+
+    // SAFETY: we reserve this frame exclusively for the new PML4, zero
+    // it through the HHDM, and only reference it through an
+    // `OffsetPageTable` built over the same HHDM window.
+    let new_pml4_frame = unsafe { alloc_zeroed_frame(hhdm) };
+
+    {
+        // Build mappings into the fresh tree.
+        let mut alloc = KernelFrameAllocator;
+        let l4 = unsafe { pml4_as_mut(new_pml4_frame, hhdm) };
+        let mut new_mapper = unsafe { OffsetPageTable::new(l4, hhdm) };
+
+        populate_hhdm(&mut new_mapper, hhdm, &mut alloc);
+        populate_kernel_image(&mut new_mapper, &mut alloc);
+        clone_heap(&mut new_mapper, &mut alloc);
+        clone_ist_stack(&mut new_mapper, &mut alloc);
+        map_framebuffer(&mut new_mapper, &mut alloc);
+    }
+
+    // Atomic swap. IRQs off so no handler runs while CR3 and MAPPER
+    // are in a mid-transition state. TLB is wholly flushed by the CR3
+    // load.
+    x86_64::instructions::interrupts::without_interrupts(|| {
+        let (_old, flags) = Cr3::read();
+        unsafe { Cr3::write(new_pml4_frame, flags) };
+        let l4 = unsafe { pml4_as_mut(new_pml4_frame, hhdm) };
+        let mapper = unsafe { OffsetPageTable::new(l4, hhdm) };
+        *MAPPER.lock() = Some(mapper);
+    });
+
+    serial_println!("paging: switched to kernel PML4");
+}
+
+/// Allocate a 4 KiB frame, zero it through the HHDM. Returns the frame.
+///
+/// # Safety
+/// The returned frame becomes the new caller's responsibility; no other
+/// code may hold a reference to its contents.
+unsafe fn alloc_zeroed_frame(hhdm: VirtAddr) -> PhysFrame<Size4KiB> {
+    let mut alloc = KernelFrameAllocator;
+    let frame = alloc
+        .allocate_frame()
+        .expect("out of frames allocating kernel PML4");
+    let virt = hhdm + frame.start_address().as_u64();
+    core::ptr::write_bytes(virt.as_mut_ptr::<u8>(), 0, 4096);
+    frame
+}
+
+/// Turn a PML4-bearing physical frame into a `&'static mut PageTable`
+/// via the HHDM.
+///
+/// # Safety
+/// `frame` must be a page-table frame with no other outstanding
+/// references, and `hhdm` must be the active HHDM offset.
+unsafe fn pml4_as_mut(frame: PhysFrame<Size4KiB>, hhdm: VirtAddr) -> &'static mut PageTable {
+    let virt = hhdm + frame.start_address().as_u64();
+    &mut *(virt.as_mut_ptr::<PageTable>())
+}
+
+/// Map the HHDM range (all memory-map-reported physical memory) into
+/// the new tree using 2 MiB pages.
+fn populate_hhdm(
+    mapper: &mut OffsetPageTable<'static>,
+    hhdm: VirtAddr,
+    alloc: &mut KernelFrameAllocator,
+) {
+    const TWO_MIB: u64 = 2 * 1024 * 1024;
+
+    let memmap = crate::boot::MEMMAP_REQUEST
+        .get_response()
+        .expect("Limine memory-map response missing");
+
+    // Cover [0, top) where `top` is the max end across *all* entries —
+    // that pulls in framebuffer MMIO, ACPI tables, and reclaimable
+    // regions, matching what Limine's HHDM did for us.
+    let mut top: u64 = 0;
+    for entry in memmap.entries() {
+        let end = entry.base + entry.length;
+        if end > top {
+            top = end;
+        }
+    }
+    let top = (top + TWO_MIB - 1) & !(TWO_MIB - 1);
+
+    let flags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE;
+    let mut phys: u64 = 0;
+    while phys < top {
+        let page = Page::<Size2MiB>::containing_address(hhdm + phys);
+        let frame = PhysFrame::<Size2MiB>::containing_address(PhysAddr::new(phys));
+        // SAFETY: HHDM is a fresh mapping into an empty tree; we own
+        // it; flushing isn't required because this PML4 isn't live.
+        unsafe {
+            mapper
+                .map_to(page, frame, flags, alloc)
+                .expect("HHDM 2 MiB map failed")
+                .ignore();
+        }
+        phys += TWO_MIB;
+    }
+}
+
+/// Map the kernel image section-by-section with tight permissions.
+/// Pages that are unmapped in the *current* (old) tree are skipped so
+/// that the IST guard unmap survives the switch.
+fn populate_kernel_image(
+    mapper: &mut OffsetPageTable<'static>,
+    alloc: &mut KernelFrameAllocator,
+) {
+    extern "C" {
+        static __limine_requests_start: u8;
+        static __limine_requests_end: u8;
+        static __text_start: u8;
+        static __text_end: u8;
+        static __rodata_start: u8;
+        static __rodata_end: u8;
+        static __data_start: u8;
+        static __data_end: u8;
+    }
+
+    let present_rw = PageTableFlags::PRESENT | PageTableFlags::WRITABLE;
+    let text_flags = PageTableFlags::PRESENT; // RX
+    let rodata_flags = PageTableFlags::PRESENT | PageTableFlags::NO_EXECUTE; // RO
+    let data_flags = present_rw | PageTableFlags::NO_EXECUTE; // RW
+
+    // SAFETY: these are link-time symbols with static addresses; taking
+    // their address is always valid.
+    let regions = unsafe {
+        [
+            (
+                VirtAddr::from_ptr(&__limine_requests_start),
+                VirtAddr::from_ptr(&__limine_requests_end),
+                data_flags,
+            ),
+            (
+                VirtAddr::from_ptr(&__text_start),
+                VirtAddr::from_ptr(&__text_end),
+                text_flags,
+            ),
+            (
+                VirtAddr::from_ptr(&__rodata_start),
+                VirtAddr::from_ptr(&__rodata_end),
+                rodata_flags,
+            ),
+            (
+                VirtAddr::from_ptr(&__data_start),
+                VirtAddr::from_ptr(&__data_end),
+                data_flags,
+            ),
+        ]
+    };
+
+    for (start, end, flags) in regions {
+        clone_range(mapper, alloc, start, end, flags);
+    }
+}
+
+/// Copy the mappings for `[start, end)` from the live (old) mapper into
+/// `mapper` with `flags`. Pages not currently mapped in the old tree
+/// are skipped — this is how the IST guard and any other intentional
+/// hole propagates forward.
+fn clone_range(
+    mapper: &mut OffsetPageTable<'static>,
+    alloc: &mut KernelFrameAllocator,
+    start: VirtAddr,
+    end: VirtAddr,
+    flags: PageTableFlags,
+) {
+    let start = VirtAddr::new(start.as_u64() & !0xFFF);
+    let end_aligned = VirtAddr::new((end.as_u64() + 0xFFF) & !0xFFF);
+    let mut addr = start;
+    while addr < end_aligned {
+        if let Some(phys) = translate(addr) {
+            let page = Page::<Size4KiB>::containing_address(addr);
+            let frame =
+                PhysFrame::<Size4KiB>::containing_address(PhysAddr::new(phys.as_u64() & !0xFFF));
+            // SAFETY: fresh tree, not yet live; we're installing a
+            // mapping that already backs the kernel.
+            unsafe {
+                match mapper.map_to(page, frame, flags, alloc) {
+                    Ok(f) => f.ignore(),
+                    Err(MapToError::PageAlreadyMapped(_)) => {}
+                    Err(e) => panic!("clone_range map_to {:#x} failed: {:?}", addr.as_u64(), e),
+                }
+            }
+        }
+        addr += 4096u64;
+    }
+}
+
+fn clone_heap(mapper: &mut OffsetPageTable<'static>, alloc: &mut KernelFrameAllocator) {
+    let base = VirtAddr::new(super::heap::HEAP_BASE as u64);
+    let end = base + super::heap::mapped_size() as u64;
+    let flags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE;
+    clone_range(mapper, alloc, base, end, flags);
+}
+
+fn clone_ist_stack(mapper: &mut OffsetPageTable<'static>, alloc: &mut KernelFrameAllocator) {
+    // The #DF stack lives in .bss and is already cloned by
+    // populate_kernel_image. Nothing extra to do here; kept as a seam
+    // for when IST stacks move out of .bss into dedicated allocations.
+    let _ = (mapper, alloc);
+}
+
+fn map_framebuffer(mapper: &mut OffsetPageTable<'static>, alloc: &mut KernelFrameAllocator) {
+    // The framebuffer lives inside HHDM (Limine maps it there), and
+    // HHDM already covers every memory-map entry including
+    // `EntryType::FRAMEBUFFER`. Nothing to do beyond HHDM. Kept as a
+    // seam for later — direct non-HHDM framebuffer mapping (e.g. with
+    // write-combining) is a follow-up.
+    let _ = (mapper, alloc);
 }

--- a/kernel/tests/pml4_switch.rs
+++ b/kernel/tests/pml4_switch.rs
@@ -20,7 +20,14 @@ use x86_64::VirtAddr;
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
+    let before = vibix::mem::paging::active_pml4_phys();
     vibix::init();
+    let after = vibix::mem::paging::active_pml4_phys();
+    assert_ne!(
+        before, after,
+        "CR3 did not change — build_and_switch_kernel_pml4 regressed"
+    );
+    serial_println!("  CR3 swapped {before:?} -> {after:?}");
     run_tests();
     exit_qemu(QemuExitCode::Success);
 }

--- a/kernel/tests/pml4_switch.rs
+++ b/kernel/tests/pml4_switch.rs
@@ -1,0 +1,85 @@
+//! Integration test: after `vibix::init` builds a fresh kernel PML4 and
+//! swaps CR3 to it, known-good virtual addresses still translate and
+//! read/write as expected, and the allocator can still grow the heap
+//! into the new tree.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::panic::PanicInfo;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+use x86_64::VirtAddr;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("kernel_text_translates", &(kernel_text_translates as fn())),
+        ("heap_ptr_translates", &(heap_ptr_translates as fn())),
+        ("stack_local_translates", &(stack_local_translates as fn())),
+        ("heap_grows_after_switch", &(heap_grows_after_switch as fn())),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+fn kernel_text_translates() {
+    use vibix::mem::paging;
+    let fn_ptr: fn() = kernel_text_translates;
+    let va = VirtAddr::new(fn_ptr as usize as u64);
+    let phys = paging::translate(va).expect("kernel .text address not mapped after CR3 switch");
+    serial_println!("  fn @ {va:?} -> {phys:?}");
+}
+
+fn heap_ptr_translates() {
+    use vibix::mem::paging;
+    let boxed = Box::new(0xCAFE_F00Du64);
+    let va = VirtAddr::new(&*boxed as *const u64 as u64);
+    let phys = paging::translate(va).expect("heap address not mapped after CR3 switch");
+    assert_eq!(*boxed, 0xCAFE_F00D);
+    serial_println!("  heap @ {va:?} -> {phys:?}");
+}
+
+fn stack_local_translates() {
+    use vibix::mem::paging;
+    let local: u64 = 0xDEAD_BEEF_DEAD_BEEF;
+    let va = VirtAddr::new(&local as *const u64 as u64);
+    let phys = paging::translate(va).expect("stack local not mapped after CR3 switch");
+    assert_eq!(local, 0xDEAD_BEEF_DEAD_BEEF);
+    serial_println!("  stack @ {va:?} -> {phys:?}");
+}
+
+fn heap_grows_after_switch() {
+    // Force the heap past the 1 MiB initial slab to exercise
+    // `heap::grow_once` → `paging::map_range` against the new tree.
+    let before = vibix::mem::heap::mapped_size();
+    let mut v: Vec<u64> = Vec::new();
+    for i in 0..(256 * 1024u64) {
+        v.push(i);
+    }
+    let after = vibix::mem::heap::mapped_size();
+    assert!(after > before, "heap did not grow after CR3 switch");
+    assert_eq!(v[12345], 12345);
+    serial_println!("  heap grew {before} -> {after} bytes");
+}

--- a/kernel/tests/pml4_switch.rs
+++ b/kernel/tests/pml4_switch.rs
@@ -35,7 +35,10 @@ fn run_tests() {
         ("kernel_text_translates", &(kernel_text_translates as fn())),
         ("heap_ptr_translates", &(heap_ptr_translates as fn())),
         ("stack_local_translates", &(stack_local_translates as fn())),
-        ("heap_grows_after_switch", &(heap_grows_after_switch as fn())),
+        (
+            "heap_grows_after_switch",
+            &(heap_grows_after_switch as fn()),
+        ),
     ];
     serial_println!("running {} tests", tests.len());
     for (name, t) in tests {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -53,6 +53,7 @@ const SMOKE_MARKERS: &[&str] = &[
     "heap: 1024 KiB",
     "paging: mapper online",
     "paging: IST guard installed",
+    "paging: switched to kernel PML4",
     "PIC remapped",
     "timer: 100 Hz",
     "vibix online.",
@@ -348,6 +349,7 @@ fn test_all() -> R<()> {
         "paging",
         "tasks",
         "preempt",
+        "pml4_switch",
     ] {
         cmd.arg("--test").arg(t);
     }


### PR DESCRIPTION
## Summary
- Build a kernel-owned PML4 with tight per-section flags (RX `.text`, RO `.rodata`, RW `.data`/`.bss`/`.limine_requests`), a 2 MiB-page HHDM covering every memory-map entry, and clone-by-translate for the heap and `#DF` IST stack so the guard-page hole in the old tree propagates forward.
- Swap CR3 under `without_interrupts` and re-root `MAPPER` at the fresh L4. After the swap, Limine's original tree is unreachable.
- `linker.ld` exposes `__text_start/end`, `__rodata_start/end`, `__data_start/end`, `__limine_requests_start/end` via `PROVIDE` inside each output section so the symbols resolve to the right addresses (previously-attempted outside-section assignments collapsed to `.bss @ 0`).
- Adds `ExecutableAddressRequest` to `boot.rs` for future phys-base use (e.g. the ELF PT_LOAD follow-up in #48).
- New integration test `pml4_switch.rs`: translate + read kernel `.text`, a `Box`-allocated heap pointer, and a stack local after the switch; force heap growth past the 1 MiB slab.
- New smoke marker `"paging: switched to kernel PML4"` added to `SMOKE_MARKERS`.

**Out of scope**, tracked as follow-ups:
- Reclaim Limine's old PML4 + `BOOTLOADER_RECLAIMABLE` — #46 (blocked on #13).
- Derive section flags from ELF PT_LOAD headers instead of linker symbols — #48.
- Framebuffer write-combining PAT — #50.
- Demand paging / COW — #51.

## Test plan
- [x] `cargo xtask test` — all host unit tests + every QEMU integration test (including 4 new `pml4_switch` cases) pass.
- [x] `cargo xtask smoke` — all 13 markers present.
- [x] `cargo xtask run` — kernel reaches `"vibix online."` past the CR3 switch.
- [ ] Manual: sanity-check on real hardware if/when applicable (QEMU-only here).
