### PR TITLE
task: remove cooperative yield_now; preemption is the only path

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ kernel/              # the kernel crate (lib + thin bin)
       task.rs        # per-task kernel stack + saved register context
       scheduler.rs   # round-robin ready queue
       switch.rs      # hand-written context-switch assembly
-  tests/             # one no_std kernel binary per file (12 total)
+  tests/             # one no_std kernel binary per file (13 total)
     basic_boot.rs
     heap_alloc.rs
     heap_grow.rs
@@ -150,6 +150,7 @@ kernel/              # the kernel crate (lib + thin bin)
     page_fault.rs
     tasks.rs
     preempt.rs
+    blocking_sync.rs
     apic_online.rs
     backtrace.rs
 xtask/               # build/iso/run/test/smoke/lint orchestrator

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A hobby x86_64 kernel, vibe-coded in Rust. Boots under the Limine boot
 protocol, prints to serial + a framebuffer console, installs a full GDT/TSS +
 IDT with CPU exception handlers, manages physical memory with a bitmap frame
 allocator, owns a growing kernel heap backed by custom paging, drives APIC
-interrupts discovered via ACPI, runs cooperative + preemptively-scheduled
-kernel tasks, and emits symbolicated panic backtraces via an embedded kernel
-symbol table.
+interrupts discovered via ACPI, runs preemptively-scheduled kernel tasks
+with blocking synchronisation primitives, and emits symbolicated panic
+backtraces via an embedded kernel symbol table.
 
 ## Status
 
