### PR TITLE
M8 prereq: load and validate hello ELF module at boot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["kernel", "xtask"]
+members = ["kernel", "xtask", "userspace/hello"]
 resolver = "2"
 
 [workspace.package]

--- a/docs/boot.md
+++ b/docs/boot.md
@@ -34,6 +34,7 @@ the bootloader can efficiently scan it.
 | `KERNEL_ADDRESS_REQUEST` | `ExecutableAddressRequest` | Physical + virtual base of the loaded kernel image (used by ksymtab) |
 | `KERNEL_FILE_REQUEST` | `ExecutableFileRequest` | The kernel ELF file itself (used by ksymtab to embed the symbol table) |
 | `RSDP_REQUEST` | `RsdpRequest` | Physical address of the ACPI RSDP (passed to `acpi::init`) |
+| `MODULE_REQUEST` | `ModuleRequest` | Boot modules (`/boot/userspace_hello.elf`) for early userspace bring-up |
 
 ## Usage
 

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -107,3 +107,7 @@ harness = false
 [[test]]
 name = "demand_paging"
 harness = false
+
+[[test]]
+name = "userspace_module"
+harness = false

--- a/kernel/limine.conf
+++ b/kernel/limine.conf
@@ -4,3 +4,4 @@ serial: yes
 /vibix
     protocol: limine
     kernel_path: boot():/boot/vibix
+    module_path: boot():/boot/userspace_hello.elf

--- a/kernel/src/boot.rs
+++ b/kernel/src/boot.rs
@@ -2,14 +2,19 @@
 //! sections so the Limine bootloader can find and fill them in before we
 //! take control.
 
+use limine::modules::InternalModule;
 use limine::request::{
     ExecutableAddressRequest, ExecutableFileRequest, FramebufferRequest, HhdmRequest,
-    MemoryMapRequest, RequestsEndMarker, RequestsStartMarker, RsdpRequest, StackSizeRequest,
+    MemoryMapRequest, ModuleRequest, RequestsEndMarker, RequestsStartMarker, RsdpRequest,
+    StackSizeRequest,
 };
 use limine::BaseRevision;
 
 /// Ask Limine for a 64 KiB bootstrap stack. Comfortable for early init.
 const STACK_SIZE: u64 = 64 * 1024;
+const INTERNAL_HELLO_MODULE: InternalModule =
+    InternalModule::new().with_path(c"/boot/userspace_hello.elf");
+const INTERNAL_HELLO_MODULES: [&InternalModule; 1] = [&INTERNAL_HELLO_MODULE];
 
 #[used]
 #[link_section = ".limine_requests"]
@@ -38,6 +43,11 @@ pub static KERNEL_ADDRESS_REQUEST: ExecutableAddressRequest = ExecutableAddressR
 #[used]
 #[link_section = ".limine_requests"]
 pub static KERNEL_FILE_REQUEST: ExecutableFileRequest = ExecutableFileRequest::new();
+
+#[used]
+#[link_section = ".limine_requests"]
+pub static MODULE_REQUEST: ModuleRequest =
+    ModuleRequest::new().with_internal_modules(&INTERNAL_HELLO_MODULES);
 
 #[used]
 #[link_section = ".limine_requests"]

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -54,6 +54,15 @@ pub extern "C" fn _start() -> ! {
     serial_println!("GDT + IDT loaded");
 
     vibix::mem::init();
+    if let Some((entry, load_segments)) = vibix::mem::userspace_module_elf_summary() {
+        serial_println!(
+            "userspace module ELF entry={:#x} load_segments={}",
+            entry.as_u64(),
+            load_segments
+        );
+    } else {
+        serial_println!("userspace module ELF missing");
+    }
     vibix::arch::init_apic(rsdp_ptr, hhdm_offset);
     vibix::time::init();
 

--- a/kernel/src/mem/elf.rs
+++ b/kernel/src/mem/elf.rs
@@ -160,21 +160,51 @@ pub(super) fn first_loaded_module_elf_summary() -> Option<(VirtAddr, usize)> {
     }
     // SAFETY: Limine keeps module file bytes resident for kernel use.
     let bytes: &[u8] = unsafe { core::slice::from_raw_parts(base, size) };
-    let parsed = parse_elf64(bytes);
+    let parsed = try_parse_elf64(bytes)?;
     Some((parsed.entry(), parsed.load_segments().count()))
+}
+
+pub(super) fn try_parse_elf64(bytes: &[u8]) -> Option<ParsedElf<'_>> {
+    if bytes.len() < core::mem::size_of::<Elf64Ehdr>() {
+        return None;
+    }
+
+    // SAFETY: length checked above and we use `read_unaligned` so no
+    // alignment assumptions are required for the input slice.
+    let ehdr = unsafe { core::ptr::read_unaligned(bytes.as_ptr().cast::<Elf64Ehdr>()) };
+    if ehdr.e_ident[..4] != ELF_MAGIC || ehdr.e_ident[4] != ELFCLASS64 {
+        return None;
+    }
+    if ehdr.e_phentsize as usize != core::mem::size_of::<Elf64Phdr>() {
+        return None;
+    }
+
+    let phoff = ehdr.e_phoff as usize;
+    let phnum = ehdr.e_phnum as usize;
+    let phsz = ehdr.e_phentsize as usize;
+    let phdr_table_end = phnum.checked_mul(phsz)?.checked_add(phoff)?;
+    if phdr_table_end > bytes.len() {
+        return None;
+    }
+
+    Some(ParsedElf {
+        ehdr,
+        phdr_bytes: &bytes[phoff..phdr_table_end],
+        phnum,
+    })
 }
 
 pub(super) fn parse_elf64(bytes: &[u8]) -> ParsedElf<'_> {
     assert!(
         bytes.len() >= core::mem::size_of::<Elf64Ehdr>(),
-        "kernel ELF too small for Ehdr"
+        "ELF too small for Ehdr"
     );
 
     // SAFETY: length checked above and we use `read_unaligned` so no
     // alignment assumptions are required for the input slice.
     let ehdr = unsafe { core::ptr::read_unaligned(bytes.as_ptr().cast::<Elf64Ehdr>()) };
