### PR TITLE
feat: framebuffer console scrollback, ANSI color, blinking cursor

### DIFF
--- a/kernel/src/framebuffer.rs
+++ b/kernel/src/framebuffer.rs
@@ -213,13 +213,16 @@ impl Console {
         for y in 0..self.height {
             for x in 0..self.width {
                 unsafe {
-                    self.buffer.add(y * self.pitch + x).write_volatile(DEFAULT_BG);
+                    self.buffer
+                        .add(y * self.pitch + x)
+                        .write_volatile(DEFAULT_BG);
                 }
             }
         }
         self.cx = 0;
         self.cy = 0;
-        self.cursor_on = false;
+        self.cursor_on = true;
+        self.draw_cursor(self.cx, self.cy, true);
     }
 
     // ── low-level rendering ───────────────────────────────────────────────
@@ -321,7 +324,9 @@ impl Console {
         for y in last_py..last_py + GLYPH_H {
             for x in 0..self.width {
                 unsafe {
-                    self.buffer.add(y * self.pitch + x).write_volatile(DEFAULT_BG);
+                    self.buffer
+                        .add(y * self.pitch + x)
+                        .write_volatile(DEFAULT_BG);
                 }
             }
         }
@@ -457,7 +462,9 @@ impl Console {
 
             Ansi::Csi => match c {
                 '0'..='9' => {
-                    self.cur_param = self.cur_param.saturating_mul(10)
+                    self.cur_param = self
+                        .cur_param
+                        .saturating_mul(10)
                         .saturating_add(c as u32 - '0' as u32);
                 }
                 ';' => {

--- a/kernel/src/framebuffer.rs
+++ b/kernel/src/framebuffer.rs
@@ -1,106 +1,486 @@
-//! Minimal text console over Limine's linear framebuffer.
+//! Text console over Limine's linear framebuffer.
 //!
-//! Uses the `font8x8` crate (8x8 bitmap glyphs). We draw directly into
-//! the framebuffer in whatever pixel format Limine reports — assumed
-//! 32 bpp little-endian XRGB / BGR variants, which is what every
-//! modern UEFI + QEMU combo hands us.
+//! Backs the display with a character grid (glyph + fg/bg colour per cell)
+//! sized to the framebuffer.  When the cursor advances past the last row the
+//! screen scrolls up one line and the evicted row is saved to a
+//! `SCROLLBACK_ROWS`-deep ring in RAM.
+//!
+//! A minimal ANSI SGR parser handles:
+//! - CSI `n m` with `n` in: 0 (reset), 1 (bold), 22 (bold off),
+//!   30-37 (set fg), 39 (default fg), 40-47 (set bg), 49 (default bg).
+//! - Control characters `\r`, `\t`, `\n`.
+//!
+//! A blinking cursor is drawn at the write position.  The blink rate is
+//! driven by the kernel task spawned in `main.rs` via [`toggle_cursor`].
+//!
+//! # Initialization order
+//!
+//! [`Console::new`] heap-allocates the cell grid via `Vec`, so it **must**
+//! be called after `mem::init()`.  Early-boot output before the heap is live
+//! uses the serial port only.
 
+use alloc::vec::Vec;
 use core::fmt::{self, Write};
 use font8x8::UnicodeFonts;
 use spin::Mutex;
 
+// ─── glyph geometry ────────────────────────────────────────────────────────
+
 const GLYPH_W: usize = 8;
 const GLYPH_H: usize = 8;
-const FG: u32 = 0x00E0_E0E0;
-const BG: u32 = 0x0000_0000;
+
+// ─── default colours ───────────────────────────────────────────────────────
+
+const DEFAULT_FG: u32 = 0x00E0_E0E0; // near-white
+const DEFAULT_BG: u32 = 0x0000_0000; // black
+
+// ─── ANSI 8-colour palettes ────────────────────────────────────────────────
+
+// 0xRRGGBB packed in the low 24 bits.
+const ANSI_NORMAL: [u32; 8] = [
+    0x00_00_00_00, // 0 black
+    0x00_AA_00_00, // 1 red
+    0x00_00_AA_00, // 2 green
+    0x00_AA_55_00, // 3 yellow (dark)
+    0x00_00_00_AA, // 4 blue
+    0x00_AA_00_AA, // 5 magenta
+    0x00_00_AA_AA, // 6 cyan
+    0x00_AA_AA_AA, // 7 white
+];
+
+const ANSI_BRIGHT: [u32; 8] = [
+    0x00_55_55_55, // 0 bright black
+    0x00_FF_55_55, // 1 bright red
+    0x00_55_FF_55, // 2 bright green
+    0x00_FF_FF_55, // 3 bright yellow
+    0x00_55_55_FF, // 4 bright blue
+    0x00_FF_55_FF, // 5 bright magenta
+    0x00_55_FF_FF, // 6 bright cyan
+    0x00_FF_FF_FF, // 7 bright white
+];
+
+// ─── scrollback ────────────────────────────────────────────────────────────
+
+/// Off-screen rows kept in the scrollback ring.
+pub const SCROLLBACK_ROWS: usize = 200;
+
+// ─── character cell ────────────────────────────────────────────────────────
+
+#[derive(Clone, Copy)]
+struct Cell {
+    ch: char,
+    fg: u32,
+    bg: u32,
+}
+
+impl Cell {
+    const fn blank() -> Self {
+        Self {
+            ch: ' ',
+            fg: DEFAULT_FG,
+            bg: DEFAULT_BG,
+        }
+    }
+}
+
+// ─── ANSI parser state ─────────────────────────────────────────────────────
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Ansi {
+    Normal,
+    Esc,
+    Csi,
+}
+
+// ─── Console ───────────────────────────────────────────────────────────────
 
 pub struct Console {
+    // Framebuffer
     buffer: *mut u32,
     width: usize,  // pixels
     height: usize, // pixels
-    pitch: usize,  // u32s per row
+    pitch: usize,  // u32s per scanline
+
+    // Grid dimensions
     cols: usize,
     rows: usize,
+
+    // Cursor position
     cx: usize,
     cy: usize,
+    cursor_on: bool, // whether the cursor is currently drawn inverted
+
+    // Character grid: `rows * cols` cells, row-major.
+    cells: Vec<Cell>,
+
+    // Scrollback ring: `SCROLLBACK_ROWS * cols` cells, row-major.
+    // `scroll_head` is the index (in rows) of the oldest stored row;
+    // `scroll_filled` is the count of valid rows (≤ SCROLLBACK_ROWS).
+    scrollback: Vec<Cell>,
+    scroll_head: usize,
+    scroll_filled: usize,
+
+    // SGR colour state.  We track base colour indices so that toggling
+    // `bold` retroactively re-selects the bright palette entry.
+    fg_base: Option<u8>, // 0-7 if an ANSI colour; None = default
+    bg_base: Option<u8>,
+    bold: bool,
+
+    // ANSI escape-sequence parser
+    ansi: Ansi,
+    params: [u32; 8], // accumulated CSI parameter values
+    nparams: usize,   // params filled so far
+    cur_param: u32,   // digit accumulator for the current parameter
 }
 
-// SAFETY: the framebuffer pointer is stable for the lifetime of the
-// kernel; we gate concurrent writes with a Mutex below.
+// SAFETY: the framebuffer pointer is stable for the kernel lifetime;
+// concurrent access is serialized through `CONSOLE`'s Mutex.
 unsafe impl Send for Console {}
 
 impl Console {
     /// Construct a console over a 32-bpp linear framebuffer.
     ///
     /// # Safety
-    /// `base` must point to a framebuffer of `height` rows, each `pitch_bytes`
-    /// bytes wide, valid for writes for the lifetime of this program.
+    /// `base` must point to a valid 32-bpp framebuffer of `height` rows,
+    /// each `pitch_bytes` bytes wide, writable for the program's lifetime.
+    ///
+    /// **Must be called after `mem::init()`** — this allocates on the heap.
     pub unsafe fn new(base: *mut u8, width: u64, height: u64, pitch_bytes: u64) -> Self {
         let pitch = (pitch_bytes / 4) as usize;
         let width = width as usize;
         let height = height as usize;
+        let cols = width / GLYPH_W;
+        let rows = height / GLYPH_H;
+
+        let mut cells = Vec::with_capacity(rows * cols);
+        cells.resize(rows * cols, Cell::blank());
+
+        let mut scrollback = Vec::with_capacity(SCROLLBACK_ROWS * cols);
+        scrollback.resize(SCROLLBACK_ROWS * cols, Cell::blank());
+
         Self {
             buffer: base as *mut u32,
             width,
             height,
             pitch,
-            cols: width / GLYPH_W,
-            rows: height / GLYPH_H,
+            cols,
+            rows,
             cx: 0,
             cy: 0,
+            cursor_on: false,
+            cells,
+            scrollback,
+            scroll_head: 0,
+            scroll_filled: 0,
+            fg_base: None,
+            bg_base: None,
+            bold: false,
+            ansi: Ansi::Normal,
+            params: [0; 8],
+            nparams: 0,
+            cur_param: 0,
         }
     }
 
+    // ── colour helpers ────────────────────────────────────────────────────
+
+    fn cur_fg(&self) -> u32 {
+        match self.fg_base {
+            None => DEFAULT_FG,
+            Some(i) => {
+                if self.bold {
+                    ANSI_BRIGHT[i as usize]
+                } else {
+                    ANSI_NORMAL[i as usize]
+                }
+            }
+        }
+    }
+
+    fn cur_bg(&self) -> u32 {
+        match self.bg_base {
+            None => DEFAULT_BG,
+            Some(i) => ANSI_NORMAL[i as usize],
+        }
+    }
+
+    // ── screen clear ──────────────────────────────────────────────────────
+
     pub fn clear(&mut self) {
+        for cell in self.cells.iter_mut() {
+            *cell = Cell::blank();
+        }
         for y in 0..self.height {
             for x in 0..self.width {
-                unsafe { self.buffer.add(y * self.pitch + x).write_volatile(BG) };
+                unsafe {
+                    self.buffer.add(y * self.pitch + x).write_volatile(DEFAULT_BG);
+                }
             }
         }
         self.cx = 0;
         self.cy = 0;
+        self.cursor_on = false;
     }
 
-    fn put_glyph(&mut self, col: usize, row: usize, glyph: [u8; 8]) {
+    // ── low-level rendering ───────────────────────────────────────────────
+
+    /// Render a single `Cell` to the framebuffer at grid position (col, row).
+    fn render_cell_at(&mut self, col: usize, row: usize, cell: Cell) {
+        let glyph = font8x8::BASIC_FONTS
+            .get(cell.ch)
+            .unwrap_or_else(|| font8x8::BASIC_FONTS.get(' ').unwrap());
         let px = col * GLYPH_W;
         let py = row * GLYPH_H;
         for (dy, bits) in glyph.iter().enumerate() {
             for dx in 0..GLYPH_W {
                 let lit = (bits >> dx) & 1 != 0;
-                let color = if lit { FG } else { BG };
+                let color = if lit { cell.fg } else { cell.bg };
                 let x = px + dx;
                 let y = py + dy;
                 if x < self.width && y < self.height {
-                    unsafe { self.buffer.add(y * self.pitch + x).write_volatile(color) };
+                    unsafe {
+                        self.buffer.add(y * self.pitch + x).write_volatile(color);
+                    }
                 }
             }
         }
     }
 
-    fn newline(&mut self) {
+    // ── cursor ────────────────────────────────────────────────────────────
+
+    /// Draw or erase the cursor at (col, row) by inverting fg/bg.
+    fn draw_cursor(&mut self, col: usize, row: usize, visible: bool) {
+        if col >= self.cols || row >= self.rows {
+            return;
+        }
+        let cell = self.cells[row * self.cols + col];
+        if visible {
+            let inv = Cell {
+                ch: cell.ch,
+                fg: cell.bg,
+                bg: cell.fg,
+            };
+            self.render_cell_at(col, row, inv);
+        } else {
+            self.render_cell_at(col, row, cell);
+        }
+    }
+
+    /// Toggle cursor visibility and repaint the cell at the write position.
+    /// Called by the blink task.
+    pub fn toggle_cursor(&mut self) {
+        self.cursor_on = !self.cursor_on;
+        let (cx, cy, on) = (self.cx, self.cy, self.cursor_on);
+        self.draw_cursor(cx, cy, on);
+    }
+
+    // ── scrolling ─────────────────────────────────────────────────────────
+
+    /// Scroll the screen up by one row.
+    ///
+    /// - The departing top row is pushed into the scrollback ring.
+    /// - Cell data is shifted up with `Vec::copy_within`.
+    /// - Pixel rows are blitted up on the framebuffer with a memmove-style
+    ///   `ptr::copy` (handles overlap).
+    /// - The vacated last pixel row is cleared to `DEFAULT_BG`.
+    fn scroll_up(&mut self) {
+        let cols = self.cols;
+
+        // Save row 0 into the scrollback ring.
+        let ring_row = (self.scroll_head + self.scroll_filled) % SCROLLBACK_ROWS;
+        let dst = ring_row * cols;
+        for i in 0..cols {
+            self.scrollback[dst + i] = self.cells[i];
+        }
+        if self.scroll_filled < SCROLLBACK_ROWS {
+            self.scroll_filled += 1;
+        } else {
+            self.scroll_head = (self.scroll_head + 1) % SCROLLBACK_ROWS;
+        }
+
+        // Shift cell grid up one row.
+        self.cells.copy_within(cols.., 0);
+        let last = (self.rows - 1) * cols;
+        for i in 0..cols {
+            self.cells[last + i] = Cell::blank();
+        }
+
+        // Blit pixel rows up (rows 1..rows → rows 0..rows-1).
+        let row_pixels = self.pitch * GLYPH_H;
+        unsafe {
+            // ptr::copy is memmove-compatible and handles overlap.
+            core::ptr::copy(
+                self.buffer.add(row_pixels),
+                self.buffer,
+                row_pixels * (self.rows - 1),
+            );
+        }
+
+        // Clear the last pixel row.
+        let last_py = (self.rows - 1) * GLYPH_H;
+        for y in last_py..last_py + GLYPH_H {
+            for x in 0..self.width {
+                unsafe {
+                    self.buffer.add(y * self.pitch + x).write_volatile(DEFAULT_BG);
+                }
+            }
+        }
+    }
+
+    // ── cursor-aware movement ─────────────────────────────────────────────
+
+    fn move_to_newline(&mut self) {
+        let (cx, cy) = (self.cx, self.cy);
+        self.draw_cursor(cx, cy, false);
         self.cx = 0;
         self.cy += 1;
         if self.cy >= self.rows {
-            // Cheap scroll: just wrap. A real scroll would memmove rows up.
-            self.cy = 0;
-            self.clear();
+            self.scroll_up();
+            self.cy = self.rows - 1;
+        }
+        let (cx, cy, on) = (self.cx, self.cy, self.cursor_on);
+        self.draw_cursor(cx, cy, on);
+    }
+
+    // ── character output ──────────────────────────────────────────────────
+
+    fn put_char(&mut self, c: char) {
+        let fg = self.cur_fg();
+        let bg = self.cur_bg();
+
+        // Erase cursor before touching this cell.
+        let (cx, cy) = (self.cx, self.cy);
+        self.draw_cursor(cx, cy, false);
+
+        // Write to grid and framebuffer.
+        let cell = Cell { ch: c, fg, bg };
+        self.cells[cy * self.cols + cx] = cell;
+        self.render_cell_at(cx, cy, cell);
+
+        // Advance, wrapping to the next line if necessary.
+        self.cx += 1;
+        if self.cx >= self.cols {
+            self.cx = 0;
+            self.cy += 1;
+            if self.cy >= self.rows {
+                self.scroll_up();
+                self.cy = self.rows - 1;
+            }
+        }
+
+        // Draw cursor at new position.
+        let (cx, cy, on) = (self.cx, self.cy, self.cursor_on);
+        self.draw_cursor(cx, cy, on);
+    }
+
+    // ── SGR (Select Graphic Rendition) ────────────────────────────────────
+
+    fn apply_sgr(&mut self) {
+        // An empty parameter list (`\x1b[m`) is treated as a single 0.
+        let n = if self.nparams == 0 { 1 } else { self.nparams };
+        for i in 0..n {
+            match self.params[i] {
+                0 => {
+                    self.fg_base = None;
+                    self.bg_base = None;
+                    self.bold = false;
+                }
+                1 => {
+                    self.bold = true;
+                }
+                22 => {
+                    self.bold = false;
+                }
+                p @ 30..=37 => {
+                    self.fg_base = Some((p - 30) as u8);
+                }
+                39 => {
+                    self.fg_base = None;
+                }
+                p @ 40..=47 => {
+                    self.bg_base = Some((p - 40) as u8);
+                }
+                49 => {
+                    self.bg_base = None;
+                }
+                _ => {}
+            }
         }
     }
 
+    // ── public character writer ───────────────────────────────────────────
+
     pub fn write_char(&mut self, c: char) {
-        match c {
-            '\n' => self.newline(),
-            '\r' => self.cx = 0,
-            c => {
-                let glyph = font8x8::BASIC_FONTS
-                    .get(c)
-                    .unwrap_or_else(|| font8x8::BASIC_FONTS.get('?').unwrap());
-                self.put_glyph(self.cx, self.cy, glyph);
-                self.cx += 1;
-                if self.cx >= self.cols {
-                    self.newline();
+        match self.ansi {
+            Ansi::Normal => match c {
+                '\x1b' => {
+                    self.ansi = Ansi::Esc;
+                }
+                '\n' => {
+                    self.move_to_newline();
+                }
+                '\r' => {
+                    let (cx, cy) = (self.cx, self.cy);
+                    self.draw_cursor(cx, cy, false);
+                    self.cx = 0;
+                    let (cx, cy, on) = (self.cx, self.cy, self.cursor_on);
+                    self.draw_cursor(cx, cy, on);
+                }
+                '\t' => {
+                    let next_tab = ((self.cx / 8) + 1) * 8;
+                    let (cx, cy) = (self.cx, self.cy);
+                    self.draw_cursor(cx, cy, false);
+                    if next_tab >= self.cols {
+                        self.move_to_newline();
+                    } else {
+                        self.cx = next_tab;
+                        let (cx, cy, on) = (self.cx, self.cy, self.cursor_on);
+                        self.draw_cursor(cx, cy, on);
+                    }
+                }
+                c => {
+                    self.put_char(c);
+                }
+            },
+
+            Ansi::Esc => {
+                if c == '[' {
+                    self.ansi = Ansi::Csi;
+                    self.params = [0; 8];
+                    self.nparams = 0;
+                    self.cur_param = 0;
+                } else {
+                    // Unrecognised escape — discard and resume normal parsing.
+                    self.ansi = Ansi::Normal;
                 }
             }
+
+            Ansi::Csi => match c {
+                '0'..='9' => {
+                    self.cur_param = self.cur_param.saturating_mul(10)
+                        .saturating_add(c as u32 - '0' as u32);
+                }
+                ';' => {
+                    if self.nparams < self.params.len() {
+                        self.params[self.nparams] = self.cur_param;
+                        self.nparams += 1;
+                    }
+                    self.cur_param = 0;
+                }
+                'm' => {
+                    // Commit the last (or only) parameter.
+                    if self.nparams < self.params.len() {
+                        self.params[self.nparams] = self.cur_param;
+                        self.nparams += 1;
+                    }
+                    self.apply_sgr();
+                    self.ansi = Ansi::Normal;
+                }
+                _ => {
+                    // Unrecognised final byte — discard the sequence.
+                    self.ansi = Ansi::Normal;
+                }
+            },
         }
     }
 }
@@ -114,13 +494,24 @@ impl Write for Console {
     }
 }
 
+// ─── global state ──────────────────────────────────────────────────────────
+
 pub static CONSOLE: Mutex<Option<Console>> = Mutex::new(None);
 
+/// Install `console` as the active console and clear the screen.
+/// Must be called after `mem::init()`.
 pub fn init(console: Console) {
     let mut guard = CONSOLE.lock();
     *guard = Some(console);
     if let Some(c) = guard.as_mut() {
         c.clear();
+    }
+}
+
+/// Toggle the cursor blink state.  Called by the cursor-blink kernel task.
+pub fn toggle_cursor() {
+    if let Some(c) = CONSOLE.lock().as_mut() {
+        c.toggle_cursor();
     }
 }
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -68,10 +68,15 @@ pub extern "C" fn _start() -> ! {
                 fb.bpp(),
                 fb.pitch()
             );
-            let console =
-                unsafe { Console::new(fb.addr(), fb.width(), fb.height(), fb.pitch()) };
-            framebuffer::init(console);
-            println!("vibix: framebuffer online");
+            if fb.bpp() == 32 {
+                let console = unsafe {
+                    Console::new(fb.addr(), fb.width(), fb.height(), fb.pitch())
+                };
+                framebuffer::init(console);
+                println!("vibix: framebuffer online");
+            } else {
+                serial_println!("unsupported framebuffer format: {} bpp", fb.bpp());
+            }
         } else {
             serial_println!("no framebuffer reported by Limine");
         }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -69,9 +69,8 @@ pub extern "C" fn _start() -> ! {
                 fb.pitch()
             );
             if fb.bpp() == 32 {
-                let console = unsafe {
-                    Console::new(fb.addr(), fb.width(), fb.height(), fb.pitch())
-                };
+                let console =
+                    unsafe { Console::new(fb.addr(), fb.width(), fb.height(), fb.pitch()) };
                 framebuffer::init(console);
                 println!("vibix: framebuffer online");
             } else {

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -7,6 +7,9 @@ use vibix::boot::{BASE_REVISION, FRAMEBUFFER_REQUEST, HHDM_REQUEST, MEMMAP_REQUE
 use vibix::framebuffer::Console;
 use vibix::{exit_qemu, framebuffer, println, serial_print, serial_println, QemuExitCode};
 
+/// How many PIT ticks between cursor blink toggles (~500 ms at 100 Hz).
+const CURSOR_BLINK_TICKS: u64 = 50;
+
 #[no_mangle]
 #[cfg_attr(
     any(feature = "ist-overflow-test", feature = "panic-test"),
@@ -20,25 +23,6 @@ pub extern "C" fn _start() -> ! {
         BASE_REVISION.is_supported(),
         "Limine base revision unsupported"
     );
-
-    if let Some(fb_response) = FRAMEBUFFER_REQUEST.get_response() {
-        if let Some(fb) = fb_response.framebuffers().next() {
-            serial_println!(
-                "framebuffer: {}x{} @ {} bpp, pitch={} bytes",
-                fb.width(),
-                fb.height(),
-                fb.bpp(),
-                fb.pitch()
-            );
-            let console = unsafe { Console::new(fb.addr(), fb.width(), fb.height(), fb.pitch()) };
-            framebuffer::init(console);
-            println!("vibix: framebuffer online");
-        } else {
-            serial_println!("no framebuffer reported by Limine");
-        }
-    } else {
-        serial_println!("no framebuffer response");
-    }
 
     if let Some(memmap) = MEMMAP_REQUEST.get_response() {
         let entries = memmap.entries();
@@ -72,6 +56,28 @@ pub extern "C" fn _start() -> ! {
     vibix::mem::init();
     vibix::arch::init_apic(rsdp_ptr, hhdm_offset);
     vibix::time::init();
+
+    // Console init must come after mem::init() — the character grid and
+    // scrollback buffer are heap-allocated inside Console::new().
+    if let Some(fb_response) = FRAMEBUFFER_REQUEST.get_response() {
+        if let Some(fb) = fb_response.framebuffers().next() {
+            serial_println!(
+                "framebuffer: {}x{} @ {} bpp, pitch={} bytes",
+                fb.width(),
+                fb.height(),
+                fb.bpp(),
+                fb.pitch()
+            );
+            let console =
+                unsafe { Console::new(fb.addr(), fb.width(), fb.height(), fb.pitch()) };
+            framebuffer::init(console);
+            println!("vibix: framebuffer online");
+        } else {
+            serial_println!("no framebuffer reported by Limine");
+        }
+    } else {
+        serial_println!("no framebuffer response");
+    }
 
     println!("vibix online.");
     serial_println!("vibix online.");
@@ -113,6 +119,7 @@ pub extern "C" fn _start() -> ! {
 
     vibix::task::init();
     vibix::task::spawn(idle_task);
+    vibix::task::spawn(cursor_blink_task);
 
     loop {
         vibix::task::yield_now();
@@ -127,6 +134,18 @@ fn idle_task() -> ! {
     loop {
         x86_64::instructions::hlt();
         vibix::task::yield_now();
+    }
+}
+
+/// Blink the framebuffer cursor at approximately 1 Hz (toggle every 500 ms).
+fn cursor_blink_task() -> ! {
+    let mut next = vibix::time::ticks() + CURSOR_BLINK_TICKS;
+    loop {
+        while vibix::time::ticks() < next {
+            vibix::task::yield_now();
+        }
+        next = next.wrapping_add(CURSOR_BLINK_TICKS);
+        vibix::framebuffer::toggle_cursor();
     }
 }
 


### PR DESCRIPTION
Implements the full scope of issue #45:

- Character grid (Cell { ch, fg, bg }) backing the console
- 200-row scrollback ring saved on scroll
- Minimal ANSI SGR parser (0/1/22/30-37/39/40-47/49)
- Timer-driven blinking cursor via kernel task

Closes #45

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it rewrites framebuffer text output to use a heap-backed cell grid with scrolling/memmove blits and adds an always-running cursor-blink task; bugs here can corrupt display memory or impact kernel scheduling/timing.
> 
> **Overview**
> Upgrades the framebuffer text console from direct glyph writes to a **heap-backed character grid** (`Cell { ch, fg, bg }`) that supports true screen scrolling and saves evicted rows into a `SCROLLBACK_ROWS` ring buffer.
> 
> Adds a minimal **ANSI SGR** parser for basic styling (reset/bold and 8-color fg/bg) plus `\r`/`\t` handling, and implements a **blinking cursor** by inverting the current cell and exposing `framebuffer::toggle_cursor()`.
> 
> Updates `main.rs` to initialize the console **after `mem::init()`** (due to `Vec` allocations) and spawns a periodic `cursor_blink_task` driven by PIT ticks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caf1f09390ee61e98768a5ef840cf290fddd7a50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->