@@ -28,10 +28,12 @@ Milestones complete:
   on demand via `paging::map_range`, framebuffer mapped Write-Combining
   via PAT, unmapped guard page below `#DF` IST stack, atomic CR3 switch to
   a kernel-owned PML4 (Limine's original tree is no longer used after init).
-- **M5 — tasks:** cooperative round-robin scheduler + PIT-driven preemption
+- **M5 — tasks:** preemptive round-robin scheduler driven by the PIT
   (10 ms slices); each task gets its own kernel stack; context switch in
   hand-written assembly (RSP save/restore); bootstrap task wraps the main
-  thread.
+  thread. Blocking primitives (`BlockingMutex`, `WaitQueue`, SPSC channel)
+  live in `kernel::sync` and park tasks via the scheduler's parked-task
+  side-table.
 - **M6 — APIC:** ACPI RSDP → XSDT/RSDT → MADT parser; LAPIC + IOAPIC
   discovered; legacy IRQ0 (timer) and IRQ1 (keyboard) routed through IOAPIC;
   8259 PIC disabled; BSP LAPIC brought online.
@@ -41,8 +43,7 @@ Milestones complete:
   backtraces emitted to serial, structured klog ring (64 KiB, leveled,
   dumped on panic).
 
-Out of scope for now: SMP / AP bring-up, preemptive userspace, blocking
-primitives, task priorities, tickless idle.
+Out of scope for now: SMP / AP bring-up, userspace, task priorities, tickless idle.
 
 ## Requirements
 
@@ -91,7 +92,7 @@ Three layers, all driven by xtask:
 
    Current integration tests: `basic_boot`, `heap_alloc`, `heap_grow`,
    `should_panic`, `timer_tick`, `paging`, `pml4_switch`, `page_fault`,
-   `tasks`, `preempt`, `apic_online`, `backtrace`.
+   `tasks`, `preempt`, `blocking_sync`, `apic_online`, `backtrace`.
 3. **End-to-end smoke** (`cargo xtask smoke`) — boots the normal kernel,
    captures serial output, and asserts on a fixed list of markers:
    `vibix booting`, `memory map:`, `hhdm offset:`, `GDT + IDT loaded`,

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ sequence, and public API for its subsystem.
 | [acpi.md](acpi.md) | ACPI RSDP/MADT parser | `kernel/src/acpi.rs` |
 | [time.md](time.md) | PIT-driven monotonic clock | `kernel/src/time.rs` |
 | [input.md](input.md) | PS/2 keyboard and ring buffer | `kernel/src/input.rs` |
-| [tasks.md](tasks.md) | Cooperative/preemptive scheduler | `kernel/src/task/` |
+| [tasks.md](tasks.md) | Preemptive scheduler + blocking primitives | `kernel/src/task/`, `kernel/src/sync/` |
 | [diagnostics.md](diagnostics.md) | klog ring, ksymtab, backtrace unwinder | `kernel/src/klog.rs`, `kernel/src/ksymtab.rs`, `kernel/src/arch/x86_64/backtrace.rs` |
 
 ## Initialization Order

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -77,9 +77,13 @@ preempted or parked task it is the instruction after the call to
 
 ### `task::init()`
 
-Wraps the current thread as the bootstrap task. Must be called once, after
-`mem::init()` (stacks are mapped via `paging::map_range`) and after interrupts are enabled (so
-preemption ticks can arrive).
+Wraps the current thread as the bootstrap task. Must be called once after
+`mem::init()` (stacks are mapped via `paging::map_range`). Safe to run
+either before or after interrupts are enabled: `preempt_tick` short-
+circuits on `sched.current.is_none()`, so a stray PIT tick that arrives
+before the bootstrap task exists simply returns. Integration tests
+initialize tasks first and then enable IRQs; `main.rs` does the reverse
+for historical reasons and both work.
 
 ### `task::spawn(entry: fn() -> !)`
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,20 +1,25 @@
 # Task Subsystem
 
-**Sources:** `kernel/src/task/`
-- `mod.rs` — public API, `init`, `spawn`, `yield_now`, `preempt_tick`
-- `task.rs` — `Task` struct: kernel stack allocation, saved register context
-- `scheduler.rs` — `Scheduler`: current task + FIFO ready queue
-- `switch.rs` — `context_switch` in hand-written assembly
+**Sources:** `kernel/src/task/`, `kernel/src/sync/`
+- `task/mod.rs` — public API, `init`, `spawn`, `preempt_tick`, `block_current`, `wake`
+- `task/task.rs` — `Task` struct: kernel stack allocation, saved register context, scheduling state
+- `task/scheduler.rs` — `Scheduler`: current task + FIFO ready queue + parked-task side-table
+- `task/switch.rs` — `context_switch` in hand-written assembly
+- `sync/` — blocking primitives (mutex, waitqueue, SPSC channel) built on `block_current` / `wake`
 
 ## Overview
 
-The task subsystem implements cooperative and preemptive kernel-mode
-multitasking. Tasks are kernel threads — they share the kernel address space
-and run entirely in ring 0. Each task has its own kernel stack and a saved
-register context that `context_switch` restores on re-entry.
+The task subsystem implements preemptive kernel-mode multitasking. Tasks
+are kernel threads — they share the kernel address space and run entirely
+in ring 0. Each task has its own kernel stack and a saved register context
+that `context_switch` restores on re-entry.
 
-There is no userspace, no per-task address space, and no blocking primitives.
-Cooperative code yields explicitly; the PIT timer drives preemption.
+There is no userspace and no per-task address space. Tasks that need to
+wait on a condition block via `sync::WaitQueue` / `sync::BlockingMutex` /
+`sync::spsc::channel`, which park the task on the scheduler's `parked`
+side-table until a wake arrives. Tasks that simply want to idle call
+`hlt` with IRQs enabled; the PIT preempt tick rotates them out when
+anyone else has work.
 
 ## Design
 
@@ -23,6 +28,7 @@ Cooperative code yields explicitly; the PIT timer drives preemption.
 A single `Lazy<Mutex<Scheduler>>` holds:
 - `current: Option<Box<Task>>` — the running task, `None` before `task::init`.
 - `ready: VecDeque<Box<Task>>` — FIFO queue of ready-to-run tasks.
+- `parked: BTreeMap<usize, Box<Task>>` — blocked tasks keyed by task id, invisible to the round-robin rotation until `wake(id)` migrates them back to `ready`.
 
 ### Task Struct
 
@@ -31,6 +37,8 @@ Each `Task` contains:
 - An unmapped guard page at the base of the stack.
 - `rsp: usize` — the saved stack pointer, updated by `context_switch`.
 - `slice_remaining_ms: u32` — remaining preemption budget in milliseconds.
+- `state: TaskState` — `Running` / `Ready` / `Blocked`, maintained by the scheduler transitions.
+- `wake_pending: AtomicBool` — cure for the wake-before-park race: set by `wake(id)` if the target task is still Running or Ready, consumed by the next `block_current`.
 
 Stacks are carved from a dedicated virtual address range
 (`TASK_STACKS_VA_BASE`), one slot per task. Each slot is
@@ -62,8 +70,8 @@ first run.
 5. Returns — which enters the new task at its saved return address.
 
 For a brand-new task this return address is the trampoline; for a previously
-preempted or yielded task it is the instruction after the call to
-`context_switch` inside `yield_now` or `preempt_tick`.
+preempted or parked task it is the instruction after the call to
+`context_switch` inside `preempt_tick` or `block_current`.
 
 ## Public API
 
@@ -78,17 +86,33 @@ preemption ticks can arrive).
 Allocates a new task and appends it to the ready queue. The task does not run
 until the scheduler reaches it.
 
-### `task::yield_now()`
+### `task::block_current()`
 
-The cooperative yield point:
-1. Disable IRQs to prevent the timer ISR from re-entering the scheduler.
-2. Under the `SCHED` lock, pop the next task from `ready`, move `current` to
-   the back of `ready`, make the popped task `current`.
-3. Release the lock, then call `context_switch`.
-4. Restore the IRQ state of the caller on return.
+Park the current task until a matching `wake(id)` fires. Used exclusively
+by the `sync` primitives; callers register themselves with a wakeup source
+(e.g. push their id onto a `WaitQueue`) before calling.
 
