### PR TITLE
docs: split shared agent playbooks

### DIFF
--- a/.claude/skills/auto-engineer/SKILL.md
+++ b/.claude/skills/auto-engineer/SKILL.md
@@ -5,6 +5,13 @@ description: Autonomously drive vibix work end-to-end — pick an unblocked issu
 
 # auto-engineer
 
+Read these shared playbooks first:
+
+- `docs/agent-playbooks/sdlc.md`
+- `docs/agent-playbooks/build-run.md`
+- `docs/agent-playbooks/testing.md`
+- `docs/agent-playbooks/pr-review.md`
+
 Closes the full SDLC loop without prompting the user between steps. Each invocation runs **one cycle** (pick → plan → implement → PR → wait → merge), then reschedules itself via `ScheduleWakeup` with prompt `/auto-engineer` for the next cycle. Stops cleanly when it runs out of work or hits something it can't safely resolve.
 
 This skill is a deliberate override of the project's default "don't merge your own PRs" rule — merging is the whole point of closing the loop. It only applies while auto-engineer is driving.
@@ -41,7 +48,7 @@ Sort preference:
 
 If the candidate list is empty → **stop** (see Stopping below) with message *"no unblocked issues — auto-engineer idle."*
 
-Assign and branch per `sdlc`:
+Assign and branch per `docs/agent-playbooks/sdlc.md`:
 
 ```sh
 gh issue edit <N> --add-assignee dburkart
@@ -66,7 +73,7 @@ The parent proceeds directly with `Edit` / `Write` per the returned plan. No use
 
 ### 4. Build + test
 
-Run in order, per the `build` and `test` skills:
+Run in order, following the shared build and testing playbooks:
 
 ```sh
 cargo xtask build
@@ -78,7 +85,7 @@ On failure: diagnose and fix in place. **Maximum 3 fix attempts per cycle.** If 
 
 ### 5. Commit and open PR
 
-Per `sdlc`:
+Per `docs/agent-playbooks/sdlc.md`:
 
 - Coherent commits (not a single mega-commit, not micro-commits). Each with the standard `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>` trailer.
 - `git push -u origin <branch>`.
@@ -92,6 +99,10 @@ Invoke the `wait-for-pr` skill. It handles:
 - CI polling with cache-friendly `ScheduleWakeup` cadence.
 - Review-bot timing (30-min bot window).
 - Auto-fix for fmt / clippy failures.
+
+The classification of actionable bugs, in-scope nits, and out-of-scope nits comes from
+`docs/agent-playbooks/pr-review.md`; this skill only owns the Claude-native loop around that
+policy.
 
 When `wait-for-pr` returns a summary:
 

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -5,31 +5,21 @@ description: Build the vibix kernel, assemble a bootable ISO, or run it under QE
 
 # Building and running vibix
 
-All build/boot orchestration goes through the `xtask` workspace crate — **never** call `cargo build` on the kernel directly. xtask handles the `-Z build-std` flags, target selection, Limine fetch, ISO assembly, and QEMU launch.
+Read `docs/agent-playbooks/build-run.md` first for the repo-level build, ISO, and QEMU facts.
 
-## Commands
+## When to use this skill
 
-```sh
-cargo xtask build              # compile kernel for x86_64-unknown-none
-cargo xtask iso                # build + produce target/vibix.iso
-cargo xtask run                # build + iso + boot under QEMU (serial on stdio)
-cargo xtask run --release      # optimized build
-cargo xtask run --fault-test   # boot with a `ud2` in _start to exercise the #UD handler
-cargo xtask clean              # wipe target/ and build/
-```
+Use this skill when the task involves:
 
-`--release` and `--fault-test` are flags that apply to `build`, `iso`, and `run`.
+- compiling the kernel
+- producing a bootable ISO
+- booting the kernel under QEMU
+- cleaning build artifacts
 
-## First run
+## Claude-specific notes
 
