### PR TITLE
#39: panic backtrace via frame pointers + embedded symbol table

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,6 +10,10 @@ rustflags = [
   "-C", "relocation-model=static",
   "-C", "code-model=kernel",
   "-C", "no-redzone=yes",
+  # The rbp-walking backtrace depends on every non-leaf having the
+  # canonical `push rbp; mov rbp, rsp` prologue; without this LLVM
+  # freely omits it in release builds and the walker dereferences junk.
+  "-C", "force-frame-pointers=yes",
 ]
 # `cargo test` for this target hands each compiled test binary to xtask,
 # which wraps it in an ISO and boots it under QEMU.

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -27,6 +27,9 @@ pc-keyboard = "0.8"
 default = []
 # Enable to trigger a UD2 after init; verifies the invalid-opcode handler path.
 fault-test = []
+# Enable to fire a deliberate `panic!()` after init; useful for eyeballing
+# the panic-path backtrace end-to-end on a real boot.
+panic-test = []
 # Enable to deliberately overflow the #DF IST stack after init; verifies
 # that the guard page below the stack catches overflow as a #PF instead
 # of letting it silently corrupt .bss. Manual verification only —

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -68,3 +68,7 @@ harness = false
 [[test]]
 name = "apic_online"
 harness = false
+
+[[test]]
+name = "backtrace"
+harness = false

--- a/kernel/linker.ld
+++ b/kernel/linker.ld
@@ -51,6 +51,15 @@ SECTIONS
         *(.dynamic)
     } :data :dynamic
 
