### PR TITLE
sync: blocking primitives (BlockingMutex, WaitQueue, SPSC channel)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -83,3 +83,7 @@ harness = false
 [[test]]
 name = "page_fault"
 harness = false
+
+[[test]]
+name = "blocking_sync"
+harness = false

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -28,6 +28,8 @@ pub mod ksymtab;
 #[cfg(target_os = "none")]
 pub mod serial;
 #[cfg(target_os = "none")]
+pub mod sync;
+#[cfg(target_os = "none")]
 pub mod task;
 #[cfg(target_os = "none")]
 pub mod test_harness;

--- a/kernel/src/sync/mod.rs
+++ b/kernel/src/sync/mod.rs
@@ -1,0 +1,54 @@
+//! Blocking synchronisation primitives: sleeping mutex, waitqueue,
+//! bounded SPSC channel.
+//!
+//! These sit on top of the round-robin scheduler in [`crate::task`]:
+//! they park the calling task with
+//! [`task::block_current`](crate::task::block_current) when they'd
+//! otherwise need to busy-wait, and wake it with
+//! [`task::wake`](crate::task::wake) once progress is possible.
+//!
+//! ## When to pick each one
+//!
+//! - [`BlockingMutex`] — mutual exclusion that doesn't burn CPU under
+//!   contention. Interface mirrors `spin::Mutex`; drop-in for any
+//!   critical section that might be held across a scheduling point.
+//! - [`WaitQueue`] — primitive building block. Tasks call
+//!   [`WaitQueue::wait_while`] with a condition; wakers call
+//!   [`WaitQueue::notify_one`] / [`notify_all`] after changing state
+//!   the condition depends on. Both of the other primitives are built
+//!   on this.
+//! - [`spsc`] — single-producer / single-consumer bounded channel.
+//!   The simplest message-passing shape; MPSC/MPMC variants can be
+//!   added as follow-ups once the SPSC case has baked in-tree.
+//!
+//! ## Task-context only
+//!
+//! Every `notify` / `wake` path here acquires the scheduler lock. The
+//! preempt-tick ISR uses `try_lock` on the same lock and bails on
+//! contention, which is safe; an ISR that calls `notify_one` directly,
+//! however, would deadlock if it interrupted a task already holding
+//! that lock. If an IRQ needs to wake a task, post to a lock-free
+//! queue (see `crate::input`'s keyboard ring) and let a kernel task
+//! drain it and call `notify_one` from task context.
+//!
+//! ## Lock order
+//!
+//! The primitives here establish a strict acquisition order so that
+//! no cycle can form:
+//!
+//! ```text
+//!   WaitQueue.inner ── ▶ (data lock, e.g. BlockingMutex.state,
+//!                          spsc::Shared.buf)
+//!   WaitQueue.inner ── ▶ SCHED  (via task::block_current /
+//!                                 task::current_id)
+//! ```
+//!
+//! Nothing acquires `WaitQueue.inner` while already holding a data
+//! lock or `SCHED`, so the graph is a DAG.
+
+pub mod mutex;
+pub mod spsc;
+pub mod waitqueue;
+
+pub use mutex::{BlockingMutex, MutexGuard};
+pub use waitqueue::WaitQueue;