-xtask will clone Limine (`v8.x-binary`) into `build/limine/` and compile the host `limine` tool. This needs `git`, `make`, and a C compiler on PATH; `xorriso` is required for ISO assembly; `qemu-system-x86_64` for `run`.
-
-## Exit QEMU
-
-`Ctrl-a x` in the serial terminal. The kernel's normal end-state is `hlt_loop()` after printing `vibix online.`, so QEMU will idle until you kill it (except when `--fault-test` triggers a panic exit).
-
-## Gotchas
-
-- Don't add `build-std` to `.cargo/config.toml` — it will break host `cargo test --lib` by conflicting with the sysroot's `std`. xtask passes `-Z build-std=core,compiler_builtins,alloc` on the CLI only for kernel-target builds.
-- The kernel `panic="abort"` profile is set at the workspace root `Cargo.toml`, not the kernel crate. For the test profile, panic=abort is enforced via `-Z panic-abort-tests` in `.cargo/config.toml` (cargo silently ignores `[profile.test] panic="abort"`).
-- If `build/limine/` is stale or corrupted, `rm -rf build/limine` and re-run — xtask will re-clone.
+- Follow the shared playbook's `cargo xtask` rules exactly; do not improvise raw kernel build commands.
+- If the task also involves validation, pair this skill with `test` so the build/run commands and the
+  test commands come from the shared playbooks instead of being duplicated here.
+- If you are running `cargo xtask run` in a non-interactive cloud environment, prefer a bounded
+  command or a persistent session so the happy-path kernel halt does not strand the turn.

--- a/.claude/skills/sdlc/SKILL.md
+++ b/.claude/skills/sdlc/SKILL.md
@@ -20,6 +20,8 @@ Use this skill when the task involves:
 
 ## Claude-specific notes
 
