### PR TITLE
mem: derive kernel PML4 flags from ELF PT_LOAD headers

### DIFF
--- a/kernel/src/boot.rs
+++ b/kernel/src/boot.rs
@@ -3,8 +3,8 @@
 //! take control.
 
 use limine::request::{
-    ExecutableAddressRequest, FramebufferRequest, HhdmRequest, MemoryMapRequest, RequestsEndMarker,
-    RequestsStartMarker, RsdpRequest, StackSizeRequest,
+    ExecutableAddressRequest, ExecutableFileRequest, FramebufferRequest, HhdmRequest,
+    MemoryMapRequest, RequestsEndMarker, RequestsStartMarker, RsdpRequest, StackSizeRequest,
 };
 use limine::BaseRevision;
 
@@ -34,6 +34,10 @@ pub static STACK_REQUEST: StackSizeRequest = StackSizeRequest::new().with_size(S
 #[used]
 #[link_section = ".limine_requests"]
 pub static KERNEL_ADDRESS_REQUEST: ExecutableAddressRequest = ExecutableAddressRequest::new();
+
+#[used]
+#[link_section = ".limine_requests"]
+pub static KERNEL_FILE_REQUEST: ExecutableFileRequest = ExecutableFileRequest::new();
 
 #[used]
 #[link_section = ".limine_requests"]

--- a/kernel/src/mem/elf.rs
+++ b/kernel/src/mem/elf.rs
@@ -90,14 +90,21 @@ pub(super) fn kernel_load_segments() -> impl Iterator<Item = LoadSegment> {
     let phoff = ehdr.e_phoff as usize;
     let phnum = ehdr.e_phnum as usize;
     let phsz = ehdr.e_phentsize as usize;
-    assert!(
-        phoff + phnum * phsz <= size,
-        "kernel ELF phdr table out of range"
-    );
+    let phdr_table_end = phnum
+        .checked_mul(phsz)
+        .and_then(|bytes| phoff.checked_add(bytes))
+        .expect("kernel ELF phdr table size overflow");
+    assert!(phdr_table_end <= size, "kernel ELF phdr table out of range");
 
-    // SAFETY: bounds checked above; the slice covers only phdrs.
-    let phdrs: &[Elf64Phdr] =
-        unsafe { core::slice::from_raw_parts(base.add(phoff) as *const Elf64Phdr, phnum) };
+    // SAFETY: bounds checked above; the slice covers only phdrs, and
+    // the alignment assertion guarantees the cast-to-reference is
+    // sound even on toolchains that place `e_phoff` oddly.
+    let phdr_ptr = unsafe { base.add(phoff) } as *const Elf64Phdr;
+    assert!(
+        phdr_ptr.align_offset(core::mem::align_of::<Elf64Phdr>()) == 0,
+        "kernel ELF phdr table misaligned"
+    );
+    let phdrs: &[Elf64Phdr] = unsafe { core::slice::from_raw_parts(phdr_ptr, phnum) };
 
     phdrs.iter().filter_map(|ph| {
         if ph.p_type != PT_LOAD || ph.p_memsz == 0 {

--- a/kernel/src/mem/elf.rs
+++ b/kernel/src/mem/elf.rs
@@ -1,0 +1,119 @@
+//! Minimal ELF64 program-header walker.
+//!
+//! Scoped to what the kernel needs to map its own image: iterate
+//! `PT_LOAD` segments and translate `p_flags` into `PageTableFlags`.
+//! Deliberately hand-rolled rather than pulling in `xmas-elf` /
+//! `goblin` — the structs are tiny and fixed, and a future userspace
+//! ELF loader can grow this module instead of adding a second parser.
+
+use x86_64::structures::paging::PageTableFlags;
+use x86_64::VirtAddr;
+
+const PT_LOAD: u32 = 1;
+const PF_X: u32 = 1 << 0;
+const PF_W: u32 = 1 << 1;
+
+const ELF_MAGIC: [u8; 4] = [0x7f, b'E', b'L', b'F'];
+const ELFCLASS64: u8 = 2;
+
+#[repr(C)]
+struct Elf64Ehdr {
+    e_ident: [u8; 16],
+    e_type: u16,
+    e_machine: u16,
+    e_version: u32,
+    e_entry: u64,
+    e_phoff: u64,
+    e_shoff: u64,
+    e_flags: u32,
+    e_ehsize: u16,
+    e_phentsize: u16,
+    e_phnum: u16,
+    e_shentsize: u16,
+    e_shnum: u16,
+    e_shstrndx: u16,
+}
+
+#[repr(C)]
+struct Elf64Phdr {
+    p_type: u32,
+    p_flags: u32,
+    p_offset: u64,
+    p_vaddr: u64,
+    p_paddr: u64,
+    p_filesz: u64,
+    p_memsz: u64,
+    p_align: u64,
+}
+
+/// One `PT_LOAD` segment of the kernel image, as the paging layer
+/// wants it: a virtual range plus the `PageTableFlags` derived from
+/// `p_flags` (`PF_W` → `WRITABLE`, no `PF_X` → `NO_EXECUTE`).
+#[derive(Clone, Copy)]
+pub(super) struct LoadSegment {
+    pub vaddr: VirtAddr,
+    pub memsz: u64,
+    pub flags: PageTableFlags,
+}
+
+/// Iterate `PT_LOAD` segments of the running kernel's ELF image,
+/// reachable through Limine's `ExecutableFileRequest`.
+///
+/// Panics with a clear message if the request response is missing,
+/// the ELF magic is wrong, or the class isn't 64-bit — any of those
+/// would mean the bootloader handed us something we can't reason
+/// about, and limping on would only corrupt page tables.
+pub(super) fn kernel_load_segments() -> impl Iterator<Item = LoadSegment> {
+    let resp = crate::boot::KERNEL_FILE_REQUEST
+        .get_response()
+        .expect("Limine executable-file response missing");
+    let file = resp.file();
+    let base = file.addr();
+    let size = file.size() as usize;
+    assert!(
+        size >= core::mem::size_of::<Elf64Ehdr>(),
+        "kernel ELF too small for Ehdr"
+    );
+
+    // SAFETY: Limine guarantees the file bytes live at this address
+    // for the lifetime of the kernel (BOOTLOADER_RECLAIMABLE-adjacent
+    // but held through `EXECUTABLE_AND_MODULES`). We only read.
+    let ehdr: &Elf64Ehdr = unsafe { &*(base as *const Elf64Ehdr) };
+    assert_eq!(ehdr.e_ident[..4], ELF_MAGIC, "kernel ELF bad magic");
+    assert_eq!(ehdr.e_ident[4], ELFCLASS64, "kernel ELF not ELFCLASS64");
+    assert_eq!(
+        ehdr.e_phentsize as usize,
+        core::mem::size_of::<Elf64Phdr>(),
+        "unexpected e_phentsize"
+    );
+
+    let phoff = ehdr.e_phoff as usize;
+    let phnum = ehdr.e_phnum as usize;
+    let phsz = ehdr.e_phentsize as usize;
+    assert!(
+        phoff + phnum * phsz <= size,
+        "kernel ELF phdr table out of range"
+    );
+
+    // SAFETY: bounds checked above; the slice covers only phdrs.
+    let phdrs: &[Elf64Phdr] =
+        unsafe { core::slice::from_raw_parts(base.add(phoff) as *const Elf64Phdr, phnum) };
+
+    phdrs.iter().filter_map(|ph| {
+        if ph.p_type != PT_LOAD || ph.p_memsz == 0 {
+            return None;
+        }
+        let mut flags = PageTableFlags::PRESENT;
+        if ph.p_flags & PF_W != 0 {
+            flags |= PageTableFlags::WRITABLE;
+        }
+        if ph.p_flags & PF_X == 0 {
+            flags |= PageTableFlags::NO_EXECUTE;
+        }
+        Some(LoadSegment {
+            vaddr: VirtAddr::new(ph.p_vaddr),
+            memsz: ph.p_memsz,
+            flags,
+        })
+    })
+}

--- a/kernel/src/mem/mod.rs
+++ b/kernel/src/mem/mod.rs
@@ -13,6 +13,8 @@
 pub mod frame;
 
 #[cfg(target_os = "none")]
+mod elf;
+#[cfg(target_os = "none")]
 pub mod heap;
 #[cfg(target_os = "none")]
 pub mod paging;

--- a/kernel/src/mem/paging.rs
+++ b/kernel/src/mem/paging.rs
@@ -11,6 +11,7 @@
 //! actually freeing it (and the `BOOTLOADER_RECLAIMABLE` frames) is
 //! issue #46.
 
+use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 use spin::Mutex;
 use x86_64::registers::control::Cr3;
@@ -358,9 +359,36 @@ fn populate_hhdm(
 /// the current (old) tree are skipped so that the IST guard hole
 /// survives the switch.
 fn populate_kernel_image(mapper: &mut OffsetPageTable<'static>, alloc: &mut KernelFrameAllocator) {
+    // PT_LOAD is byte-granular but a PTE is page-granular: two
+    // segments touching the same 4 KiB page have to agree on flags.
+    // Union per page before mapping (WRITABLE if any covering segment
+    // is writable, NO_EXECUTE only if every covering segment is NX),
+    // then map each page exactly once. Our linker script page-aligns
+    // segment boundaries today, so in practice no page is covered
+    // twice — but relying on that invariant silently would leave a
+    // boundary page mis-permissioned the first time it breaks.
+    let mut per_page: BTreeMap<u64, PageTableFlags> = BTreeMap::new();
     for seg in super::elf::kernel_load_segments() {
-        let end = VirtAddr::new(seg.vaddr.as_u64() + seg.memsz);
-        clone_range(mapper, alloc, seg.vaddr, end, seg.flags);
+        let start = seg.vaddr.as_u64() & !0xFFF;
+        let end = (seg.vaddr.as_u64() + seg.memsz + 0xFFF) & !0xFFF;
+        let mut addr = start;
+        while addr < end {
+            let entry = per_page
+                .entry(addr)
+                .or_insert(PageTableFlags::PRESENT | PageTableFlags::NO_EXECUTE);
+            if seg.flags.contains(PageTableFlags::WRITABLE) {
+                *entry |= PageTableFlags::WRITABLE;
+            }
+            if !seg.flags.contains(PageTableFlags::NO_EXECUTE) {
+                entry.remove(PageTableFlags::NO_EXECUTE);
+            }
+            addr += 0x1000;
+        }
+    }
+
+    for (va, flags) in per_page {
+        let page_va = VirtAddr::new(va);
+        clone_range(mapper, alloc, page_va, page_va + 0x1000u64, flags);
     }
 }
 

--- a/kernel/src/mem/paging.rs
+++ b/kernel/src/mem/paging.rs
@@ -207,6 +207,16 @@ pub fn translate(addr: VirtAddr) -> Option<PhysAddr> {
     })
 }
 
+/// Read the page-table flags of the leaf PTE backing `addr`, if any.
+/// Used by tests to verify that `populate_kernel_image` applied the
+/// ELF-derived `{R, W, X}` flags correctly.
+pub fn flags(addr: VirtAddr) -> Option<PageTableFlags> {
+    with_mapper(|m| match m.translate(addr) {
+        TranslateResult::Mapped { flags, .. } => Some(flags),
+        TranslateResult::NotMapped | TranslateResult::InvalidFrameAddress(_) => None,
+    })
+}
+
 /// Physical address of the currently-active PML4 (i.e. CR3).
 pub fn active_pml4_phys() -> PhysAddr {
     Cr3::read().0.start_address()
@@ -341,55 +351,16 @@ fn populate_hhdm(
     }
 }
 
-/// Map the kernel image section-by-section with tight permissions.
-/// Pages that are unmapped in the *current* (old) tree are skipped so
-/// that the IST guard unmap survives the switch.
+/// Map the kernel image segment-by-segment with tight permissions.
+/// `{R, W, X}` is derived from each `PT_LOAD`'s `p_flags` via the ELF
+/// program headers Limine hands back — a new kernel section picks up
+/// the right flags without any code change here. Pages unmapped in
+/// the current (old) tree are skipped so that the IST guard hole
+/// survives the switch.
 fn populate_kernel_image(mapper: &mut OffsetPageTable<'static>, alloc: &mut KernelFrameAllocator) {
-    extern "C" {
-        static __limine_requests_start: u8;
-        static __limine_requests_end: u8;
-        static __text_start: u8;
-        static __text_end: u8;
-        static __rodata_start: u8;
-        static __rodata_end: u8;
-        static __data_start: u8;
-        static __data_end: u8;
-    }
-
-    let present_rw = PageTableFlags::PRESENT | PageTableFlags::WRITABLE;
-    let text_flags = PageTableFlags::PRESENT; // RX
-    let rodata_flags = PageTableFlags::PRESENT | PageTableFlags::NO_EXECUTE; // RO
-    let data_flags = present_rw | PageTableFlags::NO_EXECUTE; // RW
-
-    // SAFETY: these are link-time symbols with static addresses; taking
-    // their address is always valid.
-    let regions = unsafe {
-        [
-            (
-                VirtAddr::from_ptr(&__limine_requests_start),
-                VirtAddr::from_ptr(&__limine_requests_end),
-                data_flags,
-            ),
-            (
-                VirtAddr::from_ptr(&__text_start),
-                VirtAddr::from_ptr(&__text_end),
-                text_flags,
-            ),
-            (
-                VirtAddr::from_ptr(&__rodata_start),
-                VirtAddr::from_ptr(&__rodata_end),
-                rodata_flags,
-            ),
-            (
-                VirtAddr::from_ptr(&__data_start),
-                VirtAddr::from_ptr(&__data_end),
-                data_flags,
-            ),
-        ]
-    };
-
-    for (start, end, flags) in regions {
-        clone_range(mapper, alloc, start, end, flags);
+    for seg in super::elf::kernel_load_segments() {
+        let end = VirtAddr::new(seg.vaddr.as_u64() + seg.memsz);
+        clone_range(mapper, alloc, seg.vaddr, end, seg.flags);
     }
 }
 

--- a/kernel/tests/pml4_switch.rs
+++ b/kernel/tests/pml4_switch.rs
@@ -16,6 +16,7 @@ use vibix::{
     test_harness::{test_panic_handler, Testable},
     QemuExitCode,
 };
+use x86_64::structures::paging::PageTableFlags;
 use x86_64::VirtAddr;
 
 #[no_mangle]
@@ -45,6 +46,10 @@ fn run_tests() {
         (
             "heap_grows_after_switch",
             &(heap_grows_after_switch as fn()),
+        ),
+        (
+            "elf_derived_segment_flags",
+            &(elf_derived_segment_flags as fn()),
         ),
     ];
     serial_println!("running {} tests", tests.len());
@@ -78,6 +83,47 @@ fn stack_local_translates() {
     let phys = paging::translate(va).expect("stack local not mapped after CR3 switch");
     assert_eq!(local, 0xDEAD_BEEF_DEAD_BEEF);
     serial_println!("  stack @ {va:?} -> {phys:?}");
+}
+
+fn elf_derived_segment_flags() {
+    use vibix::mem::paging;
+
+    // .text — a code address must be PRESENT, executable (no NX),
+    // and not WRITABLE. Use a fn pointer to a function in this test,
+    // which the linker places in `.text`.
+    let fn_ptr: fn() = elf_derived_segment_flags;
+    let text_va = VirtAddr::new(fn_ptr as usize as u64);
+    let text_flags = paging::flags(text_va).expect("text VA not mapped");
+    assert!(text_flags.contains(PageTableFlags::PRESENT));
+    assert!(!text_flags.contains(PageTableFlags::NO_EXECUTE), "text NX");
+    assert!(
+        !text_flags.contains(PageTableFlags::WRITABLE),
+        "text writable"
+    );
+
+    // .rodata — a &'static str literal lives in `.rodata`. Must be
+    // NX and not writable.
+    static RODATA_MARKER: &str = "vibix-rodata-marker";
+    let rodata_va = VirtAddr::new(RODATA_MARKER.as_ptr() as u64);
+    let rodata_flags = paging::flags(rodata_va).expect("rodata VA not mapped");
+    assert!(
+        rodata_flags.contains(PageTableFlags::NO_EXECUTE),
+        "rodata X"
+    );
+    assert!(!rodata_flags.contains(PageTableFlags::WRITABLE), "rodata W");
+
+    // .data — a mutable static lives in `.data`. Must be NX and
+    // writable.
+    static mut DATA_MARKER: u64 = 0xA5A5_A5A5_A5A5_A5A5;
+    let data_va = VirtAddr::new(core::ptr::addr_of!(DATA_MARKER) as u64);
+    let data_flags = paging::flags(data_va).expect("data VA not mapped");
+    assert!(data_flags.contains(PageTableFlags::NO_EXECUTE), "data X");
+    assert!(
+        data_flags.contains(PageTableFlags::WRITABLE),
+        "data not W: {data_flags:?}"
+    );
+
+    serial_println!("  text={text_flags:?} rodata={rodata_flags:?} data={data_flags:?}");
 }
 
 fn heap_grows_after_switch() {


### PR DESCRIPTION
## Summary

- `populate_kernel_image` now iterates the kernel ELF's `PT_LOAD` program headers (via a new `limine::ExecutableFileRequest`) and derives `{R, W, X}` directly from each segment's `p_flags`. The linker-symbol array (`__text_start`, `__rodata_start`, ...) and the hard-coded per-section flag table are gone — adding a new kernel section no longer requires touching `paging.rs`.
- New `mem::elf` module: ~80 lines, hand-rolled ELF64 Ehdr/Phdr walker. Deliberately no `xmas-elf` / `goblin` — a future userspace ELF loader can grow this module instead of adding a second parser.
- New `paging::flags(va) -> Option<PageTableFlags>` helper lets tests inspect leaf PTE flags.

Closes #48.

## Test plan

- [x] `cargo xtask build`
- [x] `cargo xtask test` — 19 lib tests pass; `pml4_switch` now has 5 tests (added `elf_derived_segment_flags`) and all pass. Observed flags in-kernel: `text=PRESENT`, `rodata=PRESENT|NO_EXECUTE`, `data=PRESENT|WRITABLE|NO_EXECUTE`.
- [x] `cargo xtask smoke` — all 16 serial markers present.
- [x] `cargo fmt --all --check` clean.
