### PR TITLE
sync tests: replace fixed-hlt park waits with explicit signal

### DIFF
--- a/kernel/tests/blocking_sync.rs
+++ b/kernel/tests/blocking_sync.rs
@@ -50,6 +50,11 @@ fn wait_for_ready(counter: &AtomicUsize, expected: usize, deadline_ticks: usize)
         }
         x86_64::instructions::hlt();
     }
+    // One last read after the final `hlt`: if a worker bumped the counter
+    // during that sleep, we shouldn't panic spuriously.
+    if counter.load(Ordering::SeqCst) >= expected {
+        return;
+    }
     panic!(
         "workers didn't reach the park point in time: ready={}/{}",
         counter.load(Ordering::SeqCst),

--- a/kernel/tests/blocking_sync.rs
+++ b/kernel/tests/blocking_sync.rs
@@ -33,6 +33,30 @@ fn panic(info: &PanicInfo) -> ! {
     test_panic_handler(info)
 }
 
+/// Park the driver on `hlt` until `counter` reaches `expected`, so wake-side
+/// tests fire their wake only after every worker has reached its blocking
+/// call. Each worker bumps its own slot in `counter` immediately before the
+/// blocking op (`recv`, `send`, `wait_while`); without this, the driver's
+/// wake can race the worker into the fast-path `wake_pending` bail and never
+/// actually exercise the parked-wake branch.
+///
+/// Panics if the workers don't all arrive within `deadline_ticks` hlt cycles
+/// — a real bug (worker wedged or scheduler not advancing), not the
+/// previous "probably long enough" heuristic.
+fn wait_for_ready(counter: &AtomicUsize, expected: usize, deadline_ticks: usize) {
+    for _ in 0..deadline_ticks {
+        if counter.load(Ordering::SeqCst) >= expected {
+            return;
+        }
+        x86_64::instructions::hlt();
+    }
+    panic!(
+        "workers didn't reach the park point in time: ready={}/{}",
+        counter.load(Ordering::SeqCst),
+        expected
+    );
+}
+
 fn run_tests() {
     let tests: &[(&str, &dyn Testable)] = &[
         ("channel_ping_pong", &(channel_ping_pong as fn())),
@@ -220,8 +244,10 @@ fn mutex_contention() {
 static WQ: WaitQueue = WaitQueue::new();
 static WQ_FLAG: AtomicUsize = AtomicUsize::new(0);
 static WQ_WOKEN: AtomicUsize = AtomicUsize::new(0);
+static WQ_READY: AtomicUsize = AtomicUsize::new(0);
 
 fn wq_waiter() -> ! {
+    WQ_READY.fetch_add(1, Ordering::SeqCst);
     WQ.wait_while(|| WQ_FLAG.load(Ordering::SeqCst) == 0);
     WQ_WOKEN.fetch_add(1, Ordering::SeqCst);
     loop {
@@ -232,16 +258,15 @@ fn wq_waiter() -> ! {
 fn waitqueue_notify_all() {
     WQ_FLAG.store(0, Ordering::SeqCst);
     WQ_WOKEN.store(0, Ordering::SeqCst);
+    WQ_READY.store(0, Ordering::SeqCst);
 
     task::spawn(wq_waiter);
     task::spawn(wq_waiter);
 
-    // Let both waiters reach their park. ~20 preempt ticks (200 ms
-    // wall time) is plenty for the round-robin to rotate through
-    // them and for each to park on `WQ`.
-    for _ in 0..20 {
-        x86_64::instructions::hlt();
-    }
+    // Wait until both waiters have run up to their wait_while call.
+    // Deadline is generous (~2 s) — hitting it means a worker
+    // wedged, not just "slower than expected".
+    wait_for_ready(&WQ_READY, 2, 200);
     // Nobody should be "woken" yet: flag is still 0.
     assert_eq!(
         WQ_WOKEN.load(Ordering::SeqCst),
@@ -273,12 +298,14 @@ fn waitqueue_notify_all() {
 
 static SPSC_CLOSE_RX: SpinMutex<Option<spsc::Receiver<u32>>> = SpinMutex::new(None);
 static SPSC_CLOSE_RX_SAW_NONE: AtomicUsize = AtomicUsize::new(0);
+static SPSC_CLOSE_RX_READY: AtomicUsize = AtomicUsize::new(0);
 
 fn spsc_close_rx_worker() -> ! {
     let rx = SPSC_CLOSE_RX
         .lock()
         .take()
         .expect("spsc_close_rx_worker: receiver not set");
+    SPSC_CLOSE_RX_READY.fetch_add(1, Ordering::SeqCst);
     if rx.recv().is_none() {
         SPSC_CLOSE_RX_SAW_NONE.fetch_add(1, Ordering::SeqCst);
     }
@@ -291,13 +318,12 @@ fn spsc_close_wakes_receiver() {
     let (tx, rx) = spsc::channel::<u32>(4);
     *SPSC_CLOSE_RX.lock() = Some(rx);
     SPSC_CLOSE_RX_SAW_NONE.store(0, Ordering::SeqCst);
+    SPSC_CLOSE_RX_READY.store(0, Ordering::SeqCst);
 
     task::spawn(spsc_close_rx_worker);
 
-    // Let the worker reach its park. ~200 ms wall time is plenty.
-    for _ in 0..20 {
-        x86_64::instructions::hlt();
-    }
+    // Wait until the worker has reached its recv call.
+    wait_for_ready(&SPSC_CLOSE_RX_READY, 1, 200);
 
     // Drop the sender. This must wake the parked receiver.
     drop(tx);
@@ -322,6 +348,7 @@ fn spsc_close_wakes_receiver() {
 
 static SPSC_CLOSE_TX: SpinMutex<Option<spsc::Sender<u32>>> = SpinMutex::new(None);
 static SPSC_CLOSE_TX_SAW_ERR: AtomicUsize = AtomicUsize::new(0);
+static SPSC_CLOSE_TX_READY: AtomicUsize = AtomicUsize::new(0);
 
 fn spsc_close_tx_worker() -> ! {
     let tx = SPSC_CLOSE_TX
@@ -329,6 +356,7 @@ fn spsc_close_tx_worker() -> ! {
         .take()
         .expect("spsc_close_tx_worker: sender not set");
     // Channel already has one item buffered; this send parks.
+    SPSC_CLOSE_TX_READY.fetch_add(1, Ordering::SeqCst);
     if tx.send(2).is_err() {
         SPSC_CLOSE_TX_SAW_ERR.fetch_add(1, Ordering::SeqCst);
     }
@@ -342,12 +370,11 @@ fn spsc_close_wakes_sender() {
     tx.send(1).expect("prefill send");
     *SPSC_CLOSE_TX.lock() = Some(tx);
     SPSC_CLOSE_TX_SAW_ERR.store(0, Ordering::SeqCst);
+    SPSC_CLOSE_TX_READY.store(0, Ordering::SeqCst);
 
     task::spawn(spsc_close_tx_worker);
 
-    for _ in 0..20 {
-        x86_64::instructions::hlt();
-    }
+    wait_for_ready(&SPSC_CLOSE_TX_READY, 1, 200);
 
     drop(rx);
 
@@ -628,9 +655,11 @@ fn mpmc_many_to_many() {
 static MPMC_CLOSE_RX_A: SpinMutex<Option<mpmc::Receiver<u32>>> = SpinMutex::new(None);
 static MPMC_CLOSE_RX_B: SpinMutex<Option<mpmc::Receiver<u32>>> = SpinMutex::new(None);
 static MPMC_CLOSE_RX_WOKEN: AtomicUsize = AtomicUsize::new(0);
+static MPMC_CLOSE_RX_READY: AtomicUsize = AtomicUsize::new(0);
 
 fn mpmc_close_rx_a() -> ! {
     let rx = MPMC_CLOSE_RX_A.lock().take().expect("close rx A");
+    MPMC_CLOSE_RX_READY.fetch_add(1, Ordering::SeqCst);
     if rx.recv().is_none() {
         MPMC_CLOSE_RX_WOKEN.fetch_add(1, Ordering::SeqCst);
     }
@@ -641,6 +670,7 @@ fn mpmc_close_rx_a() -> ! {
 
 fn mpmc_close_rx_b() -> ! {
     let rx = MPMC_CLOSE_RX_B.lock().take().expect("close rx B");
+    MPMC_CLOSE_RX_READY.fetch_add(1, Ordering::SeqCst);
     if rx.recv().is_none() {
         MPMC_CLOSE_RX_WOKEN.fetch_add(1, Ordering::SeqCst);
     }
@@ -654,13 +684,12 @@ fn mpmc_close_wakes_receivers() {
     *MPMC_CLOSE_RX_A.lock() = Some(rx.clone());
     *MPMC_CLOSE_RX_B.lock() = Some(rx);
     MPMC_CLOSE_RX_WOKEN.store(0, Ordering::SeqCst);
+    MPMC_CLOSE_RX_READY.store(0, Ordering::SeqCst);
 
     task::spawn(mpmc_close_rx_a);
     task::spawn(mpmc_close_rx_b);
 
-    for _ in 0..20 {
-        x86_64::instructions::hlt();
-    }
+    wait_for_ready(&MPMC_CLOSE_RX_READY, 2, 200);
 
     // Drop the sole sender; both parked receivers must wake.
     drop(tx);
@@ -687,9 +716,11 @@ fn mpmc_close_wakes_receivers() {
 static MPMC_CLOSE_TX_A: SpinMutex<Option<mpmc::Sender<u32>>> = SpinMutex::new(None);
 static MPMC_CLOSE_TX_B: SpinMutex<Option<mpmc::Sender<u32>>> = SpinMutex::new(None);
 static MPMC_CLOSE_TX_ERRS: AtomicUsize = AtomicUsize::new(0);
+static MPMC_CLOSE_TX_READY: AtomicUsize = AtomicUsize::new(0);
 
 fn mpmc_close_tx_a() -> ! {
     let tx = MPMC_CLOSE_TX_A.lock().take().expect("close tx A");
+    MPMC_CLOSE_TX_READY.fetch_add(1, Ordering::SeqCst);
     if tx.send(2).is_err() {
         MPMC_CLOSE_TX_ERRS.fetch_add(1, Ordering::SeqCst);
     }
@@ -700,6 +731,7 @@ fn mpmc_close_tx_a() -> ! {
 
 fn mpmc_close_tx_b() -> ! {
     let tx = MPMC_CLOSE_TX_B.lock().take().expect("close tx B");
+    MPMC_CLOSE_TX_READY.fetch_add(1, Ordering::SeqCst);
     if tx.send(3).is_err() {
         MPMC_CLOSE_TX_ERRS.fetch_add(1, Ordering::SeqCst);
     }
@@ -714,13 +746,12 @@ fn mpmc_close_wakes_senders() {
     *MPMC_CLOSE_TX_A.lock() = Some(tx.clone());
     *MPMC_CLOSE_TX_B.lock() = Some(tx);
     MPMC_CLOSE_TX_ERRS.store(0, Ordering::SeqCst);
+    MPMC_CLOSE_TX_READY.store(0, Ordering::SeqCst);
 
     task::spawn(mpmc_close_tx_a);
     task::spawn(mpmc_close_tx_b);
 
-    for _ in 0..20 {
-        x86_64::instructions::hlt();
-    }
+    wait_for_ready(&MPMC_CLOSE_TX_READY, 2, 200);
 
     // Drop the sole receiver; both parked senders must wake.
     drop(rx);


### PR DESCRIPTION
Closes #97

## Summary

- Replace the fixed `for _ in 0..20 { hlt; }` "let the worker reach its park" delays in the wake-side subtests of `kernel/tests/blocking_sync.rs` with a per-test `AtomicUsize` readiness signal. Each worker bumps its slot immediately before the blocking call (`recv` / `send` / `wait_while`); the driver spins on the counter — hlt-yielding between checks so the scheduler keeps running workers forward — until every worker has arrived, and only then fires the wake (drop / `notify_all`).
- A bounded deadline still guards against a wedged worker, but hitting it now means a real bug (worker never reached its blocking call, scheduler not advancing) rather than the old "probably not enough ticks" heuristic.

Affected subtests: `waitqueue_notify_all` (pre-existing, per the issue), `spsc_close_wakes_receiver` / `_sender`, `mpmc_close_wakes_receivers` / `_senders`. `channel_ping_pong` and `mutex_contention` already wait on the DONE counters and don't have a fixed-delay park window, so they're unchanged.

A generalized `WaitQueue::waiter_count()` hook would be stronger still, but that's an intentionally larger test-harness refactor and out of scope here — see #97.

## Test plan

- [x] `cargo xtask build` — clean, no new warnings
- [x] `cargo xtask test` host unit phase — 19/19 passing
- [x] `cargo xtask test` QEMU integration phase compiled `blocking_sync` successfully (local sandbox lacks `xorriso` / `qemu-system-x86_64`, so the in-QEMU run happens on CI)
- [ ] CI green across all integration tests, smoke included

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to kernel integration tests, replacing timing heuristics with explicit readiness counters and bounded deadlines; main risk is potential flakiness if the new deadline is too strict on slow environments.
> 
> **Overview**
> Refactors wake-side blocking sync tests to **eliminate fixed `hlt` delay loops** and instead wait for workers to reach their blocking points via explicit per-test `AtomicUsize` readiness counters.
> 
> Adds a shared `wait_for_ready` helper with a bounded `hlt`-based deadline, and updates the `WaitQueue` notify-all, SPSC close-wake, and MPMC close-wake subtests so the driver only triggers `notify_all`/endpoint drops after all worker tasks have started their `wait_while`/`recv`/`send` calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f727faef73c04449adc8adc676dd4bbf936646a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->