+- Each commit must include the `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
+  trailer.
 - When the runtime supports GitHub issue assignment or issue creation, you may use those features to
   reduce duplicate work and capture follow-up items; keep the shared SDLC playbook as the source of
   truth for the policy itself.
@@ -32,3 +34,4 @@ Use this skill when the task involves:
 
 - Commit directly to `main`.
 - Force-push or rewrite reviewed commits unless the user explicitly approves that change in workflow.
+- Merge a PR on the user's behalf unless asked.

--- a/.claude/skills/sdlc/SKILL.md
+++ b/.claude/skills/sdlc/SKILL.md
@@ -5,91 +5,30 @@ description: The vibix software-delivery workflow — how changes move from idea
 
 # vibix SDLC
 
-All non-trivial changes move through the same flow: **branch → commit → push → PR → review → merge**. `main` is a review-only integration branch; nothing lands there directly.
+Read `docs/agent-playbooks/sdlc.md` first for repo-level branch, commit, push, and PR policy.
 
-## Picking an issue
+Read `docs/agent-playbooks/pr-review.md` when the task includes CI interpretation or review response.
 
-When the user asks open-endedly to "pick an issue", "grab something to work on", or "what's next" — restrict the candidate set to **unassigned** issues. Fetch with:
+## When to use this skill
 
-```sh
-gh issue list --search 'no:assignee' --state open
-```
+Use this skill when the task involves:
 
-This rule does not apply when the user names a specific issue (*"let's do #12"*, *"start on the dmesg one"*) — work that issue regardless of assignee.
+- starting a new cohesive change on its own branch
+- deciding what checks to run before push
+- preparing a PR body and opening a PR
+- responding to review feedback without rewriting reviewed history
 
-## Starting work
+## Claude-specific notes
 
-Before writing any code for a new milestone or task:
-
-```sh
-git checkout main && git pull
-git checkout -b <topic-branch>
-gh issue edit <N> --add-assignee dburkart   # if this branch corresponds to a tracked issue
-```
-
-Assigning the issue signals "someone is actively on this" so concurrent sessions don't race on the same ticket. Skip only if there's no tracked issue for the work.
-
-Branch naming:
-- Milestones: `m<N>-<slug>` (e.g. `m3-interrupts`, `m4-paging`).
-- Smaller tasks: `<verb>-<slug>` (e.g. `fix-keyboard-race`, `refactor-frame-allocator`).
-
-One branch per logically cohesive piece of work. Don't stack unrelated changes on the same branch.
-
-## While working
-
-- Commit in coherent chunks — don't wait until the whole milestone is green to make the first commit, but don't micro-commit either. Aim for commits that would make sense to read individually during review.
-- Each commit message: short imperative subject (<70 chars), blank line, body that explains *why*. Always include the `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>` trailer.
-- Before pushing, run the checks that match the change (see the `test` and `build` skills). For kernel/code changes: `cargo xtask test` + `cargo xtask smoke`. For docs/process/skill-only branches: at minimum `cargo xtask build` to confirm nothing regressed; the full test + smoke pass isn't required. Don't push red branches.
-
-## Capturing out-of-scope ideas
-
-Any interesting idea, bug, latent TODO, or follow-up task that surfaces mid-work but shouldn't be tackled on the current branch goes into a GitHub issue immediately — don't rely on memory or a chat log to hold it. This applies equally to things the user raises and things Claude notices while poking around (a suspicious `unwrap`, a missing test, a cleanup that would balloon the current PR, a better design for a future milestone).
-
-Use `mcp__github__create_issue` with:
-- A short, specific title.
-- A body that explains *what* and *why* — enough context that someone (including us) coming back cold in a week can act on it.
-- Relevant labels (`bug`, `enhancement`, `milestone-N`, etc.) when they fit.
-
-Link the issue from the current PR if it was spun off mid-review ("deferred to #N"). Then get back to the original task.
-
-## Opening the PR
-
-When the branch is ready for review:
-
-1. `git push -u origin <branch>` (first push) or `git push` (subsequent).
-2. Open a PR via the GitHub MCP (`mcp__github__create_pull_request`) against `main`. Body template:
-
-```markdown
-## Summary
-<2-5 bullets: what the change does and why, grouped by subsystem>
-
-<short note on what's explicitly out of scope, if relevant>
-
-## Test plan
-- [x] <tests actually run, with results>
-- [ ] <manual checks the user should do before merging>
-```
-
-End the body at the Test plan — no "generated with" footer. Commit-level `Co-Authored-By` trailers cover attribution; the PR body is for reviewers.
-
-3. Keep the title short (<70 chars); details belong in the body.
-4. If the MCP can't reach auth, fall back to the GitHub compare URL and let the user paste the prepared body manually — never skip the review step by merging locally.
-5. Immediately hand off to the `wait-for-pr` skill — it runs the CI + review-bot wait loop and produces the consolidated report, so both the CI and "Responding to review" steps below flow from one place instead of requiring separate prompts.
-
-## Responding to review
-
-- CodeRabbit usually posts automatically. Fetch its findings with `mcp__github__get_pull_request_reviews` / `get_pull_request_comments` and classify: **actionable bugs** (fix), **nitpicks in scope** (fix if cheap), **nitpicks out of scope** (reply and defer).
-- Fixes are follow-up commits on the same branch, not amend + force-push — preserves review history.
-- Don't merge your own PRs; the user reviews and merges. If the user says "merge it," use `mcp__github__merge_pull_request`.
-
-## After merge
-
-- Delete the topic branch locally (`git branch -d <branch>`) and let GitHub delete the remote.
-- Pull `main` before starting the next piece of work.
+- When the runtime supports GitHub issue assignment or issue creation, you may use those features to
+  reduce duplicate work and capture follow-up items; keep the shared SDLC playbook as the source of
+  truth for the policy itself.
+- If you open a PR from Claude, prefer the repo's standard summary-plus-testing structure from the
+  shared playbook rather than embedding extra Claude-specific footer text.
+- If CI or review follow-up is needed, hand off to `wait-for-pr` only for Claude-specific polling
+  and automation. Review classification still comes from the shared playbook.
 
 ## Never
 
-- Commit directly to `main` — not even for "trivial" changes. Every change goes through a PR.
-- `git push --force` on a shared branch without explicit user approval.
-- Merge a PR on the user's behalf unless asked.
-- Squash or rewrite commits that have already been pushed and reviewed.
+- Commit directly to `main`.
+- Force-push or rewrite reviewed commits unless the user explicitly approves that change in workflow.

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -5,40 +5,22 @@ description: Run vibix tests — host unit tests, in-kernel QEMU integration tes
 
 # Testing vibix
 
-Three layers, all driven by xtask:
+Read `docs/agent-playbooks/testing.md` first for the repo-level test model, commands, and gotchas.
 
-```sh
-cargo xtask test     # host unit tests (cargo test --lib) + QEMU integration tests
-cargo xtask smoke    # boot the normal kernel, assert expected serial markers
-```
+## When to use this skill
 
-## Layer 1 — host unit tests
+Use this skill when the task involves:
 
-Pure-logic modules (e.g. `mem::frame::BumpFrameAllocator`) compile under host `std` because `kernel/src/lib.rs` is `#![cfg_attr(not(test), no_std)]`. Kernel-only modules gate on `#[cfg(target_os = "none")]` so they don't drag MMIO or x86 intrinsics into the host build.
+- validating kernel or boot behavior
+- adding or updating host unit tests
+- adding or updating QEMU integration tests
+- running the smoke lane after behavior changes
 
-To add host-testable logic: put it in a module that does **not** touch `x86_64`, `uart_16550`, MMIO, or Limine statics. Add `#[cfg(test)] mod tests { ... }` inline. It will run under `cargo xtask test`'s first phase.
+## Claude-specific notes
 