+    /*
+     * The 256 KiB ksymtab reservation lives as a plain static in
+     * `.rodata` — no custom output section. Giving it its own output
+     * section tripped rust-lld into merging `.data`/`.bss` into the
+     * read-only rodata PT_LOAD, leaving writable globals mapped RO.
+     * xtask locates the reservation by symbol address and patches it
+     * post-link; DWARF debug sections are stripped at the same step so
+     * they don't bloat the rodata PHDR's MemSiz into a 2 GiB wrap.
+     */
     /DISCARD/ : {
         *(.eh_frame*)
         *(.note .note.*)

--- a/kernel/src/arch/mod.rs
+++ b/kernel/src/arch/mod.rs
@@ -2,4 +2,6 @@
 pub mod x86_64;
 
 #[cfg(target_arch = "x86_64")]
+pub use x86_64::backtrace;
+#[cfg(target_arch = "x86_64")]
 pub use x86_64::{init, init_apic};

--- a/kernel/src/arch/x86_64/backtrace.rs
+++ b/kernel/src/arch/x86_64/backtrace.rs
@@ -1,0 +1,115 @@
+//! Frame-pointer-based stack unwinder.
+//!
+//! The kernel is built with `-Cforce-frame-pointers=yes`, so every
+//! non-leaf function emits the canonical System V prologue
+//! (`push rbp; mov rbp, rsp`). Each activation record then looks like:
+//!
+//! ```text
+//!     [rbp + 0]   saved rbp of the caller
+//!     [rbp + 8]   return address into the caller
+//! ```
+//!
+//! Walking `rbp` by reading the saved `rbp` at offset 0 gives us the
+//! entire chain of activations up to the first caller with no saved
+//! frame (`rbp == 0`) or to whatever kernel entry point first set up a
+//! stack. The return address at offset 8 identifies the call site.
+
+use core::arch::asm;
+
+/// Captured return address from one frame of the walk.
+#[derive(Clone, Copy)]
+pub struct Frame {
+    pub return_addr: u64,
+}
+
+/// Hard ceiling on frames walked. Protects against a corrupt chain
+/// pointing back at itself, and keeps panic output bounded.
+pub const MAX_FRAMES: usize = 32;
+
+/// Walk the caller's stack frames, invoking `f(Frame)` for each return
+/// address found, oldest-to-newest suppressed — this prints
+/// newest-to-oldest, i.e. the immediate caller first.
+///
+/// Skips the first `skip` frames (useful for hiding the walker +
+/// panic-handler frames so the user sees their own code first).
+#[inline(never)]
+pub fn walk<F: FnMut(Frame)>(skip: usize, mut f: F) {
+    let mut rbp: u64;
+    unsafe {
+        asm!("mov {}, rbp", out(reg) rbp, options(nomem, nostack, preserves_flags));
+    }
+    let mut emitted = 0usize;
+    let mut skipped = 0usize;
+    while emitted < MAX_FRAMES {
+        if !is_valid_rbp(rbp) {
+            break;
+        }
+        // SAFETY: is_valid_rbp checked canonicality + alignment.
+        let saved_rbp = unsafe { core::ptr::read_volatile(rbp as *const u64) };
+        let ret_addr = unsafe { core::ptr::read_volatile((rbp as *const u64).add(1)) };
+        if ret_addr == 0 {
+            break;
+        }
+        if skipped < skip {
+            skipped += 1;
+        } else {
+            f(Frame {
+                return_addr: ret_addr,
+            });
+            emitted += 1;
+        }
+        // A well-formed chain grows upward toward the stack base; if
+        // the saved rbp isn't strictly greater, treat the chain as
+        // corrupt and stop rather than loop forever.
+        if saved_rbp <= rbp {
+            break;
+        }
+        rbp = saved_rbp;
+    }
+}
+
+/// Basic sanity gate: upper-half canonical address, 8-byte aligned.
+/// A bad `rbp` (raw pointer from a clobbered stack) is the most likely
+/// failure mode and this keeps us from dereferencing garbage.
+fn is_valid_rbp(rbp: u64) -> bool {
+    rbp != 0 && rbp & 0b111 == 0 && rbp >= 0xffff_8000_0000_0000
+}
+
+/// Dump the caller's backtrace to COM1, one frame per line, preceded
+/// by a `backtrace:` marker so log scrapers can find it. Safe to call
+/// from the panic handler.
+///
+/// `skip` hides the walker + caller frames — callers typically pass
+/// 1 (skip the call to `dump_to_serial` itself).
+#[inline(never)]
+pub fn dump_to_serial(skip: usize) {
+    use core::fmt::Write;
+    crate::serial_println!("backtrace:");
+
+    struct SerialSink;
+    impl Write for SerialSink {
+        fn write_str(&mut self, s: &str) -> core::fmt::Result {
+            crate::serial::_print(format_args!("{}", s));
+            Ok(())
+        }
+    }
+
+    let mut idx = 0usize;
+    walk(skip + 1, |frame| {
+        let _ = write!(SerialSink, "  #{idx:<2} ");
+        let _ = crate::ksymtab::format_addr(&mut SerialSink, frame.return_addr);
+        let _ = SerialSink.write_str("\n");
+        idx += 1;
+    });
+    if idx == 0 {
+        crate::serial_println!("  <no frames — frame pointers missing or stack corrupt>");
+    }
+}
+
+/// Print a backtrace from the call site. Handy for ad-hoc debugging.
+#[macro_export]
+macro_rules! kbacktrace {
+    () => {
+        $crate::arch::backtrace::dump_to_serial(1)
+    };
+}

--- a/kernel/src/arch/x86_64/backtrace.rs
+++ b/kernel/src/arch/x86_64/backtrace.rs
@@ -40,7 +40,10 @@ pub fn walk<F: FnMut(Frame)>(skip: usize, mut f: F) {
     }
     let mut emitted = 0usize;
     let mut skipped = 0usize;
-    while emitted < MAX_FRAMES {
+    // Cap on total frames *visited* (emitted + skipped). Bounding only
+    // emitted would let a large `skip` let us walk arbitrarily far into
+    // a corrupt chain.
+    while emitted + skipped < MAX_FRAMES {
         if !is_valid_rbp(rbp) {
             break;
         }

--- a/kernel/src/arch/x86_64/mod.rs
+++ b/kernel/src/arch/x86_64/mod.rs
@@ -1,4 +1,5 @@
 pub mod apic;
+pub mod backtrace;
 pub mod gdt;
 pub mod idt;
 pub mod interrupts;

--- a/kernel/src/ksymtab.rs
+++ b/kernel/src/ksymtab.rs
@@ -76,6 +76,13 @@ struct Entry {
     name_len: u32,
 }
 
+// Pin the on-wire layout. xtask hardcodes matching `HEADER_SIZE` /
+// `ENTRY_SIZE` constants when building the blob; if either struct
+// changes, this assert fires and whoever edited it has to update
+// xtask in lockstep.
+const _: () = assert!(size_of::<Header>() == 20);
+const _: () = assert!(size_of::<Entry>() == 16);
+
 /// Pointer to the start of the reservation's bytes. Routed through a
 /// volatile read of a self-referential constant to defeat rustc's
 /// const-folding: without this, LLVM sees `KSYMTAB_RESERVATION`'s

--- a/kernel/src/ksymtab.rs
+++ b/kernel/src/ksymtab.rs
@@ -1,0 +1,191 @@
+//! Kernel symbol table embedded in the final ELF.
+//!
+//! The kernel reserves a fixed-size `.ksymtab` section (zero-filled by
+//! the linker). After the normal cargo build finishes, `xtask` parses
+//! the ELF's own symbol table, serializes a compact address→name map
+//! into this section via `objcopy --update-section`, then ships the
+//! patched ELF. At runtime the backtrace resolver reads the section
+//! through the linker-provided start/end symbols.
+//!
+//! ## Binary format
+//!
+//! ```text
+//! struct Header {
+//!     magic:      [u8; 4],   // b"KSYM"
+//!     version:    u8,        // 1
+//!     _reserved:  [u8; 3],
+//!     count:      u32 LE,    // number of entries
+//!     str_off:    u32 LE,    // byte offset from start of blob to strings
+//!     str_len:    u32 LE,    // bytes in string table
+//! }
+//! struct Entry { addr: u64 LE, name_off: u32 LE, name_len: u32 LE }
+//! // Entries are sorted by `addr` ascending.
+//! // String table is raw UTF-8 bytes; entries index into it.
+//! ```
+
+use core::fmt::{self, Write};
+use core::mem::size_of;
+use core::slice;
+
+const MAGIC: &[u8; 4] = b"KSYM";
+const VERSION: u8 = 1;
+
+/// Fixed reservation for the symbol table. Patched in place by xtask.
+/// Sized so a debug kernel's full symbol set fits with headroom; debug
+/// builds today come in around 2–3k symbols × ~50 bytes/entry.
+pub const KSYMTAB_BYTES: usize = 256 * 1024;
+
+/// Fixed-size reservation patched in place by xtask after linking. We
+/// deliberately DO NOT use a custom `#[link_section]` — a separate
+/// output section tripped rust-lld into a broken PT_LOAD layout
+/// (absorbing `.data`/`.bss` into the rodata segment under a read-only
+/// PHDR). Riding in `.rodata` is fine: xtask locates the reservation
+/// by symbol address, not by section name.
+///
+/// The explicit non-zero magic in the first four bytes forces LLVM to
+/// emit this as SHT_PROGBITS (not NOBITS), so xtask has real file
+/// bytes to overwrite.
+#[used]
+#[no_mangle]
+pub static KSYMTAB_RESERVATION: KsymtabReservation = KsymtabReservation {
+    placeholder_magic: *b"____",
+    _pad: [0; KSYMTAB_BYTES - 4],
+};
+
+#[repr(C, align(4096))]
+pub struct KsymtabReservation {
+    placeholder_magic: [u8; 4],
+    _pad: [u8; KSYMTAB_BYTES - 4],
+}
+
+#[repr(C, packed)]
+struct Header {
+    magic: [u8; 4],
+    version: u8,
+    _reserved: [u8; 3],
+    count: u32,
+    str_off: u32,
+    str_len: u32,
+}
+
+#[repr(C, packed)]
+#[derive(Clone, Copy)]
+struct Entry {
+    addr: u64,
+    name_off: u32,
+    name_len: u32,
+}
+
+/// Pointer to the start of the reservation's bytes. Routed through a
+/// volatile read of a self-referential constant to defeat rustc's
+/// const-folding: without this, LLVM sees `KSYMTAB_RESERVATION`'s
+/// compile-time initializer (`"____"` magic, zero payload) and proves
+/// every parse attempt unreachable — the post-link patch is invisible
+/// to the optimizer.
+fn raw_ptr() -> *const u8 {
+    let p: *const u8 = &KSYMTAB_RESERVATION as *const _ as *const u8;
+    // SAFETY: reading our own stack slot, which we just initialized.
+    unsafe { core::ptr::read_volatile(&p) }
+}
+
+fn raw() -> Option<&'static [u8]> {
+    // SAFETY: KSYMTAB_RESERVATION is a single `'static` object of
+    // exactly KSYMTAB_BYTES bytes.
+    unsafe { Some(slice::from_raw_parts(raw_ptr(), KSYMTAB_BYTES)) }
+}
+
+fn header() -> Option<Header> {
+    // SAFETY: pointer is to our own static, which is at least
+    // `size_of::<Header>()` bytes. The volatile read forces the load to
+    // happen at runtime against the xtask-patched bytes.
+    let hdr: Header = unsafe { core::ptr::read_volatile(raw_ptr() as *const Header) };
+    if &hdr.magic != MAGIC || hdr.version != VERSION {
+        return None;
+    }
+    Some(hdr)
+}
+
+fn entries() -> Option<&'static [Entry]> {
+    let blob = raw()?;
+    let hdr = header()?;
+    let count = { hdr.count } as usize;
+    let entries_off = size_of::<Header>();
+    let entries_bytes = count * size_of::<Entry>();
+    if entries_off + entries_bytes > blob.len() {
+        return None;
+    }
+    // SAFETY: bounds checked above; Entry is repr(C, packed).
+    let ptr = unsafe { blob.as_ptr().add(entries_off) } as *const Entry;
+    Some(unsafe { slice::from_raw_parts(ptr, count) })
+}
+
+fn strtab() -> Option<&'static [u8]> {
+    let blob = raw()?;
+    let hdr = header()?;
+    let off = { hdr.str_off } as usize;
+    let len = { hdr.str_len } as usize;
+    if off.saturating_add(len) > blob.len() {
+        return None;
+    }
+    Some(&blob[off..off + len])
+}
+
+fn name_of(e: &Entry) -> Option<&'static str> {
+    let strs = strtab()?;
+    let off = e.name_off as usize;
+    let len = e.name_len as usize;
+    if off.saturating_add(len) > strs.len() {
+        return None;
+    }
+    core::str::from_utf8(&strs[off..off + len]).ok()
+}
+
+/// Look up the symbol whose address is the greatest value not exceeding
+/// `addr`. Returns `(name, offset_from_symbol_start)` on success.
+pub fn resolve(addr: u64) -> Option<(&'static str, u64)> {
+    let entries = entries()?;
+    if entries.is_empty() {
+        return None;
+    }
+    // Binary search for the largest `addr <= target`.
+    let mut lo = 0usize;
+    let mut hi = entries.len();
+    while lo < hi {
+        let mid = (lo + hi) / 2;
+        // Copy to a local so we don't take a reference into a packed field.
+        let mid_addr = { entries[mid].addr };
+        if mid_addr <= addr {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    if lo == 0 {
+        return None;
+    }
+    let e = &entries[lo - 1];
+    let base = { e.addr };
+    let name = name_of(e)?;
+    Some((name, addr - base))
+}
+
+/// True if the symbol table has been populated with a valid header.
+/// Useful for callers that want to degrade gracefully (e.g. print raw
+/// addresses if the table wasn't built into this image).
+pub fn is_populated() -> bool {
+    header().is_some()
+}
+
+/// Number of symbols in the loaded table (0 if not populated).
+pub fn len() -> usize {
+    header().map(|h| { h.count } as usize).unwrap_or(0)
+}
+
+/// Format a single return address the way a human wants to read it:
+/// `0x<addr> <name>+0x<off>` when a symbol is found, else `0x<addr> ?`.
+pub fn format_addr<W: Write>(w: &mut W, addr: u64) -> fmt::Result {
+    match resolve(addr) {
+        Some((name, off)) => write!(w, "{addr:#018x} {name}+{off:#x}"),
+        None => write!(w, "{addr:#018x} ?"),
+    }
+}

--- a/kernel/src/ksymtab.rs
+++ b/kernel/src/ksymtab.rs
@@ -109,9 +109,12 @@ fn entries() -> Option<&'static [Entry]> {
     let blob = raw()?;
     let hdr = header()?;
     let count = { hdr.count } as usize;
+    // Checked arithmetic: a malformed blob can't be allowed to overflow
+    // the bounds math and trick us into a giant slice.
+    let entries_bytes = size_of::<Entry>().checked_mul(count)?;
     let entries_off = size_of::<Header>();
-    let entries_bytes = count * size_of::<Entry>();
-    if entries_off + entries_bytes > blob.len() {
+    let end = entries_off.checked_add(entries_bytes)?;
+    if end > blob.len() {
         return None;
     }
     // SAFETY: bounds checked above; Entry is repr(C, packed).

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -24,6 +24,8 @@ pub mod boot;
 #[cfg(target_os = "none")]
 pub mod framebuffer;
 #[cfg(target_os = "none")]
+pub mod ksymtab;
+#[cfg(target_os = "none")]
 pub mod serial;
 #[cfg(target_os = "none")]
 pub mod task;

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -8,7 +8,10 @@ use vibix::framebuffer::Console;
 use vibix::{exit_qemu, framebuffer, println, serial_print, serial_println, QemuExitCode};
 
 #[no_mangle]
-#[cfg_attr(feature = "ist-overflow-test", allow(unreachable_code))]
+#[cfg_attr(
+    any(feature = "ist-overflow-test", feature = "panic-test"),
+    allow(unreachable_code)
+)]
 pub extern "C" fn _start() -> ! {
     vibix::serial::init();
     serial_println!("vibix booting…");
@@ -77,6 +80,12 @@ pub extern "C" fn _start() -> ! {
     {
         serial_println!("fault-test: triggering #UD via ud2");
         unsafe { core::arch::asm!("ud2") };
+    }
+
+    #[cfg(feature = "panic-test")]
+    {
+        serial_println!("panic-test: triggering deliberate panic");
+        panic!("panic-test: eyeball the backtrace");
     }
 
     #[cfg(feature = "ist-overflow-test")]

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -124,6 +124,7 @@ fn idle_task() -> ! {
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     serial_println!("KERNEL PANIC: {}", info);
+    vibix::arch::backtrace::dump_to_serial(1);
     serial_println!("--- kernel log tail ---");
     vibix::klog::dump_tail_to_serial(32);
     serial_println!("--- end kernel log ---");

--- a/kernel/tests/backtrace.rs
+++ b/kernel/tests/backtrace.rs
@@ -1,0 +1,66 @@
+//! Integration test: the panic-path backtrace walker emits a
+//! `backtrace:` marker on serial and its frame addresses resolve to
+//! real kernel symbols via the embedded `.ksymtab`. We drive this via
+//! the should-panic pattern — a deliberate panic activates our custom
+//! panic handler, which validates the backtrace machinery and then
+//! reports pass/fail via QEMU's isa-debug-exit.
+
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicU32, Ordering};
+use vibix::{arch::backtrace, exit_qemu, ksymtab, serial_println, QemuExitCode};
+
+static RESOLVED_FRAMES: AtomicU32 = AtomicU32::new(0);
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    serial_println!(
+        "backtrace test: ksymtab populated = {}, symbols = {}",
+        ksymtab::is_populated(),
+        ksymtab::len()
+    );
+    if !ksymtab::is_populated() {
+        serial_println!("ksymtab missing — did xtask run embed_ksymtab?");
+        exit_qemu(QemuExitCode::Failure);
+    }
+    trigger_panic();
+    serial_println!("no panic triggered");
+    exit_qemu(QemuExitCode::Failure);
+}
+
+#[inline(never)]
+fn trigger_panic() {
+    panic!("deliberate panic for backtrace test");
+}
+
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    // Walk the stack and count how many addresses resolve to a symbol.
+    // Success criterion: backtrace emitted at least one frame AND at
+    // least one frame resolved via ksymtab — that exercises both the
+    // walker and the resolver end-to-end.
+    serial_println!("backtrace:");
+    let mut emitted = 0u32;
+    let mut resolved = 0u32;
+    backtrace::walk(1, |frame| {
+        emitted += 1;
+        match ksymtab::resolve(frame.return_addr) {
+            Some((name, off)) => {
+                serial_println!("  {:#018x} {}+{:#x}", frame.return_addr, name, off);
+                resolved += 1;
+            }
+            None => {
+                serial_println!("  {:#018x} ?", frame.return_addr);
+            }
+        }
+    });
+    RESOLVED_FRAMES.store(resolved, Ordering::SeqCst);
+    serial_println!("backtrace: {emitted} frames, {resolved} resolved");
+    if emitted == 0 || resolved == 0 {
+        exit_qemu(QemuExitCode::Failure);
+    }
+    exit_qemu(QemuExitCode::Success);
+}

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,3 +6,6 @@ edition.workspace = true
 [[bin]]
 name = "xtask"
 path = "src/main.rs"
+
+[dependencies]
+object = { version = "0.36", default-features = false, features = ["read", "std"] }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -413,8 +413,10 @@ fn run(opts: &BuildOpts) -> R<()> {
 /// the exit-code protocol (Success=65, Failure=33).
 fn test_runner(kernel: &Path) -> R<()> {
     let name = kernel.file_name().unwrap().to_string_lossy();
-    // Patch the freshly-built test ELF's .ksymtab so backtraces in
-    // integration tests resolve to names.
+    // Mirror the build() post-link fixups so integration-test ELFs pass
+    // Limine's PHDR validation and their panic-path backtraces resolve
+    // to symbol names.
+    strip_debug(kernel)?;
     embed_ksymtab(kernel)?;
     let iso = workspace_root().join("target").join(format!("{name}.iso"));
     make_iso(kernel, &iso, &format!("iso_{name}"))?;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -10,7 +10,7 @@
 //!   lint          — run clippy on xtask (host) and vibix (kernel, no_std)
 //!   clean         — remove build artifacts
 //!
-//! Flags (apply where sensible): --release, --fault-test
+//! Flags (apply where sensible): --release, --fault-test, --panic-test
 
 use std::env;
 use std::error::Error;
@@ -68,6 +68,7 @@ fn main() -> R<()> {
     let mut args: Vec<String> = env::args().skip(1).collect();
     let release = take_flag(&mut args, "--release");
     let fault_test = take_flag(&mut args, "--fault-test");
+    let panic_test = take_flag(&mut args, "--panic-test");
 
     let cmd = args
         .first()
@@ -78,6 +79,7 @@ fn main() -> R<()> {
     let opts = BuildOpts {
         release,
         fault_test,
+        panic_test,
     };
 
     match cmd.as_str() {
@@ -101,7 +103,7 @@ fn main() -> R<()> {
         other => {
             eprintln!("unknown subcommand: {other}");
             eprintln!(
-                "usage: cargo xtask [build|iso|run|test|smoke|lint|clean] [--release] [--fault-test]"
+                "usage: cargo xtask [build|iso|run|test|smoke|lint|clean] [--release] [--fault-test] [--panic-test]"
             );
             std::process::exit(2);
         }
@@ -121,6 +123,7 @@ fn take_flag(args: &mut Vec<String>, flag: &str) -> bool {
 struct BuildOpts {
     release: bool,
     fault_test: bool,
+    panic_test: bool,
 }
 
 fn workspace_root() -> PathBuf {
@@ -149,6 +152,9 @@ fn build(opts: &BuildOpts) -> R<PathBuf> {
     }
     if opts.fault_test {
         cmd.arg("--features").arg("fault-test");
+    }
+    if opts.panic_test {
+        cmd.arg("--features").arg("panic-test");
     }
     check(cmd.status()?)?;
     let bin = kernel_binary(opts);

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -200,7 +200,11 @@ fn embed_ksymtab(kernel: &Path) -> R<()> {
     // reservation's VMA into a file offset via its containing section.
     let rsv = obj
         .symbols()
-        .find(|s| s.name().map(|n| n == "KSYMTAB_RESERVATION").unwrap_or(false))
+        .find(|s| {
+            s.name()
+                .map(|n| n == "KSYMTAB_RESERVATION")
+                .unwrap_or(false)
+        })
         .ok_or("KSYMTAB_RESERVATION symbol not found in kernel ELF")?;
     let rsv_vma = rsv.address();
     let rsv_size = rsv.size() as usize;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -154,7 +154,129 @@ fn build(opts: &BuildOpts) -> R<PathBuf> {
     if !bin.exists() {
         return Err(format!("kernel binary missing at {}", bin.display()).into());
     }
+    strip_debug(&bin)?;
+    embed_ksymtab(&bin)?;
     Ok(bin)
+}
+
+/// Strip DWARF debug sections from the kernel ELF. Without this, rust-lld
+/// leaves `.debug_*` sections as orphans at VMA 0 which get pulled into
+/// the rodata PT_LOAD segment's bounding box, computing a ~2 GiB MemSiz
+/// that wraps past the kernel/user boundary and makes Limine reject the
+/// image ("No higher half PHDRs exist"). `/DISCARD/` in the linker script
+/// doesn't catch them reliably here, so strip post-link.
+fn strip_debug(kernel: &Path) -> R<()> {
+    let status = Command::new("objcopy")
+        .arg("--strip-debug")
+        .arg(kernel)
+        .status()?;
+    check(status)?;
+    Ok(())
+}
+
+/// Post-link step: read the freshly-linked ELF's own symbol table and
+/// patch a compact (addr → name) blob into the reserved `.ksymtab`
+/// section in-place. The kernel's runtime resolver parses it directly
+/// through the linker-provided bounds, giving backtraces symbol names
+/// without a second link pass.
+fn embed_ksymtab(kernel: &Path) -> R<()> {
+    use object::{Object, ObjectSection, ObjectSymbol, SymbolKind};
+    use std::io::{Seek, SeekFrom, Write};
+
+    let bytes = fs::read(kernel)?;
+    let obj = object::File::parse(&*bytes)?;
+
+    // Locate the reservation by symbol, not by section. We used to own a
+    // dedicated `.ksymtab` output section, but that tripped rust-lld into
+    // grouping `.data`/`.bss` under the read-only rodata PT_LOAD. Riding
+    // in `.rodata` keeps the layout sane; we just need to convert the
+    // reservation's VMA into a file offset via its containing section.
+    let rsv = obj
+        .symbols()
+        .find(|s| s.name().map(|n| n == "KSYMTAB_RESERVATION").unwrap_or(false))
+        .ok_or("KSYMTAB_RESERVATION symbol not found in kernel ELF")?;
+    let rsv_vma = rsv.address();
+    let rsv_size = rsv.size() as usize;
+    if rsv_size == 0 {
+        return Err("KSYMTAB_RESERVATION has zero size".into());
+    }
+    let section = obj
+        .sections()
+        .find(|s| {
+            let (addr, size) = (s.address(), s.size());
+            rsv_vma >= addr && rsv_vma + rsv_size as u64 <= addr + size
+        })
+        .ok_or("no section contains KSYMTAB_RESERVATION")?;
+    let (sec_file_off, _sec_file_size) = section
+        .file_range()
+        .ok_or("section containing KSYMTAB_RESERVATION has no file bytes")?;
+    let sec_off = sec_file_off + (rsv_vma - section.address());
+    let sec_size = rsv_size;
+
+    // Collect text-kind symbols with non-empty names. We keep all
+    // function-like symbols, including compiler-generated ones —
+    // names help even when they're mangled.
+    let mut syms: Vec<(u64, String)> = Vec::new();
+    for sym in obj.symbols() {
+        if !matches!(sym.kind(), SymbolKind::Text | SymbolKind::Unknown) {
+            continue;
+        }
+        let Ok(name) = sym.name() else { continue };
+        if name.is_empty() {
+            continue;
+        }
+        let addr = sym.address();
+        if addr == 0 {
+            continue;
+        }
+        syms.push((addr, name.to_string()));
+    }
+    syms.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.len().cmp(&b.1.len())));
+    syms.dedup_by(|a, b| a.0 == b.0);
+
+    const HEADER_SIZE: usize = 20;
+    const ENTRY_SIZE: usize = 16;
+
+    let mut entries = Vec::with_capacity(syms.len() * ENTRY_SIZE);
+    let mut strtab = Vec::<u8>::with_capacity(syms.len() * 24);
+    for (addr, name) in &syms {
+        let name_off = strtab.len() as u32;
+        let name_len = name.len() as u32;
+        strtab.extend_from_slice(name.as_bytes());
+        entries.extend_from_slice(&addr.to_le_bytes());
+        entries.extend_from_slice(&name_off.to_le_bytes());
+        entries.extend_from_slice(&name_len.to_le_bytes());
+    }
+
+    let str_off = (HEADER_SIZE + entries.len()) as u32;
+    let str_len = strtab.len() as u32;
+    let count = syms.len() as u32;
+    let used = HEADER_SIZE + entries.len() + strtab.len();
+
+    if used > sec_size {
+        return Err(format!(
+            "ksymtab blob {used} bytes exceeds reservation {sec_size}; bump KSYMTAB_BYTES"
+        )
+        .into());
+    }
+
+    let mut blob = vec![0u8; sec_size];
+    blob[0..4].copy_from_slice(b"KSYM");
+    blob[4] = 1; // version
+    blob[8..12].copy_from_slice(&count.to_le_bytes());
+    blob[12..16].copy_from_slice(&str_off.to_le_bytes());
+    blob[16..20].copy_from_slice(&str_len.to_le_bytes());
+    blob[HEADER_SIZE..HEADER_SIZE + entries.len()].copy_from_slice(&entries);
+    let str_start = HEADER_SIZE + entries.len();
+    blob[str_start..str_start + strtab.len()].copy_from_slice(&strtab);
+
+    drop(obj);
+    let mut f = fs::OpenOptions::new().write(true).open(kernel)?;
+    f.seek(SeekFrom::Start(sec_off))?;
+    f.write_all(&blob)?;
+
+    println!("→ ksymtab: {count} symbols, {used}/{sec_size} bytes");
+    Ok(())
 }
 
 fn ensure_limine() -> R<PathBuf> {
@@ -280,6 +402,9 @@ fn run(opts: &BuildOpts) -> R<()> {
 /// the exit-code protocol (Success=65, Failure=33).
 fn test_runner(kernel: &Path) -> R<()> {
     let name = kernel.file_name().unwrap().to_string_lossy();
+    // Patch the freshly-built test ELF's .ksymtab so backtraces in
+    // integration tests resolve to names.
+    embed_ksymtab(kernel)?;
     let iso = workspace_root().join("target").join(format!("{name}.iso"));
     make_iso(kernel, &iso, &format!("iso_{name}"))?;
 
@@ -352,6 +477,7 @@ fn test_all() -> R<()> {
         "tasks",
         "preempt",
         "apic_online",
+        "backtrace",
     ] {
         cmd.arg("--test").arg(t);
     }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -245,6 +245,10 @@ fn embed_ksymtab(kernel: &Path) -> R<()> {
     syms.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.len().cmp(&b.1.len())));
     syms.dedup_by(|a, b| a.0 == b.0);
 
+    // These must stay in sync with `size_of::<Header>()` and
+    // `size_of::<Entry>()` in kernel/src/ksymtab.rs — that file pins
+    // the layout with `const _: () = assert!(...)` so any drift
+    // there breaks the kernel build before we can ship a bad blob.
     const HEADER_SIZE: usize = 20;
     const ENTRY_SIZE: usize = 16;
 


### PR DESCRIPTION
## Summary
- Closes #39. Panic path now prints a frame-pointer walk resolved to `name+0xoff` via a compact symbol table patched into the kernel ELF post-link.
- Kernel is built with `-C force-frame-pointers=yes` so every non-leaf has a canonical rbp prologue; `arch::backtrace::walk` unwinds up to 32 frames with basic sanity checks (8-byte aligned rbp, higher-half, strictly increasing).
- `ksymtab` owns a 256 KiB `KSYMTAB_RESERVATION` static in `.rodata`. xtask reads the freshly-linked ELF's symbol table and overwrites the reservation in place, locating it by symbol address (a dedicated `.ksymtab` output section tripped rust-lld into a broken PT_LOAD layout). The runtime parser uses volatile reads so LLVM can't const-fold the placeholder magic.
- xtask strips DWARF via `objcopy --strip-debug` before embedding — `/DISCARD/` alone left orphan debug sections that pushed the rodata PT_LOAD's MemSiz into a 2 GiB wrap and made Limine reject the image.
- Panic handler calls `arch::backtrace::dump_to_serial` before the klog tail; a new `kbacktrace!()` macro exposes the same walk for ad-hoc use.

Out of scope: `#UD` / exception handlers don't yet emit a backtrace — they print the `InterruptStackFrame` as before. Wiring backtraces into those handlers is a follow-up.

## Test plan
- [x] `cargo xtask test` — host units + all QEMU integration tests (incl. new `backtrace` test) green
- [x] `cargo xtask smoke` — all 15 serial markers present
- [x] `cargo xtask run --fault-test` — #UD path still reports correctly (no regression; backtrace wiring is panic-only for now)
- [x] Manually eyeball a panic backtrace on real boot to confirm frame addresses look sane