-    assert_eq!(ehdr.e_ident[..4], ELF_MAGIC, "kernel ELF bad magic");
-    assert_eq!(ehdr.e_ident[4], ELFCLASS64, "kernel ELF not ELFCLASS64");
+    assert_eq!(ehdr.e_ident[..4], ELF_MAGIC, "ELF bad magic");
+    assert_eq!(ehdr.e_ident[4], ELFCLASS64, "ELF not ELFCLASS64");
     assert_eq!(
         ehdr.e_phentsize as usize,
         core::mem::size_of::<Elf64Phdr>(),
@@ -187,11 +217,8 @@ pub(super) fn parse_elf64(bytes: &[u8]) -> ParsedElf<'_> {
     let phdr_table_end = phnum
         .checked_mul(phsz)
         .and_then(|n| phoff.checked_add(n))
-        .expect("kernel ELF phdr table size overflow");
-    assert!(
-        phdr_table_end <= bytes.len(),
-        "kernel ELF phdr table out of range"
-    );
+        .expect("ELF phdr table size overflow");
+    assert!(phdr_table_end <= bytes.len(), "ELF phdr table out of range");
 
     ParsedElf {
         ehdr,
@@ -202,7 +229,7 @@ pub(super) fn parse_elf64(bytes: &[u8]) -> ParsedElf<'_> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_elf64;
+    use super::{parse_elf64, try_parse_elf64};
     use x86_64::structures::paging::PageTableFlags;
 
     const EHDR_SIZE: usize = 64;
@@ -270,10 +297,17 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "kernel ELF bad magic")]
+    #[should_panic(expected = "ELF bad magic")]
     fn rejects_bad_magic() {
         let mut bytes = sample_elf_bytes();
         bytes[0] = 0;
         let _ = parse_elf64(&bytes);
+    }
+
+    #[test]
+    fn try_parse_rejects_bad_magic() {
+        let mut bytes = sample_elf_bytes();
+        bytes[0] = 0;
+        assert!(try_parse_elf64(&bytes).is_none());
     }
 }

--- a/kernel/src/mem/elf.rs
+++ b/kernel/src/mem/elf.rs
@@ -16,10 +16,6 @@ const PF_W: u32 = 1 << 1;
 const ELF_MAGIC: [u8; 4] = [0x7f, b'E', b'L', b'F'];
 const ELFCLASS64: u8 = 2;
 
-#[cfg(target_os = "none")]
-static CACHED_MODULE_ELF_SUMMARY: spin::mutex::Mutex<Option<(VirtAddr, usize)>> =
-    spin::mutex::Mutex::new(None);
-
 #[repr(C)]
 #[derive(Clone, Copy)]
 struct Elf64Ehdr {
@@ -68,6 +64,33 @@ pub(super) struct ParsedElf<'a> {
     ehdr: Elf64Ehdr,
     phdr_bytes: &'a [u8],
     phnum: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ElfParseError {
+    TooSmallEhdr,
+    BadMagic,
+    NotElfClass64,
+    UnexpectedPhEntSize,
+    PhdrTableSizeOverflow,
+    PhdrTableOutOfRange,
+    NonCanonicalEntry,
+    NonCanonicalLoadVaddr,
+}
+
+impl ElfParseError {
+    const fn message(self) -> &'static str {
+        match self {
+            Self::TooSmallEhdr => "ELF too small for Ehdr",
+            Self::BadMagic => "ELF bad magic",
+            Self::NotElfClass64 => "ELF not ELFCLASS64",
+            Self::UnexpectedPhEntSize => "unexpected e_phentsize",
+            Self::PhdrTableSizeOverflow => "ELF phdr table size overflow",
+            Self::PhdrTableOutOfRange => "ELF phdr table out of range",
+            Self::NonCanonicalEntry => "ELF entry address is non-canonical",
+            Self::NonCanonicalLoadVaddr => "ELF PT_LOAD virtual address is non-canonical",
+        }
+    }
 }
 
 pub(super) struct LoadSegmentIter<'a> {
