### PR TITLE
sync: add mpmc channel + close/hang-up protocol

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -5,7 +5,7 @@
 - `task/task.rs` — `Task` struct: kernel stack allocation, saved register context, scheduling state
 - `task/scheduler.rs` — `Scheduler`: current task + FIFO ready queue + parked-task side-table
 - `task/switch.rs` — `context_switch` in hand-written assembly
-- `sync/` — blocking primitives (mutex, waitqueue, SPSC channel) built on `block_current` / `wake`
+- `sync/` — blocking primitives (mutex, waitqueue, SPSC + MPMC channels) built on `block_current` / `wake`
 
 ## Overview
 
@@ -16,7 +16,7 @@ that `context_switch` restores on re-entry.
 
 There is no userspace and no per-task address space. Tasks that need to
 wait on a condition block via `sync::WaitQueue` / `sync::BlockingMutex` /
-`sync::spsc::channel`, which park the task on the scheduler's `parked`
+`sync::spsc::channel` / `sync::mpmc::channel`, which park the task on the scheduler's `parked`
 side-table until a wake arrives. Tasks that simply want to idle call
 `hlt` with IRQs enabled; the PIT preempt tick rotates them out when
 anyone else has work.

--- a/kernel/src/sync/mod.rs
+++ b/kernel/src/sync/mod.rs
@@ -18,8 +18,17 @@
 //!   the condition depends on. Both of the other primitives are built
 //!   on this.
 //! - [`spsc`] — single-producer / single-consumer bounded channel.
-//!   The simplest message-passing shape; MPSC/MPMC variants can be
-//!   added as follow-ups once the SPSC case has baked in-tree.
+//!   The simplest message-passing shape; reach for this when each
+//!   side has exactly one endpoint.
+//! - [`mpmc`] — multi-producer / multi-consumer bounded channel.
+//!   Same shape as `spsc` but both endpoints are `Clone`; pay the
+//!   extra endpoint-count bookkeeping when you need fan-in or
+//!   fan-out.
+//!
+//! Both channel variants observe the close / hang-up protocol:
+//! dropping the last sender wakes parked receivers (which drain,
+//! then see `None`); dropping the last receiver wakes parked
+//! senders (which see `Err(val)`).
 //!
 //! ## Task-context only
 //!
@@ -46,6 +55,7 @@
 //! Nothing acquires `WaitQueue.inner` while already holding a data
 //! lock or `SCHED`, so the graph is a DAG.
 
+pub mod mpmc;
 pub mod mutex;
 pub mod spsc;
 pub mod waitqueue;

