### PR TITLE
shell: tiny kernel shell driven by PS/2 keyboard

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,1 @@
+scheduled_tasks.lock

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"23d53bde-3198-4807-9340-f9b8e6e4cacf","pid":422949,"acquiredAt":1776013383174}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"23d53bde-3198-4807-9340-f9b8e6e4cacf","pid":422949,"acquiredAt":1776013383174}

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -87,3 +87,7 @@ harness = false
 [[test]]
 name = "blocking_sync"
 harness = false
+
+[[test]]
+name = "shell_smoke"
+harness = false

--- a/kernel/src/input.rs
+++ b/kernel/src/input.rs
@@ -101,6 +101,22 @@ mod kernel_side {
         without_interrupts(|| SCANCODES.lock().pop())
     }
 
+    /// Non-blocking counterpart to [`read_key`]. Drains any queued
+    /// scancodes through the `pc-keyboard` state machine and returns the
+    /// first decoded key produced, or `None` if the ring is empty or the
+    /// drained codes only advanced modifier state.
+    pub fn try_read_key() -> Option<DecodedKey> {
+        while let Some(code) = try_read_scancode() {
+            let mut kbd = KEYBOARD.lock();
+            if let Ok(Some(event)) = kbd.add_byte(code) {
+                if let Some(key) = kbd.process_keyevent(event) {
+                    return Some(key);
+                }
+            }
+        }
+        None
+    }
+
     pub fn scancode_overflows() -> u64 {
         OVERFLOWS.load(Ordering::Relaxed)
     }