-## Layer 2 — QEMU integration tests
-
-Each file under `kernel/tests/*.rs` is its own `#![no_std] #![no_main]` kernel binary with its own `_start`, panic handler, and explicit test list. `cargo test --target x86_64-unknown-none` builds each, and `.cargo/config.toml` points its `runner` at `xtask test-runner`, which wraps the ELF in an ISO and boots it under QEMU.
-
-Pass/fail comes from the `isa-debug-exit` protocol:
-- Success = write `0x20` to port `0xf4` → QEMU process exits `65`
-- Failure = write `0x10` → QEMU process exits `33`
-
-`should_panic.rs` inverts its panic handler (panic → Success, no-panic → Failure) to verify the panic path itself.
-
-To add an integration test, create `kernel/tests/my_test.rs` modeled on `basic_boot.rs`, then add a `[[test]] name = "my_test" harness = false` entry to `kernel/Cargo.toml` **and** add `"my_test"` to the test name list in `xtask/src/main.rs::test_all`.
-
-## Layer 3 — smoke / regression
-
-`cargo xtask smoke` boots the normal kernel, captures serial for 4 seconds, kills QEMU, then greps the output for a fixed list of markers (see `SMOKE_MARKERS` in `xtask/src/main.rs`). Cheap lane for catching serial-pipeline regressions — rename a log line and this goes red.
-
-When adding a new boot-phase milestone log line worth regression-guarding, add it to `SMOKE_MARKERS`.
-
-## Gotchas
-
-- **Do not** add `-no-shutdown` to the `test_runner` QEMU args — it suppresses `isa-debug-exit` and causes tests to hang until the 30 s timeout. `-no-shutdown` is fine in `run` and `smoke` because neither relies on the exit device for termination.
-- `cargo test --target x86_64-unknown-none` **without** explicit `--test <name>` flags will try to build the lib's unittest harness, which fails (no std). `test_all` in xtask iterates test names explicitly for this reason.
-- `-Z panic-abort-tests = true` in `.cargo/config.toml` is required; without it, cargo builds a second `core` with `panic=unwind` that clashes with the kernel's abort core.
-- Host unit tests and kernel-target tests must not share `build-std` config — see the build skill.
+- Choose the narrowest high-signal checks that match the change, then escalate to the full `test`
+  and `smoke` flow when the risk warrants it.
+- Keep the shared playbook as the source of truth for how the three test layers work; this wrapper
+  only decides when to apply them.
+- If a task also changes build or run behavior, read `docs/agent-playbooks/build-run.md` before
+  invoking test commands so the QEMU and `xtask` assumptions stay aligned.

--- a/.claude/skills/wait-for-pr/SKILL.md
+++ b/.claude/skills/wait-for-pr/SKILL.md
@@ -40,6 +40,18 @@ Known review-bot author logins:
 - `greptile-apps` / `greptile-bot`
 - `github-advanced-security[bot]`
 