--- a/kernel/src/sync/mutex.rs
+++ b/kernel/src/sync/mutex.rs
@@ -1,0 +1,119 @@
+//! `BlockingMutex<T>` — mutual exclusion that parks on contention
+//! instead of spinning.
+//!
+//! Interface mirrors `spin::Mutex`: [`lock`] returns a RAII guard that
+//! derefs to `&mut T` and releases the lock on drop. A contended
+//! `lock` call parks the task via [`WaitQueue::wait_while`] until the
+//! current holder releases.
+//!
+//! Lock order (see [`super`] module docs): `WaitQueue.inner` → the
+//! internal `state` spin-lock. Nothing outside this module takes those
+//! two locks in reverse order, so no deadlock cycle can form.
+
+use core::cell::UnsafeCell;
+use core::ops::{Deref, DerefMut};
+use spin::Mutex as SpinMutex;
+
+use super::WaitQueue;
+
+/// Sleeping mutex.
+pub struct BlockingMutex<T: ?Sized> {
+    /// `true` while the mutex is held. Guarded by a short-lived
+    /// spinlock that nobody holds across a scheduling point.
+    state: SpinMutex<bool>,
+    /// Parked tasks waiting for the mutex to be released.
+    waiters: WaitQueue,
+    /// The protected data. `UnsafeCell` because we hand out `&mut`
+    /// through the guard; access is serialised by `state == true`.
+    data: UnsafeCell<T>,
+}
+
+// Access to `data` is serialised by the mutex protocol — safe to share
+// the mutex itself across tasks whenever `T` is `Send`.
+unsafe impl<T: ?Sized + Send> Send for BlockingMutex<T> {}
+unsafe impl<T: ?Sized + Send> Sync for BlockingMutex<T> {}
+
+impl<T> BlockingMutex<T> {
+    /// Construct a new mutex protecting `val`. `const` so the mutex
+    /// can live in a `static`.
+    pub const fn new(val: T) -> Self {
+        Self {
+            state: SpinMutex::new(false),
+            waiters: WaitQueue::new(),
+            data: UnsafeCell::new(val),
+        }
+    }
+
+    /// Consume the mutex and return the protected value.
+    pub fn into_inner(self) -> T {
+        self.data.into_inner()
+    }
+}
+
+impl<T: ?Sized> BlockingMutex<T> {
+    /// Try to acquire without parking. Returns `None` if the mutex is
+    /// currently held by someone else.
+    pub fn try_lock(&self) -> Option<MutexGuard<'_, T>> {
+        let mut held = self.state.lock();
+        if *held {
+            None
+        } else {
+            *held = true;
+            Some(MutexGuard { mu: self })
+        }
+    }
+
+    /// Acquire the mutex, parking the current task if it's contended.
+    pub fn lock(&self) -> MutexGuard<'_, T> {
+        loop {
+            // Fast path — uncontended grab.
+            {
+                let mut held = self.state.lock();
+                if !*held {
+                    *held = true;
+                    return MutexGuard { mu: self };
+                }
+            }
+            // Slow path — park until the lock looks available. The
+            // `cond` runs under the waitqueue lock, which is the lock
+            // point that makes the park race-free: if the holder
+            // releases between our fast-path check and the
+            // `wait_while` cond, the cond sees `*state == false` and
+            // returns without parking. If it releases between cond
+            // and `block_current`, `notify_one` pops us and
+            // `task::wake` sets `wake_pending` — `block_current`
+            // consumes it and returns.
+            self.waiters.wait_while(|| *self.state.lock());
+        }
+    }
+}
+
+/// RAII guard. Drop to release the mutex; wakes one waiter.
+pub struct MutexGuard<'a, T: ?Sized> {
+    mu: &'a BlockingMutex<T>,
+}
+
+impl<T: ?Sized> Deref for MutexGuard<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        // SAFETY: the mutex is held (see `state == true`), so we have
+        // exclusive access to `data`.
+        unsafe { &*self.mu.data.get() }
+    }
+}
+
+impl<T: ?Sized> DerefMut for MutexGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        // SAFETY: as above — exclusive access implied by a live guard.
+        unsafe { &mut *self.mu.data.get() }
+    }
+}
+
+impl<T: ?Sized> Drop for MutexGuard<'_, T> {
+    fn drop(&mut self) {
+        // Publish the release BEFORE notifying, so a woken waiter's
+        // cond re-check sees `*state == false`.
+        *self.mu.state.lock() = false;
+        self.mu.waiters.notify_one();
+    }
+}

--- a/kernel/src/sync/spsc.rs
+++ b/kernel/src/sync/spsc.rs
@@ -1,0 +1,147 @@
+//! Bounded single-producer / single-consumer blocking channel.
+//!
+//! Why SPSC first: the simpler shape that covers the typical
+//! "producer task hands work to a worker task" pattern without the
+//! extra synchronisation an MPMC channel needs. MPSC / MPMC variants
+//! can be added as follow-ups once this has baked in-tree.
+//!
+//! Capacity is fixed at construction. `send` / `recv` park via
+//! [`WaitQueue`] when the queue is full / empty; `try_send` /
+//! `try_recv` never park.
+//!
+//! The `Sender` and `Receiver` each own one `Arc` handle to the shared
+//! state; dropping all handles of one side does *not* currently signal
+//! the other — a sender that finishes and drops its `Sender` will
+//! leave the receiver waiting forever if the queue is empty. That's
+//! fine for the primitives' in-kernel usage today (tasks don't exit
+//! yet in M6) but is the natural follow-up shape for a channel-close
+//! protocol.
+
+use alloc::collections::VecDeque;
+use alloc::sync::Arc;
+use spin::Mutex;
+
+use super::WaitQueue;
+
+struct Inner<T> {
+    queue: VecDeque<T>,
+    capacity: usize,
+}
+
+struct Shared<T> {
+    buf: Mutex<Inner<T>>,
+    not_full: WaitQueue,
+    not_empty: WaitQueue,
+}
+
+/// Producer half of an SPSC channel.
+pub struct Sender<T> {
+    shared: Arc<Shared<T>>,
+}
+
+/// Consumer half of an SPSC channel.
+pub struct Receiver<T> {
+    shared: Arc<Shared<T>>,
+}
+
+/// Create an SPSC channel with room for `capacity` unreceived items.
+///
+/// # Panics
+///
+/// Panics if `capacity == 0`; a zero-capacity rendezvous channel is a
+/// separate (and substantially more complex) shape.
+pub fn channel<T>(capacity: usize) -> (Sender<T>, Receiver<T>) {
+    assert!(capacity > 0, "spsc::channel capacity must be > 0");
+    let shared = Arc::new(Shared {
+        buf: Mutex::new(Inner {
+            queue: VecDeque::with_capacity(capacity),
+            capacity,
+        }),
+        not_full: WaitQueue::new(),
+        not_empty: WaitQueue::new(),
+    });
+    (
+        Sender {
+            shared: shared.clone(),
+        },
+        Receiver { shared },
+    )
+}
+
+impl<T> Sender<T> {
+    /// Send `val`, parking until the channel has space.
+    pub fn send(&self, val: T) {
+        // `Option` dance because we might loop (park + retry) before
+        // the push actually lands, and a bare `val` would be
+        // borrow-checked as moved-on-previous-iteration.
+        let mut slot = Some(val);
+        loop {
+            {
+                let mut inner = self.shared.buf.lock();
+                if inner.queue.len() < inner.capacity {
+                    inner
+                        .queue
+                        .push_back(slot.take().expect("send slot populated"));
+                    drop(inner);
+                    self.shared.not_empty.notify_one();
+                    return;
+                }
+            }
+            // Full: park until the receiver pops at least one item.
+            // Re-check `len >= capacity` under the waitqueue lock via
+            // `wait_while`; `recv` calls `not_full.notify_one()` only
+            // after it has popped, so on wakeup the condition can
+            // differ — the loop retries in that case.
+            self.shared.not_full.wait_while(|| {
+                let inner = self.shared.buf.lock();
+                inner.queue.len() >= inner.capacity
+            });
+        }
+    }
+
+    /// Non-blocking send. Returns `Err(val)` if the channel is full.
+    pub fn try_send(&self, val: T) -> Result<(), T> {
+        let mut inner = self.shared.buf.lock();
+        if inner.queue.len() < inner.capacity {
+            inner.queue.push_back(val);
+            drop(inner);
+            self.shared.not_empty.notify_one();
+            Ok(())
+        } else {
+            Err(val)
+        }
+    }
+}
+
+impl<T> Receiver<T> {
+    /// Receive one item, parking until one is available.
+    pub fn recv(&self) -> T {
+        loop {
+            {
+                let mut inner = self.shared.buf.lock();
+                if let Some(val) = inner.queue.pop_front() {
+                    drop(inner);
+                    self.shared.not_full.notify_one();
+                    return val;
+                }
+            }
+            // Empty: park until the sender pushes.
+            self.shared.not_empty.wait_while(|| {
+                let inner = self.shared.buf.lock();
+                inner.queue.is_empty()
+            });
+        }
+    }
+
+    /// Non-blocking recv. Returns `None` if the channel is empty.
+    pub fn try_recv(&self) -> Option<T> {
+        let mut inner = self.shared.buf.lock();
+        if let Some(val) = inner.queue.pop_front() {
+            drop(inner);
+            self.shared.not_full.notify_one();
+            Some(val)
+        } else {
+            None
+        }
+    }
+}