-If `ready` is empty, `yield_now` returns immediately (the running task keeps
-the CPU).
+1. Disable IRQs.
+2. Under the `SCHED` lock, check the task's `wake_pending` flag. If set,
+   clear it and return without parking — this closes the wake-before-park
+   race.
+3. Otherwise, pop the next task from `ready`, move `current` into
+   `parked` keyed by its id, make the popped task `current`.
+4. Release the lock, then call `context_switch`.
+5. Restore the IRQ state of the caller on return.
+
+Panics if `ready` is empty — blocking the sole runnable task would halt
+the kernel. Integration tests always keep the bootstrap task alive.
+
+### `task::wake(id)`
+
+Transition a parked task back to `ready`, or — if the target is still
+Running or Ready — set its `wake_pending` flag so its next
+`block_current` returns immediately. Task-context only: acquires the
+same `SCHED` lock that `preempt_tick` takes with `try_lock`, so calling
+from an ISR risks deadlock. If an IRQ needs to wake a task, defer
+through a lock-free queue drained by a kernel task (see
+`kernel/src/input.rs` for the pattern).
 
 ### `task::preempt_tick()`
 
@@ -117,5 +141,5 @@ from the `#PF` and `#DF` exception handlers.
 
 - Single-CPU only; no SMP or per-CPU runqueues.
 - No task priorities — pure round-robin.
-- No blocking primitives — sleeping tasks must poll and yield.
 - No per-task address spaces — all tasks share the kernel PML4.
