### PR TITLE
#50: map the framebuffer with PAT=WC

### DIFF
--- a/kernel/src/mem/mod.rs
+++ b/kernel/src/mem/mod.rs
@@ -16,6 +16,8 @@ pub mod frame;
 pub mod heap;
 #[cfg(target_os = "none")]
 pub mod paging;
+#[cfg(target_os = "none")]
+pub mod pat;
 
 /// 4 KiB. The only page size we care about right now.
 pub const FRAME_SIZE: u64 = 4096;
@@ -40,6 +42,10 @@ impl Region {
 #[cfg(target_os = "none")]
 pub fn init() {
     frame::init();
+
+    // Reprogram PAT before we build any PTE that sets the PAT bit.
+    // Today that's just the framebuffer WC mapping in the new PML4.
+    pat::init();
 
     // Paging comes up before the heap now — `heap::init` maps its
     // initial slab through `paging::map_range` instead of carving

--- a/kernel/src/mem/paging.rs
+++ b/kernel/src/mem/paging.rs
@@ -533,7 +533,10 @@ unsafe fn set_pat_bit_4k(
             !entry.flags().contains(PageTableFlags::HUGE_PAGE),
             "set_pat_bit_4k: walked into a huge-page parent"
         );
-        let phys = entry.frame().expect("set_pat_bit_4k: missing table").start_address();
+        let phys = entry
+            .frame()
+            .expect("set_pat_bit_4k: missing table")
+            .start_address();
         let virt = hhdm + phys.as_u64();
         // SAFETY: page-table frames reached via HHDM, exclusive access
         // granted by the caller's `&mut OffsetPageTable`.

--- a/kernel/src/mem/paging.rs
+++ b/kernel/src/mem/paging.rs
@@ -6,9 +6,10 @@
 //! those are in place, [`build_and_switch_kernel_pml4`] constructs a
 //! clean tree that maps only what the kernel actually needs — kernel
 //! image per section with tight flags, HHDM via 2 MiB pages, heap, IST
-//! stack sans guard, framebuffer — and swaps CR3 to it. From that point
-//! on Limine's original tree is unreachable; actually freeing it (and
-//! the `BOOTLOADER_RECLAIMABLE` frames) is issue #46.
+//! stack sans guard, framebuffer (4 KiB PTEs with PAT=WC) — and swaps
+//! CR3 to it. From that point on Limine's original tree is unreachable;
+//! actually freeing it (and the `BOOTLOADER_RECLAIMABLE` frames) is
+//! issue #46.
 
 use spin::Mutex;
 use x86_64::registers::control::Cr3;
@@ -228,18 +229,24 @@ pub fn build_and_switch_kernel_pml4() {
         clone_heap(&mut new_mapper, &mut alloc);
         clone_ist_stack(&mut new_mapper, &mut alloc);
         clone_boot_stack(&mut new_mapper, &mut alloc);
-        map_framebuffer(&mut new_mapper, &mut alloc);
+        map_framebuffer(&mut new_mapper, hhdm, &mut alloc);
     }
 
     // Atomic swap. IRQs off so no handler runs while CR3 and MAPPER
     // are in a mid-transition state. TLB is wholly flushed by the CR3
-    // load.
+    // load; WBINVD then drops any WB-cached lines (notably framebuffer
+    // pixels written through Limine's WB HHDM mapping) so that the new
+    // WC framebuffer mapping isn't silently clobbered by stale cache
+    // evictions.
     x86_64::instructions::interrupts::without_interrupts(|| {
         let (_old, flags) = Cr3::read();
         unsafe { Cr3::write(new_pml4_frame, flags) };
         let l4 = unsafe { pml4_as_mut(new_pml4_frame, hhdm) };
         let mapper = unsafe { OffsetPageTable::new(l4, hhdm) };
         *MAPPER.lock() = Some(mapper);
+        // SAFETY: WBINVD is serializing and has no operands. Safe to
+        // issue in kernel mode with IRQs off.
+        unsafe { core::arch::asm!("wbinvd", options(nostack, preserves_flags)) };
     });
 
     serial_println!("paging: switched to kernel PML4");
@@ -298,9 +305,12 @@ fn populate_hhdm(
             EntryType::USABLE
             | EntryType::BOOTLOADER_RECLAIMABLE
             | EntryType::EXECUTABLE_AND_MODULES
-            | EntryType::FRAMEBUFFER
             | EntryType::ACPI_RECLAIMABLE
             | EntryType::ACPI_NVS => {}
+            // FRAMEBUFFER is intentionally excluded: it gets its own
+            // 4 KiB PTEs with PAT=WC installed by `map_framebuffer`.
+            // A 2 MiB HHDM huge page here would force WB cacheability
+            // on the same virtual range and defeat the point.
             _ => continue,
         }
         let start = entry.base & !(TWO_MIB - 1);
@@ -452,11 +462,93 @@ fn clone_boot_stack(mapper: &mut OffsetPageTable<'static>, alloc: &mut KernelFra
     clone_range(mapper, alloc, base, top, flags);
 }
 
-fn map_framebuffer(mapper: &mut OffsetPageTable<'static>, alloc: &mut KernelFrameAllocator) {
-    // The framebuffer lives inside HHDM (Limine maps it there), and
-    // HHDM already covers every memory-map entry including
-    // `EntryType::FRAMEBUFFER`. Nothing to do beyond HHDM. Kept as a
-    // seam for later — direct non-HHDM framebuffer mapping (e.g. with
-    // write-combining) is a follow-up.
-    let _ = (mapper, alloc);
+/// Install the linear framebuffer at its HHDM VA with 4 KiB PTEs that
+/// select the WC slot we programmed in `pat::init`. `populate_hhdm`
+/// deliberately leaves FRAMEBUFFER memory-map entries uncovered so we
+/// can own those virtual pages here with the right memory type.
+fn map_framebuffer(
+    mapper: &mut OffsetPageTable<'static>,
+    hhdm: VirtAddr,
+    alloc: &mut KernelFrameAllocator,
+) {
+    use limine::memory_map::EntryType;
+
+    let memmap = crate::boot::MEMMAP_REQUEST
+        .get_response()
+        .expect("Limine memory-map response missing");
+
+    let flags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE;
+
+    for entry in memmap.entries() {
+        if entry.entry_type != EntryType::FRAMEBUFFER {
+            continue;
+        }
+        assert!(
+            entry.base & 0xFFF == 0 && entry.length & 0xFFF == 0,
+            "framebuffer range not 4 KiB-aligned: base={:#x} len={:#x}",
+            entry.base,
+            entry.length
+        );
+        let mut phys = entry.base;
+        let end = entry.base + entry.length;
+        while phys < end {
+            let page = Page::<Size4KiB>::containing_address(hhdm + phys);
+            let frame = PhysFrame::<Size4KiB>::containing_address(PhysAddr::new(phys));
+            // SAFETY: fresh tree, not yet live. FRAMEBUFFER memory-map
+            // entries are carved out of HHDM coverage above, so no
+            // existing 2 MiB page straddles this range.
+            match unsafe { mapper.map_to(page, frame, flags, alloc) } {
+                Ok(f) => f.ignore(),
+                Err(e) => panic!("framebuffer WC map {:#x} failed: {:?}", phys, e),
+            }
+            // SAFETY: the mapping we just installed is the only
+            // reference to this PTE; OR-ing the PAT bit flips memory
+            // type from default (WB, slot 0) to WC (slot 4).
+            unsafe { set_pat_bit_4k(mapper, hhdm, page) };
+            phys += 4096;
+        }
+    }
+}
+
+/// OR the PAT bit (bit 7) onto the L1 entry backing `page` in
+/// `mapper`'s tree. Walks L4→L3→L2→L1 through the HHDM window.
+///
+/// # Safety
+/// `mapper`'s tree must be a well-formed 4-level tree reachable via
+/// `hhdm`, and `page` must already be mapped via 4 KiB PTEs (the walk
+/// panics on a huge-page parent, which would mean a broken invariant
+/// upstream in `populate_hhdm` — not a recoverable error).
+unsafe fn set_pat_bit_4k(
+    mapper: &mut OffsetPageTable<'static>,
+    hhdm: VirtAddr,
+    page: Page<Size4KiB>,
+) {
+    fn next_table<'a>(
+        parent: &PageTable,
+        index: x86_64::structures::paging::page_table::PageTableIndex,
+        hhdm: VirtAddr,
+    ) -> &'a mut PageTable {
+        let entry = &parent[index];
+        assert!(
+            !entry.flags().contains(PageTableFlags::HUGE_PAGE),
+            "set_pat_bit_4k: walked into a huge-page parent"
+        );
+        let phys = entry.frame().expect("set_pat_bit_4k: missing table").start_address();
+        let virt = hhdm + phys.as_u64();
+        // SAFETY: page-table frames reached via HHDM, exclusive access
+        // granted by the caller's `&mut OffsetPageTable`.
+        unsafe { &mut *(virt.as_mut_ptr::<PageTable>()) }
+    }
+
+    let l4 = mapper.level_4_table();
+    let l3 = next_table(l4, page.p4_index(), hhdm);
+    let l2 = next_table(l3, page.p3_index(), hhdm);
+    let l1 = next_table(l2, page.p2_index(), hhdm);
+    let entry = &mut l1[page.p1_index()];
+    let ptr = entry as *mut _ as *mut u64;
+    // SAFETY: `entry` is a live &mut reference; writing through its raw
+    // pointer is fine and avoids the `x86_64` crate's flag validation.
+    unsafe {
+        ptr.write_volatile(ptr.read_volatile() | super::pat::PAT_BIT_4K);
+    }
 }

--- a/kernel/src/mem/paging.rs
+++ b/kernel/src/mem/paging.rs
@@ -523,8 +523,13 @@ unsafe fn set_pat_bit_4k(
     hhdm: VirtAddr,
     page: Page<Size4KiB>,
 ) {
-    fn next_table<'a>(
-        parent: &PageTable,
+    // SAFETY: the returned `&mut PageTable` aliases an HHDM view of a
+    // distinct physical frame (the child table), never `parent` itself,
+    // so no `&mut` overlap is created. Tying `'a` to `parent` keeps the
+    // borrow relationship explicit; taking `&'a mut` anchors the
+    // reborrow chain from the root `level_4_table()` down.
+    unsafe fn next_table<'a>(
+        parent: &'a mut PageTable,
         index: x86_64::structures::paging::page_table::PageTableIndex,
         hhdm: VirtAddr,
     ) -> &'a mut PageTable {
@@ -543,10 +548,13 @@ unsafe fn set_pat_bit_4k(
         unsafe { &mut *(virt.as_mut_ptr::<PageTable>()) }
     }
 
-    let l4 = mapper.level_4_table();
-    let l3 = next_table(l4, page.p4_index(), hhdm);
-    let l2 = next_table(l3, page.p3_index(), hhdm);
-    let l1 = next_table(l2, page.p2_index(), hhdm);
+    let l4 = mapper.level_4_table_mut();
+    // SAFETY: `next_table` is unsafe by signature (raw pointer deref into
+    // HHDM). Each call walks to a distinct child table frame, so the
+    // &'a mut reborrow chain doesn't alias.
+    let l3 = unsafe { next_table(l4, page.p4_index(), hhdm) };
+    let l2 = unsafe { next_table(l3, page.p3_index(), hhdm) };
+    let l1 = unsafe { next_table(l2, page.p2_index(), hhdm) };
     let entry = &mut l1[page.p1_index()];
     let ptr = entry as *mut _ as *mut u64;
     // SAFETY: `entry` is a live &mut reference; writing through its raw

--- a/kernel/src/mem/pat.rs
+++ b/kernel/src/mem/pat.rs
@@ -1,0 +1,46 @@
+//! Program the IA32_PAT MSR so one slot maps to Write-Combining.
+//!
+//! Default PAT (slots 0..7): WB, WT, UC-, UC, WB, WT, UC-, UC. The low
+//! four slots are the ones selected by PTEs with PAT=0, and we leave
+//! them alone so every existing mapping keeps its default memory type.
+//! We repurpose slot 4 (selected by PAT=1, PCD=0, PWT=0) from WB to WC
+//! so the kernel can mark MMIO pages — currently just the linear
+//! framebuffer — as write-combining for burst-friendly writes.
+//!
+//! Reprogramming PAT *before* any PTE sets the PAT bit means we don't
+//! have to do the SDM "disable caching, flush, switch, re-enable" dance
+//! — no live mapping changes memory type as a side effect of the MSR
+//! write. Stale WB cache lines for the framebuffer (populated by writes
+//! through the old Limine WB mapping) are flushed later, around the CR3
+//! swap, via WBINVD.
+
+use x86_64::registers::model_specific::Msr;
+
+const IA32_PAT: u32 = 0x277;
+
+// Memory type encodings, Intel SDM Vol 3, Table 11-10.
+const WB: u64 = 0x06;
+const WT: u64 = 0x04;
+const UC_MINUS: u64 = 0x07;
+const UC: u64 = 0x00;
+const WC: u64 = 0x01;
+
+/// Raw bit position of the PAT flag in a 4 KiB PTE (bit 7). At L2/L3
+/// this same bit is PS (page-size); the `x86_64` crate's `map_to`
+/// asserts it's clear at L1, so callers install a normal mapping first
+/// and then OR this bit onto the raw PTE by hand.
+pub const PAT_BIT_4K: u64 = 1 << 7;
+
+/// Reprogram IA32_PAT so slot 4 = WC. Must run on every CPU that will
+/// use WC mappings; today that's just the BSP.
+pub fn init() {
+    let pat = WB | (WT << 8) | (UC_MINUS << 16) | (UC << 24)
+        | (WC << 32) | (WT << 40) | (UC_MINUS << 48) | (UC << 56);
+
+    // SAFETY: writing architecturally defined memory-type encodings to
+    // IA32_PAT. No existing PTE sets the PAT bit, so slot 4's change
+    // from WB to WC doesn't retroactively alter any live mapping.
+    unsafe {
+        Msr::new(IA32_PAT).write(pat);
+    }
+}

--- a/kernel/src/mem/pat.rs
+++ b/kernel/src/mem/pat.rs
@@ -34,8 +34,14 @@ pub const PAT_BIT_4K: u64 = 1 << 7;
 /// Reprogram IA32_PAT so slot 4 = WC. Must run on every CPU that will
 /// use WC mappings; today that's just the BSP.
 pub fn init() {
-    let pat = WB | (WT << 8) | (UC_MINUS << 16) | (UC << 24)
-        | (WC << 32) | (WT << 40) | (UC_MINUS << 48) | (UC << 56);
+    let pat = WB
+        | (WT << 8)
+        | (UC_MINUS << 16)
+        | (UC << 24)
+        | (WC << 32)
+        | (WT << 40)
+        | (UC_MINUS << 48)
+        | (UC << 56);
 
     // SAFETY: writing architecturally defined memory-type encodings to
     // IA32_PAT. No existing PTE sets the PAT bit, so slot 4's change


### PR DESCRIPTION
## Summary
- Reprogram `IA32_PAT` slot 4 from WB to WC in new `mem::pat`. Slots 0..3 stay default, so every mapping without the PAT bit keeps WB semantics.
- Exclude `EntryType::FRAMEBUFFER` from the 2 MiB HHDM coverage in `populate_hhdm` so no huge page straddles the FB range with the wrong memory type.
- `map_framebuffer` installs 4 KiB PTEs at the FB's HHDM VA and ORs the raw PAT bit onto each L1 entry (the `x86_64` crate's `map_to` asserts `HUGE_PAGE`/PAT is clear at L1, so the bit has to be set by hand via the page-walk).
- WBINVD right after the CR3 write in `build_and_switch_kernel_pml4` drops any WB-cached framebuffer lines populated through Limine's old WB mapping, so later evictions can't clobber WC stores.

Out of scope: the optional timing smoke test mentioned in the issue — hard to land as a deterministic regression check; happy to revisit once we have more visible drawing than boot messages.

Closes #50

## Test plan
- [x] `cargo xtask build`
- [x] `cargo xtask test` — all host unit + QEMU integration tests pass
- [x] `cargo xtask smoke` — 16/16 markers present
- [ ] Visual boot check on real hardware to confirm framebuffer still paints correctly (QEMU already exercises the code path)
