### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,4 @@ All commands are orchestrated through `cargo xtask`. See `README.md` → "Build 
 - **First build clones Limine:** `cargo xtask iso` (and `run`/`test`/`smoke`) clones the Limine bootloader into `build/limine/` on first invocation and compiles it. This is a one-time ~10s step per fresh workspace.
 - **QEMU runs headlessly in Cloud:** Tests and smoke use `-display none`. For `cargo xtask run` in Cloud, add a `timeout` wrapper or run in a tmux session since the kernel halts in `hlt_loop` forever: `timeout 6 cargo xtask run` or kill the QEMU process manually.
 - **Rust nightly auto-selected:** `rust-toolchain.toml` pins the toolchain; `rustup show` triggers installation if needed.
+- **`gh` CLI available:** Pre-installed and authenticated via `GITHUB_TOKEN`. Use for read-only GitHub queries (PR info, CI logs, etc.). Write operations (creating PRs) should use the `ManagePullRequest` tool instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+## Cursor Cloud specific instructions
+
+vibix is a bare-metal x86_64 hobby kernel in Rust. There are no web services, databases, or containers — everything compiles to a bootable ISO and runs under QEMU.
+
+### System dependencies (installed by the update script)
+
+- `qemu-system-x86` — boots the kernel and runs all integration/smoke tests
+- `xorriso` — assembles bootable ISO images
+- `build-essential` — C compiler needed to build the Limine bootloader host tool on first run
+
+### Build, test, lint, run
+
+All commands are orchestrated through `cargo xtask`. See `README.md` → "Build & run" for the full list. Key commands:
+
+| Task | Command |
+|---|---|
+| Build kernel | `cargo xtask build` |
+| Build + boot in QEMU | `cargo xtask run` (serial on stdio; exit with `Ctrl-a x`) |
+| Host unit tests + QEMU integration tests | `cargo xtask test` |
+| End-to-end smoke (serial marker assertions) | `cargo xtask smoke` |
+| Lint (CI-style, xtask only) | `cargo clippy -p xtask --all-targets -- -D warnings` |
+| Format check | `cargo fmt --all -- --check` |
+
+### Non-obvious caveats
+
+- **`cargo xtask lint` vs CI clippy:** `cargo xtask lint` runs clippy on the kernel with `--all-targets`, which includes integration test crates that may trigger pre-existing warnings. CI only runs `cargo clippy -p xtask --all-targets -- -D warnings`. Use the CI command when checking lint.
+- **First build clones Limine:** `cargo xtask iso` (and `run`/`test`/`smoke`) clones the Limine bootloader into `build/limine/` on first invocation and compiles it. This is a one-time ~10s step per fresh workspace.
+- **QEMU runs headlessly in Cloud:** Tests and smoke use `-display none`. For `cargo xtask run` in Cloud, add a `timeout` wrapper or run in a tmux session since the kernel halts in `hlt_loop` forever: `timeout 6 cargo xtask run` or kill the QEMU process manually.
+- **Rust nightly auto-selected:** `rust-toolchain.toml` pins the toolchain; `rustup show` triggers installation if needed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud-specific development instructions so future agents can quickly orient in this codebase.

### What's included

- System dependency requirements (`qemu-system-x86`, `xorriso`, `build-essential`)
- Build/test/lint/run command reference (pointing to README for details)
- Non-obvious caveats: CI vs xtask lint difference, Limine first-build clone, headless QEMU in Cloud, Rust nightly auto-selection
- `gh` CLI availability and usage guidance

### Environment verification

All checks passed during setup:

- **Lint**: `cargo fmt` clean, `cargo clippy -p xtask` clean
- **Host unit tests**: 19 passed
- **QEMU integration tests**: 13 test binaries, all passed
- **Smoke test**: all 16 serial markers present
- **Kernel boot**: full boot sequence through scheduler online
- **`gh` CLI**: authenticated, PR queries and CI status checks working
- **CI**: PR checks all green

Kernel boot serial output:
[hello_world_boot.log](https://cursor.com/agents/bc-ad7d5b3a-56b7-44ea-bacb-1100e2be6f27/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_boot.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad7d5b3a-56b7-44ea-bacb-1100e2be6f27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad7d5b3a-56b7-44ea-bacb-1100e2be6f27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