@@ -169,72 +192,31 @@ pub(super) fn first_loaded_module_elf_summary() -> Option<(VirtAddr, usize)> {
     Some((parsed.entry(), parsed.load_segments().count()))
 }
 
-#[cfg(target_os = "none")]
-pub(super) fn snapshot_module_elf_summary_before_reclaim() {
-    *CACHED_MODULE_ELF_SUMMARY.lock() = first_loaded_module_elf_summary();
-}
-
-#[cfg(target_os = "none")]
-pub(super) fn cached_module_elf_summary() -> Option<(VirtAddr, usize)> {
-    *CACHED_MODULE_ELF_SUMMARY.lock()
-}
-
 pub(super) fn try_parse_elf64(bytes: &[u8]) -> Option<ParsedElf<'_>> {
-    if bytes.len() < core::mem::size_of::<Elf64Ehdr>() {
-        return None;
-    }
-
-    // SAFETY: length checked above and we use `read_unaligned` so no
-    // alignment assumptions are required for the input slice.
-    let ehdr = unsafe { core::ptr::read_unaligned(bytes.as_ptr().cast::<Elf64Ehdr>()) };
-    if ehdr.e_ident[..4] != ELF_MAGIC || ehdr.e_ident[4] != ELFCLASS64 {
-        return None;
-    }
-    if ehdr.e_phentsize as usize != core::mem::size_of::<Elf64Phdr>() {
-        return None;
-    }
-
-    let phoff = ehdr.e_phoff as usize;
-    let phnum = ehdr.e_phnum as usize;
-    let phsz = ehdr.e_phentsize as usize;
-    let phdr_table_end = phnum.checked_mul(phsz)?.checked_add(phoff)?;
-    if phdr_table_end > bytes.len() {
-        return None;
-    }
-    VirtAddr::try_new(ehdr.e_entry).ok()?;
-    for i in 0..phnum {
-        let off = phoff + i * phsz;
-        // SAFETY: `phdr_table_end` bounds-check above guarantees every
-        // header read in this loop stays within `bytes`.
-        let ph = unsafe { core::ptr::read_unaligned(bytes.as_ptr().add(off).cast::<Elf64Phdr>()) };
-        if ph.p_type == PT_LOAD && ph.p_memsz != 0 {
-            VirtAddr::try_new(ph.p_vaddr).ok()?;
-        }
-    }
-
-    Some(ParsedElf {
-        ehdr,
-        phdr_bytes: &bytes[phoff..phdr_table_end],
-        phnum,
-    })
+    parse_elf64_inner(bytes).ok()
 }
 
 pub(super) fn parse_elf64(bytes: &[u8]) -> ParsedElf<'_> {
-    assert!(
-        bytes.len() >= core::mem::size_of::<Elf64Ehdr>(),
-        "ELF too small for Ehdr"
-    );
+    parse_elf64_inner(bytes).unwrap_or_else(|err| panic!("{}", err.message()))
+}
+
+fn parse_elf64_inner(bytes: &[u8]) -> Result<ParsedElf<'_>, ElfParseError> {
+    if bytes.len() < core::mem::size_of::<Elf64Ehdr>() {
+        return Err(ElfParseError::TooSmallEhdr);
+    }
 
     // SAFETY: length checked above and we use `read_unaligned` so no
     // alignment assumptions are required for the input slice.
     let ehdr = unsafe { core::ptr::read_unaligned(bytes.as_ptr().cast::<Elf64Ehdr>()) };
-    assert_eq!(ehdr.e_ident[..4], ELF_MAGIC, "ELF bad magic");
-    assert_eq!(ehdr.e_ident[4], ELFCLASS64, "ELF not ELFCLASS64");
-    assert_eq!(
-        ehdr.e_phentsize as usize,
-        core::mem::size_of::<Elf64Phdr>(),
-        "unexpected e_phentsize"
-    );
+    if ehdr.e_ident[..4] != ELF_MAGIC {
+        return Err(ElfParseError::BadMagic);
+    }
+    if ehdr.e_ident[4] != ELFCLASS64 {
+        return Err(ElfParseError::NotElfClass64);
+    }
+    if ehdr.e_phentsize as usize != core::mem::size_of::<Elf64Phdr>() {
+        return Err(ElfParseError::UnexpectedPhEntSize);
+    }
 
     let phoff = ehdr.e_phoff as usize;
     let phnum = ehdr.e_phnum as usize;
@@ -242,30 +224,29 @@ pub(super) fn parse_elf64(bytes: &[u8]) -> ParsedElf<'_> {
     let phdr_table_end = phnum
         .checked_mul(phsz)
         .and_then(|n| phoff.checked_add(n))
