### PR TITLE
#15: integration test for the #PF handler path

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -68,3 +68,7 @@ harness = false
 [[test]]
 name = "apic_online"
 harness = false
+
+[[test]]
+name = "page_fault"
+harness = false

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -58,11 +58,7 @@ extern "x86-interrupt" fn page_fault(frame: InterruptStackFrame, code: PageFault
     if let Some(expected) = crate::test_hook::take_page_fault_expectation() {
         use crate::test_harness::{exit_qemu, QemuExitCode};
         if addr_u64 == expected {
-            serial_println!(
-                "#PF oracle matched addr={:#x} code={:?}",
-                expected,
-                code
-            );
+            serial_println!("#PF oracle matched addr={:#x} code={:?}", expected, code);
             exit_qemu(QemuExitCode::Success);
         } else {
             serial_println!(

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -53,6 +53,28 @@ extern "x86-interrupt" fn general_protection(frame: InterruptStackFrame, code: u
 
 extern "x86-interrupt" fn page_fault(frame: InterruptStackFrame, code: PageFaultErrorCode) {
     let addr = x86_64::registers::control::Cr2::read();
+    let addr_u64 = x86_64::registers::control::Cr2::read_raw();
+
+    if let Some(expected) = crate::test_hook::take_page_fault_expectation() {
+        use crate::test_harness::{exit_qemu, QemuExitCode};
+        if addr_u64 == expected {
+            serial_println!(
+                "#PF oracle matched addr={:#x} code={:?}",
+                expected,
+                code
+            );
+            exit_qemu(QemuExitCode::Success);
+        } else {
+            serial_println!(
+                "#PF oracle MISMATCH: expected {:#x}, got {:#x} code={:?}",
+                expected,
+                addr_u64,
+                code
+            );
+            exit_qemu(QemuExitCode::Failure);
+        }
+    }
+
     serial_println!(
         "EXCEPTION: #PF addr={:?} code={:?}\n{:#?}",
         addr,

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -29,6 +29,8 @@ pub mod task;
 #[cfg(target_os = "none")]
 pub mod test_harness;
 #[cfg(target_os = "none")]
+pub mod test_hook;
+#[cfg(target_os = "none")]
 pub mod time;
 
 #[cfg(target_os = "none")]

--- a/kernel/src/test_hook.rs
+++ b/kernel/src/test_hook.rs
@@ -1,0 +1,32 @@
+//! One-shot expectation hooks for exception handlers, used by
+//! integration tests that deliberately trigger CPU faults.
+//!
+//! An `extern "x86-interrupt"` handler can't return a value to the
+//! faulting code, so tests can't write `assert_eq!` around the fault
+//! itself. Instead a test calls `expect_page_fault(addr)`, triggers the
+//! fault, and the handler consumes the expectation: a matching CR2
+//! exits QEMU with Success; a mismatch (or a stray fault when nothing
+//! is expected) takes the normal print-and-hang path and the test
+//! times out or fails.
+
+use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+static PF_EXPECTED: AtomicBool = AtomicBool::new(false);
+static PF_EXPECTED_ADDR: AtomicU64 = AtomicU64::new(0);
+
+/// Arm a one-shot expectation that the next `#PF` will occur at
+/// `addr`. Cleared by the handler when consumed.
+pub fn expect_page_fault(addr: u64) {
+    PF_EXPECTED_ADDR.store(addr, Ordering::SeqCst);
+    PF_EXPECTED.store(true, Ordering::SeqCst);
+}
+
+/// Called from the `#PF` handler. Returns the expected address if one
+/// was armed (and clears it), otherwise `None`.
+pub fn take_page_fault_expectation() -> Option<u64> {
+    if PF_EXPECTED.swap(false, Ordering::SeqCst) {
+        Some(PF_EXPECTED_ADDR.load(Ordering::SeqCst))
+    } else {
+        None
+    }
+}

--- a/kernel/tests/page_fault.rs
+++ b/kernel/tests/page_fault.rs
@@ -1,0 +1,43 @@
+//! Integration test: deliberately trigger a `#PF` at a known unmapped
+//! VA and verify the handler observes the expected fault address.
+//!
+//! Oracle: the IST guard page is the lowest 4 KiB of `DOUBLE_FAULT_STACK`,
+//! unmapped during `mem::init`. Its VA is exported by `gdt`, so we can
+//! arm the expectation, read from it once, and let the `#PF` handler
+//! `exit_qemu(Success)` on match or `Failure` on mismatch.
+
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+use core::ptr;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, QemuExitCode},
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    serial_println!("page_fault: init ok");
+
+    let guard = vibix::arch::x86_64::gdt::df_stack_guard_addr().as_u64();
+    serial_println!("page_fault: arming expectation @ {:#x}", guard);
+
+    vibix::test_hook::expect_page_fault(guard);
+
+    // The handler exits QEMU directly on match/mismatch, so this read
+    // should never return. Reach here only if the fault didn't fire —
+    // treat that as a failure.
+    unsafe {
+        let _ = ptr::read_volatile(guard as *const u64);
+    }
+
+    serial_println!("page_fault: deref did NOT fault — test failed");
+    exit_qemu(QemuExitCode::Failure);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -352,6 +352,7 @@ fn test_all() -> R<()> {
         "tasks",
         "preempt",
         "apic_online",
+        "page_fault",
     ] {
         cmd.arg("--test").arg(t);
     }


### PR DESCRIPTION
## Summary
- Add `kernel::test_hook` with a one-shot `expect_page_fault(addr)` expectation, consumed by the `#PF` handler: CR2 match → `exit_qemu(Success)`, mismatch → `exit_qemu(Failure)`. When nothing is armed, the handler takes its usual print-and-hang path.
- New `kernel/tests/page_fault.rs` uses the IST guard page (already unmapped in `mem::init`, VA exported by `gdt::df_stack_guard_addr`) as the oracle: arm, deref, confirm the handler saw exactly that address.
- Wired the new test into `kernel/Cargo.toml` and the `xtask test` list.

Closes #15.

Out of scope: fault-injection for `#DF` / `#GP` / `#DE` — each has its own quirks (file separately if useful). Recovering from the fault (we still halt in the non-test path).

## Test plan
- [x] `cargo xtask test` — 10 integration tests pass (including the new `page_fault`), host unit tests green. Serial shows `#PF oracle matched addr=0xffffffff80016000 code=PageFaultErrorCode(0x0)`.
- [x] `cargo xtask smoke` — all 15 markers present; boot path unchanged.
- [ ] Manual: confirm a stray `#PF` (no expectation armed) still prints the usual `EXCEPTION: #PF` line and halts.
