### PR TITLE
task: add per-task stack guard pages

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -71,6 +71,19 @@ extern "x86-interrupt" fn page_fault(frame: InterruptStackFrame, code: PageFault
         }
     }
 
+    // Check whether the fault address lands inside a kernel task's guard
+    // page — if so, this is a stack overflow, not a generic fault.
+    if let Some(task_id) = crate::task::find_stack_overflow(addr_u64 as usize) {
+        serial_println!(
+            "EXCEPTION: #PF task {} stack overflow addr={:#x} code={:?}\n{:#?}",
+            task_id,
+            addr_u64,
+            code,
+            frame
+        );
+        hang();
+    }
+
     serial_println!(
         "EXCEPTION: #PF addr={:?} code={:?}\n{:#?}",
         addr,

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -52,7 +52,6 @@ extern "x86-interrupt" fn general_protection(frame: InterruptStackFrame, code: u
 }
 
 extern "x86-interrupt" fn page_fault(frame: InterruptStackFrame, code: PageFaultErrorCode) {
-    let addr = x86_64::registers::control::Cr2::read();
     let addr_u64 = x86_64::registers::control::Cr2::read_raw();
 
     if let Some(expected) = crate::test_hook::take_page_fault_expectation() {
@@ -85,8 +84,8 @@ extern "x86-interrupt" fn page_fault(frame: InterruptStackFrame, code: PageFault
     }
 
     serial_println!(
-        "EXCEPTION: #PF addr={:?} code={:?}\n{:#?}",
-        addr,
+        "EXCEPTION: #PF addr={:#x} code={:?}\n{:#?}",
+        addr_u64,
         code,
         frame
     );
@@ -94,6 +93,20 @@ extern "x86-interrupt" fn page_fault(frame: InterruptStackFrame, code: PageFault
 }
 
 extern "x86-interrupt" fn double_fault(frame: InterruptStackFrame, _code: u64) -> ! {
+    // The most common task stack overflow pattern: PUSH/CALL walks RSP into
+    // the guard page, the CPU cannot write the #PF frame there (also
+    // unmapped), so it escalates to #DF. The #DF frame's stack_pointer
+    // holds the faulted RSP — check it before the generic diagnostic.
+    let faulted_rsp = frame.stack_pointer.as_u64() as usize;
+    if let Some(task_id) = crate::task::find_stack_overflow(faulted_rsp) {
+        serial_println!(
+            "EXCEPTION: #DF task {} stack overflow rsp={:#x}\n{:#?}",
+            task_id,
+            faulted_rsp,
+            frame
+        );
+        hang();
+    }
     serial_println!("EXCEPTION: #DF (double fault)\n{:#?}", frame);
     #[cfg(feature = "ist-overflow-test")]
     {

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -116,22 +116,26 @@ pub fn yield_now() {
 /// Returns the task ID of the overflowing task, or `None` if no guard
 /// page was hit.
 ///
-/// Uses `try_lock` so it is safe to call from an exception handler where
-/// the scheduler lock might already be held. If the lock is contended the
-/// check is skipped (the fault will be logged generically by the caller).
+/// Fully lock-free: derives the answer from the fixed VA layout of the
+/// task stack window, so it is always safe to call from any exception
+/// context — even when the scheduler lock is already held on this CPU.
 pub fn find_stack_overflow(addr: usize) -> Option<usize> {
-    let sched = SCHED.try_lock()?;
-    if let Some(t) = sched.current.as_deref() {
-        if t.is_guard_hit(addr) {
-            return Some(t.id);
-        }
+    use core::sync::atomic::Ordering;
+    use task::{GUARD_SIZE, NEXT_STACK_VA, TASK_SLOT_SIZE, TASK_STACKS_VA_BASE};
+
+    let next_va = NEXT_STACK_VA.load(Ordering::Relaxed);
+    if addr < TASK_STACKS_VA_BASE || addr >= next_va {
+        return None;
     }
-    for t in &sched.ready {
-        if t.is_guard_hit(addr) {
-            return Some(t.id);
-        }
+    let slot_idx = (addr - TASK_STACKS_VA_BASE) / TASK_SLOT_SIZE;
+    let slot_guard_base = TASK_STACKS_VA_BASE + slot_idx * TASK_SLOT_SIZE;
+    // Guard page occupies [slot_guard_base, slot_guard_base + GUARD_SIZE).
+    // Task IDs start at 1, so slot 0 → task 1.
+    if addr < slot_guard_base + GUARD_SIZE {
+        Some(slot_idx + 1)
+    } else {
+        None
     }
-    None
 }
 
 /// Called from the timer ISR after `notify_eoi`. Decrements the

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Tasks can hand control back explicitly with [`yield_now`], and the
 //! timer ISR calls [`preempt_tick`] every PIT interrupt to rotate tasks
-//! that never yield. Each task owns a heap-allocated kernel stack and a
+//! that never yield. Each task owns a guard-paged kernel stack and a
 //! saved register context; the hand-written switch in [`switch`] is the
 //! one place that touches `rsp`.
 //!
@@ -17,7 +17,7 @@
 //!
 //! - Priorities, per-CPU queues, tickless idle.
 //! - Blocking primitives — cooperative code polls + yields.
-//! - Per-task address spaces or guard pages.
+//! - Per-task address spaces.
 
 mod scheduler;
 mod switch;
@@ -110,6 +110,28 @@ pub fn yield_now() {
     if was_on {
         interrupts::enable();
     }
+}
+
+/// Check whether `addr` falls within any live kernel task's guard page.
+/// Returns the task ID of the overflowing task, or `None` if no guard
+/// page was hit.
+///
+/// Uses `try_lock` so it is safe to call from an exception handler where
+/// the scheduler lock might already be held. If the lock is contended the
+/// check is skipped (the fault will be logged generically by the caller).
+pub fn find_stack_overflow(addr: usize) -> Option<usize> {
+    let sched = SCHED.try_lock()?;
+    if let Some(t) = sched.current.as_deref() {
+        if t.is_guard_hit(addr) {
+            return Some(t.id);
+        }
+    }
+    for t in &sched.ready {
+        if t.is_guard_hit(addr) {
+            return Some(t.id);
+        }
+    }
+    None
 }
 
 /// Called from the timer ISR after `notify_eoi`. Decrements the

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -1,26 +1,61 @@
-//! Per-task state: a heap-allocated kernel stack and a saved stack
-//! pointer. The stack is primed on construction so the first context
-//! switch into a new task lands in `task_entry_trampoline`, which then
-//! calls the entry function.
+//! Per-task state: a guard-paged kernel stack and a saved stack pointer.
+//!
+//! Each spawned task owns a 20 KiB VA slot carved from the dedicated
+//! `TASK_STACKS_VA_BASE` window:
+//!
+//! ```text
+//!   [ guard page (4 KiB, unmapped) | stack pages (16 KiB, RW/NX) ]
+//!   ^                               ^                             ^
+//!   guard_base                   stack_base                     top
+//! ```
+//!
+//! The guard page is never mapped. A stack overflow that walks past
+//! `stack_base` takes a `#PF` whose fault address lands inside the guard,
+//! which the `#PF` handler recognises and turns into a named diagnostic
+//! instead of silent memory corruption.
+//!
+//! The stack is primed on construction so the first context switch into a
+//! new task lands in `task_entry_trampoline`, which then calls the entry
+//! function.
 
-use alloc::alloc::{alloc_zeroed, handle_alloc_error, Layout};
-use alloc::boxed::Box;
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use x86_64::structures::paging::PageTableFlags;
+use x86_64::VirtAddr;
+
+use crate::mem::paging;
 
 use super::switch::task_entry_trampoline;
 use super::DEFAULT_SLICE_MS;
 
-/// 16 KiB per task — plenty for the handful of kernel frames
-/// cooperative tasks build up between `yield_now()` calls. Aligned to
-/// 16 so the primed `rsp` is ABI-legal at the trampoline's `call`.
+/// Usable stack per task.
 const STACK_SIZE: usize = 16 * 1024;
+/// Guard page size (one 4 KiB page, never mapped).
+const GUARD_SIZE: usize = 4096;
+/// Total VA consumed per task slot: guard page + stack pages.
+const TASK_SLOT_SIZE: usize = GUARD_SIZE + STACK_SIZE;
 
-#[repr(C, align(16))]
-pub(super) struct Stack([u8; STACK_SIZE]);
+/// Base of the dedicated VA window for kernel task stacks. Chosen to sit
+/// well above the heap cap (`HEAP_BASE` + 16 MiB = `0xFFFF_C000_1000_0000`)
+/// and below the kernel image at `0xFFFF_FFFF_8000_0000`.
+const TASK_STACKS_VA_BASE: usize = 0xFFFF_D000_0000_0000;
+
+/// Bump allocator for task-stack VA slots. Monotonically increments;
+/// task stacks are never freed (tasks don't exit yet).
+static NEXT_STACK_VA: AtomicUsize = AtomicUsize::new(TASK_STACKS_VA_BASE);
+
+/// Sequential task IDs. 0 is reserved for the bootstrap task.
+static NEXT_TASK_ID: AtomicUsize = AtomicUsize::new(1);
 
 pub(super) struct Task {
-    /// Holder for the heap-allocated stack. `None` only for the
-    /// bootstrap task, which inherits the boot-time kernel stack.
-    _stack: Option<Box<Stack>>,
+    /// Stable task identifier, used in diagnostic messages.
+    pub id: usize,
+    /// Base VA of the 4 KiB guard page. The range
+    /// `[guard_base, guard_base + 4 KiB)` is permanently unmapped.
+    /// Zero for the bootstrap task, which inherits the pre-existing boot
+    /// stack (no separate guard page — that stack lives in reclaimable
+    /// bootloader memory).
+    pub guard_base: usize,
     /// Saved `rsp`. Updated on every `context_switch` out of the task.
     /// `0` is a sentinel meaning "not yet saved" — legal only for the
     /// bootstrap task before its first yield.
@@ -38,41 +73,55 @@ impl Task {
     /// away from this thread.
     pub fn bootstrap() -> Self {
         Self {
-            _stack: None,
+            id: 0,
+            guard_base: 0,
             rsp: 0,
             slice_remaining_ms: DEFAULT_SLICE_MS,
         }
     }
 
-    /// Allocate a fresh stack and prime it so the first switch into
+    /// Allocate a guard-paged stack and prime it so the first switch into
     /// this task runs `entry` via the trampoline.
     ///
-    /// Primed layout (low → high):
+    /// VA layout (low → high):
+    /// ```text
+    ///   [ guard page (unmapped) | stack pages (mapped RW/NX) ]
+    ///                            ^                           ^
+    ///                         stack_base                   top
+    /// ```
+    ///
+    /// Primed register context (low → high inside the stack):
     /// ```text
     ///   r15=0  r14=0  r13=0  r12=entry  rbp=0  rbx=0  ret=trampoline  <top>
-    ///   ^ saved rsp (initial)                          ^ rsp after 6 pops
+    ///   ^ saved rsp (initial)
     /// ```
-    /// `ret` then consumes the last slot and lands rsp on `<top>`.
     pub fn new(entry: fn() -> !) -> Self {
-        let layout = Layout::new::<Stack>();
-        // SAFETY: Stack has non-zero size and align 16; alloc_zeroed
-        // either returns a valid ptr of that layout or null (handled).
-        let stack = unsafe {
-            let ptr = alloc_zeroed(layout) as *mut Stack;
-            if ptr.is_null() {
-                handle_alloc_error(layout);
-            }
-            Box::from_raw(ptr)
-        };
+        // Bump-allocate a fresh VA slot.
+        let slot_va = NEXT_STACK_VA.fetch_add(TASK_SLOT_SIZE, Ordering::Relaxed);
+        let guard_base = slot_va;
+        let stack_base = slot_va + GUARD_SIZE;
 
-        let base = Box::as_ref(&stack) as *const Stack as *const u8 as usize;
-        let top = base + STACK_SIZE;
+        // Map only the stack pages. The guard page at `guard_base` is left
+        // unmapped intentionally — touching it raises a #PF.
+        // `Page::from_start_address` (used internally by `map_range` via
+        // `containing_address`) will catch misalignment loudly if the VA
+        // calculation is ever wrong, matching the IST guard discipline.
+        let stack_page_count = (STACK_SIZE / 4096) as u64;
+        paging::map_range(
+            VirtAddr::new(stack_base as u64),
+            stack_page_count,
+            PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE,
+        )
+        .expect("failed to map task stack");
+
+        let top = stack_base + STACK_SIZE;
 
         // Seven 8-byte slots: [r15, r14, r13, r12, rbp, rbx, ret].
         let rsp = top - 7 * 8;
         let slots = rsp as *mut usize;
-        // SAFETY: the 56 bytes at `rsp` sit inside the freshly
-        // allocated, zeroed Stack and are exclusively owned here.
+        // SAFETY: the 56 bytes at `rsp` were just mapped and are
+        // exclusively owned by this Task. No other code references this
+        // VA range until the first context switch delivers them to the CPU.
         unsafe {
             slots.add(0).write(0); // r15
             slots.add(1).write(0); // r14
@@ -85,10 +134,20 @@ impl Task {
                 .write(task_entry_trampoline as *const () as usize); // ret
         }
 
+        let id = NEXT_TASK_ID.fetch_add(1, Ordering::Relaxed);
+
         Self {
-            _stack: Some(stack),
+            id,
+            guard_base,
             rsp,
             slice_remaining_ms: DEFAULT_SLICE_MS,
         }
+    }
+
+    /// Returns `true` if `addr` falls within this task's guard page.
+    ///
+    /// Always returns `false` for the bootstrap task (`guard_base == 0`).
+    pub fn is_guard_hit(&self, addr: usize) -> bool {
+        self.guard_base != 0 && addr >= self.guard_base && addr < self.guard_base + GUARD_SIZE
     }
 }

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -20,7 +20,7 @@
 
 use core::sync::atomic::{AtomicUsize, Ordering};
 
-use x86_64::structures::paging::PageTableFlags;
+use x86_64::structures::paging::{Page, PageTableFlags, Size4KiB};
 use x86_64::VirtAddr;
 
 use crate::mem::paging;
@@ -31,18 +31,18 @@ use super::DEFAULT_SLICE_MS;
 /// Usable stack per task.
 const STACK_SIZE: usize = 16 * 1024;
 /// Guard page size (one 4 KiB page, never mapped).
-const GUARD_SIZE: usize = 4096;
+pub(super) const GUARD_SIZE: usize = 4096;
 /// Total VA consumed per task slot: guard page + stack pages.
-const TASK_SLOT_SIZE: usize = GUARD_SIZE + STACK_SIZE;
+pub(super) const TASK_SLOT_SIZE: usize = GUARD_SIZE + STACK_SIZE;
 
 /// Base of the dedicated VA window for kernel task stacks. Chosen to sit
 /// well above the heap cap (`HEAP_BASE` + 16 MiB = `0xFFFF_C000_1000_0000`)
 /// and below the kernel image at `0xFFFF_FFFF_8000_0000`.
-const TASK_STACKS_VA_BASE: usize = 0xFFFF_D000_0000_0000;
+pub(super) const TASK_STACKS_VA_BASE: usize = 0xFFFF_D000_0000_0000;
 
 /// Bump allocator for task-stack VA slots. Monotonically increments;
 /// task stacks are never freed (tasks don't exit yet).
-static NEXT_STACK_VA: AtomicUsize = AtomicUsize::new(TASK_STACKS_VA_BASE);
+pub(super) static NEXT_STACK_VA: AtomicUsize = AtomicUsize::new(TASK_STACKS_VA_BASE);
 
 /// Sequential task IDs. 0 is reserved for the bootstrap task.
 static NEXT_TASK_ID: AtomicUsize = AtomicUsize::new(1);
@@ -103,9 +103,11 @@ impl Task {
 
         // Map only the stack pages. The guard page at `guard_base` is left
         // unmapped intentionally — touching it raises a #PF.
-        // `Page::from_start_address` (used internally by `map_range` via
-        // `containing_address`) will catch misalignment loudly if the VA
-        // calculation is ever wrong, matching the IST guard discipline.
+        // Assert alignment explicitly: map_range uses containing_address
+        // (which rounds down silently), so we validate here to catch any
+        // future drift in the VA constants.
+        Page::<Size4KiB>::from_start_address(VirtAddr::new(stack_base as u64))
+            .expect("task stack base must be page aligned");
         let stack_page_count = (STACK_SIZE / 4096) as u64;
         paging::map_range(
             VirtAddr::new(stack_base as u64),


### PR DESCRIPTION
Each kernel task spawned via `task::spawn` now gets a dedicated VA slot from the `0xFFFF_D000_0000_0000` window: a 4 KiB unmapped guard page at the low end followed by 16 KiB of RW/NX-mapped stack pages. Stack overflow → #PF with fault address inside the guard → `task N stack overflow` diagnostic + halt.

Closes #17.

Generated with [Claude Code](https://claude.ai/code)