-        .expect("ELF phdr table size overflow");
-    assert!(phdr_table_end <= bytes.len(), "ELF phdr table out of range");
-    assert!(
-        VirtAddr::try_new(ehdr.e_entry).is_ok(),
-        "ELF entry address is non-canonical"
-    );
+        .ok_or(ElfParseError::PhdrTableSizeOverflow)?;
+    if phdr_table_end > bytes.len() {
+        return Err(ElfParseError::PhdrTableOutOfRange);
+    }
+    if VirtAddr::try_new(ehdr.e_entry).is_err() {
+        return Err(ElfParseError::NonCanonicalEntry);
+    }
+
     for i in 0..phnum {
         let off = phoff + i * phsz;
         // SAFETY: `phdr_table_end` bounds-check above guarantees every
         // header read in this loop stays within `bytes`.
         let ph = unsafe { core::ptr::read_unaligned(bytes.as_ptr().add(off).cast::<Elf64Phdr>()) };
-        if ph.p_type == PT_LOAD && ph.p_memsz != 0 {
-            assert!(
-                VirtAddr::try_new(ph.p_vaddr).is_ok(),
-                "ELF PT_LOAD virtual address is non-canonical"
-            );
+        if ph.p_type == PT_LOAD && ph.p_memsz != 0 && VirtAddr::try_new(ph.p_vaddr).is_err() {
+            return Err(ElfParseError::NonCanonicalLoadVaddr);
         }
     }
 
-    ParsedElf {
+    Ok(ParsedElf {
         ehdr,
         phdr_bytes: &bytes[phoff..phdr_table_end],
         phnum,
-    }
+    })
 }
 
 #[cfg(test)]

--- a/kernel/src/mem/elf.rs
+++ b/kernel/src/mem/elf.rs
@@ -17,6 +17,7 @@ const ELF_MAGIC: [u8; 4] = [0x7f, b'E', b'L', b'F'];
 const ELFCLASS64: u8 = 2;
 
 #[repr(C)]
+#[derive(Clone, Copy)]
 struct Elf64Ehdr {
     e_ident: [u8; 16],
     e_type: u16,
@@ -35,6 +36,7 @@ struct Elf64Ehdr {
 }
 
 #[repr(C)]
+#[derive(Clone, Copy)]
 struct Elf64Phdr {
     p_type: u32,
     p_flags: u32,
@@ -56,6 +58,67 @@ pub(super) struct LoadSegment {
     pub flags: PageTableFlags,
 }
 
+/// Parsed ELF64 image metadata for segment walking.
+#[derive(Clone, Copy)]
+pub(super) struct ParsedElf<'a> {
+    ehdr: Elf64Ehdr,
+    phdr_bytes: &'a [u8],
+    phnum: usize,
+}
+
+pub(super) struct LoadSegmentIter<'a> {
+    phdr_bytes: &'a [u8],
+    phnum: usize,
+    idx: usize,
+}
+
+impl<'a> Iterator for LoadSegmentIter<'a> {
+    type Item = LoadSegment;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.idx < self.phnum {
+            let off = self.idx * core::mem::size_of::<Elf64Phdr>();
+            self.idx += 1;
+            // SAFETY: `phdr_bytes` was bounds-checked to hold exactly
+            // `phnum` contiguous `Elf64Phdr` records. Unaligned reads
+            // are intentional because ELF headers are byte-packed.
+            let ph = unsafe {
+                core::ptr::read_unaligned(self.phdr_bytes.as_ptr().add(off).cast::<Elf64Phdr>())
+            };
+            if ph.p_type != PT_LOAD || ph.p_memsz == 0 {
+                continue;
+            }
+            let mut flags = PageTableFlags::PRESENT;
+            if ph.p_flags & PF_W != 0 {
+                flags |= PageTableFlags::WRITABLE;
+            }
+            if ph.p_flags & PF_X == 0 {
+                flags |= PageTableFlags::NO_EXECUTE;
+            }
+            return Some(LoadSegment {
+                vaddr: VirtAddr::new(ph.p_vaddr),
+                memsz: ph.p_memsz,
+                flags,
+            });
+        }
+        None
+    }
+}
+
+impl<'a> ParsedElf<'a> {
+    pub(super) fn load_segments(self) -> LoadSegmentIter<'a> {
+        LoadSegmentIter {
+            phdr_bytes: self.phdr_bytes,
+            phnum: self.phnum,
+            idx: 0,
+        }
+    }
+
+    pub(super) fn entry(&self) -> VirtAddr {
+        VirtAddr::new(self.ehdr.e_entry)
+    }
+}
+
 /// Iterate `PT_LOAD` segments of the running kernel's ELF image,
 /// reachable through Limine's `ExecutableFileRequest`.
 ///