--- a/kernel/src/sync/waitqueue.rs
+++ b/kernel/src/sync/waitqueue.rs
@@ -1,0 +1,123 @@
+//! Waitqueue: the one primitive on which [`super::BlockingMutex`] and
+//! [`super::spsc`] are built.
+//!
+//! A waitqueue stores the ids of tasks that have declared interest in
+//! a condition. [`WaitQueue::wait_while`] is the standard park loop;
+//! [`WaitQueue::notify_one`] and [`WaitQueue::notify_all`] are the
+//! wake side.
+//!
+//! ## Lost-wakeup protocol
+//!
+//! The tricky case is:
+//!
+//! 1. Waiter checks the condition, sees "must block", adds itself to
+//!    the queue, drops the queue lock.
+//! 2. Before the waiter reaches [`task::block_current`], the waker
+//!    runs, flips the state the condition tests, and calls
+//!    [`WaitQueue::notify_one`]. `notify_one` pops the waiter and
+//!    calls [`task::wake`], which finds the waiter still Running and
+//!    sets its `wake_pending` flag.
+//! 3. Waiter finally calls [`task::block_current`], which consumes
+//!    `wake_pending` and returns immediately.
+//! 4. Loop re-checks the condition, sees it's satisfied, returns.
+//!
+//! The invariant is: *between enqueuing self and calling
+//! `block_current`, a wake cannot be dropped on the floor.* The
+//! `wake_pending` flag on the task carries the signal across the
+//! window where the waiter is enqueued but not yet parked.
+
+use alloc::collections::VecDeque;
+use spin::Mutex;
+
+use crate::task;
+
+/// Blocking wait queue.
+///
+/// See the module docs for the lost-wakeup protocol and lock order.
+pub struct WaitQueue {
+    inner: Mutex<VecDeque<usize>>,
+}
+
+impl WaitQueue {
+    /// Create an empty wait queue. `const` so the primitive can live
+    /// in a `static`.
+    pub const fn new() -> Self {
+        Self {
+            inner: Mutex::new(VecDeque::new()),
+        }
+    }
+
+    /// Block the current task while `cond` is true.
+    ///
+    /// Classic "predicate loop" wait: on entry `cond` is checked under
+    /// the queue lock; if true, the current task enqueues itself,
+    /// drops the lock, and parks. On wake it re-checks `cond` and
+    /// returns once the predicate is false.
+    ///
+    /// `cond` is called repeatedly — make it pure and side-effect
+    /// free. It may itself take other locks (e.g. a data mutex) as
+    /// long as those locks are ordered *after* `WaitQueue.inner` in
+    /// the module's lock graph.
+    pub fn wait_while<F: FnMut() -> bool>(&self, mut cond: F) {
+        let tid = task::current_id();
+
+        loop {
+            // Enqueue first, then check. The ordering is what makes
+            // the wake-before-park race safe: if a wake fires after
+            // the push but before `block_current`, it'll either pop
+            // us from the queue (and set `wake_pending` via
+            // `task::wake`) or miss us, but in both cases the
+            // condition will also have changed, and the final
+            // `cond()` check below catches it.
+            {
+                let mut q = self.inner.lock();
+                if !cond() {
+                    return;
+                }
+                q.push_back(tid);
+            }
+
+            task::block_current();
+
+            // Woken (or wake was already pending). Remove any stale
+            // self-entry in case we came out via `wake_pending` rather
+            // than a `notify_one` pop. Cheap linear scan — queue is
+            // bounded by the number of concurrent waiters.
+            {
+                let mut q = self.inner.lock();
+                q.retain(|&id| id != tid);
+            }
+            // Fall through to loop — re-check cond.
+        }
+    }
+
+    /// Wake exactly one waiter, if any.
+    ///
+    /// Call *after* publishing the state change that would make a
+    /// waiter's `cond()` return false. Order matters: if you notify
+    /// before publishing, the waiter may observe the old state on its
+    /// re-check and park again.
+    pub fn notify_one(&self) {
+        let tid = { self.inner.lock().pop_front() };
+        if let Some(tid) = tid {
+            task::wake(tid);
+        }
+    }
+
+    /// Wake every currently-registered waiter.
+    pub fn notify_all(&self) {
+        loop {
+            let tid = { self.inner.lock().pop_front() };
+            match tid {
+                Some(tid) => task::wake(tid),
+                None => return,
+            }
+        }
+    }
+}
+
+impl Default for WaitQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -16,20 +16,24 @@
 //! ## What's *not* here (yet)
 //!
 //! - Priorities, per-CPU queues, tickless idle.
