### PR TITLE
docs: document each major subsystem in docs/

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,13 @@ arch::init()            — GDT + TSS, IDT, 8259 PIC remapped + masked
 mem::init()             — frame allocator, paging mapper, heap
 arch::init_apic()       — ACPI parse, LAPIC + IOAPIC init, IRQ routing
 time::init()            — PIT at 100 Hz
-sti                     — interrupts enabled (done by the caller)
+                          (vibix::init() returns; interrupts still disabled)
+```
+
+After `vibix::init()` returns, the caller (`main.rs`) completes initialization:
+
+```
+sti                     — interrupts enabled
 task::init()            — bootstrap task, scheduler online
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,39 @@
+# vibix Kernel — Subsystem Documentation
+
+This directory contains documentation for each major subsystem of the vibix
+kernel. Each file describes the design, key data structures, initialization
+sequence, and public API for its subsystem.
+
+## Subsystems
+
+| Document | Subsystem | Source |
+|---|---|---|
+| [boot.md](boot.md) | Limine boot protocol interface | `kernel/src/boot.rs` |
+| [serial.md](serial.md) | COM1 serial console | `kernel/src/serial.rs` |
+| [framebuffer.md](framebuffer.md) | Framebuffer text console | `kernel/src/framebuffer.rs` |
+| [memory.md](memory.md) | Physical frame allocator, heap, paging, PAT | `kernel/src/mem/` |
+| [interrupts.md](interrupts.md) | GDT, IDT, PIC, APIC, ISRs | `kernel/src/arch/x86_64/` |
+| [acpi.md](acpi.md) | ACPI RSDP/MADT parser | `kernel/src/acpi.rs` |
+| [time.md](time.md) | PIT-driven monotonic clock | `kernel/src/time.rs` |
+| [input.md](input.md) | PS/2 keyboard and ring buffer | `kernel/src/input.rs` |
+| [tasks.md](tasks.md) | Cooperative/preemptive scheduler | `kernel/src/task/` |
+| [diagnostics.md](diagnostics.md) | klog ring, ksymtab, backtrace unwinder | `kernel/src/klog.rs`, `kernel/src/ksymtab.rs`, `kernel/src/arch/x86_64/backtrace.rs` |
+
+## Initialization Order
+
+The kernel brings subsystems up in a fixed sequence. The `vibix::init()`
+function (in `kernel/src/lib.rs`) encodes the mandatory ordering for code
+shared between the main binary and integration tests:
+
+```
+serial::init()          — COM1 online; all subsequent output is visible
+arch::init()            — GDT + TSS, IDT, 8259 PIC remapped + masked
+mem::init()             — frame allocator, paging mapper, heap
+arch::init_apic()       — ACPI parse, LAPIC + IOAPIC init, IRQ routing
+time::init()            — PIT at 100 Hz
+sti                     — interrupts enabled (done by the caller)
+task::init()            — bootstrap task, scheduler online
+```
+
+The framebuffer console is optional and initialized separately in `main.rs`
+immediately after `serial::init()`, before the shared `vibix::init()` call.

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ sequence, and public API for its subsystem.
 
 ## Initialization Order
 
-The kernel brings subsystems up in a fixed sequence. The `vibix::init()`
+The kernel initializes subsystems in a fixed sequence. The `vibix::init()`
 function (in `kernel/src/lib.rs`) encodes the mandatory ordering for code
 shared between the main binary and integration tests:
 
@@ -29,7 +29,8 @@ shared between the main binary and integration tests:
 serial::init()          — COM1 online; all subsequent output is visible
 arch::init()            — GDT + TSS, IDT, 8259 PIC remapped + masked
 mem::init()             — frame allocator, paging mapper, heap
-arch::init_apic()       — ACPI parse, LAPIC + IOAPIC init, IRQ routing
+arch::init_apic(rsdp_phys, hhdm_offset)
+                        — ACPI parse, LAPIC + IOAPIC init, IRQ routing
 time::init()            — PIT at 100 Hz
                           (vibix::init() returns; interrupts still disabled)
 ```

--- a/docs/acpi.md
+++ b/docs/acpi.md
@@ -1,0 +1,95 @@
+# ACPI Subsystem
+
+**Source:** `kernel/src/acpi.rs`
+
+## Overview
+
+The ACPI subsystem parses just enough of the ACPI table hierarchy to discover
+the interrupt topology needed to bring up the APIC: the LAPIC physical address
+and the set of IOAPICs and interrupt source overrides recorded in the MADT.
+
+AML execution, the DSDT, SSDT, and any other ACPI functionality are out of
+scope.
+
+## Design
+
+Limine hands the kernel a physical pointer to the RSDP (Root System Description
+Pointer). The parser follows the chain:
+
+```
+RSDP → XSDT (64-bit pointer table, preferred)
+     → RSDT (32-bit pointer table, fallback for revision 0 firmware)
+     → MADT (signature "APIC")
+     → entries
+```
+
+All physical addresses encountered in the tables are translated to virtual by
+adding the HHDM offset. Because ACPI tables may live in ROM or reserved regions
+not covered by Limine's HHDM, `map_phys_into_hhdm` is called before each
+table is accessed.
+
+Checksums (byte-sum over the entire table = 0) are verified for the RSDP and
+every SDT that is read.
+
+## Data Structures
+
+### `AcpiInfo`
+
+Returned from `parse_madt` and stored in a global `Once<AcpiInfo>`:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `lapic_phys` | `u64` | Physical address of the Local APIC registers (may be overridden by entry type 5) |
+| `cpu_count` | `u32` | Number of enabled (or online-capable) processors |
+| `ioapics` | `[Option<IoApic>; 4]` | Up to 4 IOAPIC descriptors |
+| `overrides` | `[Option<InterruptOverride>; 16]` | ISA IRQ → GSI remappings |
+
+### `IoApic`
+
+| Field | Type | Meaning |
+|---|---|---|
+| `id` | `u8` | IOAPIC APIC ID |
+| `phys_addr` | `u32` | MMIO base address |
+| `gsi_base` | `u32` | First Global System Interrupt handled by this IOAPIC |
+
+### `InterruptOverride`
+
+| Field | Type | Meaning |
+|---|---|---|
+| `bus` | `u8` | Source bus (0 = ISA) |
+| `source` | `u8` | ISA IRQ number |
+| `gsi` | `u32` | Target Global System Interrupt |
+| `flags` | `u16` | Polarity and trigger mode bits (from the MADT entry) |
+
+## MADT Entry Types Parsed
+
+| Type | Name | Action |
+|---|---|---|
+| 0 | Processor Local APIC | Increment `cpu_count` if enabled or online-capable |
+| 1 | IOAPIC | Record `IoApic` descriptor |
+| 2 | Interrupt Source Override | Record `InterruptOverride` |
+| 5 | LAPIC Address Override | Replace `lapic_phys` with the 64-bit address |
+
+## Initialization
+
+```rust
+acpi::init(rsdp_phys, hhdm_offset);
+```
+
+Must be called after `mem::init()` (the HHDM mapper must be live to map ACPI
+table pages). Stores the result in `INFO` via `Once::call_once`. After init,
+call `acpi::info()` to get a `&'static AcpiInfo`.
+
+## API
+
+```rust
+// After acpi::init():
+if let Some(info) = acpi::info() {
+    for ioapic in info.ioapics() { /* ... */ }
+    let (gsi, flags) = info.resolve_isa_irq(1); // keyboard
+}
+```
+
+`resolve_isa_irq(irq)` maps an ISA IRQ number to a GSI and polarity/trigger
+flags, applying any override from the MADT. With no override, ISA IRQs are
+identity-mapped (IRQ N → GSI N, edge-triggered active-high).