@@ -63,6 +126,7 @@ pub(super) struct LoadSegment {
 /// the ELF magic is wrong, or the class isn't 64-bit — any of those
 /// would mean the bootloader handed us something we can't reason
 /// about, and limping on would only corrupt page tables.
+#[cfg(target_os = "none")]
 pub(super) fn kernel_load_segments() -> impl Iterator<Item = LoadSegment> {
     let resp = crate::boot::KERNEL_FILE_REQUEST
         .get_response()
@@ -78,7 +142,37 @@ pub(super) fn kernel_load_segments() -> impl Iterator<Item = LoadSegment> {
     // SAFETY: Limine guarantees the file bytes live at this address
     // for the lifetime of the kernel (BOOTLOADER_RECLAIMABLE-adjacent
     // but held through `EXECUTABLE_AND_MODULES`). We only read.
-    let ehdr: &Elf64Ehdr = unsafe { &*(base as *const Elf64Ehdr) };
+    let bytes: &[u8] = unsafe { core::slice::from_raw_parts(base, size) };
+    parse_elf64(bytes).load_segments()
+}
+
+#[cfg(target_os = "none")]
+pub(super) fn first_loaded_module_elf_summary() -> Option<(VirtAddr, usize)> {
+    let resp = crate::boot::MODULE_REQUEST.get_response()?;
+    let file = resp
+        .modules()
+        .iter()
+        .find(|f| f.path().to_bytes().ends_with(b"/boot/userspace_hello.elf"))?;
+    let base = file.addr();
+    let size = file.size() as usize;
+    if size < core::mem::size_of::<Elf64Ehdr>() {
+        return None;
+    }
+    // SAFETY: Limine keeps module file bytes resident for kernel use.
+    let bytes: &[u8] = unsafe { core::slice::from_raw_parts(base, size) };
+    let parsed = parse_elf64(bytes);
+    Some((parsed.entry(), parsed.load_segments().count()))
+}
+
+pub(super) fn parse_elf64(bytes: &[u8]) -> ParsedElf<'_> {
+    assert!(
+        bytes.len() >= core::mem::size_of::<Elf64Ehdr>(),
+        "kernel ELF too small for Ehdr"
+    );
+
+    // SAFETY: length checked above and we use `read_unaligned` so no
+    // alignment assumptions are required for the input slice.
+    let ehdr = unsafe { core::ptr::read_unaligned(bytes.as_ptr().cast::<Elf64Ehdr>()) };
     assert_eq!(ehdr.e_ident[..4], ELF_MAGIC, "kernel ELF bad magic");
     assert_eq!(ehdr.e_ident[4], ELFCLASS64, "kernel ELF not ELFCLASS64");
     assert_eq!(
@@ -92,35 +186,94 @@ pub(super) fn kernel_load_segments() -> impl Iterator<Item = LoadSegment> {
     let phsz = ehdr.e_phentsize as usize;
     let phdr_table_end = phnum
         .checked_mul(phsz)
-        .and_then(|bytes| phoff.checked_add(bytes))
+        .and_then(|n| phoff.checked_add(n))
         .expect("kernel ELF phdr table size overflow");
-    assert!(phdr_table_end <= size, "kernel ELF phdr table out of range");
-
-    // SAFETY: bounds checked above; the slice covers only phdrs, and
-    // the alignment assertion guarantees the cast-to-reference is
-    // sound even on toolchains that place `e_phoff` oddly.
-    let phdr_ptr = unsafe { base.add(phoff) } as *const Elf64Phdr;
     assert!(
-        phdr_ptr.align_offset(core::mem::align_of::<Elf64Phdr>()) == 0,
-        "kernel ELF phdr table misaligned"
+        phdr_table_end <= bytes.len(),
+        "kernel ELF phdr table out of range"
     );
-    let phdrs: &[Elf64Phdr] = unsafe { core::slice::from_raw_parts(phdr_ptr, phnum) };
 
-    phdrs.iter().filter_map(|ph| {
-        if ph.p_type != PT_LOAD || ph.p_memsz == 0 {
-            return None;
-        }
-        let mut flags = PageTableFlags::PRESENT;
-        if ph.p_flags & PF_W != 0 {
-            flags |= PageTableFlags::WRITABLE;
-        }
-        if ph.p_flags & PF_X == 0 {
-            flags |= PageTableFlags::NO_EXECUTE;
-        }
-        Some(LoadSegment {
-            vaddr: VirtAddr::new(ph.p_vaddr),
-            memsz: ph.p_memsz,
-            flags,
-        })
-    })
+    ParsedElf {
+        ehdr,
+        phdr_bytes: &bytes[phoff..phdr_table_end],
+        phnum,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_elf64;
+    use x86_64::structures::paging::PageTableFlags;
+
+    const EHDR_SIZE: usize = 64;
+    const PHDR_SIZE: usize = 56;
+
+    fn put16(buf: &mut [u8], off: usize, v: u16) {
+        buf[off..off + 2].copy_from_slice(&v.to_le_bytes());
+    }
+    fn put32(buf: &mut [u8], off: usize, v: u32) {
+        buf[off..off + 4].copy_from_slice(&v.to_le_bytes());
+    }
+    fn put64(buf: &mut [u8], off: usize, v: u64) {
+        buf[off..off + 8].copy_from_slice(&v.to_le_bytes());
+    }
+
+    fn sample_elf_bytes() -> Vec<u8> {
+        let mut bytes = vec![0u8; EHDR_SIZE + (2 * PHDR_SIZE)];
+        bytes[0..4].copy_from_slice(&[0x7f, b'E', b'L', b'F']);
+        bytes[4] = 2; // ELFCLASS64
+        bytes[5] = 1; // little-endian
+        bytes[6] = 1; // ELF v1
+        put16(&mut bytes, 16, 2); // ET_EXEC
+        put16(&mut bytes, 18, 0x3e); // x86_64
+        put32(&mut bytes, 20, 1); // EV_CURRENT
+        put64(&mut bytes, 24, 0x400080); // entry
+        put64(&mut bytes, 32, EHDR_SIZE as u64); // e_phoff
+        put16(&mut bytes, 52, EHDR_SIZE as u16); // e_ehsize
+        put16(&mut bytes, 54, PHDR_SIZE as u16); // e_phentsize
+        put16(&mut bytes, 56, 2); // e_phnum
+
+        // phdr 0: RX text-like
+        let p0 = EHDR_SIZE;
+        put32(&mut bytes, p0, 1); // PT_LOAD
+        put32(&mut bytes, p0 + 4, 1); // PF_X
+        put64(&mut bytes, p0 + 16, 0x400000); // p_vaddr
+        put64(&mut bytes, p0 + 40, 0x2000); // p_memsz
+
+        // phdr 1: RW data-like
+        let p1 = EHDR_SIZE + PHDR_SIZE;
+        put32(&mut bytes, p1, 1); // PT_LOAD
+        put32(&mut bytes, p1 + 4, 2); // PF_W
+        put64(&mut bytes, p1 + 16, 0x402000); // p_vaddr
+        put64(&mut bytes, p1 + 40, 0x1000); // p_memsz
+
+        bytes
+    }
+
+    #[test]
+    fn parses_entry_and_segment_flags() {
+        let bytes = sample_elf_bytes();
+        let parsed = parse_elf64(&bytes);
+        assert_eq!(parsed.entry().as_u64(), 0x400080);
+        let segs: Vec<_> = parsed.load_segments().collect();
+        assert_eq!(segs.len(), 2);
+
+        assert_eq!(segs[0].vaddr.as_u64(), 0x400000);
+        assert_eq!(segs[0].memsz, 0x2000);
+        assert!(!segs[0].flags.contains(PageTableFlags::WRITABLE));
+        assert!(!segs[0].flags.contains(PageTableFlags::NO_EXECUTE));
+
+        assert_eq!(segs[1].vaddr.as_u64(), 0x402000);
+        assert_eq!(segs[1].memsz, 0x1000);
+        assert!(segs[1].flags.contains(PageTableFlags::WRITABLE));
+        assert!(segs[1].flags.contains(PageTableFlags::NO_EXECUTE));
+    }
+
+    #[test]
+    #[should_panic(expected = "kernel ELF bad magic")]
+    fn rejects_bad_magic() {
+        let mut bytes = sample_elf_bytes();
+        bytes[0] = 0;
+        let _ = parse_elf64(&bytes);
+    }
 }

--- a/kernel/src/mem/elf.rs
+++ b/kernel/src/mem/elf.rs
@@ -16,6 +16,10 @@ const PF_W: u32 = 1 << 1;
 const ELF_MAGIC: [u8; 4] = [0x7f, b'E', b'L', b'F'];
 const ELFCLASS64: u8 = 2;
 
+#[cfg(target_os = "none")]
+static CACHED_MODULE_ELF_SUMMARY: spin::mutex::Mutex<Option<(VirtAddr, usize)>> =
+    spin::mutex::Mutex::new(None);
+
 #[repr(C)]
 #[derive(Clone, Copy)]
 struct Elf64Ehdr {
@@ -158,10 +162,21 @@ pub(super) fn first_loaded_module_elf_summary() -> Option<(VirtAddr, usize)> {
     if size < core::mem::size_of::<Elf64Ehdr>() {
         return None;
     }
-    // SAFETY: Limine keeps module file bytes resident for kernel use.
+    // SAFETY: Limine's module bytes are readable while its response
+    // metadata is still live (before reclaim_bootloader_memory()).
     let bytes: &[u8] = unsafe { core::slice::from_raw_parts(base, size) };
     let parsed = try_parse_elf64(bytes)?;
     Some((parsed.entry(), parsed.load_segments().count()))
+}
+
+#[cfg(target_os = "none")]
+pub(super) fn snapshot_module_elf_summary_before_reclaim() {
+    *CACHED_MODULE_ELF_SUMMARY.lock() = first_loaded_module_elf_summary();
+}
+
+#[cfg(target_os = "none")]
+pub(super) fn cached_module_elf_summary() -> Option<(VirtAddr, usize)> {
+    *CACHED_MODULE_ELF_SUMMARY.lock()
 }
 
 pub(super) fn try_parse_elf64(bytes: &[u8]) -> Option<ParsedElf<'_>> {

--- a/kernel/src/mem/elf.rs
+++ b/kernel/src/mem/elf.rs
@@ -186,6 +186,16 @@ pub(super) fn try_parse_elf64(bytes: &[u8]) -> Option<ParsedElf<'_>> {
     if phdr_table_end > bytes.len() {
         return None;
     }
+    VirtAddr::try_new(ehdr.e_entry).ok()?;
+    for i in 0..phnum {
+        let off = phoff + i * phsz;
+        // SAFETY: `phdr_table_end` bounds-check above guarantees every
+        // header read in this loop stays within `bytes`.
+        let ph = unsafe { core::ptr::read_unaligned(bytes.as_ptr().add(off).cast::<Elf64Phdr>()) };
+        if ph.p_type == PT_LOAD && ph.p_memsz != 0 {
+            VirtAddr::try_new(ph.p_vaddr).ok()?;
+        }
+    }
 
     Some(ParsedElf {
         ehdr,
@@ -219,6 +229,22 @@ pub(super) fn parse_elf64(bytes: &[u8]) -> ParsedElf<'_> {
         .and_then(|n| phoff.checked_add(n))
         .expect("ELF phdr table size overflow");
     assert!(phdr_table_end <= bytes.len(), "ELF phdr table out of range");
+    assert!(
+        VirtAddr::try_new(ehdr.e_entry).is_ok(),
+        "ELF entry address is non-canonical"
+    );
+    for i in 0..phnum {
+        let off = phoff + i * phsz;
+        // SAFETY: `phdr_table_end` bounds-check above guarantees every
+        // header read in this loop stays within `bytes`.
+        let ph = unsafe { core::ptr::read_unaligned(bytes.as_ptr().add(off).cast::<Elf64Phdr>()) };
+        if ph.p_type == PT_LOAD && ph.p_memsz != 0 {
+            assert!(
+                VirtAddr::try_new(ph.p_vaddr).is_ok(),
+                "ELF PT_LOAD virtual address is non-canonical"
+            );
+        }
+    }
 
     ParsedElf {
         ehdr,
@@ -309,5 +335,28 @@ mod tests {
         let mut bytes = sample_elf_bytes();
         bytes[0] = 0;
         assert!(try_parse_elf64(&bytes).is_none());
+    }
+
+    #[test]
+    fn try_parse_rejects_non_canonical_entry() {
+        let mut bytes = sample_elf_bytes();
+        put64(&mut bytes, 24, 0x0001_0000_0000_0000);
+        assert!(try_parse_elf64(&bytes).is_none());
+    }
+
+    #[test]
+    fn try_parse_rejects_non_canonical_load_vaddr() {
+        let mut bytes = sample_elf_bytes();
+        let p0 = EHDR_SIZE;
+        put64(&mut bytes, p0 + 16, 0x0001_0000_0000_0000);
+        assert!(try_parse_elf64(&bytes).is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "ELF entry address is non-canonical")]
+    fn parse_panics_non_canonical_entry() {
+        let mut bytes = sample_elf_bytes();
+        put64(&mut bytes, 24, 0x0001_0000_0000_0000);
+        let _ = parse_elf64(&bytes);
     }
 }

--- a/kernel/src/mem/mod.rs
+++ b/kernel/src/mem/mod.rs
@@ -23,6 +23,12 @@ pub mod pat;
 #[cfg(target_os = "none")]
 pub mod vma;
 
+#[cfg(target_os = "none")]
+use spin::Once;
+
+#[cfg(target_os = "none")]
+static USERSPACE_MODULE_ELF_SUMMARY: Once<Option<(x86_64::VirtAddr, usize)>> = Once::new();
+
 /// 4 KiB. The only page size we care about right now.
 pub const FRAME_SIZE: u64 = 4096;
 
@@ -59,6 +65,10 @@ pub fn init() {
         .expect("Limine HHDM response missing");
     paging::init(x86_64::VirtAddr::new(hhdm.offset()));
 
+    // Snapshot Limine module metadata before reclaiming BOOTLOADER_RECLAIMABLE
+    // memory; the response structs themselves live there.
+    USERSPACE_MODULE_ELF_SUMMARY.call_once(elf::first_loaded_module_elf_summary);
+
     heap::init();
     crate::arch::x86_64::ist_guard::install();
 
@@ -77,5 +87,5 @@ pub fn init() {
 /// userspace module delivered by Limine, if present and well-formed.
 #[cfg(target_os = "none")]
 pub fn userspace_module_elf_summary() -> Option<(x86_64::VirtAddr, usize)> {
-    elf::first_loaded_module_elf_summary()
+    USERSPACE_MODULE_ELF_SUMMARY.get().copied().flatten()
 }

--- a/kernel/src/mem/mod.rs
+++ b/kernel/src/mem/mod.rs
@@ -12,7 +12,7 @@
 
 pub mod frame;
 
-#[cfg(target_os = "none")]
+#[cfg(any(target_os = "none", test))]
 mod elf;
 #[cfg(target_os = "none")]
 pub mod heap;
@@ -71,4 +71,11 @@ pub fn init() {
     // and all BOOTLOADER_RECLAIMABLE regions now that we no longer need
     // the bootloader's page-table tree or its data structures.
     paging::reclaim_bootloader_memory();
+}
+
+/// Return the parsed entry point and loadable-segment count for the first
+/// userspace module delivered by Limine, if present and well-formed.
+#[cfg(target_os = "none")]
+pub fn userspace_module_elf_summary() -> Option<(x86_64::VirtAddr, usize)> {
+    elf::first_loaded_module_elf_summary()
 }

--- a/kernel/tests/userspace_module.rs
+++ b/kernel/tests/userspace_module.rs
@@ -1,0 +1,48 @@
+//! Integration test: module request delivers the hello ELF and parser
+//! exposes entry point + load segments.
+
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[(
+        "userspace_module_elf_present_and_parsed",
+        &(userspace_module_elf_present_and_parsed as fn()),
+    )];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+fn userspace_module_elf_present_and_parsed() {
+    let (entry, segs) =
+        vibix::mem::userspace_module_elf_summary().expect("userspace hello module missing");
+    assert!(entry.as_u64() > 0, "module entry must be non-zero");
+    assert!(segs > 0, "module must contain at least one PT_LOAD segment");
+    serial_println!(
+        "userspace module parsed: entry={:#x} segments={}",
+        entry.as_u64(),
+        segs
+    );
+}

--- a/userspace/hello/Cargo.toml
+++ b/userspace/hello/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "userspace_hello"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "userspace_hello"
+path = "src/main.rs"
+
+[dependencies]

--- a/userspace/hello/Cargo.toml
+++ b/userspace/hello/Cargo.toml
@@ -8,5 +8,3 @@ license.workspace = true
 [[bin]]
 name = "userspace_hello"
 path = "src/main.rs"
-
-[dependencies]

--- a/userspace/hello/src/main.rs
+++ b/userspace/hello/src/main.rs
@@ -1,0 +1,18 @@
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    loop {
+        core::hint::spin_loop();
+    }
+}
+
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    loop {
+        core::hint::spin_loop();
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -64,6 +64,7 @@ const SMOKE_MARKERS: &[&str] = &[
     "vibix online.",
     "interrupts enabled",
     "tasks: scheduler online",
+    "userspace module ELF entry=",
 ];
 
 fn main() -> R<()> {
@@ -136,6 +137,28 @@ fn workspace_root() -> PathBuf {
         .parent()
         .unwrap()
         .to_path_buf()
+}
+
+fn userspace_hello_binary() -> PathBuf {
+    workspace_root()
+        .join("target")
+        .join(KERNEL_TARGET)
+        .join("debug")
+        .join("userspace_hello")
+}
+
+fn build_userspace_hello() -> R<PathBuf> {
+    let mut cmd = Command::new("cargo");
+    cmd.current_dir(workspace_root())
+        .args(["build", "--package", "userspace_hello"])
+        .args(KERNEL_BUILD_STD_ARGS);
+    check(cmd.status()?)?;
+    let bin = userspace_hello_binary();
+    if !bin.exists() {
+        return Err(format!("userspace hello binary missing at {}", bin.display()).into());
+    }
+    strip_debug(&bin)?;
+    Ok(bin)
 }
 
 fn kernel_binary(opts: &BuildOpts) -> PathBuf {
@@ -327,12 +350,14 @@ fn ensure_limine() -> R<PathBuf> {
 /// (so parallel test runs don't stomp each other).
 fn make_iso(kernel: &Path, iso_out: &Path, staging: &str) -> R<()> {
     let limine = ensure_limine()?;
+    let userspace_hello = build_userspace_hello()?;
     let iso_root = workspace_root().join("build").join(staging);
     let _ = fs::remove_dir_all(&iso_root);
     fs::create_dir_all(iso_root.join("boot/limine"))?;
     fs::create_dir_all(iso_root.join("EFI/BOOT"))?;
 
     fs::copy(kernel, iso_root.join("boot/vibix"))?;
+    fs::copy(userspace_hello, iso_root.join("boot/userspace_hello.elf"))?;
     fs::copy(
         workspace_root().join("kernel/limine.conf"),
         iso_root.join("boot/limine/limine.conf"),
@@ -513,6 +538,7 @@ fn test_all() -> R<()> {
         "priority",
         "per_task_cr3",
         "demand_paging",
+        "userspace_module",
     ] {
         cmd.arg("--test").arg(t);
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #20

## Summary
- add a Limine `ModuleRequest` for `/boot/userspace_hello.elf` and include that module in ISO staging
- add a tiny `userspace_hello` no-std ELF crate so the module path is always populated in local/CI boots
- refactor `mem::elf` into a byte-slice parser (`parse_elf64`) reusable beyond the kernel image, and expose module ELF summary plumbing
- add `try_parse_elf64` and use it for module summary paths so malformed module ELFs degrade to `None` instead of panicking
- validate canonical virtual addresses (`e_entry`, `PT_LOAD.p_vaddr`) in `try_parse_elf64`, and assert the same invariant in `parse_elf64`
- snapshot userspace module ELF summary during `mem::init` *before* reclaiming `BOOTLOADER_RECLAIMABLE` memory, then serve later callers from cached data
- remove redundant dead cache state from `mem::elf` and keep a single module-summary cache owner in `mem::mod`
- unify duplicate parse validation behind one shared internal parser path to keep `try_parse_elf64` and `parse_elf64` invariants aligned
- normalize generic parse panic text (`ELF ...`) and remove the empty `userspace_hello` dependencies table
- log module ELF entry/segment summary during boot and add a dedicated integration test + smoke marker coverage for this path

Out of scope in this PR: ring-3 transition, syscall entry/return, and user address-space mapping.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo xtask build`
- [x] `cargo xtask test`
- [x] `cargo xtask smoke`
- [x] `cargo clippy -p xtask --all-targets -- -D warnings`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd0189d4-e668-4152-a1ec-18a2204371e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd0189d4-e668-4152-a1ec-18a2204371e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