-//! - Blocking primitives — cooperative code polls + yields.
 //! - Per-task address spaces.
+//!
+//! Blocking primitives (mutex-that-sleeps, channels, waitqueues) live
+//! in [`crate::sync`] and are built on top of [`block_current`] and
+//! [`wake`] below.
 
 mod scheduler;
 mod switch;
 mod task;
 
 use alloc::boxed::Box;
+use core::sync::atomic::Ordering;
 use spin::{Lazy, Mutex};
 use x86_64::instructions::interrupts;
 
 use scheduler::Scheduler;
 use switch::context_switch;
-use task::Task;
+use task::{Task, TaskState};
 
 use crate::serial_println;
 use crate::time::TICK_MS;
@@ -76,14 +80,16 @@ pub fn yield_now() {
     // deadlock the incoming task's own call to `yield_now`.
     let (prev_rsp_ptr, next_rsp) = {
         let mut sched = SCHED.lock();
-        let Some(next) = sched.ready.pop_front() else {
+        let Some(mut next) = sched.ready.pop_front() else {
             if was_on {
                 interrupts::enable();
             }
             return;
         };
-        let prev = sched.current.take().expect("yield_now before task::init");
+        let mut prev = sched.current.take().expect("yield_now before task::init");
 
+        prev.state = TaskState::Ready;
+        next.state = TaskState::Running;
         let next_rsp = next.rsp;
         sched.current = Some(next);
         sched.current.as_mut().unwrap().slice_remaining_ms = DEFAULT_SLICE_MS;
@@ -169,14 +175,16 @@ pub fn preempt_tick() {
         }
     }
 
-    let Some(next) = sched.ready.pop_front() else {
+    let Some(mut next) = sched.ready.pop_front() else {
         // Slice expired but nobody else is ready. Reload and keep
         // running — prevents repeated try_lock churn on every tick.
         sched.current.as_mut().unwrap().slice_remaining_ms = DEFAULT_SLICE_MS;
         return;
     };
 
-    let prev = sched.current.take().unwrap();
+    let mut prev = sched.current.take().unwrap();
+    prev.state = TaskState::Ready;
+    next.state = TaskState::Running;
     let next_rsp = next.rsp;
     sched.current = Some(next);
     sched.current.as_mut().unwrap().slice_remaining_ms = DEFAULT_SLICE_MS;
@@ -191,5 +199,169 @@ pub fn preempt_tick() {
     // lock drop and the context switch.
     unsafe {
         context_switch(prev_rsp_ptr, next_rsp);
+    }
+}
+
+/// Return the id of the currently-running task.
+///
+/// Must be called after [`init`]. Briefly locks the scheduler, so do
+/// not call from an ISR context or while holding any lock whose
+/// ordering places it *after* `SCHED`.
+pub fn current_id() -> usize {
+    SCHED
+        .lock()
+        .current
+        .as_ref()
+        .expect("current_id before task::init")
+        .id
+}
+
+/// Block the current task until some later [`wake`] call with its id.
+///
+/// Callers are responsible for registering the current task with a
+/// wakeup source (e.g. pushing their id onto a
+/// [`crate::sync::WaitQueue`]) *before* invoking this function — see
+/// [`crate::sync::WaitQueue::wait_while`] for the standard pattern.
+///
+/// The function is race-free against a [`wake`] call that fires
+/// between "register" and "block": [`wake`] sets the target task's
+/// `wake_pending` flag if the task is still Running or Ready, and the
+/// fast path here consumes the flag and returns without parking.
+///
+/// # Panics
+///
+/// Panics if there is no other task in the ready queue — blocking the
+/// sole runnable task would halt the kernel forever. In practice the
+/// bootstrap task is always ready, so this only fires if something
+/// genuinely wedged the scheduler.
+pub fn block_current() {
+    let was_on = interrupts::are_enabled();
+    interrupts::disable();
+
+    let (prev_rsp_ptr, next_rsp) = {
+        let mut sched = SCHED.lock();
+
+        // Fast path: a prior wake() set wake_pending while we were
+        // still Running. Clear and return without parking — this
+        // closes the wake-before-park race.
+        //
+        // AcqRel on swap: Acquire pairs with wake()'s Release store so
+        // anything the waker published before setting the flag is
+        // visible to us; Release on the clear keeps later reads (e.g.
+        // the condition in wait_while) from being hoisted above this
+        // point.
+        if sched
+            .current
+            .as_ref()
+            .expect("block_current before task::init")
+            .wake_pending
+            .swap(false, Ordering::AcqRel)
+        {
+            drop(sched);
+            if was_on {
+                interrupts::enable();
+            }
+            return;
+        }
+
+        let Some(mut next) = sched.ready.pop_front() else {
+            panic!("task::block_current: no ready task to switch to");
+        };
+        let mut prev = sched.current.take().unwrap();
+        prev.state = TaskState::Blocked;
+        next.state = TaskState::Running;
+        let prev_id = prev.id;
+        let next_rsp = next.rsp;
+        sched.current = Some(next);
+        sched.current.as_mut().unwrap().slice_remaining_ms = DEFAULT_SLICE_MS;
+        sched.parked.insert(prev_id, prev);
+
+        let prev_ref = sched
+            .parked
+            .get_mut(&prev_id)
+            .expect("just inserted into parked");
+        // SAFETY: `prev_ref` is `&mut Box<Task>`; the Box heap-allocates
+        // the Task, so `&mut prev_ref.rsp` points at stable memory that
+        // survives any BTreeMap rebalance (rebalancing moves the Box,
+        // not the heap-allocated Task it points at). Same invariant as
+        // yield_now's ready-queue push.
+        let prev_rsp_ptr: *mut usize = &mut prev_ref.rsp as *mut usize;
+
+        (prev_rsp_ptr, next_rsp)
+    };
+
+    // SAFETY: same switch invariant as yield_now — IRQs are masked,
+    // the SCHED lock is dropped so the incoming task can re-enter the
+    // scheduler, and prev_rsp_ptr targets stable heap memory.
+    unsafe {
+        context_switch(prev_rsp_ptr, next_rsp);
+    }
+
+    if was_on {
+        interrupts::enable();
+    }
+}
+
+/// Unpark the task with id `id`, or record a pending wake if the task
+/// is still Running / Ready so that its next [`block_current`] call
+/// returns without parking.
+///
+/// Task-context only. The scheduler lock is the same one `preempt_tick`
+/// uses with `try_lock`, so calling this from an ISR is a deadlock risk
+/// if the ISR interrupts a task already holding it. If you need an
+/// ISR-originating wake, defer it through a lock-free queue drained by
+/// a kernel task — the keyboard input ring is the pattern.
+///
+/// A wake on an unknown id (task exited — which M6 doesn't have yet —
+/// or never existed) is silently ignored.
+pub fn wake(id: usize) {
+    let was_on = interrupts::are_enabled();
+    interrupts::disable();
+
+    let mut sched = SCHED.lock();
+
+    // Parked → Ready is the happy path: move the Box across and hand
+    // the task a fresh slice so it gets a full tick the next time the
+    // scheduler rotates through.
+    if let Some(mut task) = sched.parked.remove(&id) {
+        task.state = TaskState::Ready;
+        task.slice_remaining_ms = DEFAULT_SLICE_MS;
+        sched.ready.push_back(task);
+        drop(sched);
+        if was_on {
+            interrupts::enable();
+        }
+        return;
+    }
+
+    // Task is Running or Ready. Set wake_pending so the next
+    // block_current call on it returns immediately. This is the
+    // wake-before-park race cure — see `block_current`'s fast path.
+    if let Some(current) = sched.current.as_ref() {
+        if current.id == id {
+            current.wake_pending.store(true, Ordering::Release);
+            drop(sched);
+            if was_on {
+                interrupts::enable();
+            }
+            return;
+        }
+    }
+    for task in sched.ready.iter() {
+        if task.id == id {
+            task.wake_pending.store(true, Ordering::Release);
+            drop(sched);
+            if was_on {
+                interrupts::enable();
+            }
+            return;
+        }
+    }
+
+    // Unknown id — drop the wake on the floor. Tasks don't exit yet so
+    // this only fires if somebody handed us a stale or invented id.
+    drop(sched);
+    if was_on {
+        interrupts::enable();
     }
 }

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -1,17 +1,26 @@
-//! Round-robin scheduler state. Holds the currently-running task and
-//! a FIFO ready queue. Rescheduling happens from either `yield_now()`
-//! (cooperative) or `preempt_tick()` (PIT ISR); `yield_now` masks IRQs
-//! across the lock/switch window so the two paths can't race on the
-//! queue.
+//! Round-robin scheduler state. Holds the currently-running task, a
+//! FIFO ready queue, and a side-table of blocked (parked) tasks.
+//! Rescheduling happens from either `yield_now()` (cooperative) or
+//! `preempt_tick()` (PIT ISR); `yield_now` masks IRQs across the
+//! lock/switch window so the two paths can't race on the queue.
+//!
+//! Blocked tasks are parked in `parked` (keyed by task id) and are
+//! invisible to the round-robin rotation. `task::wake(id)` migrates
+//! them back to `ready`.
 
 use alloc::boxed::Box;
-use alloc::collections::VecDeque;
+use alloc::collections::{BTreeMap, VecDeque};
 
 use super::task::Task;
 
 pub(super) struct Scheduler {
     pub current: Option<Box<Task>>,
     pub ready: VecDeque<Box<Task>>,
+    /// Tasks that have called `block_current` and are waiting to be
+    /// unparked by `wake(id)`. Keyed by task id for O(log n) lookup.
+    /// Blocking primitives (see `crate::sync`) move tasks in and out
+    /// of here via the task-level API.
+    pub parked: BTreeMap<usize, Box<Task>>,
 }
 
 impl Scheduler {
@@ -19,6 +28,7 @@ impl Scheduler {
         Self {
             current: None,
             ready: VecDeque::new(),
+            parked: BTreeMap::new(),
         }
     }
 }

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -18,7 +18,7 @@
 //! new task lands in `task_entry_trampoline`, which then calls the entry
 //! function.
 
-use core::sync::atomic::{AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use x86_64::structures::paging::{Page, PageTableFlags, Size4KiB};
 use x86_64::VirtAddr;
@@ -27,6 +27,19 @@ use crate::mem::paging;
 
 use super::switch::task_entry_trampoline;
 use super::DEFAULT_SLICE_MS;
+
+/// Scheduling state of a [`Task`].
+///
+/// `Running` and `Ready` tasks live on `Scheduler::current` or in
+/// `Scheduler::ready`; `Blocked` tasks are parked in `Scheduler::parked`
+/// and invisible to the round-robin rotation until something calls
+/// [`super::wake`].
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) enum TaskState {
+    Running,
+    Ready,
+    Blocked,
+}
 
 /// Usable stack per task.
 const STACK_SIZE: usize = 16 * 1024;
@@ -65,6 +78,16 @@ pub(super) struct Task {
     /// to the back of the ready queue and the counter is reloaded from
     /// `DEFAULT_SLICE_MS`.
     pub slice_remaining_ms: u32,
+    /// Current scheduling state — Running (is `Scheduler::current`),
+    /// Ready (in `Scheduler::ready`), or Blocked (parked in
+    /// `Scheduler::parked`).
+    pub state: TaskState,
+    /// Set by [`super::wake`] when the target task is Running or Ready
+    /// at wake time. The task's next [`super::block_current`] call
+    /// consumes the flag and returns without parking — this is what
+    /// guards against the "wake before park" lost-wakeup race in
+    /// [`crate::sync::WaitQueue::wait_while`].
+    pub wake_pending: AtomicBool,
 }
 
 impl Task {
@@ -77,6 +100,8 @@ impl Task {
             guard_base: 0,
             rsp: 0,
             slice_remaining_ms: DEFAULT_SLICE_MS,
+            state: TaskState::Running,
+            wake_pending: AtomicBool::new(false),
         }
     }
 
@@ -143,6 +168,8 @@ impl Task {
             guard_base,
             rsp,
             slice_remaining_ms: DEFAULT_SLICE_MS,
+            state: TaskState::Ready,
+            wake_pending: AtomicBool::new(false),
         }
     }
 

--- a/kernel/tests/blocking_sync.rs
+++ b/kernel/tests/blocking_sync.rs
@@ -1,0 +1,242 @@
+//! Integration test: blocking primitives (BlockingMutex, WaitQueue,
+//! bounded SPSC channel) park and wake tasks correctly under the
+//! round-robin scheduler.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use spin::Mutex as SpinMutex;
+use vibix::sync::spsc;
+use vibix::sync::{BlockingMutex, WaitQueue};
+use vibix::{
+    exit_qemu, serial_println, task,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("channel_ping_pong", &(channel_ping_pong as fn())),
+        ("mutex_contention", &(mutex_contention as fn())),
+        ("waitqueue_notify_all", &(waitqueue_notify_all as fn())),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+// --- channel_ping_pong ----------------------------------------------
+//
+// A producer sends 0..N through a small bounded channel. A consumer
+// receives and checksums. The capacity is 4 so the producer must
+// block at least (N - 4) times, proving the "full" path actually
+// parks.
+
+static CH_PROD_DONE: AtomicUsize = AtomicUsize::new(0);
+static CH_CONS_DONE: AtomicUsize = AtomicUsize::new(0);
+static CH_SUM: AtomicUsize = AtomicUsize::new(0);
+
+// Hand-off globals: driver deposits the endpoints, each worker takes
+// its own on first run. `SpinMutex<Option<_>>` is the no-runtime-cost
+// way to avoid `static_mut_refs` (the endpoints can't be reconstructed
+// in a const context, so this has to be runtime).
+static CH_TX: SpinMutex<Option<spsc::Sender<u32>>> = SpinMutex::new(None);
+static CH_RX: SpinMutex<Option<spsc::Receiver<u32>>> = SpinMutex::new(None);
+
+const CH_N: u32 = 60;
+
+fn ch_producer() -> ! {
+    let tx = CH_TX.lock().take().expect("producer: CH_TX not set");
+    for i in 0..CH_N {
+        tx.send(i);
+    }
+    CH_PROD_DONE.fetch_add(1, Ordering::SeqCst);
+    loop {
+        task::yield_now();
+    }
+}
+
+fn ch_consumer() -> ! {
+    let rx = CH_RX.lock().take().expect("consumer: CH_RX not set");
+    for _ in 0..CH_N {
+        let v = rx.recv();
+        CH_SUM.fetch_add(v as usize, Ordering::SeqCst);
+    }
+    CH_CONS_DONE.fetch_add(1, Ordering::SeqCst);
+    loop {
+        task::yield_now();
+    }
+}
+
+fn channel_ping_pong() {
+    let (tx, rx) = spsc::channel::<u32>(4);
+    *CH_TX.lock() = Some(tx);
+    *CH_RX.lock() = Some(rx);
+    CH_PROD_DONE.store(0, Ordering::SeqCst);
+    CH_CONS_DONE.store(0, Ordering::SeqCst);
+    CH_SUM.store(0, Ordering::SeqCst);
+
+    task::spawn(ch_producer);
+    task::spawn(ch_consumer);
+
+    // Drive the scheduler until both workers finish or we time out.
+    // 100_000 yields is comfortably enough for 60 messages through a
+    // capacity-4 channel; failure fails fast instead of hanging CI.
+    for _ in 0..100_000 {
+        if CH_PROD_DONE.load(Ordering::SeqCst) == 1 && CH_CONS_DONE.load(Ordering::SeqCst) == 1 {
+            break;
+        }
+        task::yield_now();
+    }
+
+    assert_eq!(
+        CH_PROD_DONE.load(Ordering::SeqCst),
+        1,
+        "producer didn't finish — send() likely wedged on a lost wakeup"
+    );
+    assert_eq!(
+        CH_CONS_DONE.load(Ordering::SeqCst),
+        1,
+        "consumer didn't finish — recv() likely wedged on a lost wakeup"
+    );
+    let expected: usize = (0..CH_N).map(|i| i as usize).sum();
+    assert_eq!(
+        CH_SUM.load(Ordering::SeqCst),
+        expected,
+        "checksum mismatch — channel reordered or dropped items"
+    );
+}
+
+// --- mutex_contention -----------------------------------------------
+//
+// Three worker tasks each increment a shared counter N times under a
+// blocking mutex. The final value proves the mutex actually serialised
+// the accesses (no lost updates) and that each worker made progress
+// (no forever-parked tasks).
+
+static MU: BlockingMutex<u64> = BlockingMutex::new(0);
+static MU_DONE: AtomicUsize = AtomicUsize::new(0);
+
+const MU_ROUNDS: u64 = 200;
+
+fn mu_worker() -> ! {
+    for _ in 0..MU_ROUNDS {
+        {
+            let mut g = MU.lock();
+            *g += 1;
+        }
+        // Yield between iterations so the workers actually interleave
+        // — without a yield the 10 ms preempt slice will let each
+        // worker burn through all its rounds while holding nothing
+        // contended, and we wouldn't exercise the blocking path.
+        task::yield_now();
+    }
+    MU_DONE.fetch_add(1, Ordering::SeqCst);
+    loop {
+        task::yield_now();
+    }
+}
+
+fn mutex_contention() {
+    // Reset shared state. BlockingMutex doesn't expose a const reset;
+    // locking is how we zero it.
+    *MU.lock() = 0;
+    MU_DONE.store(0, Ordering::SeqCst);
+
+    task::spawn(mu_worker);
+    task::spawn(mu_worker);
+    task::spawn(mu_worker);
+
+    for _ in 0..100_000 {
+        if MU_DONE.load(Ordering::SeqCst) == 3 {
+            break;
+        }
+        task::yield_now();
+    }
+
+    assert_eq!(
+        MU_DONE.load(Ordering::SeqCst),
+        3,
+        "not all mutex workers finished"
+    );
+    assert_eq!(
+        *MU.lock(),
+        3 * MU_ROUNDS,
+        "lost updates — mutex didn't serialise the increments"
+    );
+}
+
+// --- waitqueue_notify_all -------------------------------------------
+//
+// Two waiters park on a waitqueue until a condition flips. The driver
+// flips the condition then calls `notify_all`; both waiters must wake
+// and make forward progress.
+
+static WQ: WaitQueue = WaitQueue::new();
+static WQ_FLAG: AtomicUsize = AtomicUsize::new(0);
+static WQ_WOKEN: AtomicUsize = AtomicUsize::new(0);
+
+fn wq_waiter() -> ! {
+    WQ.wait_while(|| WQ_FLAG.load(Ordering::SeqCst) == 0);
+    WQ_WOKEN.fetch_add(1, Ordering::SeqCst);
+    loop {
+        task::yield_now();
+    }
+}
+
+fn waitqueue_notify_all() {
+    WQ_FLAG.store(0, Ordering::SeqCst);
+    WQ_WOKEN.store(0, Ordering::SeqCst);
+
+    task::spawn(wq_waiter);
+    task::spawn(wq_waiter);
+
+    // Let both waiters reach their park. A handful of yields is
+    // enough — round-robin will rotate through them immediately.
+    for _ in 0..200 {
+        task::yield_now();
+    }
+    // Nobody should be "woken" yet: flag is still 0.
+    assert_eq!(
+        WQ_WOKEN.load(Ordering::SeqCst),
+        0,
+        "waiters woke before the flag flipped"
+    );
+
+    // Publish the state change, then notify.
+    WQ_FLAG.store(1, Ordering::SeqCst);
+    WQ.notify_all();
+
+    for _ in 0..10_000 {
+        if WQ_WOKEN.load(Ordering::SeqCst) == 2 {
+            break;
+        }
+        task::yield_now();
+    }
+    assert_eq!(
+        WQ_WOKEN.load(Ordering::SeqCst),
+        2,
+        "notify_all didn't wake both waiters"
+    );
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -500,6 +500,7 @@ fn test_all() -> R<()> {
         "apic_online",
         "backtrace",
         "page_fault",
+        "blocking_sync",
     ] {
         cmd.arg("--test").arg(t);
     }


### PR DESCRIPTION
Closes #24.

## Summary

- **`task::block_current` / `task::wake(id)` / `task::current_id`** — scheduler-layer plumbing. Adds `TaskState` (Running / Ready / Blocked), a `wake_pending: AtomicBool` on `Task`, and a `parked: BTreeMap<id, Box<Task>>` side-table on the scheduler. `block_current` is race-free against a wake that fires between "register waiter" and "actually park" — the `wake_pending` flag carries the signal.
- **`kernel::sync`** — three primitives built on top of the above:
  - `WaitQueue` — `wait_while(cond)` + `notify_one` / `notify_all`.
  - `BlockingMutex<T>` — `spin::Mutex`-shaped API, but parks on contention.
  - `spsc::channel<T>(capacity)` — bounded single-producer / single-consumer blocking channel.
- **`kernel/tests/blocking_sync.rs`** — QEMU integration test covering channel ping-pong (capacity 4, 60 msgs, forces send-side parks), three-way mutex contention, and `notify_all` with two parked waiters.

All `notify` / `wake` paths are task-context only. The doc comments spell out the rule and point at the existing keyboard input ring as the pattern for ISR-originated wakes.

## Lock order (documented in `kernel/src/sync/mod.rs`)

```
WaitQueue.inner ─▶ data lock (BlockingMutex.state, spsc::Shared.buf)
WaitQueue.inner ─▶ SCHED     (via task::block_current / task::current_id)
```

Nothing reverses either edge, so the graph is a DAG — no deadlock cycle can form.

## Follow-ups (explicitly out of scope)

- MPSC / MPMC channel variants.
- Channel close / hang-up protocol (dropped `Sender` doesn't currently unblock the `Receiver`).
- Priority inheritance on `BlockingMutex` — needed once task priorities land (#25).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p xtask --all-targets -- -D warnings`
- [x] `cargo xtask build --release`
- [x] Host unit tests (`cargo xtask test` — host portion, 19 tests, all pass)
- [x] QEMU integration tests — rely on CI (QEMU not installed in the autonomous environment; the kernel builds cleanly for `x86_64-unknown-none` and the `blocking_sync` test binary links)
- [x] `cargo xtask smoke` — rely on CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes core scheduler behavior by introducing blocking/unblocking (`block_current`/`wake`) and new task state transitions, which can deadlock or wedge the kernel if incorrect. New sync primitives rely on precise lock ordering and wakeup semantics under contention.
> 
> **Overview**
> Adds a new `sync` module providing blocking primitives: `WaitQueue` (`wait_while` + `notify_one`/`notify_all`), `BlockingMutex<T>` (parks on contention), and a bounded SPSC channel (`spsc::channel`, `send`/`recv` block; `try_send`/`try_recv` do not).
> 
> Extends the task scheduler to support blocking/unblocking by tracking `TaskState`, adding a `parked` table for blocked tasks, and implementing `task::current_id`, `task::block_current`, and `task::wake` with a `wake_pending` race-avoidance flag.
> 
> Wires in a new `blocking_sync` QEMU integration test and includes it in `kernel/Cargo.toml` and `cargo xtask test`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85b6e9ff5a31580f7505e9d667b6b4db76a24f20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->