### PR TITLE
mem: replace bump frame allocator with a reclaiming bitmap

### DIFF
--- a/kernel/src/mem/frame.rs
+++ b/kernel/src/mem/frame.rs
@@ -167,7 +167,11 @@ mod global {
     use spin::{Mutex, Once};
 
     static REGIONS: Once<([Region; MAX_REGIONS], usize)> = Once::new();
-    static mut BITMAP: [u64; BITMAP_WORDS] = [!0u64; BITMAP_WORDS];
+    // Zero-initialized so the bitmap lives in `.bss` instead of `.data`
+    // (saves ~128 KiB in the kernel image). `BitmapFrameAllocator::new`
+    // writes `!0` to every word before handing out any frame, so the
+    // initial value here is irrelevant for correctness.
+    static mut BITMAP: [u64; BITMAP_WORDS] = [0u64; BITMAP_WORDS];
     static ALLOCATOR: Once<Mutex<BitmapFrameAllocator<'static>>> = Once::new();
 
     pub fn init() {

--- a/kernel/src/mem/frame.rs
+++ b/kernel/src/mem/frame.rs
@@ -1,84 +1,145 @@
-//! Bump physical-frame allocator.
+//! Bitmap physical-frame allocator.
 //!
-//! Walks an ordered slice of USABLE `Region`s, handing out 4 KiB frames
-//! in ascending physical order. Frames are never returned — this is a
-//! one-way allocator, appropriate for one-shot boot allocations (e.g.
-//! the kernel heap and page-table pages). A reclaiming allocator is a
-//! later milestone.
+//! One bit per 4 KiB frame. A set bit means "used", a clear bit "free".
+//! Bits outside Limine's USABLE regions (and bits past the tracked
+//! capacity) are kept set forever so the scanner skips them.
+//!
+//! Constant-time deallocate, roughly linear-in-bitmap-words allocate
+//! (with a `next_hint` to skip past the already-scanned prefix on the
+//! common case). Fine for the scales we care about — 4 GiB of RAM is
+//! 128 KiB of bitmap, 16384 `u64` words.
 //!
 //! Kept free of `limine` and `x86_64` types so its bookkeeping can be
 //! unit-tested on the host.
 
 use super::{Region, FRAME_SIZE};
 
-pub struct BumpFrameAllocator<'a> {
-    regions: &'a [Region],
-    /// Next candidate physical address. Always frame-aligned.
-    cursor: u64,
-    /// Index into `regions` we're currently carving from.
-    region_idx: usize,
+pub struct BitmapFrameAllocator<'a> {
+    /// Bit `i` tracks frame at physical address `i * FRAME_SIZE`.
+    bitmap: &'a mut [u64],
+    /// Number of frames the caller told us to track. Bits in
+    /// `[total_frames, bitmap.len() * 64)` are pinned set.
+    total_frames: usize,
+    /// Lowest frame index that might be free. Maintained as a hint, not
+    /// a guarantee: allocate scans forward from here and wraps once.
+    next_hint: usize,
 }
 
-impl<'a> BumpFrameAllocator<'a> {
-    /// Construct an allocator over the given USABLE regions. Regions
-    /// should be non-overlapping; ordering is not required but starting
-    /// at the lowest `start` gives deterministic output.
-    pub fn new(regions: &'a [Region]) -> Self {
-        let mut me = Self {
-            regions,
-            cursor: 0,
-            region_idx: 0,
-        };
-        me.advance_to_next_region();
+impl<'a> BitmapFrameAllocator<'a> {
+    /// Build an allocator covering `[0, total_frames)` frames. `bitmap`
+    /// must have at least `ceil(total_frames / 64)` words.
+    ///
+    /// All tracked frames start marked used; pass USABLE regions to
+    /// `release_region` (done for you by [`Self::with_regions`]) to mark
+    /// them free. Frames in `[total_frames, bitmap.len() * 64)` stay
+    /// pinned so the scanner never hands them out.
+    pub fn new(bitmap: &'a mut [u64], total_frames: usize) -> Self {
+        assert!(
+            bitmap.len() * 64 >= total_frames,
+            "bitmap too small for {total_frames} frames",
+        );
+        for word in bitmap.iter_mut() {
+            *word = !0u64;
+        }
+        Self {
+            bitmap,
+            total_frames,
+            next_hint: 0,
+        }
+    }
+
+    /// Convenience constructor: mark every frame used, then release the
+    /// frames covered by `regions`.
+    pub fn with_regions(bitmap: &'a mut [u64], total_frames: usize, regions: &[Region]) -> Self {
+        let mut me = Self::new(bitmap, total_frames);
+        for r in regions {
+            me.release_region(*r);
+        }
         me
     }
 
-    fn advance_to_next_region(&mut self) {
-        while self.region_idx < self.regions.len() {
-            let r = &self.regions[self.region_idx];
-            let aligned = align_up(r.start, FRAME_SIZE);
-            if aligned + FRAME_SIZE <= r.start + r.len {
-                self.cursor = aligned;
-                return;
+    /// Mark all frames fully inside `region` as free.
+    pub fn release_region(&mut self, region: Region) {
+        let region_end = region.start.saturating_add(region.len);
+        let start = align_up(region.start, FRAME_SIZE);
+        if start >= region_end || region_end - start < FRAME_SIZE {
+            return;
+        }
+        let mut addr = start;
+        while addr + FRAME_SIZE <= region_end {
+            let idx = (addr / FRAME_SIZE) as usize;
+            if idx < self.total_frames {
+                self.clear_bit(idx);
+                if idx < self.next_hint {
+                    self.next_hint = idx;
+                }
             }
-            self.region_idx += 1;
+            addr += FRAME_SIZE;
         }
     }
 
     /// Allocate one 4 KiB physical frame. Returns the frame's starting
-    /// physical address, or `None` when all regions are exhausted.
+    /// physical address, or `None` if the pool is exhausted.
     pub fn allocate_frame(&mut self) -> Option<u64> {
-        while self.region_idx < self.regions.len() {
-            let region = self.regions[self.region_idx];
-            let end = region.start + region.len;
-            if self.cursor + FRAME_SIZE <= end {
-                let frame = self.cursor;
-                self.cursor += FRAME_SIZE;
-                return Some(frame);
+        let total_words = self.bitmap.len();
+        let start_word = self.next_hint / 64;
+        for offset in 0..total_words {
+            let w = (start_word + offset) % total_words;
+            let word = self.bitmap[w];
+            if word == !0u64 {
+                continue;
             }
-            self.region_idx += 1;
-            self.advance_to_next_region();
+            let bit = (!word).trailing_zeros() as usize;
+            let idx = w * 64 + bit;
+            if idx >= self.total_frames {
+                continue;
+            }
+            self.bitmap[w] |= 1u64 << bit;
+            self.next_hint = idx + 1;
+            return Some((idx as u64) * FRAME_SIZE);
         }
         None
     }
 
-    /// Allocate `count` *contiguous* frames within a single region.
-    /// Used by heap init to carve a big-enough slab in one go.
-    /// Returns the starting physical address.
-    pub fn allocate_contiguous(&mut self, count: u64) -> Option<u64> {
-        let needed = count * FRAME_SIZE;
-        while self.region_idx < self.regions.len() {
-            let region = self.regions[self.region_idx];
-            let end = region.start + region.len;
-            if self.cursor + needed <= end {
-                let start = self.cursor;
-                self.cursor += needed;
-                return Some(start);
-            }
-            self.region_idx += 1;
-            self.advance_to_next_region();
+    /// Return a previously-allocated frame to the pool. Panics on
+    /// double-free or on addresses outside the tracked range.
+    pub fn deallocate_frame(&mut self, phys: u64) {
+        assert!(
+            phys & (FRAME_SIZE - 1) == 0,
+            "deallocate_frame: {phys:#x} is not frame-aligned",
+        );
+        let idx = (phys / FRAME_SIZE) as usize;
+        assert!(
+            idx < self.total_frames,
+            "deallocate_frame: {phys:#x} outside tracked range",
+        );
+        assert!(
+            self.get_bit(idx),
+            "deallocate_frame: double-free of {phys:#x}",
+        );
+        self.clear_bit(idx);
+        if idx < self.next_hint {
+            self.next_hint = idx;
         }
-        None
+    }
+
+    /// Number of currently-free tracked frames.
+    pub fn free_frames(&self) -> usize {
+        let total_bits = self.bitmap.len() * 64;
+        let set_bits: usize = self.bitmap.iter().map(|w| w.count_ones() as usize).sum();
+        let clear_bits = total_bits - set_bits;
+        // `clear_bits` only counts bits in `[0, total_frames)` because
+        // we pin the tail set in `new`. No subtraction needed.
+        debug_assert!(clear_bits <= self.total_frames);
+        clear_bits
+    }
+
+    fn clear_bit(&mut self, idx: usize) {
+        self.bitmap[idx / 64] &= !(1u64 << (idx % 64));
+    }
+
+    fn get_bit(&self, idx: usize) -> bool {
+        (self.bitmap[idx / 64] >> (idx % 64)) & 1 == 1
     }
 }
 
@@ -93,16 +154,21 @@ fn align_up(x: u64, a: u64) -> u64 {
 /// 64 is comfortable headroom for real hardware.
 pub const MAX_REGIONS: usize = 64;
 
+/// Largest physical address we're willing to track in the bitmap. Sized
+/// for 4 GiB of RAM; a higher USABLE region's top panics at init. 4 GiB
+/// → 1 Mi frames → 16384 `u64` words → 128 KiB of `.bss`.
+pub const MAX_PHYS_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+pub const BITMAP_WORDS: usize = (MAX_PHYS_BYTES / FRAME_SIZE / 64) as usize;
+
 #[cfg(target_os = "none")]
 mod global {
-    use super::{BumpFrameAllocator, Region, MAX_REGIONS};
+    use super::{BitmapFrameAllocator, Region, BITMAP_WORDS, MAX_PHYS_BYTES, MAX_REGIONS};
     use crate::boot::MEMMAP_REQUEST;
     use spin::{Mutex, Once};
 
-    /// Snapshot of USABLE regions taken once at boot. The trailing
-    /// `usize` is the number of populated entries.
     static REGIONS: Once<([Region; MAX_REGIONS], usize)> = Once::new();
-    static ALLOCATOR: Once<Mutex<BumpFrameAllocator<'static>>> = Once::new();
+    static mut BITMAP: [u64; BITMAP_WORDS] = [!0u64; BITMAP_WORDS];
+    static ALLOCATOR: Once<Mutex<BitmapFrameAllocator<'static>>> = Once::new();
 
     pub fn init() {
         let memmap = MEMMAP_REQUEST
@@ -112,20 +178,46 @@ mod global {
         let regions = REGIONS.call_once(|| {
             let mut buf = [Region::new(0, 0); MAX_REGIONS];
             let mut n = 0;
+            let mut max_end: u64 = 0;
             for entry in memmap.entries() {
                 if entry.entry_type == limine::memory_map::EntryType::USABLE {
                     assert!(n < MAX_REGIONS, "more USABLE regions than MAX_REGIONS");
                     buf[n] = Region::new(entry.base, entry.length);
                     n += 1;
+                    let end = entry.base.saturating_add(entry.length);
+                    if end > max_end {
+                        max_end = end;
+                    }
                 }
             }
+            assert!(
+                max_end <= MAX_PHYS_BYTES,
+                "USABLE region ends at {:#x}, above MAX_PHYS_BYTES = {:#x}",
+                max_end,
+                MAX_PHYS_BYTES,
+            );
             (buf, n)
         });
         let slice: &'static [Region] = &regions.0[..regions.1];
-        ALLOCATOR.call_once(|| Mutex::new(BumpFrameAllocator::new(slice)));
+
+        // SAFETY: init runs exactly once; we hand the bitmap's unique
+        // &'static mut to the Once-wrapped allocator and never touch the
+        // static again.
+        let bitmap: &'static mut [u64] = unsafe {
+            let ptr = core::ptr::addr_of_mut!(BITMAP) as *mut u64;
+            core::slice::from_raw_parts_mut(ptr, BITMAP_WORDS)
+        };
+        let total_frames = (MAX_PHYS_BYTES / super::FRAME_SIZE) as usize;
+        ALLOCATOR.call_once(|| {
+            Mutex::new(BitmapFrameAllocator::with_regions(
+                bitmap,
+                total_frames,
+                slice,
+            ))
+        });
     }
 
-    pub fn global() -> &'static Mutex<BumpFrameAllocator<'static>> {
+    pub fn global() -> &'static Mutex<BitmapFrameAllocator<'static>> {
         ALLOCATOR.get().expect("frame::init not called")
     }
 }
@@ -137,6 +229,10 @@ pub use global::{global, init};
 mod tests {
     use super::*;
 
+    fn mk(words: usize, total_frames: usize) -> (Vec<u64>, usize) {
+        (vec![!0u64; words], total_frames)
+    }
+
     #[test]
     fn align_up_works() {
         assert_eq!(align_up(0, 4096), 0);
@@ -147,8 +243,9 @@ mod tests {
 
     #[test]
     fn single_region_yields_frames_in_order() {
-        let regions = [Region::new(0x1000, 0x4000)]; // 4 frames
-        let mut a = BumpFrameAllocator::new(&regions);
+        let (mut bm, n) = mk(1, 8);
+        let regions = [Region::new(0x1000, 0x4000)];
+        let mut a = BitmapFrameAllocator::with_regions(&mut bm, n, &regions);
         assert_eq!(a.allocate_frame(), Some(0x1000));
         assert_eq!(a.allocate_frame(), Some(0x2000));
         assert_eq!(a.allocate_frame(), Some(0x3000));
@@ -158,11 +255,12 @@ mod tests {
 
     #[test]
     fn unaligned_region_start_is_rounded_up() {
-        let regions = [Region::new(0x1100, 0x3000)]; // not frame-aligned
-        let mut a = BumpFrameAllocator::new(&regions);
-        // Region spans [0x1100, 0x4100). Aligned start = 0x2000. Only
-        // frames [0x2000, 0x3000) and [0x3000, 0x4000) fit fully; the
-        // next would end at 0x5000, past the region.
+        let (mut bm, n) = mk(1, 8);
+        let regions = [Region::new(0x1100, 0x3000)];
+        let mut a = BitmapFrameAllocator::with_regions(&mut bm, n, &regions);
+        // Region spans [0x1100, 0x4100). Aligned start = 0x2000. Frames
+        // [0x2000, 0x3000) and [0x3000, 0x4000) fit; [0x4000, 0x5000)
+        // would run past the region end.
         assert_eq!(a.allocate_frame(), Some(0x2000));
         assert_eq!(a.allocate_frame(), Some(0x3000));
         assert_eq!(a.allocate_frame(), None);
@@ -170,11 +268,9 @@ mod tests {
 
     #[test]
     fn walks_across_multiple_regions() {
-        let regions = [
-            Region::new(0x1000, 0x2000),  // 2 frames
-            Region::new(0x10000, 0x1000), // 1 frame
-        ];
-        let mut a = BumpFrameAllocator::new(&regions);
+        let (mut bm, n) = mk(4, 64);
+        let regions = [Region::new(0x1000, 0x2000), Region::new(0x10000, 0x1000)];
+        let mut a = BitmapFrameAllocator::with_regions(&mut bm, n, &regions);
         assert_eq!(a.allocate_frame(), Some(0x1000));
         assert_eq!(a.allocate_frame(), Some(0x2000));
         assert_eq!(a.allocate_frame(), Some(0x10000));
@@ -183,32 +279,79 @@ mod tests {
 
     #[test]
     fn region_too_small_is_skipped() {
-        // 0x800 < one frame: region contributes nothing.
+        let (mut bm, n) = mk(4, 64);
         let regions = [Region::new(0x1000, 0x800), Region::new(0x10000, 0x1000)];
-        let mut a = BumpFrameAllocator::new(&regions);
+        let mut a = BitmapFrameAllocator::with_regions(&mut bm, n, &regions);
         assert_eq!(a.allocate_frame(), Some(0x10000));
         assert_eq!(a.allocate_frame(), None);
     }
 
     #[test]
-    fn allocate_contiguous_stays_within_a_region() {
-        let regions = [
-            Region::new(0x1000, 0x2000),   // 2 frames — too small
-            Region::new(0x10000, 0x10000), // 16 frames
-        ];
-        let mut a = BumpFrameAllocator::new(&regions);
-        // 4 frames needed; region 0 can't fit → must come from region 1.
-        assert_eq!(a.allocate_contiguous(4), Some(0x10000));
-        // Subsequent single-frame allocs continue inside region 1.
-        assert_eq!(a.allocate_frame(), Some(0x14000));
-    }
-
-    #[test]
     fn exhaustion_is_sticky() {
+        let (mut bm, n) = mk(1, 2);
         let regions = [Region::new(0x1000, 0x1000)];
-        let mut a = BumpFrameAllocator::new(&regions);
+        let mut a = BitmapFrameAllocator::with_regions(&mut bm, n, &regions);
         assert!(a.allocate_frame().is_some());
         assert_eq!(a.allocate_frame(), None);
         assert_eq!(a.allocate_frame(), None);
+    }
+
+    #[test]
+    fn dealloc_returns_frame_to_pool() {
+        let (mut bm, n) = mk(1, 8);
+        let regions = [Region::new(0x0, 0x4000)];
+        let mut a = BitmapFrameAllocator::with_regions(&mut bm, n, &regions);
+        let f0 = a.allocate_frame().unwrap();
+        let f1 = a.allocate_frame().unwrap();
+        let f2 = a.allocate_frame().unwrap();
+        assert_eq!(a.free_frames(), 1);
+        a.deallocate_frame(f1);
+        assert_eq!(a.free_frames(), 2);
+        // Hint moved back to f1 — next alloc should pick it up.
+        assert_eq!(a.allocate_frame(), Some(f1));
+        a.deallocate_frame(f0);
+        a.deallocate_frame(f2);
+    }
+
+    #[test]
+    fn map_unmap_loop_returns_free_frames_to_baseline() {
+        let (mut bm, n) = mk(2, 64);
+        let regions = [Region::new(0x0, 64 * 4096)];
+        let mut a = BitmapFrameAllocator::with_regions(&mut bm, n, &regions);
+        let baseline = a.free_frames();
+        for _ in 0..1000 {
+            let f = a.allocate_frame().unwrap();
+            a.deallocate_frame(f);
+        }
+        assert_eq!(a.free_frames(), baseline);
+    }
+
+    #[test]
+    fn free_frames_counts_only_tracked_bits() {
+        // Bitmap has 128 bits of storage but we only track 10.
+        let (mut bm, n) = mk(2, 10);
+        let regions = [Region::new(0x0, 10 * 4096)];
+        let a = BitmapFrameAllocator::with_regions(&mut bm, n, &regions);
+        assert_eq!(a.free_frames(), 10);
+    }
+
+    #[test]
+    #[should_panic(expected = "double-free")]
+    fn double_free_panics() {
+        let (mut bm, n) = mk(1, 4);
+        let regions = [Region::new(0x0, 0x4000)];
+        let mut a = BitmapFrameAllocator::with_regions(&mut bm, n, &regions);
+        let f = a.allocate_frame().unwrap();
+        a.deallocate_frame(f);
+        a.deallocate_frame(f);
+    }
+
+    #[test]
+    #[should_panic(expected = "outside tracked range")]
+    fn dealloc_out_of_range_panics() {
+        let (mut bm, n) = mk(1, 4);
+        let regions = [Region::new(0x0, 0x4000)];
+        let mut a = BitmapFrameAllocator::with_regions(&mut bm, n, &regions);
+        a.deallocate_frame(0x10000);
     }
 }

--- a/kernel/src/mem/mod.rs
+++ b/kernel/src/mem/mod.rs
@@ -1,9 +1,10 @@
 //! Physical-frame allocator, kernel heap, and paging.
 //!
-//!  - `frame::BumpFrameAllocator` bumps through Limine's USABLE regions.
-//!    Pure logic, no `limine`/`x86_64` dependencies → host-testable.
-//!    A global instance is installed by `frame::init` and shared by
-//!    the heap and the paging layer.
+//!  - `frame::BitmapFrameAllocator` tracks one bit per 4 KiB frame over
+//!    Limine's USABLE regions and reclaims frames on `deallocate_frame`.
+//!    Pure logic, no `limine`/`x86_64` dependencies → host-testable. A
+//!    global instance is installed by `frame::init` and shared by the
+//!    heap and the paging layer.
 //!  - `heap` pulls one contiguous 1 MiB slice of frames from the global
 //!    allocator and hands it to `linked_list_allocator::LockedHeap`.
 //!  - `paging` wraps Limine's active PML4 in an `OffsetPageTable` so

--- a/kernel/src/mem/paging.rs
+++ b/kernel/src/mem/paging.rs
@@ -22,9 +22,11 @@ use x86_64::{PhysAddr, VirtAddr};
 use super::frame;
 use crate::serial_println;
 
-/// Frame allocator adapter: pulls 4 KiB frames from the global
-/// `BumpFrameAllocator`. Zero-sized; construct ad-hoc wherever you need
-/// to hand the mapper a `FrameAllocator`.
+/// Frame allocator adapter: pulls 4 KiB frames from (and, via
+/// [`FrameDeallocator`], returns them to) the global
+/// [`BitmapFrameAllocator`](frame::BitmapFrameAllocator). Zero-sized;
+/// construct ad-hoc wherever you need to hand the mapper a
+/// `FrameAllocator`.
 pub struct KernelFrameAllocator;
 
 unsafe impl FrameAllocator<Size4KiB> for KernelFrameAllocator {

--- a/kernel/src/mem/paging.rs
+++ b/kernel/src/mem/paging.rs
@@ -13,8 +13,8 @@ use spin::{Mutex, Once};
 use x86_64::registers::control::Cr3;
 use x86_64::structures::paging::mapper::{MapToError, TranslateResult, UnmapError};
 use x86_64::structures::paging::{
-    FrameAllocator, Mapper, OffsetPageTable, Page, PageTable, PageTableFlags, PhysFrame, Size4KiB,
-    Translate,
+    FrameAllocator, FrameDeallocator, Mapper, OffsetPageTable, Page, PageTable, PageTableFlags,
+    PhysFrame, Size4KiB, Translate,
 };
 use x86_64::{PhysAddr, VirtAddr};
 
@@ -30,6 +30,14 @@ unsafe impl FrameAllocator<Size4KiB> for KernelFrameAllocator {
     fn allocate_frame(&mut self) -> Option<PhysFrame<Size4KiB>> {
         let phys = frame::global().lock().allocate_frame()?;
         Some(PhysFrame::containing_address(PhysAddr::new(phys)))
+    }
+}
+
+impl FrameDeallocator<Size4KiB> for KernelFrameAllocator {
+    unsafe fn deallocate_frame(&mut self, frame: PhysFrame<Size4KiB>) {
+        frame::global()
+            .lock()
+            .deallocate_frame(frame.start_address().as_u64());
     }
 }
 
@@ -142,14 +150,28 @@ pub fn map_phys_into_hhdm(
     })
 }
 
-/// Unmap `page` and flush the TLB. The backing frame is leaked — we
-/// don't have a reclaiming frame allocator yet.
+/// Unmap `page` and flush the TLB. Returns the physical frame the page
+/// was backed by. The caller owns that frame from here on — either
+/// return it to the global allocator with [`unmap_and_free`], or hold
+/// on to it (e.g. when unmapping a physical region the allocator never
+/// owned, like the IST guard page which lives in `.bss`).
 pub fn unmap(page: Page<Size4KiB>) -> Result<PhysFrame<Size4KiB>, UnmapError> {
     with_mapper(|m| {
         let (frame, flush) = m.unmap(page)?;
         flush.flush();
         Ok(frame)
     })
+}
+
+/// Unmap `page` and return its backing frame to the global frame
+/// allocator. Use this for mappings whose frame originally came from
+/// [`map`] / [`map_range`].
+pub fn unmap_and_free(page: Page<Size4KiB>) -> Result<(), UnmapError> {
+    let frame = unmap(page)?;
+    // SAFETY: the caller's contract is that `page`'s frame came from
+    // the global allocator — `map` is the only supported producer.
+    unsafe { KernelFrameAllocator.deallocate_frame(frame) };
+    Ok(())
 }
 
 /// Translate a virtual address to its backing physical address, if any.

--- a/kernel/tests/paging.rs
+++ b/kernel/tests/paging.rs
@@ -27,8 +27,13 @@ fn panic(info: &PanicInfo) -> ! {
 }
 
 fn run_tests() {
-    let tests: &[(&str, &dyn Testable)] =
-        &[("map_roundtrip_unmap", &(map_roundtrip_unmap as fn()))];
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("map_roundtrip_unmap", &(map_roundtrip_unmap as fn())),
+        (
+            "map_unmap_loop_reclaims",
+            &(map_unmap_loop_reclaims as fn()),
+        ),
+    ];
     serial_println!("running {} tests", tests.len());
     for (name, t) in tests {
         serial_println!("test {name}");
@@ -64,9 +69,40 @@ fn map_roundtrip_unmap() {
         assert_eq!(ptr.read_volatile(), 0xCAFE_F00D_DEAD_BEEF);
     }
 
-    paging::unmap(page).expect("unmap failed");
+    paging::unmap_and_free(page).expect("unmap failed");
     assert!(
         paging::translate(va).is_none(),
         "translate after unmap still returned Some"
+    );
+}
+
+/// Map / unmap in a loop and assert the free-frame count returns to
+/// baseline — guards against the bump-allocator regression where every
+/// unmap leaked a frame.
+fn map_unmap_loop_reclaims() {
+    use vibix::mem::{frame, paging};
+
+    let va = VirtAddr::new(0xFFFF_C000_BEEF_0000);
+    let page: Page<Size4KiB> = Page::from_start_address(va).unwrap();
+    let flags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE;
+
+    // First map/unmap lazily allocates intermediate page-table frames
+    // (PDPT/PD/PT) that stay populated across subsequent iterations.
+    // Take the baseline *after* that one-time cost so we measure pure
+    // leaf-frame accounting over the loop below.
+    paging::map(page, flags).expect("warm-up map");
+    paging::unmap_and_free(page).expect("warm-up unmap");
+
+    let baseline = frame::global().lock().free_frames();
+
+    for _ in 0..64 {
+        paging::map(page, flags).expect("map failed in loop");
+        paging::unmap_and_free(page).expect("unmap failed in loop");
+    }
+
+    let after = frame::global().lock().free_frames();
+    assert_eq!(
+        after, baseline,
+        "frame accounting drifted: {baseline} → {after}"
     );
 }


### PR DESCRIPTION
## Summary
- Replace the one-way `BumpFrameAllocator` with a `BitmapFrameAllocator` — one bit per 4 KiB frame, 128 KiB static bitmap sized for up to 4 GiB of RAM, scans with a `next_hint` for amortized cheap allocate and O(1) deallocate.
- Teach `paging::KernelFrameAllocator` to `FrameDeallocator<Size4KiB>` and add `paging::unmap_and_free` as the "unmap and return the frame to the pool" path. Plain `unmap` still returns the frame without deallocating so the IST guard (which backs `.bss`, not allocator memory) stays sound.
- Host tests cover dealloc, reuse, tight loops, double-free and out-of-range panics, and tracked-bit counting.
- New in-kernel integration test `map_unmap_loop_reclaims` catches the exact regression the bump allocator had — maps/unmaps 64× at a fixed VA and asserts the free-frame count returns to baseline after a one-iteration warm-up (for lazily-allocated intermediate page-table frames).

Unblocks #12 (owning our own PML4 + freeing Limine's), #46 (reclaiming `BOOTLOADER_RECLAIMABLE`), and any future path that wants heap shrink.

Closes #13.

## Test plan
- [x] `cargo test -p vibix --lib` — 16/16 passing, including 5 new bitmap tests
- [x] `cargo xtask test` — all in-kernel integration tests pass, including the new `map_unmap_loop_reclaims`
- [x] `cargo xtask smoke` — all 15 serial markers present
- [x] `cargo fmt --all --check` and `cargo clippy -p xtask --all-targets -- -D warnings` clean