+## What "done" means
+
+The PR isn't ready for a summary until **all** are true:
+
+1. Every GitHub Actions check is in a terminal state: `success`, `failure`, `skipped`,
+   `cancelled`, `neutral`, `timed_out`, or `stale`. Nothing `in_progress`, `queued`, or
+   `pending`.
+2. No check is sitting in `action_required` waiting on manual approval (flag it and stop — the user
+   needs to act).
+3. At least one review-bot comment / review exists, **or** 30 minutes have elapsed since the PR
+   opened (bots may not be wired up on this repo; don't block forever).
+
 ## Poll cadence
 
 Use `ScheduleWakeup` between ticks. Tune `delaySeconds` to stay friendly to the 5-minute prompt-cache TTL:

--- a/.claude/skills/wait-for-pr/SKILL.md
+++ b/.claude/skills/wait-for-pr/SKILL.md
@@ -5,7 +5,11 @@ description: After opening a PR or pushing a fix, wait for all CI checks AND rev
 
 # wait-for-pr
 
-Right after a PR is opened or a new commit is pushed to its branch, don't stop at the first `gh pr checks` poll — checks take minutes and review bots (CodeRabbit, Greptile, GHAS) post later still. This skill runs the full wait loop so the user sees one consolidated report instead of prompting "are we there yet?" repeatedly.
+Read `docs/agent-playbooks/pr-review.md` first for repo-level CI readiness and review-classification
+rules.
+
+This skill keeps only the Claude-specific wait loop and automation needed to turn those shared rules
+into a single consolidated PR-status report.
 
 ## When to invoke
 
@@ -23,13 +27,12 @@ gh pr list --head "$(git branch --show-current)" --json number,url --jq '.[0]'
 
 Record the number and URL; reuse them for every poll tick.
 
-## What "done" means
+## Shared-vs-Claude split
 
-The PR isn't ready for a summary until **all** are true:
-
-1. Every GitHub Actions check is in a terminal state: `success`, `failure`, `skipped`, `cancelled`, `neutral`, `timed_out`, or `stale`. Nothing `in_progress`, `queued`, or `pending`.
-2. No check is sitting in `action_required` waiting on manual approval (flag it and stop — the user needs to act).
-3. At least one review-bot comment / review exists, **or** 30 minutes have elapsed since the PR opened (bots may not be wired up on this repo; don't block forever).
+- The shared playbook defines what CI-ready means and how to classify review findings.
+- This wrapper defines the Claude-only polling cadence, wake-up loop, and optional auto-fix behavior.
+- If the repo's review policy changes, update the shared playbook first and keep this file focused on
+  runtime mechanics.
 
 Known review-bot author logins:
 
@@ -124,37 +127,13 @@ Never auto-fix:
 
 ## Summarize
 
-When everything has reported, output one structured report:
+When everything has reported, output one structured report that follows the buckets from
+`docs/agent-playbooks/pr-review.md`:
 
-```
-## PR #<N> — <title>
-
-### CI
-- ✓ <check-name>        [success]
-- ✗ <check-name>        [failure] — <short conclusion if available>
-- ⊘ <check-name>        [skipped]
-
-Overall: <ALL PASSING | N check(s) failed>
-
-### Review findings
-
-**Actionable bugs** (fix before merge):
-- <file:line> — <description>
-
-**In-scope nits** (cheap to fix):
-- <file:line> — <description>
-
-**Out-of-scope nits** (defer):
-- <description> → reply "deferred to #<issue> / future work"
-
-**No findings** (if the review bots posted nothing actionable)
-```
-
-Classification matches the `sdlc` skill:
-
-- **Actionable bugs**: correctness issues, panics, unsoundness, broken invariants.
-- **In-scope nits**: style / naming / minor issues on code this PR actually changed.
-- **Out-of-scope nits**: suggestions about untouched code, or architectural changes that would balloon scope.
+- PR number and title
+- CI results grouped by pass/fail/skipped state
+- Review findings grouped into actionable bugs, in-scope nits, and out-of-scope nits
+- Any explicit follow-up items that were deferred
 
 If the 30-min bot timeout hit with no comment, note it explicitly:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,30 +1,23 @@
 ## Cursor Cloud specific instructions
 
-vibix is a bare-metal x86_64 hobby kernel in Rust. There are no web services, databases, or containers — everything compiles to a bootable ISO and runs under QEMU.
+vibix is a bare-metal x86_64 hobby kernel in Rust. There are no web services, databases, or
+containers; everything compiles to a bootable ISO and runs under QEMU.
 
-### System dependencies (installed by the update script)
+## Shared playbooks
 
-- `qemu-system-x86` — boots the kernel and runs all integration/smoke tests
-- `xorriso` — assembles bootable ISO images
-- `build-essential` — C compiler needed to build the Limine bootloader host tool on first run
+Read these repo-level playbooks before acting in the corresponding area:
 
-### Build, test, lint, run
+- `docs/agent-playbooks/build-run.md` for build, ISO, and QEMU behavior
+- `docs/agent-playbooks/testing.md` for host, QEMU, and smoke testing
+- `docs/agent-playbooks/sdlc.md` for branch, commit, push, and PR policy
+- `docs/agent-playbooks/pr-review.md` for CI readiness and review classification
 
-All commands are orchestrated through `cargo xtask`. See `README.md` → "Build & run" for the full list. Key commands:
+## Cursor Cloud runtime notes
 
-| Task | Command |
-|---|---|
-| Build kernel | `cargo xtask build` |
-| Build + boot in QEMU | `cargo xtask run` (serial on stdio; exit with `Ctrl-a x`) |
-| Host unit tests + QEMU integration tests | `cargo xtask test` |
-| End-to-end smoke (serial marker assertions) | `cargo xtask smoke` |
-| Lint (CI-style, xtask only) | `cargo clippy -p xtask --all-targets -- -D warnings` |
-| Format check | `cargo fmt --all -- --check` |
-
-### Non-obvious caveats
-
-- **`cargo xtask lint` vs CI clippy:** `cargo xtask lint` runs clippy on the kernel with `--all-targets`, which includes integration test crates that may trigger pre-existing warnings. CI only runs `cargo clippy -p xtask --all-targets -- -D warnings`. Use the CI command when checking lint.
-- **First build clones Limine:** `cargo xtask iso` (and `run`/`test`/`smoke`) clones the Limine bootloader into `build/limine/` on first invocation and compiles it. This is a one-time ~10s step per fresh workspace.
-- **QEMU runs headlessly in Cloud:** Tests and smoke use `-display none`. For `cargo xtask run` in Cloud, add a `timeout` wrapper or run in a tmux session since the kernel halts in `hlt_loop` forever: `timeout 6 cargo xtask run` or kill the QEMU process manually.
-- **Rust nightly auto-selected:** `rust-toolchain.toml` pins the toolchain; `rustup show` triggers installation if needed.
-- **`gh` CLI available:** Pre-installed and authenticated via `GITHUB_TOKEN`. Use for read-only GitHub queries (PR info, CI logs, etc.). Write operations (creating PRs) should use the `ManagePullRequest` tool instead.
+- In Cursor Cloud, prefer `timeout 6 cargo xtask run` or a tmux-backed session when booting the
+  kernel manually; the happy path halts in `hlt_loop()` and does not exit on its own.
+- The CI-style lint command to trust in Cloud is `cargo clippy -p xtask --all-targets -- -D warnings`.
+  `cargo xtask lint` is broader and can include pre-existing kernel-target warnings.
+- `rust-toolchain.toml` pins nightly. `rustup show` will install or select it when needed.
+- `gh` is available for read-only GitHub inspection. Use Cursor-native tooling for write actions
+  such as PR creation or updates.

--- a/docs/agent-playbooks/build-run.md
+++ b/docs/agent-playbooks/build-run.md
@@ -1,0 +1,52 @@
+# Build and run playbook
+
+This playbook captures repo-level build and boot behavior that applies across agent runtimes.
+
+## Core rule
+
+All build and boot orchestration goes through `cargo xtask`. Do not invoke `cargo build`
+directly on the kernel crate; `xtask` owns the target selection, `-Z build-std` flags,
+Limine fetch, ISO assembly, and QEMU launch behavior.
+
+## Commands
+
+```sh
+cargo xtask build              # compile kernel for x86_64-unknown-none
+cargo xtask iso                # build + produce target/vibix.iso
+cargo xtask run                # build + iso + boot under QEMU (serial on stdio)
+cargo xtask run --release      # optimized build
+cargo xtask run --fault-test   # boot with a `ud2` in _start to exercise the #UD handler
+cargo xtask run --panic-test   # trigger a deliberate panic to test backtraces
+cargo xtask clean              # wipe target/ and build/
+```
+
+`--release`, `--fault-test`, and `--panic-test` are accepted by the relevant `xtask`
+subcommands.
+
+## First run
+
+The first `iso`, `run`, `test`, or `smoke` invocation clones Limine into `build/limine/`
+and compiles the host `limine` tool. That requires:
+
+- `git`
+- `make`
+- a C compiler on `PATH`
+- `xorriso`
+- `qemu-system-x86_64`
+
+## QEMU behavior
+
+- `cargo xtask run` launches QEMU with serial attached to stdio.
+- The normal kernel end-state is `hlt_loop()`, so QEMU idles until it is exited manually.
+- In an interactive terminal, exit QEMU with `Ctrl-a x`.
+- In Cursor Cloud, prefer `timeout 6 cargo xtask run` or a tmux-backed session, because
+  the kernel does not terminate on its own in the happy path.
+
+## Gotchas
+
+- Do not add `build-std` to `.cargo/config.toml`. Host tests rely on the normal sysroot
+  `std`, while kernel-target builds need `xtask` to pass `-Z build-std` only on the CLI.
+- The workspace root `Cargo.toml` owns the kernel `panic = "abort"` profile settings.
+  The test profile behavior is enforced with `-Z panic-abort-tests` in `.cargo/config.toml`.
+- If `build/limine/` is stale or corrupted, remove that directory and rerun an `xtask`
+  command to let the repo re-clone it.

--- a/docs/agent-playbooks/build-run.md
+++ b/docs/agent-playbooks/build-run.md
@@ -39,8 +39,6 @@ and compiles the host `limine` tool. That requires:
 - `cargo xtask run` launches QEMU with serial attached to stdio.
 - The normal kernel end-state is `hlt_loop()`, so QEMU idles until it is exited manually.
 - In an interactive terminal, exit QEMU with `Ctrl-a x`.
-- In Cursor Cloud, prefer `timeout 6 cargo xtask run` or a tmux-backed session, because
-  the kernel does not terminate on its own in the happy path.
 
 ## Gotchas
 

--- a/docs/agent-playbooks/pr-review.md
+++ b/docs/agent-playbooks/pr-review.md
@@ -1,0 +1,41 @@
+# PR review playbook
+
+This playbook captures repo-level PR readiness and review classification rules that apply across
+agent runtimes.
+
+## CI readiness
+
+A PR is ready for a final review summary only when:
+
+1. All required checks have reached a terminal state.
+2. No check is waiting on manual approval.
+3. The reviewer-facing summary clearly separates passing checks from failures or skipped jobs.
+
+Do not report "all clear" while core CI is still pending.
+
+## Review classification
+
+Classify feedback into these buckets:
+
+- **Actionable bugs**: correctness issues, broken invariants, panics, unsound behavior, or changes
+  that can regress the expected kernel or tooling behavior
+- **In-scope nits**: small improvements on code changed by the PR that are cheap to address without
+  expanding scope
+- **Out-of-scope nits**: architectural suggestions or cleanup requests that would materially expand
+  the PR beyond its intended goal
+
+## Response policy
+
+- Fix actionable bugs before merge.
+- Fix in-scope nits when the cost is low and the change improves the review outcome.
+- Defer out-of-scope nits to a follow-up issue or handoff note.
+- Prefer follow-up commits on the same branch instead of rewriting reviewed history.
+
+## Review summary shape
+
+A good summary includes:
+
+- PR number and title
+- CI results, grouped by pass/fail/skipped state
+- Review findings, grouped by the buckets above
+- Any explicit follow-up items that were deferred

--- a/docs/agent-playbooks/sdlc.md
+++ b/docs/agent-playbooks/sdlc.md
@@ -1,0 +1,89 @@
+# SDLC playbook
+
+This playbook captures repo-level delivery policy that applies across agent runtimes.
+
+## Default flow
+
+All non-trivial changes move through the same flow:
+
+`branch -> commit -> push -> PR -> review -> merge`
+
+`main` is a review-only integration branch. Do not land changes there directly.
+
+## Picking work
+
+When work is open-ended and issue-driven, prefer unassigned issues so parallel sessions do not
+collide:
+
+```sh
+gh issue list --search 'no:assignee' --state open
+```
+
+If the user names a specific issue, work that issue regardless of assignee.
+
+## Starting work
+
+Start each cohesive change on its own topic branch from `main`.
+
+Suggested naming:
+
+- Milestones: `m<N>-<slug>`
+- Smaller tasks: `<verb>-<slug>`
+
+If the runtime supports issue assignment and the branch maps to a tracked issue, assign it before
+or during the work so concurrent sessions do not race on the same ticket.
+
+## While working
+
+- Keep commits coherent. Avoid both mega-commits and noisy micro-commits.
+- Use short imperative subjects and a body that explains why the change exists.
+- Run the checks that match the scope before pushing:
+  - Kernel or behavior changes: `cargo xtask test` and `cargo xtask smoke`
+  - Docs/process/skill-only changes: at minimum run a targeted validation step appropriate for the
+    runtime; use `cargo xtask build` when you want a low-cost repo sanity check
+- Do not push a knowingly red branch.
+
+## Capturing follow-up work
+
+If a useful follow-up comes up mid-task but is out of scope for the current branch, capture it in
+the repo's issue tracker when the runtime has write access. Include enough context that someone can
+act on it later without the current chat transcript.
+
+If the runtime is read-only for issues, record the follow-up in the PR summary or final handoff.
+
+## Opening the PR
+
+When the branch is ready for review:
+
+1. Push the branch.
+2. Open a PR against `main`.
+3. Keep the title short; put detail in the body.
+4. Include a concise summary and the exact tests or checks you actually ran.
+
+Suggested PR body structure:
+
+```markdown
+## Summary
+- <what changed>
+- <why it changed>
+
+## Testing
+- <exact command and result>
+```
+
+## Responding to review
+
+- Treat correctness issues and broken invariants as must-fix items.
+- Fixes should normally be follow-up commits on the same branch.
+- Distinguish cheap in-scope nits from out-of-scope suggestions that should be deferred.
+
+## After merge
+
+- Delete the local topic branch when it is no longer needed.
+- Pull `main` before starting the next cohesive change.
+
+## Never
+
+- Commit directly to `main`.
+- Force-push a shared branch without explicit approval.
+- Rewrite commits that have already been reviewed unless there is a strong, explicit reason.

--- a/docs/agent-playbooks/sdlc.md
+++ b/docs/agent-playbooks/sdlc.md
@@ -67,8 +67,8 @@ Suggested PR body structure:
 - <what changed>
 - <why it changed>
 
-## Testing
-- <exact command and result>
+## Test plan
+- [x] <exact command and result>
 ```
 
 ## Responding to review

--- a/docs/agent-playbooks/testing.md
+++ b/docs/agent-playbooks/testing.md
@@ -1,0 +1,67 @@
+# Testing playbook
+
+This playbook captures repo-level test behavior that applies across agent runtimes.
+
+## Core commands
+
+```sh
+cargo xtask test     # host unit tests + QEMU integration tests
+cargo xtask smoke    # boot the normal kernel and assert expected serial markers
+```
+
+Run `cargo xtask test` for code changes that can affect logic or boot behavior. Run
+`cargo xtask smoke` when you need end-to-end confidence that the normal boot path still
+prints the expected serial markers.
+
+## Layer 1 - host unit tests
+
+Pure-logic modules can compile under host `std` because `kernel/src/lib.rs` is
+`#![cfg_attr(not(test), no_std)]`.
+
+Use inline `#[cfg(test)] mod tests { ... }` blocks for code that does not touch:
+
+- `x86_64`
+- `uart_16550`
+- MMIO
+- Limine statics
+
+Those tests run in the first phase of `cargo xtask test`.
+
+## Layer 2 - QEMU integration tests
+
+Each file under `kernel/tests/*.rs` is its own `#![no_std] #![no_main]` kernel binary
+with its own `_start`, panic handler, and explicit test list. The repo builds them for
+`x86_64-unknown-none`, wraps them in ISOs, and boots them under QEMU through
+`xtask test-runner`.
+
+Pass/fail comes from the `isa-debug-exit` protocol:
+
+- Success: write `0x20` to port `0xf4`, which makes QEMU exit `65`
+- Failure: write `0x10` to port `0xf4`, which makes QEMU exit `33`
+
+`should_panic.rs` intentionally inverts its panic handler so the panic path itself is
+tested.
+
+To add a new integration test:
+
+1. Create `kernel/tests/my_test.rs` modeled on an existing test such as `basic_boot.rs`.
+2. Add a `[[test]] name = "my_test" harness = false` entry to `kernel/Cargo.toml`.
+3. Add `"my_test"` to the explicit test-name list in `xtask/src/main.rs::test_all`.
+
+## Layer 3 - smoke regression
+
+`cargo xtask smoke` boots the normal kernel, captures serial output for a short window,
+then checks that every marker in `SMOKE_MARKERS` is present.
+
+When a new boot-phase log line becomes part of the expected healthy path, add it to
+`SMOKE_MARKERS` so the smoke lane protects it.
+
+## Gotchas
+
+- Do not add `-no-shutdown` to the `test_runner` QEMU args. It breaks the
+  `isa-debug-exit` pass/fail protocol and causes tests to hang until timeout.
+- Do not run `cargo test --target x86_64-unknown-none` without explicit `--test <name>`
+  arguments. Cargo will try to build the library unittest harness and fail because that
+  flow expects `std`.
+- Keep host tests and kernel-target tests on separate `build-std` paths. `xtask` owns
+  the kernel-target flags so host unit tests can use the normal sysroot.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add shared `docs/agent-playbooks/` docs for build/run, testing, SDLC, and PR review policy
- slim `AGENTS.md` into a Cursor-native wrapper that points at the shared playbooks
- refactor the Claude skills to consume the shared playbooks and keep Claude-only orchestration details local
- address review feedback by restoring Claude-specific SDLC guardrails, clarifying the `wait-for-pr` done criteria, and keeping the shared build playbook runtime-agnostic

## Testing
- [x] `git diff --check`
- [x] `cargo xtask build` (sanity check for this docs/process-only refactor)
- [x] `rg "Cursor Cloud" docs/agent-playbooks`
- [x] `rg "## Test plan|Co-Authored-By: Claude Opus 4.6|Merge a PR on the user's behalf unless asked|## What \"done\" means" /workspace`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45cc1246-116e-4f43-bee0-eab80cae3dc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45cc1246-116e-4f43-bee0-eab80cae3dc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