--- a/kernel/src/input.rs
+++ b/kernel/src/input.rs
@@ -105,13 +105,21 @@ mod kernel_side {
     /// scancodes through the `pc-keyboard` state machine and returns the
     /// first decoded key produced, or `None` if the ring is empty or the
     /// drained codes only advanced modifier state.
+    /// Feed one scancode through the `pc-keyboard` state machine. Returns
+    /// `Some(key)` only when the byte completes a decoded keypress; scancodes
+    /// that only advance modifier state yield `None`.
+    fn decode_scancode(code: u8) -> Option<DecodedKey> {
+        let mut kbd = KEYBOARD.lock();
+        if let Ok(Some(event)) = kbd.add_byte(code) {
+            return kbd.process_keyevent(event);
+        }
+        None
+    }
+
     pub fn try_read_key() -> Option<DecodedKey> {
         while let Some(code) = try_read_scancode() {
-            let mut kbd = KEYBOARD.lock();
-            if let Ok(Some(event)) = kbd.add_byte(code) {
-                if let Some(key) = kbd.process_keyevent(event) {
-                    return Some(key);
-                }
+            if let Some(key) = decode_scancode(code) {
+                return Some(key);
             }
         }
         None
@@ -129,11 +137,8 @@ mod kernel_side {
     pub fn read_key() -> DecodedKey {
         loop {
             while let Some(code) = try_read_scancode() {
-                let mut kbd = KEYBOARD.lock();
-                if let Ok(Some(event)) = kbd.add_byte(code) {
-                    if let Some(key) = kbd.process_keyevent(event) {
-                        return key;
-                    }
+                if let Some(key) = decode_scancode(code) {
+                    return key;
                 }
             }
             interrupts::disable();

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -28,6 +28,8 @@ pub mod ksymtab;
 #[cfg(target_os = "none")]
 pub mod serial;
 #[cfg(target_os = "none")]
+pub mod shell;
+#[cfg(target_os = "none")]
 pub mod sync;
 #[cfg(target_os = "none")]
 pub mod task;

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -5,7 +5,7 @@ use core::panic::PanicInfo;
 
 use vibix::boot::{BASE_REVISION, FRAMEBUFFER_REQUEST, HHDM_REQUEST, MEMMAP_REQUEST, RSDP_REQUEST};
 use vibix::framebuffer::Console;
-use vibix::{exit_qemu, framebuffer, println, serial_print, serial_println, QemuExitCode};
+use vibix::{exit_qemu, framebuffer, println, serial_println, QemuExitCode};
 
 /// How many PIT ticks between cursor blink toggles (~500 ms at 100 Hz).
 const CURSOR_BLINK_TICKS: u64 = 50;
@@ -122,24 +122,12 @@ pub extern "C" fn _start() -> ! {
     serial_println!("interrupts enabled");
 
     vibix::task::init();
-    vibix::task::spawn(idle_task);
+    vibix::task::spawn(vibix::shell::run);
     vibix::task::spawn(cursor_blink_task);
 
-    loop {
-        // `read_key` itself blocks on `hlt` until a scancode arrives;
-        // the PIT preempt tick can switch us out of that wait to any
-        // other ready task.
-        match vibix::input::read_key() {
-            pc_keyboard::DecodedKey::Unicode(c) => serial_print!("{}", c),
-            pc_keyboard::DecodedKey::RawKey(key) => serial_print!("[{:?}]", key),
-        }
-    }
-}
-
-fn idle_task() -> ! {
-    // `hlt` with IRQs on parks the CPU until the next interrupt, at
-    // which point `preempt_tick` may rotate us out. No explicit yield
-    // needed.
+    // Bootstrap task becomes the idle loop. `hlt` with IRQs on parks
+    // the CPU until the next interrupt; the PIT `preempt_tick` then
+    // rotates us to any other ready task (shell, cursor_blink).
     loop {
         x86_64::instructions::hlt();
     }

--- a/kernel/src/mem/frame.rs
+++ b/kernel/src/mem/frame.rs
@@ -229,6 +229,13 @@ mod global {
 #[cfg(target_os = "none")]
 pub use global::{global, init};
 
+/// Number of free 4 KiB physical frames in the global allocator. Briefly
+/// locks the allocator — suitable for diagnostics, not hot paths.
+#[cfg(target_os = "none")]
+pub fn free_frames() -> usize {
+    global().lock().free_frames()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/kernel/src/mem/heap.rs
+++ b/kernel/src/mem/heap.rs
@@ -133,6 +133,24 @@ pub fn mapped_size() -> usize {
     ALLOCATOR.mapped_size()
 }
 
+/// Snapshot of heap occupancy. `used + free == mapped_size()`.
+pub struct HeapStats {
+    pub used: usize,
+    pub free: usize,
+    pub mapped: usize,
+}
+
+/// Read a consistent snapshot of the heap. Briefly locks the inner
+/// allocator — do not call from allocation-sensitive paths.
+pub fn stats() -> HeapStats {
+    let h = ALLOCATOR.inner.lock();
+    HeapStats {
+        used: h.used(),
+        free: h.free(),
+        mapped: ALLOCATOR.mapped_size(),
+    }
+}
+
 /// Map the initial slab and hand it to the inner heap. Requires
 /// `paging::init` to have run so `map_range` is live.
 pub fn init() {

--- a/kernel/src/mem/heap.rs
+++ b/kernel/src/mem/heap.rs
@@ -142,12 +142,19 @@ pub struct HeapStats {
 
 /// Read a consistent snapshot of the heap. Briefly locks the inner
 /// allocator — do not call from allocation-sensitive paths.
+///
+/// `mapped` is derived from `used + free` inside the same lock scope so
+/// it can't disagree with the other two fields. Reading `mapped` from
+/// the separate `AtomicUsize` would race with `grow_locked`, which
+/// releases the inner lock between `extend()` and the atomic bump.
 pub fn stats() -> HeapStats {
     let h = ALLOCATOR.inner.lock();
+    let used = h.used();
+    let free = h.free();
     HeapStats {
-        used: h.used(),
-        free: h.free(),
-        mapped: ALLOCATOR.mapped_size(),
+        used,
+        free,
+        mapped: used + free,
     }
 }
 

--- a/kernel/src/shell/mod.rs
+++ b/kernel/src/shell/mod.rs
@@ -14,6 +14,7 @@ use core::sync::atomic::{AtomicBool, Ordering};
 use pc_keyboard::DecodedKey;
 
 use crate::mem::{frame, heap, FRAME_SIZE};
+use crate::task::TaskStateView;
 use crate::{input, serial_print, serial_println, task, time};
 
 /// Flipped to `true` the first time the shell's `run` enters its main
@@ -129,10 +130,15 @@ fn cmd_tasks() {
     task::for_each_task(|t| tasks.push(t));
 
     for t in tasks {
+        let tag = match t.state {
+            TaskStateView::Running => "[run]",
+            TaskStateView::Ready => "[rdy]",
+            TaskStateView::Blocked => "[blk]",
+        };
         serial_println!(
             "  task {:>3} {} slice={} ms",
             t.id,
-            if t.is_current { "[run]" } else { "[rdy]" },
+            tag,
             t.slice_remaining_ms,
         );
     }

--- a/kernel/src/shell/mod.rs
+++ b/kernel/src/shell/mod.rs
@@ -22,6 +22,10 @@ use crate::{input, serial_print, serial_println, task, time};
 pub static SHELL_ONLINE: AtomicBool = AtomicBool::new(false);
 
 const PROMPT: &str = "vibix> ";
+/// Maximum line length in bytes. Additional keystrokes past this cap
+/// are silently dropped so a stuck key or keyboard auto-repeat can't
+/// grow the input buffer unchecked against the 16 MiB heap ceiling.
+const MAX_LINE_LEN: usize = 256;
 
 /// Task entry point. Spawn as `task::spawn(shell::run)`.
 pub fn run() -> ! {
@@ -45,8 +49,10 @@ pub fn run() -> ! {
                 }
             }
             Some(DecodedKey::Unicode(c)) if !c.is_control() => {
-                line.push(c);
-                serial_print!("{}", c);
+                if line.len() + c.len_utf8() <= MAX_LINE_LEN {
+                    line.push(c);
+                    serial_print!("{}", c);
+                }
             }
             Some(_) => {}
             // Nothing in the scancode ring. Halt until the next IRQ

--- a/kernel/src/shell/mod.rs
+++ b/kernel/src/shell/mod.rs
@@ -1,0 +1,123 @@
+//! Tiny kernel shell, spawned as its own preemptively-scheduled task.
+//!
+//! Reads a line from the PS/2 keyboard, dispatches it against a small
+//! table of builtins, and loops. When no input is pending the task
+//! `hlt`s — the keyboard ISR wakes the CPU on the next keypress, and
+//! the PIT preempt tick rotates other tasks in meanwhile.
+//!
+//! The input path is PS/2-only for now. Serial RX is orthogonal (needs
+//! IOAPIC IRQ4 routing) and deliberately out of scope for this module.
+
+use alloc::string::String;
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use pc_keyboard::DecodedKey;
+
+use crate::mem::{frame, heap, FRAME_SIZE};
+use crate::{input, serial_print, serial_println, task, time};
+
+/// Flipped to `true` the first time the shell's `run` enters its main
+/// loop. Integration tests poll this to confirm the shell actually
+/// started; `main` doesn't care.
+pub static SHELL_ONLINE: AtomicBool = AtomicBool::new(false);
+
+const PROMPT: &str = "vibix> ";
+
+/// Task entry point. Spawn as `task::spawn(shell::run)`.
+pub fn run() -> ! {
+    serial_println!("shell: prompt online");
+    SHELL_ONLINE.store(true, Ordering::SeqCst);
+    prompt();
+
+    let mut line = String::new();
+    loop {
+        match input::try_read_key() {
+            Some(DecodedKey::Unicode('\r')) | Some(DecodedKey::Unicode('\n')) => {
+                serial_print!("\r\n");
+                dispatch(line.trim());
+                line.clear();
+                prompt();
+            }
+            // Backspace (0x08) or DEL (0x7f) — both map to "erase one char".
+            Some(DecodedKey::Unicode('\x08')) | Some(DecodedKey::Unicode('\x7f')) => {
+                if line.pop().is_some() {
+                    serial_print!("\x08 \x08");
+                }
+            }
+            Some(DecodedKey::Unicode(c)) if !c.is_control() => {
+                line.push(c);
+                serial_print!("{}", c);
+            }
+            Some(_) => {}
+            // Nothing in the scancode ring. Halt until the next IRQ
+            // (keyboard press wakes us; PIT rotates us out on slice
+            // expiry).
+            None => x86_64::instructions::hlt(),
+        }
+    }
+}
+
+fn prompt() {
+    serial_print!("{}", PROMPT);
+}
+
+fn dispatch(line: &str) {
+    if line.is_empty() {
+        return;
+    }
+    let (cmd, rest) = match line.split_once(' ') {
+        Some((c, r)) => (c, r.trim_start()),
+        None => (line, ""),
+    };
+    match cmd {
+        "help" => cmd_help(),
+        "uptime" => cmd_uptime(),
+        "mem" => cmd_mem(),
+        "tasks" => cmd_tasks(),
+        "echo" => serial_println!("{}", rest),
+        "panic" => panic!("shell: panic builtin invoked"),
+        _ => serial_println!("unknown command: {} (try `help`)", cmd),
+    }
+}
+
+fn cmd_help() {
+    serial_println!("builtins:");
+    serial_println!("  help            show this list");
+    serial_println!("  uptime          milliseconds since boot");
+    serial_println!("  mem             heap + free-frame counters");
+    serial_println!("  tasks           live task ids and remaining slices");
+    serial_println!("  echo <args>     echo the rest of the line");
+    serial_println!("  panic           trigger a kernel panic (test aid)");
+}
+
+fn cmd_uptime() {
+    let ms = time::uptime_ms();
+    serial_println!("uptime: {} ms ({}.{:03} s)", ms, ms / 1000, ms % 1000);
+}
+
+fn cmd_mem() {
+    let h = heap::stats();
+    serial_println!(
+        "heap:   used {} B, free {} B, mapped {} KiB",
+        h.used,
+        h.free,
+        h.mapped / 1024,
+    );
+    let free = frame::free_frames();
+    serial_println!(
+        "frames: {} free ({} KiB)",
+        free,
+        (free as u64 * FRAME_SIZE) / 1024,
+    );
+}
+
+fn cmd_tasks() {
+    task::for_each_task(|t| {
+        serial_println!(
+            "  task {:>3} {} slice={} ms",
+            t.id,
+            if t.is_current { "[run]" } else { "[rdy]" },
+            t.slice_remaining_ms,
+        );
+    });
+}

--- a/kernel/src/shell/mod.rs
+++ b/kernel/src/shell/mod.rs
@@ -38,7 +38,9 @@ pub fn run() -> ! {
         match input::try_read_key() {
             Some(DecodedKey::Unicode('\r')) | Some(DecodedKey::Unicode('\n')) => {
                 serial_print!("\r\n");
-                dispatch(line.trim());
+                // Only strip leading whitespace so `echo` can round-trip
+                // user-entered trailing spaces.
+                dispatch(line.trim_start());
                 line.clear();
                 prompt();
             }
@@ -72,7 +74,7 @@ fn dispatch(line: &str) {
         return;
     }
     let (cmd, rest) = match line.split_once(' ') {
-        Some((c, r)) => (c, r.trim_start()),
+        Some((c, r)) => (c, r),
         None => (line, ""),
     };
     match cmd {
@@ -118,12 +120,20 @@ fn cmd_mem() {
 }
 
 fn cmd_tasks() {
-    task::for_each_task(|t| {
+    // Collect the snapshot before any serial I/O: `for_each_task` holds
+    // the scheduler lock for the duration of its closure, so printing
+    // inside it would both lengthen the critical section and invite
+    // lock-ordering trouble if the serial path ever grows dependencies
+    // on the scheduler.
+    let mut tasks: alloc::vec::Vec<task::TaskInfo> = alloc::vec::Vec::new();
+    task::for_each_task(|t| tasks.push(t));
+
+    for t in tasks {
         serial_println!(
             "  task {:>3} {} slice={} ms",
             t.id,
             if t.is_current { "[run]" } else { "[rdy]" },
             t.slice_remaining_ms,
         );
-    });
+    }
 }

--- a/kernel/src/shell/mod.rs
+++ b/kernel/src/shell/mod.rs
@@ -121,15 +121,7 @@ fn cmd_mem() {
 }
 
 fn cmd_tasks() {
-    // Collect the snapshot before any serial I/O: `for_each_task` holds
-    // the scheduler lock for the duration of its closure, so printing
-    // inside it would both lengthen the critical section and invite
-    // lock-ordering trouble if the serial path ever grows dependencies
-    // on the scheduler.
-    let mut tasks: alloc::vec::Vec<task::TaskInfo> = alloc::vec::Vec::new();
-    task::for_each_task(|t| tasks.push(t));
-
-    for t in tasks {
+    task::for_each_task(|t| {
         let tag = match t.state {
             TaskStateView::Running => "[run]",
             TaskStateView::Ready => "[rdy]",
@@ -141,5 +133,5 @@ fn cmd_tasks() {
             tag,
             t.slice_remaining_ms,
         );
-    }
+    });
 }

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -66,6 +66,38 @@ pub fn spawn(entry: fn() -> !) {
     sched.ready.push_back(Box::new(Task::new(entry)));
 }
 
+/// Snapshot of one task's diagnostic-relevant fields. Returned by
+/// [`for_each_task`] so callers (e.g. the shell's `tasks` builtin) can
+/// enumerate live tasks without touching the scheduler's internals.
+#[derive(Clone, Copy)]
+pub struct TaskInfo {
+    pub id: usize,
+    pub slice_remaining_ms: u32,
+    /// `true` for the currently-running task, `false` for ready-queue entries.
+    pub is_current: bool,
+}
+
+/// Invoke `f` once per live task (current first, then ready queue in
+/// FIFO order). Holds the scheduler lock for the duration, so `f` must
+/// not call back into `task::*`.
+pub fn for_each_task(mut f: impl FnMut(TaskInfo)) {
+    let sched = SCHED.lock();
+    if let Some(cur) = sched.current.as_ref() {
+        f(TaskInfo {
+            id: cur.id,
+            slice_remaining_ms: cur.slice_remaining_ms,
+            is_current: true,
+        });
+    }
+    for t in sched.ready.iter() {
+        f(TaskInfo {
+            id: t.id,
+            slice_remaining_ms: t.slice_remaining_ms,
+            is_current: false,
+        });
+    }
+}
+
 /// Check whether `addr` falls within any live kernel task's guard page.
 /// Returns the task ID of the overflowing task, or `None` if no guard
 /// page was hit.

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -66,6 +66,14 @@ pub fn spawn(entry: fn() -> !) {
     sched.ready.push_back(Box::new(Task::new(entry)));
 }
 
+/// Public view of a task's scheduling state, used by [`TaskInfo`].
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum TaskStateView {
+    Running,
+    Ready,
+    Blocked,
+}
+
 /// Snapshot of one task's diagnostic-relevant fields. Returned by
 /// [`for_each_task`] so callers (e.g. the shell's `tasks` builtin) can
 /// enumerate live tasks without touching the scheduler's internals.
@@ -73,27 +81,40 @@ pub fn spawn(entry: fn() -> !) {
 pub struct TaskInfo {
     pub id: usize,
     pub slice_remaining_ms: u32,
-    /// `true` for the currently-running task, `false` for ready-queue entries.
-    pub is_current: bool,
+    pub state: TaskStateView,
 }
 
-/// Invoke `f` once per live task (current first, then ready queue in
-/// FIFO order). Holds the scheduler lock for the duration, so `f` must
-/// not call back into `task::*`.
+impl TaskInfo {
+    pub fn is_current(&self) -> bool {
+        self.state == TaskStateView::Running
+    }
+}
+
+/// Invoke `f` once per live task: current first, then ready queue in
+/// FIFO order, then parked (blocked) tasks in id order. Holds the
+/// scheduler lock for the duration, so `f` must not call back into
+/// `task::*`.
 pub fn for_each_task(mut f: impl FnMut(TaskInfo)) {
     let sched = SCHED.lock();
     if let Some(cur) = sched.current.as_ref() {
         f(TaskInfo {
             id: cur.id,
             slice_remaining_ms: cur.slice_remaining_ms,
-            is_current: true,
+            state: TaskStateView::Running,
         });
     }
     for t in sched.ready.iter() {
         f(TaskInfo {
             id: t.id,
             slice_remaining_ms: t.slice_remaining_ms,
-            is_current: false,
+            state: TaskStateView::Ready,
+        });
+    }
+    for t in sched.parked.values() {
+        f(TaskInfo {
+            id: t.id,
+            slice_remaining_ms: t.slice_remaining_ms,
+            state: TaskStateView::Blocked,
         });
     }
 }

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -84,38 +84,42 @@ pub struct TaskInfo {
     pub state: TaskStateView,
 }
 
-impl TaskInfo {
-    pub fn is_current(&self) -> bool {
-        self.state == TaskStateView::Running
-    }
-}
-
 /// Invoke `f` once per live task: current first, then ready queue in
-/// FIFO order, then parked (blocked) tasks in id order. Holds the
-/// scheduler lock for the duration, so `f` must not call back into
-/// `task::*`.
+/// FIFO order, then parked (blocked) tasks in id order. Snapshots the
+/// scheduler under lock and drops it before invoking `f`, so the
+/// callback is free to touch any other subsystem (including serial I/O
+/// and other `task::*` calls).
 pub fn for_each_task(mut f: impl FnMut(TaskInfo)) {
-    let sched = SCHED.lock();
-    if let Some(cur) = sched.current.as_ref() {
-        f(TaskInfo {
-            id: cur.id,
-            slice_remaining_ms: cur.slice_remaining_ms,
-            state: TaskStateView::Running,
-        });
-    }
-    for t in sched.ready.iter() {
-        f(TaskInfo {
-            id: t.id,
-            slice_remaining_ms: t.slice_remaining_ms,
-            state: TaskStateView::Ready,
-        });
-    }
-    for t in sched.parked.values() {
-        f(TaskInfo {
-            id: t.id,
-            slice_remaining_ms: t.slice_remaining_ms,
-            state: TaskStateView::Blocked,
-        });
+    let snapshot: alloc::vec::Vec<TaskInfo> = {
+        let sched = SCHED.lock();
+        let mut out = alloc::vec::Vec::with_capacity(
+            sched.current.is_some() as usize + sched.ready.len() + sched.parked.len(),
+        );
+        if let Some(cur) = sched.current.as_ref() {
+            out.push(TaskInfo {
+                id: cur.id,
+                slice_remaining_ms: cur.slice_remaining_ms,
+                state: TaskStateView::Running,
+            });
+        }
+        for t in sched.ready.iter() {
+            out.push(TaskInfo {
+                id: t.id,
+                slice_remaining_ms: t.slice_remaining_ms,
+                state: TaskStateView::Ready,
+            });
+        }
+        for t in sched.parked.values() {
+            out.push(TaskInfo {
+                id: t.id,
+                slice_remaining_ms: t.slice_remaining_ms,
+                state: TaskStateView::Blocked,
+            });
+        }
+        out
+    };
+    for info in snapshot {
+        f(info);
     }
 }
 

--- a/kernel/tests/shell_smoke.rs
+++ b/kernel/tests/shell_smoke.rs
@@ -1,0 +1,60 @@
+//! Integration test: spawning `shell::run` flips the `SHELL_ONLINE`
+//! flag after a handful of yields, proving the shell task actually got
+//! scheduled and entered its main loop.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use core::sync::atomic::Ordering;
+
+use vibix::{
+    exit_qemu, serial_println,
+    shell::SHELL_ONLINE,
+    task,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    task::init();
+    // Enable preemption: without IF=1 the PIT won't fire and the
+    // spawned shell task will never get the CPU back from the driver.
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[(
+        "shell_task_comes_online",
+        &(shell_task_comes_online as fn()),
+    )];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+fn shell_task_comes_online() {
+    assert!(!SHELL_ONLINE.load(Ordering::SeqCst));
+    task::spawn(vibix::shell::run);
+    for _ in 0..100 {
+        if SHELL_ONLINE.load(Ordering::SeqCst) {
+            return;
+        }
+        // PIT preempt ticks rotate the spawned shell task in.
+        x86_64::instructions::hlt();
+    }
+    panic!("SHELL_ONLINE never flipped — shell task didn't start");
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -501,6 +501,7 @@ fn test_all() -> R<()> {
         "backtrace",
         "page_fault",
         "blocking_sync",
+        "shell_smoke",
     ] {
         cmd.arg("--test").arg(t);
     }


### PR DESCRIPTION
Closes #40

## Summary
- Adds a cooperative kernel-task shell (`kernel/src/shell/mod.rs`) reading from PS/2 with `try_read_key`, dispatching six builtins: `help`, `uptime`, `mem`, `tasks`, `echo`, `panic`.
- Replaces the ad-hoc `read_key` echo loop in `_start` with `task::spawn(shell::run)`; the bootstrap task becomes an idle `hlt + yield` loop.
- Small diagnostic accessors to keep the shell from reaching into internals: `input::try_read_key`, `task::for_each_task` + `TaskInfo`, `mem::heap::stats`, `mem::frame::free_frames`.
- Serial RX is deliberately out of scope — needs IOAPIC IRQ4 routing orthogonal to shell semantics.

## Test plan
- [x] `cargo xtask build` — warnings pre-existing (guard_base dead_code from #71).
- [x] `cargo xtask test` — 19 host unit tests pass; all integration tests pass including new `shell_smoke` asserting `SHELL_ONLINE` flips after spawn.
- [x] `cargo xtask smoke` — all 16 boot markers present, including `shell: prompt online`.
- [x] Manual: boot in QEMU with PS/2 keyboard, type `help`, `uptime`, `mem`, `tasks`, `echo hello`, verify output on serial.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new preemptively-scheduled shell task and changes the boot flow to run it, touching the kernel task scheduler and keyboard input path. Also exposes new heap/frame/task introspection helpers that could affect locking/diagnostic behavior if misused.
> 
> **Overview**
> Introduces a tiny interactive kernel shell (`shell::run`) that reads PS/2 keyboard input, maintains a bounded line buffer, and dispatches builtins like `help`, `uptime`, `mem`, `tasks`, `echo`, and `panic`.
> 
> Boot now spawns the shell as a task and turns the bootstrap thread into the idle `hlt` loop, replacing the previous direct keyboard-echo loop in `main`.
> 
> Adds non-blocking keyboard input via `input::try_read_key` (factoring scancode decoding), plus small diagnostic accessors (`heap::stats`, `frame::free_frames`, `task::for_each_task`/`TaskInfo`) to support shell commands, and wires up a new `shell_smoke` QEMU integration test in `Cargo.toml`/`xtask`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 126979cc9fe66f02d3944824ac716e50f767a1ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->