--- a/kernel/src/sync/mpmc.rs
+++ b/kernel/src/sync/mpmc.rs
@@ -236,6 +236,14 @@ impl<T> Receiver<T> {
             // Drain-first: buffered items win over close detection.
             // A receiver that had some in flight when the last
             // sender dropped must still get them.
+            //
+            // The closed check MUST happen under the same `buf` lock
+            // acquisition as the pop attempt. Otherwise a sender
+            // could push + drop between the unlock and the count
+            // load: its `notify_one` / `notify_all` would fire into
+            // an empty waitqueue (we're not parked yet), we'd then
+            // see `sender_count == 0`, return None, and strand the
+            // item in the queue.
             {
                 let mut inner = self.shared.buf.lock();
                 if let Some(val) = inner.queue.pop_front() {
@@ -243,9 +251,9 @@ impl<T> Receiver<T> {
                     self.shared.not_full.notify_one();
                     return Some(val);
                 }
-            }
-            if self.shared.sender_count.load(Ordering::Acquire) == 0 {
-                return None;
+                if self.shared.sender_count.load(Ordering::Acquire) == 0 {
+                    return None;
+                }
             }
             // Park until a sender pushes or the last sender drops.
             self.shared.not_empty.wait_while(|| {

--- a/kernel/src/sync/mpmc.rs
+++ b/kernel/src/sync/mpmc.rs
@@ -179,12 +179,17 @@ impl<T> Sender<T> {
     pub fn send(&self, val: T) -> Result<(), T> {
         let mut slot = Some(val);
         loop {
-            // Fast path: check closed, then try to push.
-            if self.shared.receiver_count.load(Ordering::Acquire) == 0 {
-                return Err(slot.take().expect("send slot populated"));
-            }
+            // Close check + push must happen under one `buf` lock
+            // acquisition — symmetric to the drain-first check in
+            // `Receiver::recv`. Otherwise: sender loads
+            // `receiver_count = 1`, the last receiver drops (count
+            // →0), sender acquires buf and pushes, returns Ok with
+            // the item stranded (no live receiver will ever pop).
             {
                 let mut inner = self.shared.buf.lock();
+                if self.shared.receiver_count.load(Ordering::Acquire) == 0 {
+                    return Err(slot.take().expect("send slot populated"));
+                }
                 if inner.queue.len() < inner.capacity {
                     inner
                         .queue
@@ -212,10 +217,11 @@ impl<T> Sender<T> {
     /// Non-blocking send. Returns a [`TrySendError`] that
     /// distinguishes "full right now" from "channel closed".
     pub fn try_send(&self, val: T) -> Result<(), TrySendError<T>> {
+        let mut inner = self.shared.buf.lock();
+        // Closed-check under the buf lock (see `send` for the race).
         if self.shared.receiver_count.load(Ordering::Acquire) == 0 {
             return Err(TrySendError::Closed(val));
         }
-        let mut inner = self.shared.buf.lock();
         if inner.queue.len() < inner.capacity {
             inner.queue.push_back(val);
             drop(inner);

--- a/kernel/src/sync/mpmc.rs
+++ b/kernel/src/sync/mpmc.rs
@@ -1,0 +1,276 @@
+//! Bounded multi-producer / multi-consumer blocking channel.
+//!
+//! Same bounded-queue shape as [`super::spsc`], but both endpoints
+//! are [`Clone`] so any number of producer / consumer tasks can share
+//! the channel. Internals are a [`spin::Mutex`]-protected [`VecDeque`]
+//! plus the same two wait queues (`not_full`, `not_empty`); the
+//! additional complexity over SPSC is endpoint-count bookkeeping for
+//! the close / hang-up protocol.
+//!
+//! ## Close semantics
+//!
+//! When the last [`Sender`] is dropped the channel becomes *closed to
+//! sends*. Any parked [`Receiver`] wakes, drains whatever is buffered,
+//! then observes `None` from [`Receiver::recv`]. Symmetric when the
+//! last [`Receiver`] is dropped: any parked [`Sender`] wakes and sees
+//! [`Err`] from [`Sender::send`], the inner value returned to the
+//! caller.
+//!
+//! Endpoint counts are tracked explicitly (`sender_count`,
+//! `receiver_count`: `AtomicUsize`) rather than inferred from
+//! [`Arc::strong_count`]. Both endpoints share a single `Arc`, so the
+//! strong count can't distinguish "last sender" from "last receiver".
+//!
+//! ## Lock order
+//!
+//! Same as `super`: `WaitQueue.inner` → `buf` lock → `SCHED`. Endpoint
+//! counts are atomics and take no lock at all.
+
+use alloc::collections::VecDeque;
+use alloc::sync::Arc;
+use core::sync::atomic::{AtomicUsize, Ordering};
+use spin::Mutex;
+
+use super::WaitQueue;
+
+struct Inner<T> {
+    queue: VecDeque<T>,
+    capacity: usize,
+}
+
+struct Shared<T> {
+    buf: Mutex<Inner<T>>,
+    not_full: WaitQueue,
+    not_empty: WaitQueue,
+    /// Number of live [`Sender`] handles. When this transitions to 0,
+    /// the channel is closed to sends and any parked receivers are
+    /// woken so they can observe `None`.
+    sender_count: AtomicUsize,
+    /// Number of live [`Receiver`] handles. When this transitions to
+    /// 0, parked senders wake and their `send` calls return `Err`.
+    receiver_count: AtomicUsize,
+}
+
+/// Producer half of an MPMC channel. [`Clone`]able; each clone counts
+/// as one live sender for close-detection purposes.
+pub struct Sender<T> {
+    shared: Arc<Shared<T>>,
+}
+
+/// Consumer half of an MPMC channel. [`Clone`]able; each clone counts
+/// as one live receiver.
+pub struct Receiver<T> {
+    shared: Arc<Shared<T>>,
+}
+
+/// Error type for [`Sender::try_send`]. Distinguishes the two
+/// non-success cases because callers typically want different
+/// behaviour: `Full` may retry later, `Closed` should abandon.
+#[derive(Debug)]
+pub enum TrySendError<T> {
+    /// Channel is at capacity right now.
+    Full(T),
+    /// Every [`Receiver`] has been dropped; further sends are
+    /// impossible.
+    Closed(T),
+}
+
+impl<T> TrySendError<T> {
+    /// Consume the error and return the value that could not be sent.
+    pub fn into_inner(self) -> T {
+        match self {
+            TrySendError::Full(v) | TrySendError::Closed(v) => v,
+        }
+    }
+}
+
+/// Error type for [`Receiver::try_recv`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum TryRecvError {
+    /// Queue is empty but the channel is still open.
+    Empty,
+    /// Every [`Sender`] has been dropped and the queue is drained.
+    Closed,
+}
+
+/// Create an MPMC channel with room for `capacity` unreceived items.
+///
+/// # Panics
+///
+/// Panics if `capacity == 0`; zero-capacity rendezvous channels are
+/// a separate (substantially more involved) shape and not supported
+/// here.
+pub fn channel<T>(capacity: usize) -> (Sender<T>, Receiver<T>) {
+    assert!(capacity > 0, "mpmc::channel capacity must be > 0");
+    let shared = Arc::new(Shared {
+        buf: Mutex::new(Inner {
+            queue: VecDeque::with_capacity(capacity),
+            capacity,
+        }),
+        not_full: WaitQueue::new(),
+        not_empty: WaitQueue::new(),
+        sender_count: AtomicUsize::new(1),
+        receiver_count: AtomicUsize::new(1),
+    });
+    (
+        Sender {
+            shared: shared.clone(),
+        },
+        Receiver { shared },
+    )
+}
+
+impl<T> Clone for Sender<T> {
+    fn clone(&self) -> Self {
+        // Bump before handing out the new handle. The existing `self`
+        // already counts for >= 1, so the count is strictly positive
+        // throughout — no 0 → 1 race with a concurrent `drop` of the
+        // "last" sender (there isn't one while `self` lives).
+        self.shared.sender_count.fetch_add(1, Ordering::Relaxed);
+        Self {
+            shared: self.shared.clone(),
+        }
+    }
+}
+
+impl<T> Clone for Receiver<T> {
+    fn clone(&self) -> Self {
+        self.shared.receiver_count.fetch_add(1, Ordering::Relaxed);
+        Self {
+            shared: self.shared.clone(),
+        }
+    }
+}
+
+impl<T> Drop for Sender<T> {
+    fn drop(&mut self) {
+        // AcqRel: any queue writes published under `buf` before this
+        // drop must be visible to a receiver that wakes on the
+        // close-notify below and loads `sender_count` with Acquire.
+        let prev = self.shared.sender_count.fetch_sub(1, Ordering::AcqRel);
+        if prev == 1 {
+            // Last sender gone: wake every parked receiver so it can
+            // drain whatever is buffered and then observe the closed
+            // state.
+            self.shared.not_empty.notify_all();
+        }
+    }
+}
+
+impl<T> Drop for Receiver<T> {
+    fn drop(&mut self) {
+        let prev = self.shared.receiver_count.fetch_sub(1, Ordering::AcqRel);
+        if prev == 1 {
+            // Last receiver gone: wake every parked sender so each
+            // can return `Err(val)`.
+            self.shared.not_full.notify_all();
+        }
+    }
+}
+
+impl<T> Sender<T> {
+    /// Send `val`, parking until the channel has space or every
+    /// [`Receiver`] has been dropped.
+    ///
+    /// Returns `Ok(())` on successful enqueue, `Err(val)` if the
+    /// channel is closed. A closed-detection that fires while parked
+    /// still returns `Err(val)` — the value is never dropped on the
+    /// floor.
+    pub fn send(&self, val: T) -> Result<(), T> {
+        let mut slot = Some(val);
+        loop {
+            // Fast path: check closed, then try to push.
+            if self.shared.receiver_count.load(Ordering::Acquire) == 0 {
+                return Err(slot.take().expect("send slot populated"));
+            }
+            {
+                let mut inner = self.shared.buf.lock();
+                if inner.queue.len() < inner.capacity {
+                    inner
+                        .queue
+                        .push_back(slot.take().expect("send slot populated"));
+                    drop(inner);
+                    self.shared.not_empty.notify_one();
+                    return Ok(());
+                }
+            }
+            // Slow path: park until space or close. The cond re-reads
+            // closed under the waitqueue lock so a close that fires
+            // between our check and the park is caught by either the
+            // cond or the `wake_pending` flag (see waitqueue module
+            // docs).
+            self.shared.not_full.wait_while(|| {
+                if self.shared.receiver_count.load(Ordering::Acquire) == 0 {
+                    return false;
+                }
+                let inner = self.shared.buf.lock();
+                inner.queue.len() >= inner.capacity
+            });
+        }
+    }
+
+    /// Non-blocking send. Returns a [`TrySendError`] that
+    /// distinguishes "full right now" from "channel closed".
+    pub fn try_send(&self, val: T) -> Result<(), TrySendError<T>> {
+        if self.shared.receiver_count.load(Ordering::Acquire) == 0 {
+            return Err(TrySendError::Closed(val));
+        }
+        let mut inner = self.shared.buf.lock();
+        if inner.queue.len() < inner.capacity {
+            inner.queue.push_back(val);
+            drop(inner);
+            self.shared.not_empty.notify_one();
+            Ok(())
+        } else {
+            Err(TrySendError::Full(val))
+        }
+    }
+}
+
+impl<T> Receiver<T> {
+    /// Receive one item, parking until one is available. Returns
+    /// `None` once every [`Sender`] has been dropped *and* the
+    /// internal queue has been drained.
+    pub fn recv(&self) -> Option<T> {
+        loop {
+            // Drain-first: buffered items win over close detection.
+            // A receiver that had some in flight when the last
+            // sender dropped must still get them.
+            {
+                let mut inner = self.shared.buf.lock();
+                if let Some(val) = inner.queue.pop_front() {
+                    drop(inner);
+                    self.shared.not_full.notify_one();
+                    return Some(val);
+                }
+            }
+            if self.shared.sender_count.load(Ordering::Acquire) == 0 {
+                return None;
+            }
+            // Park until a sender pushes or the last sender drops.
+            self.shared.not_empty.wait_while(|| {
+                if self.shared.sender_count.load(Ordering::Acquire) == 0 {
+                    return false;
+                }
+                let inner = self.shared.buf.lock();
+                inner.queue.is_empty()
+            });
+        }
+    }
+
+    /// Non-blocking recv. Returns [`TryRecvError::Empty`] if the
+    /// queue has nothing right now, [`TryRecvError::Closed`] if the
+    /// queue is drained *and* every sender is gone.
+    pub fn try_recv(&self) -> Result<T, TryRecvError> {
+        let mut inner = self.shared.buf.lock();
+        if let Some(val) = inner.queue.pop_front() {
+            drop(inner);
+            self.shared.not_full.notify_one();
+            Ok(val)
+        } else if self.shared.sender_count.load(Ordering::Acquire) == 0 {
+            Err(TryRecvError::Closed)
+        } else {
+            Err(TryRecvError::Empty)
+        }
+    }
+}

--- a/kernel/src/sync/spsc.rs
+++ b/kernel/src/sync/spsc.rs
@@ -1,24 +1,29 @@
 //! Bounded single-producer / single-consumer blocking channel.
 //!
-//! Why SPSC first: the simpler shape that covers the typical
-//! "producer task hands work to a worker task" pattern without the
-//! extra synchronisation an MPMC channel needs. MPSC / MPMC variants
-//! can be added as follow-ups once this has baked in-tree.
+//! Why SPSC alongside [`super::mpmc`]: the endpoint-unique shape
+//! covers the common "producer task hands work to a worker task"
+//! pattern without paying for the MPMC counters on every clone/drop.
+//! `Sender` and `Receiver` are intentionally `!Clone` here — callers
+//! who need fan-in / fan-out reach for `mpmc` instead.
 //!
 //! Capacity is fixed at construction. `send` / `recv` park via
 //! [`WaitQueue`] when the queue is full / empty; `try_send` /
 //! `try_recv` never park.
 //!
-//! The `Sender` and `Receiver` each own one `Arc` handle to the shared
-//! state; dropping all handles of one side does *not* currently signal
-//! the other — a sender that finishes and drops its `Sender` will
-//! leave the receiver waiting forever if the queue is empty. That's
-//! fine for the primitives' in-kernel usage today (tasks don't exit
-//! yet in M6) but is the natural follow-up shape for a channel-close
-//! protocol.
+//! ## Close semantics
+//!
+//! Dropping the [`Sender`] wakes any parked [`Receiver`]; once the
+//! buffered queue is drained, `recv` returns `None`. Symmetric when
+//! the [`Receiver`] is dropped: the parked `Sender`'s `send` returns
+//! `Err(val)` so the caller can recover the value.
+//!
+//! Because each side has exactly one endpoint, close state is two
+//! `AtomicBool`s (`sender_closed`, `receiver_closed`) rather than the
+//! reference counts `mpmc` needs.
 
 use alloc::collections::VecDeque;
 use alloc::sync::Arc;
+use core::sync::atomic::{AtomicBool, Ordering};
 use spin::Mutex;
 
 use super::WaitQueue;
@@ -32,6 +37,13 @@ struct Shared<T> {
     buf: Mutex<Inner<T>>,
     not_full: WaitQueue,
     not_empty: WaitQueue,
+    /// Set in `Drop for Sender`. Observed by a parked / about-to-park
+    /// receiver to distinguish "queue happens to be empty" from
+    /// "no more data will ever arrive".
+    sender_closed: AtomicBool,
+    /// Set in `Drop for Receiver`. Observed by the sender to return
+    /// `Err(val)` instead of blocking forever on a full queue.
+    receiver_closed: AtomicBool,
 }
 
 /// Producer half of an SPSC channel.
@@ -42,6 +54,33 @@ pub struct Sender<T> {
 /// Consumer half of an SPSC channel.
 pub struct Receiver<T> {
     shared: Arc<Shared<T>>,
+}
+
+/// Error returned by [`Sender::try_send`] when the push did not land.
+#[derive(Debug)]
+pub enum TrySendError<T> {
+    /// Queue is at capacity right now.
+    Full(T),
+    /// [`Receiver`] has been dropped; the channel is closed.
+    Closed(T),
+}
+
+impl<T> TrySendError<T> {
+    /// Consume the error and return the value that could not be sent.
+    pub fn into_inner(self) -> T {
+        match self {
+            TrySendError::Full(v) | TrySendError::Closed(v) => v,
+        }
+    }
+}
+
+/// Error returned by [`Receiver::try_recv`] when no value was popped.
+#[derive(Debug, PartialEq, Eq)]
+pub enum TryRecvError {
+    /// Queue is empty but the channel is still open.
+    Empty,
+    /// [`Sender`] has been dropped and the queue is drained.
+    Closed,
 }
 
 /// Create an SPSC channel with room for `capacity` unreceived items.
@@ -59,6 +98,8 @@ pub fn channel<T>(capacity: usize) -> (Sender<T>, Receiver<T>) {
         }),
         not_full: WaitQueue::new(),
         not_empty: WaitQueue::new(),
+        sender_closed: AtomicBool::new(false),
+        receiver_closed: AtomicBool::new(false),
     });
     (
         Sender {
@@ -68,14 +109,38 @@ pub fn channel<T>(capacity: usize) -> (Sender<T>, Receiver<T>) {
     )
 }
 
+impl<T> Drop for Sender<T> {
+    fn drop(&mut self) {
+        // Release so the receiver, when it loads `sender_closed` with
+        // Acquire, also sees whatever was pushed before we dropped.
+        self.shared.sender_closed.store(true, Ordering::Release);
+        // Wake any parked receiver so it can drain the queue and then
+        // observe closed.
+        self.shared.not_empty.notify_all();
+    }
+}
+
+impl<T> Drop for Receiver<T> {
+    fn drop(&mut self) {
+        self.shared.receiver_closed.store(true, Ordering::Release);
+        // Wake the parked sender (if any) so `send` returns `Err`.
+        self.shared.not_full.notify_all();
+    }
+}
+
 impl<T> Sender<T> {
-    /// Send `val`, parking until the channel has space.
-    pub fn send(&self, val: T) {
-        // `Option` dance because we might loop (park + retry) before
-        // the push actually lands, and a bare `val` would be
-        // borrow-checked as moved-on-previous-iteration.
+    /// Send `val`, parking until the channel has space or the
+    /// [`Receiver`] has been dropped.
+    ///
+    /// Returns `Ok(())` on successful enqueue, `Err(val)` if the
+    /// channel is closed (receiver side dropped). The value is
+    /// returned so callers can recover it.
+    pub fn send(&self, val: T) -> Result<(), T> {
         let mut slot = Some(val);
         loop {
+            if self.shared.receiver_closed.load(Ordering::Acquire) {
+                return Err(slot.take().expect("send slot populated"));
+            }
             {
                 let mut inner = self.shared.buf.lock();
                 if inner.queue.len() < inner.capacity {
@@ -84,23 +149,30 @@ impl<T> Sender<T> {
                         .push_back(slot.take().expect("send slot populated"));
                     drop(inner);
                     self.shared.not_empty.notify_one();
-                    return;
+                    return Ok(());
                 }
             }
-            // Full: park until the receiver pops at least one item.
-            // Re-check `len >= capacity` under the waitqueue lock via
-            // `wait_while`; `recv` calls `not_full.notify_one()` only
-            // after it has popped, so on wakeup the condition can
-            // differ — the loop retries in that case.
+            // Full: park until the receiver pops or drops. Re-check
+            // both predicates under the waitqueue lock so a close
+            // that fires between check and park is caught here (or
+            // via `wake_pending`; see waitqueue module docs).
             self.shared.not_full.wait_while(|| {
+                if self.shared.receiver_closed.load(Ordering::Acquire) {
+                    return false;
+                }
                 let inner = self.shared.buf.lock();
                 inner.queue.len() >= inner.capacity
             });
         }
     }
 
-    /// Non-blocking send. Returns `Err(val)` if the channel is full.
-    pub fn try_send(&self, val: T) -> Result<(), T> {
+    /// Non-blocking send. Returns [`TrySendError::Full`] when the
+    /// queue is at capacity and [`TrySendError::Closed`] when the
+    /// receiver has been dropped.
+    pub fn try_send(&self, val: T) -> Result<(), TrySendError<T>> {
+        if self.shared.receiver_closed.load(Ordering::Acquire) {
+            return Err(TrySendError::Closed(val));
+        }
         let mut inner = self.shared.buf.lock();
         if inner.queue.len() < inner.capacity {
             inner.queue.push_back(val);
@@ -108,40 +180,55 @@ impl<T> Sender<T> {
             self.shared.not_empty.notify_one();
             Ok(())
         } else {
-            Err(val)
+            Err(TrySendError::Full(val))
         }
     }
 }
 
 impl<T> Receiver<T> {
-    /// Receive one item, parking until one is available.
-    pub fn recv(&self) -> T {
+    /// Receive one item, parking until one is available or the
+    /// [`Sender`] is dropped and the queue is drained. Returns
+    /// `None` only when the channel is closed *and* empty.
+    pub fn recv(&self) -> Option<T> {
         loop {
+            // Drain-first: buffered items beat close detection so a
+            // receiver whose sender exited mid-stream still gets
+            // everything that was in flight.
             {
                 let mut inner = self.shared.buf.lock();
                 if let Some(val) = inner.queue.pop_front() {
                     drop(inner);
                     self.shared.not_full.notify_one();
-                    return val;
+                    return Some(val);
                 }
             }
-            // Empty: park until the sender pushes.
+            if self.shared.sender_closed.load(Ordering::Acquire) {
+                return None;
+            }
             self.shared.not_empty.wait_while(|| {
+                if self.shared.sender_closed.load(Ordering::Acquire) {
+                    return false;
+                }
                 let inner = self.shared.buf.lock();
                 inner.queue.is_empty()
             });
         }
     }
 
-    /// Non-blocking recv. Returns `None` if the channel is empty.
-    pub fn try_recv(&self) -> Option<T> {
+    /// Non-blocking recv. Returns [`TryRecvError::Empty`] when the
+    /// queue is empty but the sender is still live, and
+    /// [`TryRecvError::Closed`] when the queue is drained *and* the
+    /// sender has been dropped.
+    pub fn try_recv(&self) -> Result<T, TryRecvError> {
         let mut inner = self.shared.buf.lock();
         if let Some(val) = inner.queue.pop_front() {
             drop(inner);
             self.shared.not_full.notify_one();
-            Some(val)
+            Ok(val)
+        } else if self.shared.sender_closed.load(Ordering::Acquire) {
+            Err(TryRecvError::Closed)
         } else {
-            None
+            Err(TryRecvError::Empty)
         }
     }
 }

--- a/kernel/src/sync/spsc.rs
+++ b/kernel/src/sync/spsc.rs
@@ -194,6 +194,13 @@ impl<T> Receiver<T> {
             // Drain-first: buffered items beat close detection so a
             // receiver whose sender exited mid-stream still gets
             // everything that was in flight.
+            //
+            // The closed check MUST happen under the same `buf` lock
+            // as the pop attempt. Otherwise a sender could push +
+            // drop between our unlock and the `sender_closed` load:
+            // its `notify_one` would fire into an empty waitqueue
+            // (we're not parked yet), we'd then see `sender_closed`
+            // and return None, stranding the item in the queue.
             {
                 let mut inner = self.shared.buf.lock();
                 if let Some(val) = inner.queue.pop_front() {
@@ -201,9 +208,9 @@ impl<T> Receiver<T> {
                     self.shared.not_full.notify_one();
                     return Some(val);
                 }
-            }
-            if self.shared.sender_closed.load(Ordering::Acquire) {
-                return None;
+                if self.shared.sender_closed.load(Ordering::Acquire) {
+                    return None;
+                }
             }
             self.shared.not_empty.wait_while(|| {
                 if self.shared.sender_closed.load(Ordering::Acquire) {

--- a/kernel/src/sync/spsc.rs
+++ b/kernel/src/sync/spsc.rs
@@ -138,11 +138,17 @@ impl<T> Sender<T> {
     pub fn send(&self, val: T) -> Result<(), T> {
         let mut slot = Some(val);
         loop {
-            if self.shared.receiver_closed.load(Ordering::Acquire) {
-                return Err(slot.take().expect("send slot populated"));
-            }
+            // The closed-check + push MUST happen under one `buf`
+            // lock acquisition — symmetric to the recv-side drain
+            // check. Otherwise: sender loads `receiver_closed =
+            // false`, receiver drops (setting the flag), sender
+            // acquires buf, pushes, returns Ok with the item
+            // stranded (no live receiver will ever pop it).
             {
                 let mut inner = self.shared.buf.lock();
+                if self.shared.receiver_closed.load(Ordering::Acquire) {
+                    return Err(slot.take().expect("send slot populated"));
+                }
                 if inner.queue.len() < inner.capacity {
                     inner
                         .queue
@@ -170,10 +176,11 @@ impl<T> Sender<T> {
     /// queue is at capacity and [`TrySendError::Closed`] when the
     /// receiver has been dropped.
     pub fn try_send(&self, val: T) -> Result<(), TrySendError<T>> {
+        let mut inner = self.shared.buf.lock();
+        // Closed-check under the buf lock (see `send` for the race).
         if self.shared.receiver_closed.load(Ordering::Acquire) {
             return Err(TrySendError::Closed(val));
         }
-        let mut inner = self.shared.buf.lock();
         if inner.queue.len() < inner.capacity {
             inner.queue.push_back(val);
             drop(inner);

--- a/kernel/tests/blocking_sync.rs
+++ b/kernel/tests/blocking_sync.rs
@@ -11,7 +11,7 @@ use core::panic::PanicInfo;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 use spin::Mutex as SpinMutex;
-use vibix::sync::spsc;
+use vibix::sync::{mpmc, spsc};
 use vibix::sync::{BlockingMutex, WaitQueue};
 use vibix::{
     exit_qemu, serial_println, task,
@@ -38,6 +38,24 @@ fn run_tests() {
         ("channel_ping_pong", &(channel_ping_pong as fn())),
         ("mutex_contention", &(mutex_contention as fn())),
         ("waitqueue_notify_all", &(waitqueue_notify_all as fn())),
+        (
+            "spsc_close_wakes_receiver",
+            &(spsc_close_wakes_receiver as fn()),
+        ),
+        (
+            "spsc_close_wakes_sender",
+            &(spsc_close_wakes_sender as fn()),
+        ),
+        ("mpmc_many_to_one", &(mpmc_many_to_one as fn())),
+        ("mpmc_many_to_many", &(mpmc_many_to_many as fn())),
+        (
+            "mpmc_close_wakes_receivers",
+            &(mpmc_close_wakes_receivers as fn()),
+        ),
+        (
+            "mpmc_close_wakes_senders",
+            &(mpmc_close_wakes_senders as fn()),
+        ),
     ];
     serial_println!("running {} tests", tests.len());
     for (name, t) in tests {
@@ -69,7 +87,7 @@ const CH_N: u32 = 60;
 fn ch_producer() -> ! {
     let tx = CH_TX.lock().take().expect("producer: CH_TX not set");
     for i in 0..CH_N {
-        tx.send(i);
+        tx.send(i).expect("producer: send returned Err");
     }
     CH_PROD_DONE.fetch_add(1, Ordering::SeqCst);
     loop {
@@ -80,7 +98,7 @@ fn ch_producer() -> ! {
 fn ch_consumer() -> ! {
     let rx = CH_RX.lock().take().expect("consumer: CH_RX not set");
     for _ in 0..CH_N {
-        let v = rx.recv();
+        let v = rx.recv().expect("consumer: recv returned None");
         CH_SUM.fetch_add(v as usize, Ordering::SeqCst);
     }
     CH_CONS_DONE.fetch_add(1, Ordering::SeqCst);
@@ -245,5 +263,464 @@ fn waitqueue_notify_all() {
         WQ_WOKEN.load(Ordering::SeqCst),
         2,
         "notify_all didn't wake both waiters"
+    );
+}
+
+// --- spsc_close_wakes_receiver --------------------------------------
+//
+// A receiver parks on an empty SPSC channel. The driver drops the
+// sender; the receiver must wake and observe `None` from `recv`.
+
+static SPSC_CLOSE_RX: SpinMutex<Option<spsc::Receiver<u32>>> = SpinMutex::new(None);
+static SPSC_CLOSE_RX_SAW_NONE: AtomicUsize = AtomicUsize::new(0);
+
+fn spsc_close_rx_worker() -> ! {
+    let rx = SPSC_CLOSE_RX
+        .lock()
+        .take()
+        .expect("spsc_close_rx_worker: receiver not set");
+    if rx.recv().is_none() {
+        SPSC_CLOSE_RX_SAW_NONE.fetch_add(1, Ordering::SeqCst);
+    }
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn spsc_close_wakes_receiver() {
+    let (tx, rx) = spsc::channel::<u32>(4);
+    *SPSC_CLOSE_RX.lock() = Some(rx);
+    SPSC_CLOSE_RX_SAW_NONE.store(0, Ordering::SeqCst);
+
+    task::spawn(spsc_close_rx_worker);
+
+    // Let the worker reach its park. ~200 ms wall time is plenty.
+    for _ in 0..20 {
+        x86_64::instructions::hlt();
+    }
+
+    // Drop the sender. This must wake the parked receiver.
+    drop(tx);
+
+    for _ in 0..1_000 {
+        if SPSC_CLOSE_RX_SAW_NONE.load(Ordering::SeqCst) == 1 {
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+    assert_eq!(
+        SPSC_CLOSE_RX_SAW_NONE.load(Ordering::SeqCst),
+        1,
+        "receiver didn't observe None after sender dropped"
+    );
+}
+
+// --- spsc_close_wakes_sender ----------------------------------------
+//
+// A sender fills a capacity-1 channel and then parks on `send`. The
+// driver drops the receiver; the sender must wake and observe `Err`.
+
+static SPSC_CLOSE_TX: SpinMutex<Option<spsc::Sender<u32>>> = SpinMutex::new(None);
+static SPSC_CLOSE_TX_SAW_ERR: AtomicUsize = AtomicUsize::new(0);
+
+fn spsc_close_tx_worker() -> ! {
+    let tx = SPSC_CLOSE_TX
+        .lock()
+        .take()
+        .expect("spsc_close_tx_worker: sender not set");
+    // Channel already has one item buffered; this send parks.
+    if tx.send(2).is_err() {
+        SPSC_CLOSE_TX_SAW_ERR.fetch_add(1, Ordering::SeqCst);
+    }
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn spsc_close_wakes_sender() {
+    let (tx, rx) = spsc::channel::<u32>(1);
+    tx.send(1).expect("prefill send");
+    *SPSC_CLOSE_TX.lock() = Some(tx);
+    SPSC_CLOSE_TX_SAW_ERR.store(0, Ordering::SeqCst);
+
+    task::spawn(spsc_close_tx_worker);
+
+    for _ in 0..20 {
+        x86_64::instructions::hlt();
+    }
+
+    drop(rx);
+
+    for _ in 0..1_000 {
+        if SPSC_CLOSE_TX_SAW_ERR.load(Ordering::SeqCst) == 1 {
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+    assert_eq!(
+        SPSC_CLOSE_TX_SAW_ERR.load(Ordering::SeqCst),
+        1,
+        "sender didn't observe Err after receiver dropped"
+    );
+}
+
+// --- mpmc_many_to_one -----------------------------------------------
+//
+// Three producer tasks each push a disjoint range; one consumer
+// drains all 3*M items and checksums. Exercises `Sender: Clone` and
+// the Mutex-protected queue under fan-in contention.
+
+static MPMC_M2O_TX: SpinMutex<Option<mpmc::Sender<u32>>> = SpinMutex::new(None);
+static MPMC_M2O_RX: SpinMutex<Option<mpmc::Receiver<u32>>> = SpinMutex::new(None);
+static MPMC_M2O_SUM: AtomicUsize = AtomicUsize::new(0);
+static MPMC_M2O_PROD_DONE: AtomicUsize = AtomicUsize::new(0);
+static MPMC_M2O_CONS_DONE: AtomicUsize = AtomicUsize::new(0);
+
+const MPMC_M2O_PRODUCERS: u32 = 3;
+const MPMC_M2O_PER_PROD: u32 = 20;
+
+// One of three static slots each producer claims on entry. Mirrors
+// the CH_TX pattern but with per-producer handoff to avoid racing on
+// a single mutex for the take.
+static MPMC_M2O_TX_A: SpinMutex<Option<mpmc::Sender<u32>>> = SpinMutex::new(None);
+static MPMC_M2O_TX_B: SpinMutex<Option<mpmc::Sender<u32>>> = SpinMutex::new(None);
+static MPMC_M2O_TX_C: SpinMutex<Option<mpmc::Sender<u32>>> = SpinMutex::new(None);
+
+fn mpmc_m2o_prod_a() -> ! {
+    let tx = MPMC_M2O_TX_A.lock().take().expect("m2o prod A: tx not set");
+    for i in 0..MPMC_M2O_PER_PROD {
+        tx.send(i).expect("m2o prod A: send failed");
+    }
+    MPMC_M2O_PROD_DONE.fetch_add(1, Ordering::SeqCst);
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn mpmc_m2o_prod_b() -> ! {
+    let tx = MPMC_M2O_TX_B.lock().take().expect("m2o prod B: tx not set");
+    for i in 0..MPMC_M2O_PER_PROD {
+        tx.send(100 + i).expect("m2o prod B: send failed");
+    }
+    MPMC_M2O_PROD_DONE.fetch_add(1, Ordering::SeqCst);
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn mpmc_m2o_prod_c() -> ! {
+    let tx = MPMC_M2O_TX_C.lock().take().expect("m2o prod C: tx not set");
+    for i in 0..MPMC_M2O_PER_PROD {
+        tx.send(1000 + i).expect("m2o prod C: send failed");
+    }
+    MPMC_M2O_PROD_DONE.fetch_add(1, Ordering::SeqCst);
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn mpmc_m2o_cons() -> ! {
+    let rx = MPMC_M2O_RX.lock().take().expect("m2o cons: rx not set");
+    let total = MPMC_M2O_PRODUCERS * MPMC_M2O_PER_PROD;
+    for _ in 0..total {
+        let v = rx.recv().expect("m2o cons: recv returned None");
+        MPMC_M2O_SUM.fetch_add(v as usize, Ordering::SeqCst);
+    }
+    MPMC_M2O_CONS_DONE.fetch_add(1, Ordering::SeqCst);
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn mpmc_many_to_one() {
+    let (tx, rx) = mpmc::channel::<u32>(4);
+    *MPMC_M2O_TX_A.lock() = Some(tx.clone());
+    *MPMC_M2O_TX_B.lock() = Some(tx.clone());
+    *MPMC_M2O_TX_C.lock() = Some(tx.clone());
+    // Retain the original in TX so the driver can observe the close
+    // path via `drop` after cloning to the three workers, but we
+    // don't need it after this point; drop it immediately so the
+    // channel closes once the workers finish.
+    *MPMC_M2O_TX.lock() = Some(tx);
+    MPMC_M2O_TX.lock().take();
+
+    *MPMC_M2O_RX.lock() = Some(rx);
+    MPMC_M2O_SUM.store(0, Ordering::SeqCst);
+    MPMC_M2O_PROD_DONE.store(0, Ordering::SeqCst);
+    MPMC_M2O_CONS_DONE.store(0, Ordering::SeqCst);
+
+    task::spawn(mpmc_m2o_prod_a);
+    task::spawn(mpmc_m2o_prod_b);
+    task::spawn(mpmc_m2o_prod_c);
+    task::spawn(mpmc_m2o_cons);
+
+    for _ in 0..5_000 {
+        if MPMC_M2O_PROD_DONE.load(Ordering::SeqCst) == MPMC_M2O_PRODUCERS as usize
+            && MPMC_M2O_CONS_DONE.load(Ordering::SeqCst) == 1
+        {
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+
+    assert_eq!(
+        MPMC_M2O_PROD_DONE.load(Ordering::SeqCst),
+        MPMC_M2O_PRODUCERS as usize,
+        "not all producers finished"
+    );
+    assert_eq!(
+        MPMC_M2O_CONS_DONE.load(Ordering::SeqCst),
+        1,
+        "consumer didn't finish"
+    );
+    let expected: usize = (0..MPMC_M2O_PER_PROD).map(|i| i as usize).sum::<usize>()
+        + (0..MPMC_M2O_PER_PROD)
+            .map(|i| (100 + i) as usize)
+            .sum::<usize>()
+        + (0..MPMC_M2O_PER_PROD)
+            .map(|i| (1000 + i) as usize)
+            .sum::<usize>();
+    assert_eq!(
+        MPMC_M2O_SUM.load(Ordering::SeqCst),
+        expected,
+        "checksum mismatch — fan-in dropped or duplicated items"
+    );
+}
+
+// --- mpmc_many_to_many ----------------------------------------------
+//
+// Two producers and two consumers share a channel. The aggregate sum
+// across both consumers must equal the expected total.
+
+static MPMC_M2M_TX_A: SpinMutex<Option<mpmc::Sender<u32>>> = SpinMutex::new(None);
+static MPMC_M2M_TX_B: SpinMutex<Option<mpmc::Sender<u32>>> = SpinMutex::new(None);
+static MPMC_M2M_RX_A: SpinMutex<Option<mpmc::Receiver<u32>>> = SpinMutex::new(None);
+static MPMC_M2M_RX_B: SpinMutex<Option<mpmc::Receiver<u32>>> = SpinMutex::new(None);
+static MPMC_M2M_SUM: AtomicUsize = AtomicUsize::new(0);
+static MPMC_M2M_RECEIVED: AtomicUsize = AtomicUsize::new(0);
+static MPMC_M2M_PROD_DONE: AtomicUsize = AtomicUsize::new(0);
+static MPMC_M2M_CONS_DONE: AtomicUsize = AtomicUsize::new(0);
+
+const MPMC_M2M_PER_PROD: u32 = 20;
+const MPMC_M2M_TOTAL: usize = 2 * MPMC_M2M_PER_PROD as usize;
+
+fn mpmc_m2m_prod_a() -> ! {
+    let tx = MPMC_M2M_TX_A.lock().take().expect("m2m prod A: tx");
+    for i in 0..MPMC_M2M_PER_PROD {
+        tx.send(i).expect("m2m prod A: send");
+    }
+    MPMC_M2M_PROD_DONE.fetch_add(1, Ordering::SeqCst);
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn mpmc_m2m_prod_b() -> ! {
+    let tx = MPMC_M2M_TX_B.lock().take().expect("m2m prod B: tx");
+    for i in 0..MPMC_M2M_PER_PROD {
+        tx.send(500 + i).expect("m2m prod B: send");
+    }
+    MPMC_M2M_PROD_DONE.fetch_add(1, Ordering::SeqCst);
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+// Each consumer drains until `recv` returns None (channel closed
+// after both senders drop). They cooperatively share the total.
+fn mpmc_m2m_cons_a() -> ! {
+    let rx = MPMC_M2M_RX_A.lock().take().expect("m2m cons A: rx");
+    while let Some(v) = rx.recv() {
+        MPMC_M2M_SUM.fetch_add(v as usize, Ordering::SeqCst);
+        MPMC_M2M_RECEIVED.fetch_add(1, Ordering::SeqCst);
+    }
+    MPMC_M2M_CONS_DONE.fetch_add(1, Ordering::SeqCst);
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn mpmc_m2m_cons_b() -> ! {
+    let rx = MPMC_M2M_RX_B.lock().take().expect("m2m cons B: rx");
+    while let Some(v) = rx.recv() {
+        MPMC_M2M_SUM.fetch_add(v as usize, Ordering::SeqCst);
+        MPMC_M2M_RECEIVED.fetch_add(1, Ordering::SeqCst);
+    }
+    MPMC_M2M_CONS_DONE.fetch_add(1, Ordering::SeqCst);
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn mpmc_many_to_many() {
+    let (tx, rx) = mpmc::channel::<u32>(4);
+    *MPMC_M2M_TX_A.lock() = Some(tx.clone());
+    *MPMC_M2M_TX_B.lock() = Some(tx.clone());
+    // The driver's original `tx` drops at end of scope (immediately
+    // below) — only the two cloned handles held by the producer
+    // tasks keep the channel open.
+    drop(tx);
+    *MPMC_M2M_RX_A.lock() = Some(rx.clone());
+    *MPMC_M2M_RX_B.lock() = Some(rx);
+    MPMC_M2M_SUM.store(0, Ordering::SeqCst);
+    MPMC_M2M_RECEIVED.store(0, Ordering::SeqCst);
+    MPMC_M2M_PROD_DONE.store(0, Ordering::SeqCst);
+    MPMC_M2M_CONS_DONE.store(0, Ordering::SeqCst);
+
+    task::spawn(mpmc_m2m_prod_a);
+    task::spawn(mpmc_m2m_prod_b);
+    task::spawn(mpmc_m2m_cons_a);
+    task::spawn(mpmc_m2m_cons_b);
+
+    for _ in 0..5_000 {
+        if MPMC_M2M_PROD_DONE.load(Ordering::SeqCst) == 2
+            && MPMC_M2M_CONS_DONE.load(Ordering::SeqCst) == 2
+        {
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+
+    assert_eq!(
+        MPMC_M2M_PROD_DONE.load(Ordering::SeqCst),
+        2,
+        "not all producers finished"
+    );
+    assert_eq!(
+        MPMC_M2M_CONS_DONE.load(Ordering::SeqCst),
+        2,
+        "consumers didn't observe channel close"
+    );
+    assert_eq!(
+        MPMC_M2M_RECEIVED.load(Ordering::SeqCst),
+        MPMC_M2M_TOTAL,
+        "total item count mismatch across consumers"
+    );
+    let expected: usize = (0..MPMC_M2M_PER_PROD).map(|i| i as usize).sum::<usize>()
+        + (0..MPMC_M2M_PER_PROD)
+            .map(|i| (500 + i) as usize)
+            .sum::<usize>();
+    assert_eq!(
+        MPMC_M2M_SUM.load(Ordering::SeqCst),
+        expected,
+        "checksum mismatch — m2m dropped or duplicated items"
+    );
+}
+
+// --- mpmc_close_wakes_receivers -------------------------------------
+//
+// Two receivers park on an empty channel. The driver drops the
+// sender; both receivers must wake and observe `None`.
+
+static MPMC_CLOSE_RX_A: SpinMutex<Option<mpmc::Receiver<u32>>> = SpinMutex::new(None);
+static MPMC_CLOSE_RX_B: SpinMutex<Option<mpmc::Receiver<u32>>> = SpinMutex::new(None);
+static MPMC_CLOSE_RX_WOKEN: AtomicUsize = AtomicUsize::new(0);
+
+fn mpmc_close_rx_a() -> ! {
+    let rx = MPMC_CLOSE_RX_A.lock().take().expect("close rx A");
+    if rx.recv().is_none() {
+        MPMC_CLOSE_RX_WOKEN.fetch_add(1, Ordering::SeqCst);
+    }
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn mpmc_close_rx_b() -> ! {
+    let rx = MPMC_CLOSE_RX_B.lock().take().expect("close rx B");
+    if rx.recv().is_none() {
+        MPMC_CLOSE_RX_WOKEN.fetch_add(1, Ordering::SeqCst);
+    }
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn mpmc_close_wakes_receivers() {
+    let (tx, rx) = mpmc::channel::<u32>(4);
+    *MPMC_CLOSE_RX_A.lock() = Some(rx.clone());
+    *MPMC_CLOSE_RX_B.lock() = Some(rx);
+    MPMC_CLOSE_RX_WOKEN.store(0, Ordering::SeqCst);
+
+    task::spawn(mpmc_close_rx_a);
+    task::spawn(mpmc_close_rx_b);
+
+    for _ in 0..20 {
+        x86_64::instructions::hlt();
+    }
+
+    // Drop the sole sender; both parked receivers must wake.
+    drop(tx);
+
+    for _ in 0..1_000 {
+        if MPMC_CLOSE_RX_WOKEN.load(Ordering::SeqCst) == 2 {
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+    assert_eq!(
+        MPMC_CLOSE_RX_WOKEN.load(Ordering::SeqCst),
+        2,
+        "receivers didn't both wake on last-sender drop"
+    );
+}
+
+// --- mpmc_close_wakes_senders ---------------------------------------
+//
+// Channel of capacity 1 is prefilled; two senders each park on
+// `send`. The driver drops the sole receiver; both senders must
+// wake and observe `Err`.
+
+static MPMC_CLOSE_TX_A: SpinMutex<Option<mpmc::Sender<u32>>> = SpinMutex::new(None);
+static MPMC_CLOSE_TX_B: SpinMutex<Option<mpmc::Sender<u32>>> = SpinMutex::new(None);
+static MPMC_CLOSE_TX_ERRS: AtomicUsize = AtomicUsize::new(0);
+
+fn mpmc_close_tx_a() -> ! {
+    let tx = MPMC_CLOSE_TX_A.lock().take().expect("close tx A");
+    if tx.send(2).is_err() {
+        MPMC_CLOSE_TX_ERRS.fetch_add(1, Ordering::SeqCst);
+    }
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn mpmc_close_tx_b() -> ! {
+    let tx = MPMC_CLOSE_TX_B.lock().take().expect("close tx B");
+    if tx.send(3).is_err() {
+        MPMC_CLOSE_TX_ERRS.fetch_add(1, Ordering::SeqCst);
+    }
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn mpmc_close_wakes_senders() {
+    let (tx, rx) = mpmc::channel::<u32>(1);
+    tx.send(1).expect("prefill send");
+    *MPMC_CLOSE_TX_A.lock() = Some(tx.clone());
+    *MPMC_CLOSE_TX_B.lock() = Some(tx);
+    MPMC_CLOSE_TX_ERRS.store(0, Ordering::SeqCst);
+
+    task::spawn(mpmc_close_tx_a);
+    task::spawn(mpmc_close_tx_b);
+
+    for _ in 0..20 {
+        x86_64::instructions::hlt();
+    }
+
+    // Drop the sole receiver; both parked senders must wake.
+    drop(rx);
+
+    for _ in 0..1_000 {
+        if MPMC_CLOSE_TX_ERRS.load(Ordering::SeqCst) == 2 {
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+    assert_eq!(
+        MPMC_CLOSE_TX_ERRS.load(Ordering::SeqCst),
+        2,
+        "senders didn't both wake with Err on last-receiver drop"
     );
 }

--- a/kernel/tests/blocking_sync.rs
+++ b/kernel/tests/blocking_sync.rs
@@ -370,7 +370,6 @@ fn spsc_close_wakes_sender() {
 // drains all 3*M items and checksums. Exercises `Sender: Clone` and
 // the Mutex-protected queue under fan-in contention.
 
-static MPMC_M2O_TX: SpinMutex<Option<mpmc::Sender<u32>>> = SpinMutex::new(None);
 static MPMC_M2O_RX: SpinMutex<Option<mpmc::Receiver<u32>>> = SpinMutex::new(None);
 static MPMC_M2O_SUM: AtomicUsize = AtomicUsize::new(0);
 static MPMC_M2O_PROD_DONE: AtomicUsize = AtomicUsize::new(0);
@@ -387,9 +386,15 @@ static MPMC_M2O_TX_B: SpinMutex<Option<mpmc::Sender<u32>>> = SpinMutex::new(None
 static MPMC_M2O_TX_C: SpinMutex<Option<mpmc::Sender<u32>>> = SpinMutex::new(None);
 
 fn mpmc_m2o_prod_a() -> ! {
-    let tx = MPMC_M2O_TX_A.lock().take().expect("m2o prod A: tx not set");
-    for i in 0..MPMC_M2O_PER_PROD {
-        tx.send(i).expect("m2o prod A: send failed");
+    {
+        let tx = MPMC_M2O_TX_A.lock().take().expect("m2o prod A: tx not set");
+        for i in 0..MPMC_M2O_PER_PROD {
+            tx.send(i).expect("m2o prod A: send failed");
+        }
+        // tx drops here at end of the inner scope; releases this
+        // producer's sender count. The `-> !` function never
+        // returns, so the drop would never run if tx were a
+        // top-level local.
     }
     MPMC_M2O_PROD_DONE.fetch_add(1, Ordering::SeqCst);
     loop {
@@ -398,9 +403,11 @@ fn mpmc_m2o_prod_a() -> ! {
 }
 
 fn mpmc_m2o_prod_b() -> ! {
-    let tx = MPMC_M2O_TX_B.lock().take().expect("m2o prod B: tx not set");
-    for i in 0..MPMC_M2O_PER_PROD {
-        tx.send(100 + i).expect("m2o prod B: send failed");
+    {
+        let tx = MPMC_M2O_TX_B.lock().take().expect("m2o prod B: tx not set");
+        for i in 0..MPMC_M2O_PER_PROD {
+            tx.send(100 + i).expect("m2o prod B: send failed");
+        }
     }
     MPMC_M2O_PROD_DONE.fetch_add(1, Ordering::SeqCst);
     loop {
@@ -409,9 +416,11 @@ fn mpmc_m2o_prod_b() -> ! {
 }
 
 fn mpmc_m2o_prod_c() -> ! {
-    let tx = MPMC_M2O_TX_C.lock().take().expect("m2o prod C: tx not set");
-    for i in 0..MPMC_M2O_PER_PROD {
-        tx.send(1000 + i).expect("m2o prod C: send failed");
+    {
+        let tx = MPMC_M2O_TX_C.lock().take().expect("m2o prod C: tx not set");
+        for i in 0..MPMC_M2O_PER_PROD {
+            tx.send(1000 + i).expect("m2o prod C: send failed");
+        }
     }
     MPMC_M2O_PROD_DONE.fetch_add(1, Ordering::SeqCst);
     loop {
@@ -437,12 +446,9 @@ fn mpmc_many_to_one() {
     *MPMC_M2O_TX_A.lock() = Some(tx.clone());
     *MPMC_M2O_TX_B.lock() = Some(tx.clone());
     *MPMC_M2O_TX_C.lock() = Some(tx.clone());
-    // Retain the original in TX so the driver can observe the close
-    // path via `drop` after cloning to the three workers, but we
-    // don't need it after this point; drop it immediately so the
-    // channel closes once the workers finish.
-    *MPMC_M2O_TX.lock() = Some(tx);
-    MPMC_M2O_TX.lock().take();
+    // Drop the driver's original tx; only the three cloned handles
+    // in TX_A/_B/_C keep the channel open until the workers finish.
+    drop(tx);
 
     *MPMC_M2O_RX.lock() = Some(rx);
     MPMC_M2O_SUM.store(0, Ordering::SeqCst);
@@ -505,9 +511,14 @@ const MPMC_M2M_PER_PROD: u32 = 20;
 const MPMC_M2M_TOTAL: usize = 2 * MPMC_M2M_PER_PROD as usize;
 
 fn mpmc_m2m_prod_a() -> ! {
-    let tx = MPMC_M2M_TX_A.lock().take().expect("m2m prod A: tx");
-    for i in 0..MPMC_M2M_PER_PROD {
-        tx.send(i).expect("m2m prod A: send");
+    {
+        let tx = MPMC_M2M_TX_A.lock().take().expect("m2m prod A: tx");
+        for i in 0..MPMC_M2M_PER_PROD {
+            tx.send(i).expect("m2m prod A: send");
+        }
+        // tx drops here — critical for consumers' `while let Some`
+        // loop to terminate once both producers finish. `-> !` means
+        // we'd otherwise hold tx forever in the hlt loop.
     }
     MPMC_M2M_PROD_DONE.fetch_add(1, Ordering::SeqCst);
     loop {
@@ -516,9 +527,11 @@ fn mpmc_m2m_prod_a() -> ! {
 }
 
 fn mpmc_m2m_prod_b() -> ! {
-    let tx = MPMC_M2M_TX_B.lock().take().expect("m2m prod B: tx");
-    for i in 0..MPMC_M2M_PER_PROD {
-        tx.send(500 + i).expect("m2m prod B: send");
+    {
+        let tx = MPMC_M2M_TX_B.lock().take().expect("m2m prod B: tx");
+        for i in 0..MPMC_M2M_PER_PROD {
+            tx.send(500 + i).expect("m2m prod B: send");
+        }
     }
     MPMC_M2M_PROD_DONE.fetch_add(1, Ordering::SeqCst);
     loop {

--- a/kernel/tests/blocking_sync.rs
+++ b/kernel/tests/blocking_sync.rs
@@ -454,7 +454,7 @@ fn mpmc_many_to_one() {
     task::spawn(mpmc_m2o_prod_c);
     task::spawn(mpmc_m2o_cons);
 
-    for _ in 0..5_000 {
+    for _ in 0..2_000 {
         if MPMC_M2O_PROD_DONE.load(Ordering::SeqCst) == MPMC_M2O_PRODUCERS as usize
             && MPMC_M2O_CONS_DONE.load(Ordering::SeqCst) == 1
         {
@@ -572,7 +572,7 @@ fn mpmc_many_to_many() {
     task::spawn(mpmc_m2m_cons_a);
     task::spawn(mpmc_m2m_cons_b);
 
-    for _ in 0..5_000 {
+    for _ in 0..2_000 {
         if MPMC_M2M_PROD_DONE.load(Ordering::SeqCst) == 2
             && MPMC_M2M_CONS_DONE.load(Ordering::SeqCst) == 2
         {


### PR DESCRIPTION
Closes #94.

## Summary

- **`sync::mpmc::channel`** — new bounded MPMC channel with `Sender: Clone` / `Receiver: Clone`. Internals mirror `spsc` (`Mutex<VecDeque>` + `not_full` / `not_empty` wait queues) plus two `AtomicUsize` endpoint counters. `Arc::strong_count` can't distinguish last-sender from last-receiver (both endpoints share one `Arc`), so explicit counters are the only correct shape.
- **Close / hang-up protocol** on both variants:
  - Dropping the last `Sender` → parked `Receiver`s wake, drain whatever's buffered, then observe `None`.
  - Dropping the last `Receiver` → parked `Sender`s wake and their `send` returns `Err(val)` (value recoverable).
  - SPSC uses two `AtomicBool`s (endpoints are unique); MPMC uses counters, firing `notify_all` on the `1 -> 0` transition.
- **Breaking signature changes in `spsc`** (only in-tree caller is the integration test, updated in this PR):
  - `Sender::send` → `Result<(), T>`
  - `Receiver::recv` → `Option<T>`
  - `try_send` / `try_recv` now return `TrySendError` / `TryRecvError` enums so callers can distinguish full-right-now from closed.
- **New integration subtests** (in the existing `blocking_sync.rs`): `spsc_close_wakes_receiver`, `spsc_close_wakes_sender`, `mpmc_many_to_one`, `mpmc_many_to_many`, `mpmc_close_wakes_receivers`, `mpmc_close_wakes_senders`.

## Correctness notes

The lost-wakeup protocol from #93 carries over: the close flag / count is re-read under the waitqueue lock inside the `wait_while` cond, so a close that fires between the fast-path check and `block_current` is caught by either the cond re-check or the task's `wake_pending` backstop. Drain-first semantics mean a receiver gets everything buffered even if the last sender dropped while data was in flight.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p xtask --all-targets -- -D warnings`
- [x] `cargo xtask build`
- [x] Host unit tests (`cargo xtask test` host portion, 19 pass)
- [x] `blocking_sync` test binary links cleanly for `x86_64-unknown-none`
- [x] QEMU integration tests (`blocking_sync`) — rely on CI; QEMU isn't installed in this autonomous environment.
- [x] `cargo xtask smoke` — relies on CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new blocking `mpmc` channel and changes `spsc` channel APIs to support close/hang-up behavior, which affects core kernel synchronization and task wakeup paths and could introduce deadlocks or lost-wakeup regressions if incorrect.
> 
> **Overview**
> Adds a new bounded blocking `sync::mpmc::channel` with `Sender`/`Receiver` cloning support and explicit endpoint-count tracking, including close/hang-up semantics that wake blocked peers when the last endpoint drops.
> 
> Updates `sync::spsc` to implement the same close protocol and **changes its public API** (`send` now returns `Result`, `recv` returns `Option`, and `try_send`/`try_recv` return typed error enums distinguishing *full/empty* vs *closed*).
> 
> Expands the `blocking_sync` integration tests to cover SPSC close wakeups plus MPMC fan-in/fan-out and close wakeup behavior, and updates task subsystem docs to mention the new MPMC channel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb556d16ae9565c902d1b3a23eaa2b9dc99df95a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->