--- a/docs/boot.md
+++ b/docs/boot.md
@@ -1,0 +1,66 @@
+# Boot Subsystem
+
+**Source:** `kernel/src/boot.rs`
+
+## Overview
+
+vibix boots under the [Limine boot protocol](https://github.com/limine-bootloader/limine/blob/trunk/PROTOCOL.md).
+The boot subsystem is a thin collection of Limine request statics that the
+bootloader locates via dedicated link sections and fills in before transferring
+control to `_start`.
+
+No initialization function is required — the statics are populated by the
+bootloader before the kernel runs. All other subsystems that need boot
+information (memory map, HHDM offset, RSDP) call the relevant `.get_response()`
+method directly.
+
+## Design
+
+Limine's protocol works by embedding well-known magic-number structs (requests)
+in the kernel binary inside a specific linker section. The bootloader scans the
+image, fills each request in place, then jumps to the kernel entry point. The
+start and end markers (`_START_MARKER`, `_END_MARKER`) delimit this section so
+the bootloader can efficiently scan it.
+
+## Requests
+
+| Static | Type | Purpose |
+|---|---|---|
+| `BASE_REVISION` | `BaseRevision` | Asserts protocol compatibility (checked in `_start`) |
+| `FRAMEBUFFER_REQUEST` | `FramebufferRequest` | Linear framebuffer address, dimensions, pixel format |
+| `MEMMAP_REQUEST` | `MemoryMapRequest` | Physical memory map (USABLE, reserved, reclaimable regions) |
+| `HHDM_REQUEST` | `HhdmRequest` | Higher-Half Direct Map base offset |
+| `STACK_REQUEST` | `StackSizeRequest` | Requests a 64 KiB bootstrap stack |
+| `KERNEL_ADDRESS_REQUEST` | `ExecutableAddressRequest` | Physical + virtual base of the loaded kernel image (used by ksymtab) |
+| `KERNEL_FILE_REQUEST` | `ExecutableFileRequest` | The kernel ELF file itself (used by ksymtab to embed the symbol table) |
+| `RSDP_REQUEST` | `RsdpRequest` | Physical address of the ACPI RSDP (passed to `acpi::init`) |
+
+## Usage
+
+All requests are `pub` and can be accessed from anywhere in the kernel:
+
+```rust
+use vibix::boot::HHDM_REQUEST;
+
+let hhdm_offset = HHDM_REQUEST
+    .get_response()
+    .expect("Limine HHDM response missing")
+    .offset();
+```
+
+`get_response()` returns `None` if the bootloader did not fill in the request
+(e.g., the bootloader does not support that feature). Most callers `expect` or
+`unwrap` these responses because the kernel cannot make progress without them.
+
+## Higher-Half Direct Map
+
+The HHDM offset is a key constant for the rest of the kernel. Limine maps all
+of physical memory at `HHDM_OFFSET + physical_address`. Subsystems that need to
+dereference physical addresses (ACPI table walking, APIC MMIO, paging) add the
+HHDM offset to convert physical → virtual.
+
+## Linker Integration
+
+`kernel/linker.ld` reserves the `.limine_requests` section so the bootloader
+can find all requests. The start and end marker objects delimit the extent of
+this section.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,0 +1,177 @@
+# Diagnostics Subsystem
+
+**Sources:**
+- `kernel/src/klog.rs` — leveled ring-buffer log
+- `kernel/src/ksymtab.rs` — embedded kernel symbol table
+- `kernel/src/arch/x86_64/backtrace.rs` — frame-pointer stack unwinder
+
+## Overview
+
+Three components work together to provide structured kernel logging and
+symbolicated panic backtraces:
+
+1. **klog** retains the most recent log records in a fixed 64 KiB ring buffer.
+   On panic, the last N records are dumped to serial.
+2. **ksymtab** embeds a post-link symbol table (address → name mappings) in the
+   kernel `.rodata` section. It is patched in place by `xtask` after linking.
+3. **backtrace** walks the frame-pointer chain from any point in the kernel and
+   resolves each return address through ksymtab.
+
+---
+
+## klog (`klog.rs`)
+
+### Design
+
+The ring buffer stores records in the format:
+
+```
+[level: u8][len_lo: u8][len_hi: u8][utf8 payload: len bytes]
+```
+
+The buffer is 64 KiB (`RING_BYTES`). When full, the oldest record is evicted to
+make room. Records longer than `RECORD_MAX = 512` bytes are truncated.
+
+The write path (`_log`):
+1. Checks the level threshold (default: `Info`).
+2. Formats `args` into a `FixedBuf` (stack-allocated, avoids heap during logging).
+3. Under an interrupt-disabled lock, pushes the record into the ring.
+4. Forwards the formatted message to `serial::_print` and `framebuffer::_print`.
+
+The interrupt-disable is necessary on the kernel target so that an ISR that logs
+cannot deadlock against code that logged on the main thread while holding the
+ring lock.
+
+### Levels
+
+| Level | Value | Macro |
+|---|---|---|
+| `Error` | 0 | `kerror!(...)` |
+| `Warn` | 1 | `kwarn!(...)` |
+| `Info` | 2 | `kinfo!(...)` |
+| `Debug` | 3 | `kdebug!(...)` |
+| `Trace` | 4 | `ktrace!(...)` |
+
+The global threshold (default `Info`) is stored in an `AtomicU8`. Records at
+levels above the threshold are silently dropped.
+
+### API
+
+```rust
+// Logging macros (most common usage):
+kinfo!("heap: {} KiB", size / 1024);
+kerror!("frame allocator: OOM");
+
+// Control:
+klog::set_threshold(Level::Debug);
+klog::threshold() -> Level;
+klog::enabled(level: Level) -> bool;
+
+// Output:
+klog::drain_to(&mut w) -> fmt::Result;      // all records, oldest first
+klog::tail_to(&mut w, n) -> fmt::Result;    // last n records
+klog::dump_tail_to_serial(n: usize);        // panic-safe serial dump
+```
+
+### Host Testability
+
+`klog` compiles under `cargo test --lib`. A `TEST_LOCK` serializes tests that
+access the global ring (because the ring is global, concurrent tests would
+interleave records). Tests cover wrap-around eviction, level filtering, and tail
+slicing.
+
+---
+
+## ksymtab (`ksymtab.rs`)
+
+### Design
+
+The kernel symbol table maps `u64` return addresses to `&'static str` function
+names. It is embedded in a 256 KiB reserved region in `.rodata` and patched in
+place by `cargo xtask build` / `cargo xtask iso` after the kernel is linked:
+
+1. The linker produces the kernel ELF.
+2. `xtask` reads the ELF's symbol table (`.symtab`), encodes address/name pairs
+   into a compact binary format, and writes them into the reserved `.rodata`
+   region using the `KERNEL_FILE_REQUEST` Limine response.
+3. At runtime, `ksymtab` reads that patched region to resolve addresses.
+
+### API
+
+```rust
+// Resolve a return address to a name (if known):
+ksymtab::lookup(addr: u64) -> Option<&'static str>;
+
+// Format an address as "name+offset" or "0x<hex>" if unknown:
+ksymtab::format_addr(w: &mut impl Write, addr: u64) -> fmt::Result;
+```
+
+`format_addr` is used by the backtrace printer to produce output like:
+
+```
+backtrace:
+  #0  vibix::arch::backtrace::dump_to_serial+0x3c
+  #1  vibix::_start::panic+0x18
+  ...
+```
+
+---
+
+## Backtrace Unwinder (`backtrace.rs`)
+
+### Design
+
+The kernel is compiled with `-Cforce-frame-pointers=yes`. Every non-leaf
+function emits the System V AMD64 prologue:
+
+```asm
+push rbp
+mov  rbp, rsp
+```
+
+This creates a linked list of saved-RBP values on the stack. Each frame looks
+like:
+
+```
+[rbp + 0]  saved RBP of caller
+[rbp + 8]  return address into caller
+```
+
+`walk(skip, f)` reads the current `RBP` register, then follows the chain:
+1. Validates each `rbp` (non-zero, 8-byte aligned, canonical higher-half address).
+2. Reads `[rbp]` (saved rbp) and `[rbp+8]` (return address).
+3. Calls `f(Frame { return_addr })` after skipping the first `skip` frames.
+4. Detects a corrupt chain if `saved_rbp <= rbp` (stack grows downward, so the
+   saved value must be strictly greater) and stops.
+5. Caps total frames walked at `MAX_FRAMES = 32`.
+
+### API
+
+```rust
+// Walk the call stack from the current point:
+backtrace::walk(skip: usize, f: impl FnMut(Frame));
+
+// Dump to COM1 (panic-safe):
+backtrace::dump_to_serial(skip: usize);
+
+// Macro shorthand:
+kbacktrace!();  // equivalent to dump_to_serial(1)
+```
+
+### Panic Integration
+
+The panic handler in `main.rs` calls the three diagnostics tools in sequence:
+
+```rust
+fn panic(info: &PanicInfo) -> ! {
+    serial_println!("KERNEL PANIC: {}", info);
+    arch::backtrace::dump_to_serial(1);
+    serial_println!("--- kernel log tail ---");
+    klog::dump_tail_to_serial(32);
+    serial_println!("--- end kernel log ---");
+    exit_qemu(QemuExitCode::Failure)
+}
+```
+
+This produces a symbolicated backtrace followed by the last 32 log records,
+giving full context for diagnosing a panic from the serial output alone.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -25,7 +25,7 @@ symbolicated panic backtraces:
 
 The ring buffer stores records in the format:
 
-```
+```text
 [level: u8][len_lo: u8][len_hi: u8][utf8 payload: len bytes]
 ```
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -92,15 +92,15 @@ place by `cargo xtask build` / `cargo xtask iso` after the kernel is linked:
 
 1. The linker produces the kernel ELF.
 2. `xtask` reads the ELF's symbol table (`.symtab`), encodes address/name pairs
-   into a compact binary format, and writes them into the reserved `.rodata`
-   region using the `KERNEL_FILE_REQUEST` Limine response.
+   into a compact binary format, and patches them into the reserved `.rodata`
+   region by overwriting the kernel ELF file in place (via `objcopy --update-section`).
 3. At runtime, `ksymtab` reads that patched region to resolve addresses.
 
 ### API
 
 ```rust
-// Resolve a return address to a name (if known):
-ksymtab::lookup(addr: u64) -> Option<&'static str>;
+// Resolve a return address to (name, offset) if known:
+ksymtab::resolve(addr: u64) -> Option<(&'static str, u64)>;
 
 // Format an address as "name+offset" or "0x<hex>" if unknown:
 ksymtab::format_addr(w: &mut impl Write, addr: u64) -> fmt::Result;
@@ -108,7 +108,7 @@ ksymtab::format_addr(w: &mut impl Write, addr: u64) -> fmt::Result;
 
 `format_addr` is used by the backtrace printer to produce output like:
 
-```
+```text
 backtrace:
   #0  vibix::arch::backtrace::dump_to_serial+0x3c
   #1  vibix::_start::panic+0x18
@@ -132,7 +132,7 @@ mov  rbp, rsp
 This creates a linked list of saved-RBP values on the stack. Each frame looks
 like:
 
-```
+```text
 [rbp + 0]  saved RBP of caller
 [rbp + 8]  return address into caller
 ```

--- a/docs/framebuffer.md
+++ b/docs/framebuffer.md
@@ -1,0 +1,71 @@
+# Framebuffer Subsystem
+
+**Source:** `kernel/src/framebuffer.rs`
+
+## Overview
+
+The framebuffer subsystem provides a minimal text console rendered directly into
+the linear framebuffer that Limine sets up. It uses 8×8 bitmap glyphs from the
+`font8x8` crate and draws characters in a fixed light-gray-on-black color
+scheme.
+
+## Design
+
+### `Console`
+
+The `Console` struct holds a raw `*mut u32` pointer to the framebuffer, the
+display dimensions (width, height in pixels; pitch in `u32`s per row), the
+computed grid size (cols, rows), and the current cursor position (cx, cy).
+
+Rendering is pixel-perfect: each glyph is an 8×8 bit matrix from
+`font8x8::BASIC_FONTS`. A set bit is drawn in foreground color (`0x00E0_E0E0`,
+near-white), a clear bit in background (`0x0000_0000`, black).
+
+### Scrolling
+
+The console does not implement true scrolling. When the cursor reaches the last
+row, the entire screen is cleared and writing wraps back to row 0. This is
+intentional for a hobby kernel where simplicity beats polish.
+
+### Concurrency
+
+`Console` holds a raw pointer. A `Mutex<Option<Console>>` (`CONSOLE`) provides
+mutual exclusion. The `unsafe impl Send for Console` assertion is sound because
+the framebuffer pointer is stable for the lifetime of the kernel and all
+concurrent writes go through the mutex.
+
+## Initialization
+
+```rust
+// In main.rs, after obtaining the Limine framebuffer response:
+let console = unsafe { Console::new(fb.addr(), fb.width(), fb.height(), fb.pitch()) };
+framebuffer::init(console);
+```
+
+`init` places the console into `CONSOLE` and clears the screen. If no
+framebuffer is available the global stays `None` and all `print!` calls silently
+no-op.
+
+## API
+
+### Macros
+
+```rust
+print!("hello");
+println!("value = {}", x);
+```
+
+These mirror the standard library macros but route through the framebuffer
+console. They are the primary display output path; `serial_println!` is the
+debug path.
+
+### `_print(args: fmt::Arguments)`
+
+Internal; called by the macros. Acquires `CONSOLE`, short-circuits if `None`.
+
+## PAT / Write-Combining
+
+The framebuffer physical pages are mapped Write-Combining via the PAT subsystem
+(see [memory.md](memory.md)) during the kernel PML4 build. This reduces the
+penalty of word-at-a-time pixel writes by coalescing them in the CPU write
+buffers before flushing to the display adapter.

--- a/docs/input.md
+++ b/docs/input.md
@@ -40,7 +40,7 @@ the keyboard state machine. It maps raw scancodes to `DecodedKey` values
 
 ## ISR Path
 
-```
+```text
 keyboard ISR
   → input::push_scancode_from_isr(code)
       → SCANCODES.lock().push(code)
@@ -51,7 +51,7 @@ send EOI. No decoding, no logging, no sleeping.
 
 ## Consumer Path
 
-```
+```rust
 input::read_key() -> DecodedKey
 ```
 

--- a/docs/input.md
+++ b/docs/input.md
@@ -1,0 +1,81 @@
+# Input Subsystem
+
+**Source:** `kernel/src/input.rs`
+
+## Overview
+
+The input subsystem provides a PS/2 keyboard driver built on a generic
+interrupt-safe ring buffer. Scancodes are pushed by the keyboard ISR and
+decoded on the consumer side using the `pc-keyboard` crate's state machine.
+
+## Design
+
+### `RingBuffer<T, N>`
+
+A fixed-capacity, single-reader / single-writer ring buffer implemented with a
+`[MaybeUninit<T>; N]` array. Operations:
+
+| Method | Description |
+|---|---|
+| `push(v) -> bool` | Appends `v`; returns `false` (dropping `v`) if full |
+| `pop() -> Option<T>` | Removes and returns the oldest element |
+| `is_empty() -> bool` | — |
+| `len() -> usize` | Current occupancy |
+
+`RingBuffer` is generic over `T: Copy` and const `N`, and has no kernel-only
+dependencies, making it host-unit-testable.
+
+### Scancode Ring (`SCANCODES`)
+
+A `Mutex<RingBuffer<u8, 128>>` holds raw PS/2 scancodes. Capacity 128 is
+ample for normal typing; firmware key-repeat bursts stay well below that
+between consumer polls. If the ring is full when the ISR tries to push, the
+scancode is dropped and `OVERFLOWS` is incremented.
+
+### Keyboard Decoder (`KEYBOARD`)
+
+A `Lazy<Mutex<Keyboard<Us104Key, ScancodeSet1>>>` (from `pc-keyboard`) holds
+the keyboard state machine. It maps raw scancodes to `DecodedKey` values
+(either Unicode characters or raw keycodes for modifier/function keys).
+
+## ISR Path
+
+```
+keyboard ISR
+  → input::push_scancode_from_isr(code)
+      → SCANCODES.lock().push(code)
+```
+
+The ISR is intentionally minimal: read the scancode from port `0x60`, push it,
+send EOI. No decoding, no logging, no sleeping.
+
+## Consumer Path
+
+```
+input::read_key() -> DecodedKey
+```
+
+`read_key()` busy-polls `try_read_scancode()` and feeds each scancode through
+the `pc-keyboard` state machine. When `process_keyevent` produces a key, it
+returns. If the ring is empty the function disables IRQs, checks again, and
+issues `enable_and_hlt()` — this atomically enables interrupts and halts the
+CPU, ensuring no scancode can be missed between the empty-check and the `hlt`.
+
+## API (kernel side)
+
+```rust
+// From ISR (interrupts already masked):
+input::push_scancode_from_isr(code: u8);
+
+// From task / main loop:
+let key: DecodedKey = input::read_key(); // blocks until a key arrives
+let scancode: Option<u8> = input::try_read_scancode(); // non-blocking
+let overflows: u64 = input::scancode_overflows();
+```
+
+## Overflow Tracking
+
+`scancode_overflows()` returns the number of scancodes dropped because the ring
+was full. A non-zero value means the consumer is not polling fast enough and
+modifier-key state in the `pc-keyboard` decoder may be desynchronized (e.g.,
+a key-release scancode was dropped, leaving a key stuck in the "pressed" state).

--- a/docs/interrupts.md
+++ b/docs/interrupts.md
@@ -33,7 +33,7 @@ stack the faulting code was on.
 
 A 20 KiB static buffer (`DOUBLE_FAULT_STACK`) is allocated page-aligned. The
 TSS points its IST[0] entry to the top of this buffer. The lowest 4 KiB page
-of the buffer becomes the guard page (unmapped by `ist_guard::init()`) after
+of the buffer becomes the guard page (unmapped by `ist_guard::install()`) after
 paging is up, leaving 16 KiB of usable stack for the `#DF` handler.
 
 `df_stack_guard_addr()` returns the virtual address of the guard page so
@@ -173,7 +173,7 @@ ISRs are deliberately thin: no decoding, no logging, no blocking I/O.
 
 ## IST Guard Page (`ist_guard.rs`)
 
-After paging is initialized, `ist_guard::init()` unmaps the 4 KiB page at
+After paging is initialized, `ist_guard::install()` unmaps the 4 KiB page at
 `gdt::df_stack_guard_addr()`. This is the lowest page of the `DOUBLE_FAULT_STACK`
 buffer. An overflow of the `#DF` IST stack walks RSP downward into this unmapped
 page, triggering a `#PF` with a fault address that identifies the overflow,

--- a/docs/interrupts.md
+++ b/docs/interrupts.md
@@ -143,11 +143,9 @@ low) before writing the IOAPIC redirection entry.
 
 ### EOI Protocol
 
-Both the LAPIC and the legacy PIC need an EOI (End-Of-Interrupt) signal at the
-end of each ISR. `pic::notify_eoi(vector)` handles both: it always writes to
-the LAPIC EOI register, and if the vector is in the slave PIC range it also
-sends an EOI to the slave PIC's command port. This keeps the hybrid path working
-during the brief window between PIC remap and APIC takeover.
+EOI handling is centralized in `pic::notify_eoi(vector)`: it always writes to
+the LAPIC EOI register. No PIC EOI is needed — the 8259 is fully masked after
+`pic::init_and_disable()` and never delivers interrupts.
 
 ---
 

--- a/docs/interrupts.md
+++ b/docs/interrupts.md
@@ -1,0 +1,180 @@
+# Interrupts Subsystem
+
+**Sources:** `kernel/src/arch/x86_64/`
+- `gdt.rs` — Global Descriptor Table and Task State Segment
+- `idt.rs` — Interrupt Descriptor Table and exception handlers
+- `pic.rs` — 8259 PIC remap and mask
+- `apic.rs` — Local APIC and IOAPIC initialization and IRQ routing
+- `interrupts.rs` — hardware IRQ vectors and ISR implementations
+- `ist_guard.rs` — unmapped guard page below the `#DF` IST stack
+
+All components are initialized by `arch::init()` followed by
+`arch::init_apic()`. Interrupts remain disabled until `_start` calls `sti`
+after both return.
+
+---
+
+## GDT and TSS (`gdt.rs`)
+
+### Design
+
+vibix uses a minimal GDT with three entries:
+
+1. **Kernel code segment** — `DPL=0`, 64-bit code.
+2. **Kernel data segment** — `DPL=0`.
+3. **TSS descriptor** — points to the kernel TSS.
+
+The TSS is required solely to register an Interrupt Stack Table (IST) entry for
+the `#DF` (double-fault) handler. When the CPU takes a double fault it switches
+RSP to the IST stack, bypassing whatever (potentially corrupt or overflowed)
+stack the faulting code was on.
+
+### IST Stack
+
+A 20 KiB static buffer (`DOUBLE_FAULT_STACK`) is allocated page-aligned. The
+TSS points its IST[0] entry to the top of this buffer. The lowest 4 KiB page
+of the buffer becomes the guard page (unmapped by `ist_guard::init()`) after
+paging is up, leaving 16 KiB of usable stack for the `#DF` handler.
+
+`df_stack_guard_addr()` returns the virtual address of the guard page so
+`ist_guard` can unmap it.
+
+### Initialization
+
+```rust
+gdt::init();
+// Loads the GDT, sets CS/DS/ES/FS/GS/SS, loads the TSS selector.
+```
+
+---
+
+## IDT and Exception Handlers (`idt.rs`)
+
+### Design
+
+The IDT registers handlers for the following vectors:
+
+| Vector | Name | Handler behavior |
+|---|---|---|
+| `#DE` (0) | Divide Error | Log to serial + halt |
+| `#UD` (6) | Invalid Opcode | Log to serial + halt |
+| `#GP` (13) | General Protection | Log error code + frame + halt |
+| `#PF` (14) | Page Fault | Check test hook / stack overflow; log + halt |
+| `#DF` (8) | Double Fault | Uses IST[0]; check stack overflow; log + halt |
+| 0x20 | Timer IRQ | See `interrupts.rs` |
+| 0x21 | Keyboard IRQ | See `interrupts.rs` |
+
+The `#DF` vector has an IST index (`DOUBLE_FAULT_IST_INDEX = 0`) so the CPU
+always switches to the dedicated IST stack regardless of the current RSP.
+
+### Page Fault Hook
+
+The `#PF` handler checks `test_hook::take_page_fault_expectation()` before
+the normal diagnostic path. Integration tests that deliberately trigger a page
+fault (e.g., the `page_fault` test) pre-arm this hook with the expected fault
+address. A matching fault exits QEMU with success; a mismatch exits with
+failure.
+
+The `#PF` handler also checks whether the fault address falls inside a kernel
+task's guard page (via `task::find_stack_overflow`). If it does, the output
+identifies the overflowing task by ID before halting.
+
+### Initialization
+
+```rust
+idt::init();
+// Calls IDT.load() — installs the static IDT into IDTR.
+```
+
+---
+
+## 8259 PIC (`pic.rs`)
+
+### Design
+
+The legacy 8259 Programmable Interrupt Controller ships remapped to vector
+offsets `0x20` (master) and `0x28` (slave) at `pic::init_and_disable()`. This
+puts legacy IRQs above the CPU exception range (0–31) so that e.g. IRQ0 fires
+at vector 0x20 instead of colliding with the `#DE` exception.
+
+Immediately after remapping, all IRQ lines on both PICs are masked. Once the
+IOAPIC is configured the PIC remains permanently disabled and the APIC handles
+all interrupts.
+
+### Constants
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `PIC_1_OFFSET` | `0x20` | Vector base for master PIC (and for LAPIC vectors too) |
+| `PIC_2_OFFSET` | `0x28` | Vector base for slave PIC |
+
+---
+
+## LAPIC and IOAPIC (`apic.rs`)
+
+### Design
+
+vibix uses the xAPIC (MMIO) interface. The LAPIC and IOAPIC physical addresses
+come from the ACPI MADT (see [acpi.md](acpi.md)).
+
+**LAPIC initialization (`init_bsp`):**
+1. Maps the LAPIC MMIO region (`0x1000` bytes) into the HHDM window with
+   `NO_CACHE | WRITE_THROUGH` flags so MMIO accesses are not cached.
+2. Reads and logs the BSP LAPIC ID.
+3. Sets the Task Priority Register (TPR) to 0 — all interrupt priorities
+   allowed.
+4. Sets the Spurious Interrupt Vector (SVR) to vector `0xFF` with the APIC
+   software-enable bit, bringing the LAPIC online.
+
+**IOAPIC initialization (`ioapic_init`):**
+1. Maps each IOAPIC MMIO region (also `NO_CACHE | WRITE_THROUGH`).
+2. Reads the IOAPIC version register to find the max redirection-entry count.
+3. Masks all redirection entries on startup.
+
+**IRQ routing (`route_legacy_irq`):**
+
+After init, `arch::init_apic` routes two legacy ISA IRQs:
+- IRQ0 (PIT timer) → vector `0x20` (Timer)
+- IRQ1 (PS/2 keyboard) → vector `0x21` (Keyboard)
+
+The MADT `InterruptSourceOverride` records are consulted for each ISA IRQ to
+determine the correct GSI, trigger mode (edge/level), and polarity (active-high/
+low) before writing the IOAPIC redirection entry.
+
+### EOI Protocol
+
+Both the LAPIC and the legacy PIC need an EOI (End-Of-Interrupt) signal at the
+end of each ISR. `pic::notify_eoi(vector)` handles both: it always writes to
+the LAPIC EOI register, and if the vector is in the slave PIC range it also
+sends an EOI to the slave PIC's command port. This keeps the hybrid path working
+during the brief window between PIC remap and APIC takeover.
+
+---
+
+## Hardware ISRs (`interrupts.rs`)
+
+### Timer ISR (`timer_interrupt`, vector 0x20)
+
+1. `time::on_tick()` — increment the monotonic tick counter.
+2. `notify_eoi(Timer)` — send EOI before any preemption (avoids a second
+   tick interrupt landing on the incoming task before it sends its own EOI).
+3. `task::preempt_tick()` — check the current task's time slice; rotate if
+   expired.
+
+### Keyboard ISR (`keyboard_interrupt`, vector 0x21)
+
+1. Read one scancode byte from I/O port `0x60`.
+2. `input::push_scancode_from_isr(code)` — push into the lock-free ring buffer.
+3. `notify_eoi(Keyboard)` — acknowledge.
+
+ISRs are deliberately thin: no decoding, no logging, no blocking I/O.
+
+---
+
+## IST Guard Page (`ist_guard.rs`)
+
+After paging is initialized, `ist_guard::init()` unmaps the 4 KiB page at
+`gdt::df_stack_guard_addr()`. This is the lowest page of the `DOUBLE_FAULT_STACK`
+buffer. An overflow of the `#DF` IST stack walks RSP downward into this unmapped
+page, triggering a `#PF` with a fault address that identifies the overflow,
+rather than silently corrupting adjacent kernel data.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,0 +1,147 @@
+# Memory Subsystem
+
+**Sources:** `kernel/src/mem/`
+- `mod.rs` — module root, `mem::init()`, shared types
+- `frame.rs` — bitmap physical frame allocator
+- `heap.rs` — growing kernel heap (`#[global_allocator]`)
+- `paging.rs` — kernel page-table mapper, PML4 builder, CR3 switch
+- `pat.rs` — Page Attribute Table (Write-Combining slot)
+
+## Overview
+
+The memory subsystem manages all physical and virtual memory used by the kernel.
+It has three layers that build on each other:
+
+```
+Physical frames  ←  BitmapFrameAllocator   (frame.rs)
+Virtual mappings ←  OffsetPageTable / PML4  (paging.rs)
+Heap allocations ←  GrowingHeap            (heap.rs)
+```
+
+`mem::init()` calls all three in order:
+
+```rust
+pub fn init() {
+    frame::init();   // scan Limine memmap, build bitmap
+    paging::init();  // wrap Limine's PML4, build kernel-owned PML4, switch CR3
+    heap::init();    // map initial 1 MiB slab, register #[global_allocator]
+}
+```
+
+## Frame Allocator (`frame.rs`)
+
+### Design
+
+`BitmapFrameAllocator` tracks 4 KiB physical frames with one bit per frame.
+
+- **Set bit** = frame used/reserved.
+- **Clear bit** = frame available.
+
+The bitmap lives in `.bss` as a static array (`BITMAP_WORDS = 16384 u64` words
+= 128 KiB), covering up to 4 GiB of physical RAM. At init, all bits are set to
+`1` (used), then every USABLE region from the Limine memory map is released
+(bits cleared). Frames outside any USABLE region are permanently marked used and
+never handed out.
+
+Allocation scans forward from `next_hint`, finding the first word with a clear
+bit. `next_hint` advances on each allocation and wraps only when no free frame
+is found ahead, making allocation effectively O(1) on the common path.
+
+Deallocation is O(1): compute the bit index from the physical address, clear it,
+and update `next_hint` if the freed frame is before the current hint.
+
+### Constants
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `FRAME_SIZE` | 4096 | Bytes per frame |
+| `MAX_PHYS_BYTES` | 4 GiB | Highest tracked physical address |
+| `BITMAP_WORDS` | 16384 | `u64` words in the bitmap (= MAX_PHYS_BYTES / 4096 / 64) |
+| `MAX_REGIONS` | 64 | Max USABLE regions snapshotted from Limine |
+
+### Host Testability
+
+`BitmapFrameAllocator` depends only on `Region` and `FRAME_SIZE`, both free of
+Limine or x86_64 types. It compiles against host `std` under `cargo test --lib`
+and has a comprehensive unit-test suite in `frame.rs`.
+
+## Heap Allocator (`heap.rs`)
+
+### Design
+
+`GrowingHeap` is a `GlobalAlloc` wrapper around `linked_list_allocator::LockedHeap`.
+It reserves a 16 MiB virtual window starting at `HEAP_BASE = 0xFFFF_C000_0000_0000`
+and backs it on demand:
+
+- **Init:** `heap::init()` maps the first 1 MiB (`INITIAL_HEAP_SIZE`) with
+  `paging::map_range` and hands it to the inner `LockedHeap`. The smoke marker
+  `"heap: 1024 KiB"` confirms this.
+- **Grow:** When `alloc()` sees a null result it takes `grow_lock`, re-checks
+  (another concurrent path may have grown already), and if still OOM calls
+  `grow_locked()`. This maps the next `GROW_CHUNK_BYTES` (64 KiB) chunk and
+  calls `Heap::extend`. Growth is monotonic — the heap never shrinks.
+- **Cap:** Once `mapped` reaches `HEAP_MAX_SIZE` (16 MiB) `grow_locked` returns
+  false and `alloc` returns null. A null from the global allocator causes Rust's
+  allocator-error handler to panic.
+
+### Constants
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `HEAP_BASE` | `0xFFFF_C000_0000_0000` | Virtual base of the heap window |
+| `INITIAL_HEAP_SIZE` | 1 MiB | Backed at init |
+| `HEAP_MAX_SIZE` | 16 MiB | Hard cap |
+| `GROW_CHUNK_FRAMES` | 16 | Frames mapped per grow step (= 64 KiB) |
+
+## Paging (`paging.rs`)
+
+### Design
+
+The paging subsystem goes through two phases:
+
+**Phase 1 — wrap Limine's tree:** `paging::init(hhdm_offset)` reads `CR3`,
+wraps the active Limine PML4 in an `OffsetPageTable`, and stores it in
+`MAPPER`. Early subsystems (heap init, IST guard page) call `map_range` /
+`unmap_page` through this mapper.
+
+**Phase 2 — build and switch the kernel PML4:** After the heap is live,
+`build_and_switch_kernel_pml4()` (called from `mem::init`) constructs a fresh
+PML4 that maps exactly:
+- The kernel text, rodata, and data/bss sections with tight flags (RX, RO, RW
+  respectively) derived from the ELF section headers in the embedded kernel file.
+- HHDM as 2 MiB pages (`Size2MiB`) for efficiency.
+- The heap window.
+- The IST stack (without the guard page that sits below it).
+- The framebuffer with Write-Combining PAT bits.
+
+CR3 is then atomically switched to the new PML4 via `Cr3::write`. After the
+switch, Limine's original page table is no longer reachable; reclaiming its
+frames is tracked in issue #46.
+
+### Key Functions
+
+| Function | Description |
+|---|---|
+| `paging::init(hhdm)` | Wraps Limine's PML4 in `MAPPER` |
+| `map_range(start, frames, flags)` | Maps `frames` pages at `start` VA, allocating PTs from the frame pool |
+| `unmap_page(page)` | Unmaps a single page and returns its frame to the pool |
+| `map_phys_into_hhdm(phys, size, flags)` | Maps a physical range into the HHDM window (used by ACPI + APIC) |
+| `build_and_switch_kernel_pml4()` | Constructs the final kernel PML4 and switches CR3 |
+| `with_mapper(f)` | Runs a closure with exclusive access to the active mapper |
+
+### `KernelFrameAllocator`
+
+A zero-sized adapter that implements `x86_64`'s `FrameAllocator<Size4KiB>` by
+delegating to `frame::global()`. Constructed inline wherever the mapper APIs
+need a frame allocator.
+
+## Page Attribute Table (`pat.rs`)
+
+The PAT subsystem reprograms MSR `0x277` to assign Write-Combining (`WC`) to
+PAT entry 7 (PAT4 in the Intel naming). The framebuffer pages are then mapped
+with `PAT | PWT` bits in their PTEs, hitting the WC entry. WC coalesces
+write-combined stores before flushing to MMIO, reducing the number of bus
+cycles for pixel blitting.
+
+`pat::init()` is called inside `build_and_switch_kernel_pml4` before the
+framebuffer mappings are installed.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -12,7 +12,7 @@
 The memory subsystem manages all physical and virtual memory used by the kernel.
 It has three layers that build on each other:
 
-```
+```text
 Physical frames  ←  BitmapFrameAllocator   (frame.rs)
 Virtual mappings ←  OffsetPageTable / PML4  (paging.rs)
 Heap allocations ←  GrowingHeap            (heap.rs)
@@ -23,7 +23,7 @@ Heap allocations ←  GrowingHeap            (heap.rs)
 ```rust
 pub fn init() {
     frame::init();   // scan Limine memmap, build bitmap
-    paging::init();  // wrap Limine's PML4, build kernel-owned PML4, switch CR3
+    paging::init(hhdm_offset);  // wrap Limine's PML4, build kernel-owned PML4, switch CR3
     heap::init();    // map initial 1 MiB slab, register #[global_allocator]
 }
 ```
@@ -122,7 +122,7 @@ frames is tracked in issue #46.
 
 | Function | Description |
 |---|---|
-| `paging::init(hhdm)` | Wraps Limine's PML4 in `MAPPER` |
+| `paging::init(hhdm_offset)` | Wraps Limine's PML4 in `MAPPER` |
 | `map_range(start, frames, flags)` | Maps `frames` pages at `start` VA, allocating PTs from the frame pool |
 | `unmap_page(page)` | Unmaps a single page and returns its frame to the pool |
 | `map_phys_into_hhdm(phys, size, flags)` | Maps a physical range into the HHDM window (used by ACPI + APIC) |

--- a/docs/serial.md
+++ b/docs/serial.md
@@ -1,0 +1,46 @@
+# Serial Subsystem
+
+**Source:** `kernel/src/serial.rs`
+
+## Overview
+
+The serial subsystem drives the COM1 16550 UART (I/O port `0x3F8`). It is the
+primary log sink and is the first subsystem initialized in `_start`. All
+`serial_print!` / `serial_println!` macro output arrives here.
+
+## Design
+
+A single global `Mutex<SerialPort>` wraps the `uart_16550` crate's driver. The
+mutex ensures mutual exclusion between concurrent users (main thread and ISRs),
+though in practice all ISRs in vibix halt on fault so a deadlock from within an
+ISR is not a current concern.
+
+The output path is intentionally simple — `_print` just calls
+`SerialPort::write_fmt`. There is no buffering, no formatting layer, and no
+log-level filtering at this layer. For structured, leveled logging see the
+[klog subsystem](diagnostics.md).
+
+## API
+
+### `serial::init()`
+
+Programs the 16550 UART (baud rate, FIFO, interrupts disabled on the UART
+side). Must be the first call in `_start` so that early panics and assertions
+are visible.
+
+### Macros
+
+```rust
+serial_print!("hello");
+serial_println!("value = {}", x);
+```
+
+These are thin wrappers around `serial::_print`. They work identically to
+`print!` / `println!` from the standard library.
+
+## Implementation Notes
+
+- The UART is initialized at the standard 115200 baud (set by `uart_16550`).
+- The lock is a spin mutex — writes busy-wait if the port is temporarily held.
+- Output is not buffered; each macro call flushes immediately to the UART FIFO.
+- `serial_println!()` with no arguments emits a bare newline.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -100,7 +100,7 @@ Called from the timer ISR (with IRQs already masked by the interrupt gate):
 ### `task::find_stack_overflow(addr) -> Option<usize>`
 
 Lock-free check: given a fault address, determine whether it falls inside a
-kernel task's guard page. Returns the task ID (slot index + 1) if so. Called
+kernel task's guard page. Returns the slot index (zero-based) if so. Called
 from the `#PF` and `#DF` exception handlers.
 
 ## Constants

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,0 +1,121 @@
+# Task Subsystem
+
+**Sources:** `kernel/src/task/`
+- `mod.rs` — public API, `init`, `spawn`, `yield_now`, `preempt_tick`
+- `task.rs` — `Task` struct: kernel stack allocation, saved register context
+- `scheduler.rs` — `Scheduler`: current task + FIFO ready queue
+- `switch.rs` — `context_switch` in hand-written assembly
+
+## Overview
+
+The task subsystem implements cooperative and preemptive kernel-mode
+multitasking. Tasks are kernel threads — they share the kernel address space
+and run entirely in ring 0. Each task has its own kernel stack and a saved
+register context that `context_switch` restores on re-entry.
+
+There is no userspace, no per-task address space, and no blocking primitives.
+Cooperative code yields explicitly; the PIT timer drives preemption.
+
+## Design
+
+### Scheduler State
+
+A single `Lazy<Mutex<Scheduler>>` holds:
+- `current: Option<Box<Task>>` — the running task, `None` before `task::init`.
+- `ready: VecDeque<Box<Task>>` — FIFO queue of ready-to-run tasks.
+
+### Task Struct
+
+Each `Task` contains:
+- A heap-allocated kernel stack (see constants below).
+- An unmapped guard page at the base of the stack.
+- `rsp: usize` — the saved stack pointer, updated by `context_switch`.
+- `slice_remaining_ms: u32` — remaining preemption budget in milliseconds.
+
+Stacks are carved from a dedicated virtual address range
+(`TASK_STACKS_VA_BASE`), one slot per task. Each slot is
+`TASK_SLOT_SIZE = GUARD_SIZE + STACK_SIZE` bytes. The guard page is the lowest
+page of the slot; the usable stack sits above it.
+
+### `Task::bootstrap()`
+
+Wraps the currently-executing thread (the `_start` / init thread) as a task.
+The `rsp` is left at `0` — `context_switch` writes a real value when this task
+is first switched away from. This avoids the need to fake a stack frame for the
+initial thread.
+
+### `Task::new(entry)`
+
+Allocates a stack, maps it via `paging::map_range`, and builds a fake initial
+stack frame so that when `context_switch` restores registers and returns, it
+jumps to `entry`. The trampoline frame enables interrupts on the new task's
+first run.
+
+## Context Switch (`switch.rs`)
+
+`context_switch(prev_rsp_ptr, next_rsp)` is written in inline assembly. It:
+
+1. Pushes all callee-saved registers onto the current stack.
+2. Writes `RSP` to `*prev_rsp_ptr`.
+3. Loads `next_rsp` into `RSP`.
+4. Pops the callee-saved registers from the new stack.
+5. Returns — which enters the new task at its saved return address.
+
+For a brand-new task this return address is the trampoline; for a previously
+preempted or yielded task it is the instruction after the call to
+`context_switch` inside `yield_now` or `preempt_tick`.
+
+## Public API
+
+### `task::init()`
+
+Wraps the current thread as the bootstrap task. Must be called once, after
+`mem::init()` (stacks are heap-allocated) and after interrupts are enabled (so
+preemption ticks can arrive).
+
+### `task::spawn(entry: fn() -> !)`
+
+Allocates a new task and appends it to the ready queue. The task does not run
+until the scheduler reaches it.
+
+### `task::yield_now()`
+
+The cooperative yield point:
+1. Disable IRQs to prevent the timer ISR from re-entering the scheduler.
+2. Under the `SCHED` lock, pop the next task from `ready`, move `current` to
+   the back of `ready`, make the popped task `current`.
+3. Release the lock, then call `context_switch`.
+4. Restore the IRQ state of the caller on return.
+
+If `ready` is empty, `yield_now` returns immediately (the running task keeps
+the CPU).
+
+### `task::preempt_tick()`
+
+Called from the timer ISR (with IRQs already masked by the interrupt gate):
+- `try_lock` the scheduler — bail on contention so the ISR never blocks.
+- Decrement `slice_remaining_ms` by `TICK_MS`. If it reaches zero and a ready
+  task exists, rotate and call `context_switch`.
+
+### `task::find_stack_overflow(addr) -> Option<usize>`
+
+Lock-free check: given a fault address, determine whether it falls inside a
+kernel task's guard page. Returns the task ID (slot index + 1) if so. Called
+from the `#PF` and `#DF` exception handlers.
+
+## Constants
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `DEFAULT_SLICE_MS` | 10 | Preemption time slice per task |
+| `GUARD_SIZE` | 4096 | Guard page size (one 4 KiB page) |
+| `STACK_SIZE` | 64 KiB | Usable kernel stack per task |
+| `TASK_SLOT_SIZE` | `GUARD_SIZE + STACK_SIZE` | VA bytes reserved per task |
+| `TASK_STACKS_VA_BASE` | (higher-half) | Base VA for the task stack window |
+
+## Limitations
+
+- Single-CPU only; no SMP or per-CPU runqueues.
+- No task priorities — pure round-robin.
+- No blocking primitives — sleeping tasks must poll and yield.
+- No per-task address spaces — all tasks share the kernel PML4.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -109,7 +109,7 @@ from the `#PF` and `#DF` exception handlers.
 |---|---|---|
 | `DEFAULT_SLICE_MS` | 10 | Preemption time slice per task |
 | `GUARD_SIZE` | 4096 | Guard page size (one 4 KiB page) |
-| `STACK_SIZE` | 64 KiB | Usable kernel stack per task |
+| `STACK_SIZE` | 16 KiB | Usable kernel stack per task |
 | `TASK_SLOT_SIZE` | `GUARD_SIZE + STACK_SIZE` | VA bytes reserved per task |
 | `TASK_STACKS_VA_BASE` | (higher-half) | Base VA for the task stack window |
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -27,7 +27,7 @@ A single `Lazy<Mutex<Scheduler>>` holds:
 ### Task Struct
 
 Each `Task` contains:
-- A heap-allocated kernel stack (see constants below).
+- A mapped kernel stack region (via `paging::map_range`, see constants below).
 - An unmapped guard page at the base of the stack.
 - `rsp: usize` — the saved stack pointer, updated by `context_switch`.
 - `slice_remaining_ms: u32` — remaining preemption budget in milliseconds.
@@ -70,7 +70,7 @@ preempted or yielded task it is the instruction after the call to
 ### `task::init()`
 
 Wraps the current thread as the bootstrap task. Must be called once, after
-`mem::init()` (stacks are heap-allocated) and after interrupts are enabled (so
+`mem::init()` (stacks are mapped via `paging::map_range`) and after interrupts are enabled (so
 preemption ticks can arrive).
 
 ### `task::spawn(entry: fn() -> !)`

--- a/docs/time.md
+++ b/docs/time.md
@@ -1,0 +1,62 @@
+# Time Subsystem
+
+**Source:** `kernel/src/time.rs`
+
+## Overview
+
+The time subsystem provides a monotonic millisecond-resolution clock driven by
+the Programmable Interval Timer (PIT). It is the simplest possible hardware
+timer: channel 0 fires IRQ0 at a fixed rate, and the ISR increments a global
+tick counter.
+
+## Design
+
+### PIT Programming
+
+`time::init()` programs PIT channel 0 in **rate-generator mode** (mode 2):
+
+- Command byte `0x34` written to port `0x43`:
+  - Channel 0, lobyte/hibyte access, mode 2 (rate generator), binary counting.
+- Divisor `PIT_FREQ_HZ / TICK_HZ = 1_193_182 / 100 ≈ 11932` written as
+  low byte then high byte to port `0x40`.
+
+This produces ~100 IRQ0 interrupts per second, each 10 ms apart.
+
+### Tick Counter
+
+A single `AtomicU64` (`TICKS`) is incremented by `on_tick()` on every timer
+interrupt. Relaxed ordering is used because all callers only need eventual
+visibility, not strict synchronization.
+
+## Constants
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `PIT_FREQ_HZ` | 1_193_182 | PIT oscillator frequency in Hz |
+| `TICK_HZ` | 100 | Desired interrupt rate in Hz |
+| `TICK_MS` | 10 | Milliseconds per tick (`1000 / TICK_HZ`) |
+
+## API
+
+```rust
+time::init();          // Call once after arch::init_apic(); before sti.
+
+time::on_tick();       // Called from the timer ISR. Increments TICKS.
+time::ticks() -> u64;  // Raw tick count since init.
+time::uptime_ms() -> u64; // Milliseconds since init (= ticks * TICK_MS).
+```
+
+## Relationship to the Scheduler
+
+The task scheduler uses `TICK_MS` directly to decrement each task's
+`slice_remaining_ms` on every `preempt_tick()` call. A task gets a
+`DEFAULT_SLICE_MS = 10` ms time slice, which corresponds to exactly one PIT
+tick at 100 Hz.
+
+## Limitations
+
+- Resolution is 10 ms — not suitable for high-resolution timing.
+- `uptime_ms()` overflows after ~585 million years. Not a concern.
+- The PIT is replaced by the LAPIC timer in future SMP milestones, at which
+  point the LAPIC timer will drive per-CPU scheduling and the PIT may be
+  repurposed or disabled.


### PR DESCRIPTION
Creates a `docs/` directory with one Markdown file per major kernel subsystem: boot, serial, framebuffer, memory, interrupts, acpi, time, input, tasks, and diagnostics. Adds a `docs/README.md` index with an overview and the required initialization order.

Closes #78

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding new markdown files; no runtime behavior or build output should be affected aside from doc packaging/rendering.
> 
> **Overview**
> Adds a new `docs/` documentation set with one Markdown file per major kernel subsystem (boot, serial, framebuffer, memory, interrupts, ACPI, time, input, tasks, diagnostics).
> 
> Introduces `docs/README.md` as an index that links each subsystem doc to its source files and records the required kernel initialization order (including the optional framebuffer init split).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f264066973def4399bc7937bb1785c8a8ead9c3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->