+- No task exit — spawned tasks must park on `hlt` forever once done.

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -126,7 +126,9 @@ pub extern "C" fn _start() -> ! {
     vibix::task::spawn(cursor_blink_task);
 
     loop {
-        vibix::task::yield_now();
+        // `read_key` itself blocks on `hlt` until a scancode arrives;
+        // the PIT preempt tick can switch us out of that wait to any
+        // other ready task.
         match vibix::input::read_key() {
             pc_keyboard::DecodedKey::Unicode(c) => serial_print!("{}", c),
             pc_keyboard::DecodedKey::RawKey(key) => serial_print!("[{:?}]", key),
@@ -135,9 +137,11 @@ pub extern "C" fn _start() -> ! {
 }
 
 fn idle_task() -> ! {
+    // `hlt` with IRQs on parks the CPU until the next interrupt, at
+    // which point `preempt_tick` may rotate us out. No explicit yield
+    // needed.
     loop {
         x86_64::instructions::hlt();
-        vibix::task::yield_now();
     }
 }
 
@@ -146,7 +150,9 @@ fn cursor_blink_task() -> ! {
     let mut next = vibix::time::ticks() + CURSOR_BLINK_TICKS;
     loop {
         while vibix::time::ticks() < next {
-            vibix::task::yield_now();
+            // Wake on the next timer tick, recheck. Preemption
+            // rotates other tasks in and out while we sleep.
+            x86_64::instructions::hlt();
         }
         next = next.wrapping_add(CURSOR_BLINK_TICKS);
         vibix::framebuffer::toggle_cursor();

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -1,10 +1,15 @@
-//! Round-robin kernel tasks, cooperative + PIT-driven preemption.
+//! Round-robin kernel tasks, preemptively scheduled off the PIT tick.
 //!
-//! Tasks can hand control back explicitly with [`yield_now`], and the
-//! timer ISR calls [`preempt_tick`] every PIT interrupt to rotate tasks
-//! that never yield. Each task owns a guard-paged kernel stack and a
-//! saved register context; the hand-written switch in [`switch`] is the
-//! one place that touches `rsp`.
+//! The timer ISR calls [`preempt_tick`] every PIT interrupt; once the
+//! running task's time slice is exhausted, the scheduler rotates to
+//! the next task in the ready queue. Tasks that want to block on a
+//! condition call [`block_current`] (via [`crate::sync`]); tasks that
+//! have nothing to do halt and let the next timer IRQ either resume
+//! them or switch to something else.
+//!
+//! Each task owns a guard-paged kernel stack and a saved register
+//! context; the hand-written switch in [`switch`] is the one place
+//! that touches `rsp`.
 //!
 //! ## Ordering
 //!
@@ -45,7 +50,7 @@ pub(crate) const DEFAULT_SLICE_MS: u32 = 10;
 static SCHED: Lazy<Mutex<Scheduler>> = Lazy::new(|| Mutex::new(Scheduler::new()));
 
 /// Install the bootstrap task wrapping the currently-running thread.
-/// Must be called exactly once, before any [`spawn`] or [`yield_now`].
+/// Must be called exactly once, before any [`spawn`].
 pub fn init() {
     let mut sched = SCHED.lock();
     assert!(sched.current.is_none(), "task::init called twice");
@@ -59,63 +64,6 @@ pub fn init() {
 pub fn spawn(entry: fn() -> !) {
     let mut sched = SCHED.lock();
     sched.ready.push_back(Box::new(Task::new(entry)));
-}
-
-/// Yield the CPU to the next runnable task. If no other task is
-/// ready, returns immediately. Safe to call from any task (including
-/// the bootstrap task after [`init`]).
-pub fn yield_now() {
-    // Mask IRQs across the lock + switch so the timer ISR's preempt
-    // path can't mutate the ready queue between our lock drop and the
-    // context_switch (which would invalidate `prev_rsp_ptr`). `was_on`
-    // lives on this task's stack — when we're eventually switched back
-    // in, it'll be restored and we re-enable iff this task was running
-    // with IRQs on. Tasks first entered via the trampoline always come
-    // back here with IRQs on, regardless of our caller's state.
-    let was_on = interrupts::are_enabled();
-    interrupts::disable();
-
-    // Carve out the switch parameters under the lock, then drop the
-    // lock BEFORE the context switch. Holding it across would
-    // deadlock the incoming task's own call to `yield_now`.
-    let (prev_rsp_ptr, next_rsp) = {
-        let mut sched = SCHED.lock();
-        let Some(mut next) = sched.ready.pop_front() else {
-            if was_on {
-                interrupts::enable();
-            }
-            return;
-        };
-        let mut prev = sched.current.take().expect("yield_now before task::init");
-
-        prev.state = TaskState::Ready;
-        next.state = TaskState::Running;
-        let next_rsp = next.rsp;
-        sched.current = Some(next);
-        sched.current.as_mut().unwrap().slice_remaining_ms = DEFAULT_SLICE_MS;
-        sched.ready.push_back(prev);
-        let prev_ref = sched.ready.back_mut().expect("just pushed");
-        let prev_rsp_ptr: *mut usize = &mut prev_ref.rsp as *mut usize;
-
-        (prev_rsp_ptr, next_rsp)
-    };
-
-    // SAFETY: `prev_rsp_ptr` points at the `rsp` field of a Box<Task>
-    // in the ready queue. The Box indirection pins the Task's address
-    // — a VecDeque reallocation would move the Box, not the Task
-    // itself — so the pointer stays valid even if an IRQ fires before
-    // `context_switch` reaches its write. The Task can't be dropped
-    // until someone re-acquires SCHED and pops it, which can't happen
-    // between this lock drop and that write on a single CPU. We've
-    // also masked IRQs for the duration, so the preempt tick can't
-    // fire and re-enter the scheduler while the switch is in flight.
-    unsafe {
-        context_switch(prev_rsp_ptr, next_rsp);
-    }
-
-    if was_on {
-        interrupts::enable();
-    }
 }
 
 /// Check whether `addr` falls within any live kernel task's guard page.
@@ -148,15 +96,17 @@ pub fn find_stack_overflow(addr: usize) -> Option<usize> {
 /// current task's slice; if it's exhausted and there's another task
 /// ready, rotates and context-switches. Bails on lock contention so
 /// the ISR never blocks on a task that's in the middle of its own
-/// cooperative switch.
+/// [`block_current`] switch.
 ///
 /// Runs with IRQs masked (interrupt gate). The switched-in task
-/// resumes either via IRET (if it was last preempted) or through
-/// `yield_now`'s tail (if it was last suspended cooperatively) — both
-/// paths restore a correct IF on return to task code.
+/// resumes either via IRET (if it was last preempted at tick time)
+/// or through [`block_current`]'s tail (if it was last suspended on
+/// a waitqueue); both paths restore a correct IF on return to task
+/// code.
 pub fn preempt_tick() {
-    // `try_lock` + bail: yield_now (or another preempt tick mid-switch)
-    // may already hold SCHED. We'll get another tick in 10 ms.
+    // `try_lock` + bail: block_current (or another preempt tick
+    // mid-switch) may already hold SCHED. We'll get another tick in
+    // 10 ms.
     let Some(mut sched) = SCHED.try_lock() else {
         return;
     };
@@ -193,10 +143,13 @@ pub fn preempt_tick() {
     let prev_rsp_ptr: *mut usize = &mut prev_ref.rsp as *mut usize;
     drop(sched);
 
-    // SAFETY: same invariant as `yield_now` — `prev_rsp_ptr` stays
-    // valid because Box pins the Task's address, and IRQs are masked
-    // inside the ISR so no other scheduler path can race us between
-    // lock drop and the context switch.
+    // SAFETY: `prev_rsp_ptr` points at the `rsp` field of a Box<Task>
+    // in the ready queue. The Box indirection pins the Task's address
+    // — a VecDeque reallocation would move the Box, not the heap-
+    // allocated Task it points at — so the pointer stays valid even
+    // though the VecDeque could mutate from under us. IRQs are already
+    // masked inside the ISR, so no other scheduler path can race us
+    // between lock drop and the context switch.
     unsafe {
         context_switch(prev_rsp_ptr, next_rsp);
     }
@@ -284,15 +237,15 @@ pub fn block_current() {
         // the Task, so `&mut prev_ref.rsp` points at stable memory that
         // survives any BTreeMap rebalance (rebalancing moves the Box,
         // not the heap-allocated Task it points at). Same invariant as
-        // yield_now's ready-queue push.
+        // preempt_tick's ready-queue push.
         let prev_rsp_ptr: *mut usize = &mut prev_ref.rsp as *mut usize;
 
         (prev_rsp_ptr, next_rsp)
     };
 
-    // SAFETY: same switch invariant as yield_now — IRQs are masked,
-    // the SCHED lock is dropped so the incoming task can re-enter the
-    // scheduler, and prev_rsp_ptr targets stable heap memory.
+    // SAFETY: IRQs are masked, the SCHED lock is dropped so the
+    // incoming task can re-enter the scheduler, and prev_rsp_ptr
+    // targets stable heap memory (see the insert comment above).
     unsafe {
         context_switch(prev_rsp_ptr, next_rsp);
     }

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -1,8 +1,11 @@
 //! Round-robin scheduler state. Holds the currently-running task, a
 //! FIFO ready queue, and a side-table of blocked (parked) tasks.
-//! Rescheduling happens from either `yield_now()` (cooperative) or
-//! `preempt_tick()` (PIT ISR); `yield_now` masks IRQs across the
-//! lock/switch window so the two paths can't race on the queue.
+//!
+//! Rescheduling happens from either `preempt_tick()` (PIT ISR, on
+//! slice exhaustion) or `block_current()` (task voluntarily parking
+//! on a waitqueue). Both paths lock the scheduler, update the queues,
+//! then drop the lock before `context_switch` to avoid deadlocking
+//! the incoming task's own scheduler entry.
 //!
 //! Blocked tasks are parked in `parked` (keyed by task id) and are
 //! invisible to the round-robin rotation. `task::wake(id)` migrates

--- a/kernel/src/task/switch.rs
+++ b/kernel/src/task/switch.rs
@@ -60,8 +60,7 @@ task_entry_trampoline:
     // task entered for the first time from the preempt ISR (which
     // runs with IF=0 under an interrupt gate) still receives future
     // timer IRQs and can itself be preempted. `sti` when IF is
-    // already set is a no-op, so the cooperative-yield path is
-    // unaffected.
+    // already set is a no-op.
     sti
     call r12
     ud2

--- a/kernel/src/task/switch.rs
+++ b/kernel/src/task/switch.rs
@@ -5,7 +5,8 @@
 //! (`rbx`, `rbp`, `r12`-`r15`) plus `rsp` of the outgoing task, then
 //! loads the incoming task's state symmetrically. That's the entire
 //! saved context — caller-saved registers belong to whichever function
-//! called `yield_now()` and Rust/LLVM handle them for us.
+//! called into the scheduler (`preempt_tick` or `block_current`) and
+//! Rust/LLVM handle them for us.
 //!
 //! A new task's stack is primed so that the first `context_switch`
 //! into it returns into `task_entry_trampoline`, which reads the entry

--- a/kernel/tests/blocking_sync.rs
+++ b/kernel/tests/blocking_sync.rs
@@ -138,20 +138,25 @@ fn channel_ping_pong() {
 static MU: BlockingMutex<u64> = BlockingMutex::new(0);
 static MU_DONE: AtomicUsize = AtomicUsize::new(0);
 
-const MU_ROUNDS: u64 = 200;
+const MU_ROUNDS: u64 = 10;
+/// Busy-work inside the critical section, sized so each lock holder
+/// spans at least one preempt tick (~10 ms). Without this, three
+/// workers each complete their rounds in <1 ms — the mutex is never
+/// actually contended because one worker releases before the next
+/// even tries to acquire, and the `wait_while` / `notify_one` park
+/// path goes untested. ~200k `pause` ≈ 1–2 ms on typical QEMU; the
+/// preempt tick falls inside it and the other workers run headlong
+/// into a lock that's still held.
+const MU_CRIT_SPINS: usize = 200_000;
 
 fn mu_worker() -> ! {
     for _ in 0..MU_ROUNDS {
-        {
-            let mut g = MU.lock();
-            *g += 1;
+        let mut g = MU.lock();
+        for _ in 0..MU_CRIT_SPINS {
+            core::hint::spin_loop();
         }
-        // `spin_loop` between iterations so the preempt tick finds a
-        // natural rotation point — without the mutex being contended
-        // on every acquire, three un-yielding workers could each burn
-        // a full 10 ms slice before the next rotation, and we'd
-        // barely exercise the blocking path.
-        core::hint::spin_loop();
+        *g += 1;
+        // Guard dropped at end of scope -> notify_one wakes a waiter.
     }
     MU_DONE.fetch_add(1, Ordering::SeqCst);
     loop {

--- a/kernel/tests/blocking_sync.rs
+++ b/kernel/tests/blocking_sync.rs
@@ -73,7 +73,7 @@ fn ch_producer() -> ! {
     }
     CH_PROD_DONE.fetch_add(1, Ordering::SeqCst);
     loop {
-        task::yield_now();
+        x86_64::instructions::hlt();
     }
 }
 
@@ -85,7 +85,7 @@ fn ch_consumer() -> ! {
     }
     CH_CONS_DONE.fetch_add(1, Ordering::SeqCst);
     loop {
-        task::yield_now();
+        x86_64::instructions::hlt();
     }
 }
 
@@ -100,14 +100,14 @@ fn channel_ping_pong() {
     task::spawn(ch_producer);
     task::spawn(ch_consumer);
 
-    // Drive the scheduler until both workers finish or we time out.
-    // 100_000 yields is comfortably enough for 60 messages through a
-    // capacity-4 channel; failure fails fast instead of hanging CI.
-    for _ in 0..100_000 {
+    // Park the driver on `hlt` until both workers finish or the
+    // deadline passes. `hlt` wakes on the next PIT tick (~10 ms),
+    // handing the CPU to producer/consumer in between.
+    for _ in 0..2_000 {
         if CH_PROD_DONE.load(Ordering::SeqCst) == 1 && CH_CONS_DONE.load(Ordering::SeqCst) == 1 {
             break;
         }
-        task::yield_now();
+        x86_64::instructions::hlt();
     }
 
     assert_eq!(
@@ -146,15 +146,16 @@ fn mu_worker() -> ! {
             let mut g = MU.lock();
             *g += 1;
         }
-        // Yield between iterations so the workers actually interleave
-        // — without a yield the 10 ms preempt slice will let each
-        // worker burn through all its rounds while holding nothing
-        // contended, and we wouldn't exercise the blocking path.
-        task::yield_now();
+        // `spin_loop` between iterations so the preempt tick finds a
+        // natural rotation point — without the mutex being contended
+        // on every acquire, three un-yielding workers could each burn
+        // a full 10 ms slice before the next rotation, and we'd
+        // barely exercise the blocking path.
+        core::hint::spin_loop();
     }
     MU_DONE.fetch_add(1, Ordering::SeqCst);
     loop {
-        task::yield_now();
+        x86_64::instructions::hlt();
     }
 }
 
@@ -168,11 +169,11 @@ fn mutex_contention() {
     task::spawn(mu_worker);
     task::spawn(mu_worker);
 
-    for _ in 0..100_000 {
+    for _ in 0..2_000 {
         if MU_DONE.load(Ordering::SeqCst) == 3 {
             break;
         }
-        task::yield_now();
+        x86_64::instructions::hlt();
     }
 
     assert_eq!(
@@ -201,7 +202,7 @@ fn wq_waiter() -> ! {
     WQ.wait_while(|| WQ_FLAG.load(Ordering::SeqCst) == 0);
     WQ_WOKEN.fetch_add(1, Ordering::SeqCst);
     loop {
-        task::yield_now();
+        x86_64::instructions::hlt();
     }
 }
 
@@ -212,10 +213,11 @@ fn waitqueue_notify_all() {
     task::spawn(wq_waiter);
     task::spawn(wq_waiter);
 
-    // Let both waiters reach their park. A handful of yields is
-    // enough — round-robin will rotate through them immediately.
-    for _ in 0..200 {
-        task::yield_now();
+    // Let both waiters reach their park. ~20 preempt ticks (200 ms
+    // wall time) is plenty for the round-robin to rotate through
+    // them and for each to park on `WQ`.
+    for _ in 0..20 {
+        x86_64::instructions::hlt();
     }
     // Nobody should be "woken" yet: flag is still 0.
     assert_eq!(
@@ -228,11 +230,11 @@ fn waitqueue_notify_all() {
     WQ_FLAG.store(1, Ordering::SeqCst);
     WQ.notify_all();
 
-    for _ in 0..10_000 {
+    for _ in 0..1_000 {
         if WQ_WOKEN.load(Ordering::SeqCst) == 2 {
             break;
         }
-        task::yield_now();
+        x86_64::instructions::hlt();
     }
     assert_eq!(
         WQ_WOKEN.load(Ordering::SeqCst),

--- a/kernel/tests/preempt.rs
+++ b/kernel/tests/preempt.rs
@@ -1,7 +1,7 @@
 //! Integration test: the PIT preempts tasks that never yield.
 //!
-//! Spawns two workers that spin on a counter with no cooperative
-//! cooperative yield, then the driver sleeps on `hlt` watching `uptime_ms()`
+//! Spawns two workers that spin on a counter with no voluntary park,
+//! then the driver sleeps on `hlt` watching `uptime_ms()`
 //! until the deadline passes. Both workers must have made progress —
 //! if either counter is still zero, preemption didn't rotate through.
 

--- a/kernel/tests/preempt.rs
+++ b/kernel/tests/preempt.rs
@@ -1,7 +1,7 @@
 //! Integration test: the PIT preempts tasks that never yield.
 //!
 //! Spawns two workers that spin on a counter with no cooperative
-//! `yield_now`, then the driver sleeps on `hlt` watching `uptime_ms()`
+//! cooperative yield, then the driver sleeps on `hlt` watching `uptime_ms()`
 //! until the deadline passes. Both workers must have made progress —
 //! if either counter is still zero, preemption didn't rotate through.
 

--- a/kernel/tests/tasks.rs
+++ b/kernel/tests/tasks.rs
@@ -1,5 +1,11 @@
-//! Integration test: cooperative kernel tasks actually interleave, and
-//! a spawned task can flip a flag the driver task polls.
+//! Integration test: kernel tasks actually interleave under
+//! preemption, and a spawned task can flip a flag the driver polls.
+//!
+//! Post-#92 there's no cooperative yield — this test relies entirely
+//! on the PIT preempt tick to rotate tasks. It's distinct from
+//! `preempt.rs` (which exercises the never-yielding tight-loop case)
+//! in that these workers block cleanly on `hlt` and `spin_loop`, the
+//! same way real kernel tasks are expected to idle.
 
 #![no_std]
 #![no_main]
@@ -19,6 +25,9 @@ use vibix::{
 pub extern "C" fn _start() -> ! {
     vibix::init();
     task::init();
+    // Enable preemption: without IF=1 the PIT won't fire and the
+    // workers will never get the CPU back from the driver.
+    x86_64::instructions::interrupts::enable();
     run_tests();
     exit_qemu(QemuExitCode::Success);
 }
@@ -47,27 +56,26 @@ static A: AtomicUsize = AtomicUsize::new(0);
 static B: AtomicUsize = AtomicUsize::new(0);
 const ROUNDS: usize = 50;
 
-// M5 has no task-exit primitive, so worker tasks that finish their
-// real work park in a yield loop. They stay in the ready queue for
-// subsequent tests in this binary — safe because later tests only
-// assert on counters/flags of their own, not on queue shape.
+// Worker tasks that count up and then park on `hlt`. Preemption
+// rotates them in and out every time slice; there is no explicit
+// yield point.
 fn task_a() -> ! {
     for _ in 0..ROUNDS {
         A.fetch_add(1, Ordering::SeqCst);
-        task::yield_now();
+        core::hint::spin_loop();
     }
     loop {
-        task::yield_now();
+        x86_64::instructions::hlt();
     }
 }
 
 fn task_b() -> ! {
     for _ in 0..ROUNDS {
         B.fetch_add(1, Ordering::SeqCst);
-        task::yield_now();
+        core::hint::spin_loop();
     }
     loop {
-        task::yield_now();
+        x86_64::instructions::hlt();
     }
 }
 
@@ -78,11 +86,16 @@ fn two_tasks_interleave() {
     task::spawn(task_a);
     task::spawn(task_b);
 
-    // Drive the scheduler from the driver (bootstrap) task. ROUNDS*3
-    // yields is comfortably enough for both workers to finish their
-    // ROUNDS bumps under round-robin.
-    for _ in 0..(ROUNDS * 3) {
-        task::yield_now();
+    // Park the driver on `hlt` until both counters are full or the
+    // deadline passes. `hlt` wakes on the next PIT tick (~10 ms),
+    // giving us a 100 Hz polling loop that hands the CPU to workers
+    // in between.
+    let deadline_iters = 1_000;
+    for _ in 0..deadline_iters {
+        if A.load(Ordering::SeqCst) == ROUNDS && B.load(Ordering::SeqCst) == ROUNDS {
+            break;
+        }
+        x86_64::instructions::hlt();
     }
 
     let a = A.load(Ordering::SeqCst);
@@ -96,7 +109,7 @@ static FLAG: AtomicBool = AtomicBool::new(false);
 fn flag_setter() -> ! {
     FLAG.store(true, Ordering::SeqCst);
     loop {
-        task::yield_now();
+        x86_64::instructions::hlt();
     }
 }
 
@@ -104,13 +117,14 @@ fn spawn_then_join_via_flag() {
     FLAG.store(false, Ordering::SeqCst);
     task::spawn(flag_setter);
 
-    // Poll + yield until the flag flips. Bound the loop so a
-    // scheduler bug fails the test fast instead of hanging CI.
+    // Poll + hlt until the flag flips. Bounded so a scheduler
+    // regression fails the test in ~1 s of wall time instead of
+    // hanging CI.
     for _ in 0..1_000 {
         if FLAG.load(Ordering::SeqCst) {
             return;
         }
-        task::yield_now();
+        x86_64::instructions::hlt();
     }
     panic!("flag never flipped — scheduler didn't run the spawned task");
 }

--- a/kernel/tests/tasks.rs
+++ b/kernel/tests/tasks.rs
@@ -55,14 +55,22 @@ fn run_tests() {
 static A: AtomicUsize = AtomicUsize::new(0);
 static B: AtomicUsize = AtomicUsize::new(0);
 const ROUNDS: usize = 50;
+/// Enough `pause` iterations per round that each worker spans several
+/// preempt ticks rather than collapsing into a single 10 ms slice.
+/// ~100k `pause` instructions ≈ a millisecond of real work, so ROUNDS
+/// rounds of it comfortably crosses the 10 ms boundary and forces
+/// rotation.
+const INNER_SPINS: usize = 100_000;
 
-// Worker tasks that count up and then park on `hlt`. Preemption
-// rotates them in and out every time slice; there is no explicit
-// yield point.
+// Worker tasks that count up while doing enough busy work to span
+// multiple preempt slices, then park on `hlt`. No explicit yield —
+// preemption alone is what rotates them.
 fn task_a() -> ! {
     for _ in 0..ROUNDS {
         A.fetch_add(1, Ordering::SeqCst);
-        core::hint::spin_loop();
+        for _ in 0..INNER_SPINS {
+            core::hint::spin_loop();
+        }
     }
     loop {
         x86_64::instructions::hlt();
@@ -72,7 +80,9 @@ fn task_a() -> ! {
 fn task_b() -> ! {
     for _ in 0..ROUNDS {
         B.fetch_add(1, Ordering::SeqCst);
-        core::hint::spin_loop();
+        for _ in 0..INNER_SPINS {
+            core::hint::spin_loop();
+        }
     }
     loop {
         x86_64::instructions::hlt();
@@ -87,12 +97,21 @@ fn two_tasks_interleave() {
     task::spawn(task_b);
 
     // Park the driver on `hlt` until both counters are full or the
-    // deadline passes. `hlt` wakes on the next PIT tick (~10 ms),
-    // giving us a 100 Hz polling loop that hands the CPU to workers
-    // in between.
-    let deadline_iters = 1_000;
+    // deadline passes. `hlt` wakes on the next PIT tick (~10 ms), so
+    // this is a 100 Hz sampling loop. `saw_overlap` turns the weak
+    // "both eventually finish" check into a real proof of preemptive
+    // interleaving — if the scheduler ran them sequentially (A to
+    // completion, then B), we'd never observe a moment where both
+    // are partially done.
+    let deadline_iters = 2_000;
+    let mut saw_overlap = false;
     for _ in 0..deadline_iters {
-        if A.load(Ordering::SeqCst) == ROUNDS && B.load(Ordering::SeqCst) == ROUNDS {
+        let a = A.load(Ordering::SeqCst);
+        let b = B.load(Ordering::SeqCst);
+        if a > 0 && b > 0 && a < ROUNDS && b < ROUNDS {
+            saw_overlap = true;
+        }
+        if a == ROUNDS && b == ROUNDS {
             break;
         }
         x86_64::instructions::hlt();
@@ -102,6 +121,10 @@ fn two_tasks_interleave() {
     let b = B.load(Ordering::SeqCst);
     assert_eq!(a, ROUNDS, "task_a didn't run to completion (a={a})");
     assert_eq!(b, ROUNDS, "task_b didn't run to completion (b={b})");
+    assert!(
+        saw_overlap,
+        "workers never overlapped — preemption didn't rotate them"
+    );
 }
 
 static FLAG: AtomicBool = AtomicBool::new(false);


### PR DESCRIPTION
Closes #92.

## Summary

With PIT preemption (#18) live and blocking primitives (#24 / #93) covering the "wait for something" case, `task::yield_now` is dead weight. This PR deletes it and rewrites the two callers + two integration tests that depended on it.

- **`kernel/src/task/mod.rs`** — delete `pub fn yield_now`, update module / preempt_tick doc comments to drop the cooperative framing.
- **`kernel/src/task/scheduler.rs`** / **`switch.rs`** — doc refreshes: the two rescheduling entry points are now `preempt_tick` (tick-driven) and `block_current` (voluntary park).
- **`kernel/src/main.rs`** — `idle_task` becomes `loop { hlt }`; `cursor_blink_task` replaces a yield-spin with `hlt`; the keyboard drain drops its leading yield (`read_key` already parks on `hlt` internally).
- **`kernel/tests/tasks.rs`** — enables IRQs after `task::init()` and drives progress via `hlt` + counter polling. Workers `spin_loop` between bumps so preemption has a natural rotation point.
- **`kernel/tests/blocking_sync.rs`** — same treatment: drivers and idle-tails use `hlt` instead of `yield_now`; mutex worker uses `spin_loop` between rounds.
- **`kernel/tests/preempt.rs`** — one-line doc fix (stale `yield_now` mention).
- **Docs** — `docs/tasks.md` rewritten around `block_current` / `wake`, `docs/README.md` row updated, `README.md` M5 entry + integration-test list refreshed, "out of scope" line drops "blocking primitives".

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p xtask --all-targets -- -D warnings`
- [x] `cargo xtask build` + `cargo xtask build --release`
- [x] Host unit tests (19 tests, all pass)
- [ ] QEMU integration tests (`tasks`, `preempt`, `blocking_sync`) — rely on CI; QEMU isn't installed in this autonomous environment. The kernel and every test binary link cleanly for `x86_64-unknown-none`.
- [ ] `cargo xtask smoke` — relies on CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core task scheduling by removing `task::yield_now` and shifting remaining code/tests to rely on PIT preemption + `hlt`/blocking primitives, which could introduce hangs if preemption or wake/park behavior regresses. Changes are conceptually straightforward but affect kernel runtime behavior and integration tests.
> 
> **Overview**
> Removes the cooperative scheduling path by deleting `task::yield_now`, making PIT-driven `preempt_tick` and blocking via `block_current`/`wake` the only ways tasks stop running.
> 
> Updates the kernel main loop and background tasks to idle using `hlt` instead of yielding, and rewrites integration tests (`tasks`, `blocking_sync`) to drive progress via timer ticks/`hlt` (including adding spin work to force real preempted interleaving and mutex contention). Documentation/README are refreshed to describe preemption-only scheduling and the blocking sync primitives, and the integration-test list is updated to include `blocking_sync`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75fdd2ad6020c7fd2626c3394d88829456ac98c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->