### PR TITLE
task: priority-aware scheduler with nice values + affinity metadata

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -91,3 +91,7 @@ harness = false
 [[test]]
 name = "shell_smoke"
 harness = false
+
+[[test]]
+name = "priority"
+harness = false

--- a/kernel/src/shell/mod.rs
+++ b/kernel/src/shell/mod.rs
@@ -128,10 +128,12 @@ fn cmd_tasks() {
             TaskStateView::Blocked => "[blk]",
         };
         serial_println!(
-            "  task {:>3} {} slice={} ms",
+            "  task {:>3} {} slice={} ms prio={} nice={}",
             t.id,
             tag,
             t.slice_remaining_ms,
+            t.priority,
+            t.nice,
         );
     });
 }

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -111,14 +111,7 @@ pub fn set_priority(id: usize, priority: u8) -> bool {
     if found {
         // If a ready task now outranks the running one, shorten its slice
         // so the next tick swaps it out.
-        if let Some(cur) = sched.current.as_ref() {
-            let cur_prio = cur.priority;
-            if let Some(top_ready) = sched.highest_ready_priority() {
-                if top_ready > cur_prio {
-                    sched.current.as_mut().unwrap().slice_remaining_ms = 0;
-                }
-            }
-        }
+        preempt_if_higher_ready(&mut sched);
     }
 
     drop(sched);
@@ -153,14 +146,7 @@ pub fn adjust_nice(id: usize, delta: i8) -> Option<i8> {
     });
 
     if result.is_some() {
-        if let Some(cur) = sched.current.as_ref() {
-            let cur_prio = cur.priority;
-            if let Some(top_ready) = sched.highest_ready_priority() {
-                if top_ready > cur_prio {
-                    sched.current.as_mut().unwrap().slice_remaining_ms = 0;
-                }
-            }
-        }
+        preempt_if_higher_ready(&mut sched);
     }
 
     drop(sched);
@@ -293,6 +279,22 @@ fn maybe_preempt_current_for_priority(sched: &mut Scheduler, new_prio: u8) {
     };
     if new_prio > cur.priority {
         cur.slice_remaining_ms = 0;
+    }
+}
+
+/// Query the ready bank and shorten the current slice to zero if any
+/// ready task outranks the running one. Must be called with the
+/// scheduler lock held.
+fn preempt_if_higher_ready(sched: &mut Scheduler) {
+    let Some(cur) = sched.current.as_ref() else {
+        return;
+    };
+    let cur_prio = cur.priority;
+    if sched
+        .highest_ready_priority()
+        .is_some_and(|p| p > cur_prio)
+    {
+        sched.current.as_mut().unwrap().slice_remaining_ms = 0;
     }
 }
 

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -145,8 +145,8 @@ pub fn adjust_nice(id: usize, delta: i8) -> Option<i8> {
     let current_prio = find_priority(&sched, id);
     let result = current_prio.map(|prio| {
         let current_nice = nice_from_priority(prio);
-        let new_nice = (current_nice as i16 + delta as i16)
-            .clamp(NICE_MIN as i16, NICE_MAX as i16) as i8;
+        let new_nice =
+            (current_nice as i16 + delta as i16).clamp(NICE_MIN as i16, NICE_MAX as i16) as i8;
         let new_prio = priority_from_nice(new_nice);
         apply_priority(&mut sched, id, new_prio);
         new_nice

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -290,10 +290,7 @@ fn preempt_if_higher_ready(sched: &mut Scheduler) {
         return;
     };
     let cur_prio = cur.priority;
-    if sched
-        .highest_ready_priority()
-        .is_some_and(|p| p > cur_prio)
-    {
+    if sched.highest_ready_priority().is_some_and(|p| p > cur_prio) {
         sched.current.as_mut().unwrap().slice_remaining_ms = 0;
     }
 }

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -20,13 +20,19 @@
 //!
 //! ## What's *not* here (yet)
 //!
-//! - Priorities, per-CPU queues, tickless idle.
+//! - Per-CPU queues, tickless idle.
 //! - Per-task address spaces.
+//! - Priority inheritance on blocking primitives (tracked for a later
+//!   pass alongside the sleeping-mutex work).
+//!
+//! Scheduling priorities and UNIX-style nice values are live (see
+//! [`priority`] and [`spawn_with_priority`] / [`set_priority`]).
 //!
 //! Blocking primitives (mutex-that-sleeps, channels, waitqueues) live
 //! in [`crate::sync`] and are built on top of [`block_current`] and
 //! [`wake`] below.
 
+pub mod priority;
 mod scheduler;
 mod switch;
 mod task;
@@ -35,6 +41,11 @@ use alloc::boxed::Box;
 use core::sync::atomic::Ordering;
 use spin::{Lazy, Mutex};
 use x86_64::instructions::interrupts;
+
+pub use priority::{
+    clamp_priority, nice_from_priority, priority_from_nice, AFFINITY_ALL, DEFAULT_PRIORITY,
+    MAX_PRIORITY, NICE_MAX, NICE_MIN,
+};
 
 use scheduler::Scheduler;
 use switch::context_switch;
@@ -59,11 +70,230 @@ pub fn init() {
     serial_println!("tasks: scheduler online");
 }
 
-/// Queue a new task running `entry`. The task starts at the back of
-/// the ready queue and will run when scheduling reaches it.
+/// Queue a new task running `entry` at [`DEFAULT_PRIORITY`]. The task
+/// starts at the back of its priority's ready FIFO and will run when
+/// scheduling reaches it.
 pub fn spawn(entry: fn() -> !) {
+    spawn_with_priority(entry, DEFAULT_PRIORITY);
+}
+
+/// Like [`spawn`] but starts the task at a caller-chosen priority.
+/// Values above [`MAX_PRIORITY`] are clamped.
+pub fn spawn_with_priority(entry: fn() -> !, priority: u8) {
+    let task = Box::new(Task::new_with_priority(entry, priority));
+    let new_prio = task.priority;
     let mut sched = SCHED.lock();
-    sched.ready.push_back(Box::new(Task::new(entry)));
+    sched.push_ready(task);
+    maybe_preempt_current_for_priority(&mut sched, new_prio);
+}
+
+/// Like [`spawn_with_priority`] but accepts a UNIX-style nice value
+/// (`-20..=19`). Wrapper for API ergonomics — mapping lives in
+/// [`priority_from_nice`].
+pub fn spawn_with_nice(entry: fn() -> !, nice: i8) {
+    spawn_with_priority(entry, priority_from_nice(nice));
+}
+
+/// Update the priority of task `id` in place. Takes effect on the next
+/// scheduling decision: if the task is currently ready it moves to the
+/// correct priority bucket; if it is running and its priority dropped
+/// below another ready task, the current slice is ended so the higher-
+/// priority task preempts at the next tick.
+///
+/// Returns `true` if a task with `id` was found, `false` otherwise.
+pub fn set_priority(id: usize, priority: u8) -> bool {
+    let priority = clamp_priority(priority);
+    let was_on = interrupts::are_enabled();
+    interrupts::disable();
+    let mut sched = SCHED.lock();
+
+    let found = apply_priority(&mut sched, id, priority);
+    if found {
+        // If a ready task now outranks the running one, shorten its slice
+        // so the next tick swaps it out.
+        if let Some(cur) = sched.current.as_ref() {
+            let cur_prio = cur.priority;
+            if let Some(top_ready) = sched.highest_ready_priority() {
+                if top_ready > cur_prio {
+                    sched.current.as_mut().unwrap().slice_remaining_ms = 0;
+                }
+            }
+        }
+    }
+
+    drop(sched);
+    if was_on {
+        interrupts::enable();
+    }
+    found
+}
+
+/// Like [`set_priority`] but with a nice-value argument. Returns
+/// whether a task with `id` was found.
+pub fn set_nice(id: usize, nice: i8) -> bool {
+    set_priority(id, priority_from_nice(nice))
+}
+
+/// Adjust task `id`'s nice value by `delta`, clamped to the legal
+/// range. Returns the resulting nice value, or `None` if the id is
+/// unknown.
+pub fn adjust_nice(id: usize, delta: i8) -> Option<i8> {
+    let was_on = interrupts::are_enabled();
+    interrupts::disable();
+    let mut sched = SCHED.lock();
+
+    let current_prio = find_priority(&sched, id);
+    let result = current_prio.map(|prio| {
+        let current_nice = nice_from_priority(prio);
+        let new_nice = (current_nice as i16 + delta as i16)
+            .clamp(NICE_MIN as i16, NICE_MAX as i16) as i8;
+        let new_prio = priority_from_nice(new_nice);
+        apply_priority(&mut sched, id, new_prio);
+        new_nice
+    });
+
+    if result.is_some() {
+        if let Some(cur) = sched.current.as_ref() {
+            let cur_prio = cur.priority;
+            if let Some(top_ready) = sched.highest_ready_priority() {
+                if top_ready > cur_prio {
+                    sched.current.as_mut().unwrap().slice_remaining_ms = 0;
+                }
+            }
+        }
+    }
+
+    drop(sched);
+    if was_on {
+        interrupts::enable();
+    }
+    result
+}
+
+/// Set the CPU affinity mask of task `id`. Bit `n` set means the task
+/// may run on CPU `n`. On the single-CPU kernel the mask is stored but
+/// not enforced. Returns `true` if the id was found.
+///
+/// A mask of `0` is rejected (a task must be runnable somewhere) and
+/// returns `false` without modifying the task.
+pub fn set_affinity(id: usize, mask: u64) -> bool {
+    if mask == 0 {
+        return false;
+    }
+    let was_on = interrupts::are_enabled();
+    interrupts::disable();
+    let mut sched = SCHED.lock();
+
+    let mut found = false;
+    if let Some(cur) = sched.current.as_mut() {
+        if cur.id == id {
+            cur.affinity = mask;
+            found = true;
+        }
+    }
+    if !found {
+        'outer: for queue in sched.ready.values_mut() {
+            for task in queue.iter_mut() {
+                if task.id == id {
+                    task.affinity = mask;
+                    found = true;
+                    break 'outer;
+                }
+            }
+        }
+    }
+    if !found {
+        if let Some(task) = sched.parked.get_mut(&id) {
+            task.affinity = mask;
+            found = true;
+        }
+    }
+
+    drop(sched);
+    if was_on {
+        interrupts::enable();
+    }
+    found
+}
+
+/// Return the current scheduling priority of the currently-running
+/// task. Useful for callers that want to spawn a helper at the same
+/// or adjusted priority.
+pub fn current_priority() -> u8 {
+    SCHED
+        .lock()
+        .current
+        .as_ref()
+        .map(|t| t.priority)
+        .unwrap_or(DEFAULT_PRIORITY)
+}
+
+fn find_priority(sched: &Scheduler, id: usize) -> Option<u8> {
+    if let Some(cur) = sched.current.as_ref() {
+        if cur.id == id {
+            return Some(cur.priority);
+        }
+    }
+    for queue in sched.ready.values() {
+        for task in queue.iter() {
+            if task.id == id {
+                return Some(task.priority);
+            }
+        }
+    }
+    sched.parked.get(&id).map(|t| t.priority)
+}
+
+/// Mutate the stored priority of task `id` across current/ready/parked
+/// and re-bucket if it's in the ready bank. Returns `true` on hit.
+fn apply_priority(sched: &mut Scheduler, id: usize, new_priority: u8) -> bool {
+    if let Some(cur) = sched.current.as_mut() {
+        if cur.id == id {
+            cur.priority = new_priority;
+            return true;
+        }
+    }
+
+    // Search ready queues; if found, remove and re-bucket at new priority.
+    let mut moved: Option<Box<Task>> = None;
+    let mut drop_key: Option<u8> = None;
+    for (&prio, queue) in sched.ready.iter_mut() {
+        if let Some(pos) = queue.iter().position(|t| t.id == id) {
+            let mut task = queue.remove(pos).expect("position just confirmed");
+            task.priority = new_priority;
+            if queue.is_empty() {
+                drop_key = Some(prio);
+            }
+            moved = Some(task);
+            break;
+        }
+    }
+    if let Some(k) = drop_key {
+        sched.ready.remove(&k);
+    }
+    if let Some(task) = moved {
+        sched.push_ready(task);
+        return true;
+    }
+
+    if let Some(task) = sched.parked.get_mut(&id) {
+        task.priority = new_priority;
+        return true;
+    }
+
+    false
+}
+
+/// If a ready task at `new_prio` outranks the currently-running task,
+/// end the current slice so the PIT tick preempts promptly. Must be
+/// called with the scheduler lock held.
+fn maybe_preempt_current_for_priority(sched: &mut Scheduler, new_prio: u8) {
+    let Some(cur) = sched.current.as_mut() else {
+        return;
+    };
+    if new_prio > cur.priority {
+        cur.slice_remaining_ms = 0;
+    }
 }
 
 /// Public view of a task's scheduling state, used by [`TaskInfo`].
@@ -82,6 +312,12 @@ pub struct TaskInfo {
     pub id: usize,
     pub slice_remaining_ms: u32,
     pub state: TaskStateView,
+    /// Effective priority (`0..=MAX_PRIORITY`). Higher values preempt.
+    pub priority: u8,
+    /// UNIX-style nice value (`-20..=19`). Derived from `priority`.
+    pub nice: i8,
+    /// CPU affinity mask (bit `n` = allowed on CPU `n`).
+    pub affinity: u64,
 }
 
 /// Invoke `f` once per live task: current first, then ready queue in
@@ -93,20 +329,26 @@ pub fn for_each_task(mut f: impl FnMut(TaskInfo)) {
     let snapshot: alloc::vec::Vec<TaskInfo> = {
         let sched = SCHED.lock();
         let mut out = alloc::vec::Vec::with_capacity(
-            sched.current.is_some() as usize + sched.ready.len() + sched.parked.len(),
+            sched.current.is_some() as usize + sched.ready_count() + sched.parked.len(),
         );
         if let Some(cur) = sched.current.as_ref() {
             out.push(TaskInfo {
                 id: cur.id,
                 slice_remaining_ms: cur.slice_remaining_ms,
                 state: TaskStateView::Running,
+                priority: cur.priority,
+                nice: nice_from_priority(cur.priority),
+                affinity: cur.affinity,
             });
         }
-        for t in sched.ready.iter() {
+        for t in sched.iter_ready() {
             out.push(TaskInfo {
                 id: t.id,
                 slice_remaining_ms: t.slice_remaining_ms,
                 state: TaskStateView::Ready,
+                priority: t.priority,
+                nice: nice_from_priority(t.priority),
+                affinity: t.affinity,
             });
         }
         for t in sched.parked.values() {
@@ -114,6 +356,9 @@ pub fn for_each_task(mut f: impl FnMut(TaskInfo)) {
                 id: t.id,
                 slice_remaining_ms: t.slice_remaining_ms,
                 state: TaskStateView::Blocked,
+                priority: t.priority,
+                nice: nice_from_priority(t.priority),
+                affinity: t.affinity,
             });
         }
         out
@@ -175,14 +420,19 @@ pub fn preempt_tick() {
     }
 
     {
+        let top_ready = sched.highest_ready_priority();
         let current = sched.current.as_mut().unwrap();
         current.slice_remaining_ms = current.slice_remaining_ms.saturating_sub(TICK_MS as u32);
-        if current.slice_remaining_ms > 0 {
+        // Preempt immediately if something at a strictly higher
+        // priority is ready — don't wait for the current slice to
+        // wind down before handing over.
+        let higher_ready = top_ready.is_some_and(|p| p > current.priority);
+        if current.slice_remaining_ms > 0 && !higher_ready {
             return;
         }
     }
 
-    let Some(mut next) = sched.ready.pop_front() else {
+    let Some(mut next) = sched.pop_highest() else {
         // Slice expired but nobody else is ready. Reload and keep
         // running — prevents repeated try_lock churn on every tick.
         sched.current.as_mut().unwrap().slice_remaining_ms = DEFAULT_SLICE_MS;
@@ -193,10 +443,18 @@ pub fn preempt_tick() {
     prev.state = TaskState::Ready;
     next.state = TaskState::Running;
     let next_rsp = next.rsp;
+    let prev_prio = prev.priority;
     sched.current = Some(next);
     sched.current.as_mut().unwrap().slice_remaining_ms = DEFAULT_SLICE_MS;
-    sched.ready.push_back(prev);
-    let prev_ref = sched.ready.back_mut().expect("just pushed");
+    sched.push_ready(prev);
+    // The push above put `prev` at the back of its priority's queue;
+    // retrieve the pointer through the bank to keep the Box-stability
+    // invariant.
+    let prev_ref = sched
+        .ready
+        .get_mut(&prev_prio)
+        .and_then(|q| q.back_mut())
+        .expect("just pushed");
     let prev_rsp_ptr: *mut usize = &mut prev_ref.rsp as *mut usize;
     drop(sched);
 
@@ -274,7 +532,7 @@ pub fn block_current() {
             return;
         }
 
-        let Some(mut next) = sched.ready.pop_front() else {
+        let Some(mut next) = sched.pop_highest() else {
             panic!("task::block_current: no ready task to switch to");
         };
         let mut prev = sched.current.take().unwrap();
@@ -336,7 +594,11 @@ pub fn wake(id: usize) {
     if let Some(mut task) = sched.parked.remove(&id) {
         task.state = TaskState::Ready;
         task.slice_remaining_ms = DEFAULT_SLICE_MS;
-        sched.ready.push_back(task);
+        let prio = task.priority;
+        sched.push_ready(task);
+        // If the newly-ready task outranks the current one, cut the
+        // current slice short so the next tick rotates it in.
+        maybe_preempt_current_for_priority(&mut sched, prio);
         drop(sched);
         if was_on {
             interrupts::enable();
@@ -357,15 +619,20 @@ pub fn wake(id: usize) {
             return;
         }
     }
-    for task in sched.ready.iter() {
+    let ready_hit = sched.iter_ready().any(|task| {
         if task.id == id {
             task.wake_pending.store(true, Ordering::Release);
-            drop(sched);
-            if was_on {
-                interrupts::enable();
-            }
-            return;
+            true
+        } else {
+            false
         }
+    });
+    if ready_hit {
+        drop(sched);
+        if was_on {
+            interrupts::enable();
+        }
+        return;
     }
 
     // Unknown id — drop the wake on the floor. Tasks don't exit yet so

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -423,18 +423,24 @@ pub fn preempt_tick() {
         let top_ready = sched.highest_ready_priority();
         let current = sched.current.as_mut().unwrap();
         current.slice_remaining_ms = current.slice_remaining_ms.saturating_sub(TICK_MS as u32);
-        // Preempt immediately if something at a strictly higher
-        // priority is ready — don't wait for the current slice to
-        // wind down before handing over.
+        // Preempt immediately if something at strictly higher priority
+        // is ready. Otherwise keep running until the slice expires; when
+        // it does, only rotate if a peer at the same priority is ready
+        // — handing off to a strictly lower-priority task would defeat
+        // the whole point of priorities.
         let higher_ready = top_ready.is_some_and(|p| p > current.priority);
-        if current.slice_remaining_ms > 0 && !higher_ready {
+        let peer_ready = top_ready.is_some_and(|p| p == current.priority);
+        if !higher_ready && (current.slice_remaining_ms > 0 || !peer_ready) {
+            if current.slice_remaining_ms == 0 {
+                current.slice_remaining_ms = DEFAULT_SLICE_MS;
+            }
             return;
         }
     }
 
     let Some(mut next) = sched.pop_highest() else {
-        // Slice expired but nobody else is ready. Reload and keep
-        // running — prevents repeated try_lock churn on every tick.
+        // Shouldn't happen: the guard above already returned when the
+        // ready bank was empty. Reload defensively.
         sched.current.as_mut().unwrap().slice_remaining_ms = DEFAULT_SLICE_MS;
         return;
     };

--- a/kernel/src/task/priority.rs
+++ b/kernel/src/task/priority.rs
@@ -16,7 +16,12 @@ pub const MAX_PRIORITY: u8 = 39;
 
 /// Priority assigned to tasks spawned without an explicit priority.
 /// Corresponds to nice 0.
-pub const DEFAULT_PRIORITY: u8 = 20;
+///
+/// Set so the full nice range (`-20..=19`) round-trips through
+/// `priority_from_nice` / `nice_from_priority` without saturating at
+/// [`MAX_PRIORITY`]: nice = -20 maps to priority 39, nice = 19 maps to
+/// priority 0.
+pub const DEFAULT_PRIORITY: u8 = 19;
 
 /// Number of distinct priority levels (0..=MAX_PRIORITY).
 pub const NUM_PRIORITIES: usize = MAX_PRIORITY as usize + 1;
@@ -40,7 +45,8 @@ pub const fn priority_from_nice(nice: i8) -> u8 {
     } else {
         nice
     };
-    // nice -20 → 39, nice 0 → 20 (DEFAULT_PRIORITY), nice 19 → 1.
+    // nice -20 → 39 (MAX_PRIORITY), nice 0 → 19 (DEFAULT_PRIORITY),
+    // nice 19 → 0.
     (DEFAULT_PRIORITY as i16 - clamped as i16) as u8
 }
 

--- a/kernel/src/task/priority.rs
+++ b/kernel/src/task/priority.rs
@@ -48,7 +48,11 @@ pub const fn priority_from_nice(nice: i8) -> u8 {
 /// produce this priority. Priorities above [`MAX_PRIORITY`] clamp to
 /// `NICE_MIN`.
 pub const fn nice_from_priority(prio: u8) -> i8 {
-    let p = if prio > MAX_PRIORITY { MAX_PRIORITY } else { prio };
+    let p = if prio > MAX_PRIORITY {
+        MAX_PRIORITY
+    } else {
+        prio
+    };
     (DEFAULT_PRIORITY as i16 - p as i16) as i8
 }
 
@@ -60,4 +64,3 @@ pub const fn clamp_priority(p: u8) -> u8 {
         p
     }
 }
-

--- a/kernel/src/task/priority.rs
+++ b/kernel/src/task/priority.rs
@@ -1,0 +1,63 @@
+//! Task scheduling priorities, nice values, and CPU affinity.
+//!
+//! Priorities run 0..=[`MAX_PRIORITY`] with higher values running first.
+//! Nice values follow the UNIX convention (`-20..=19`, lower = hotter)
+//! and map onto priority via [`priority_from_nice`]. Default-spawned
+//! tasks land at [`DEFAULT_PRIORITY`] (nice 0).
+//!
+//! CPU affinity is a bitmask over logical CPUs (bit `n` set means the
+//! task may run on CPU `n`). The kernel is single-CPU today, so the
+//! mask is stored but not enforced — it exists so userspace-visible
+//! affinity APIs can be wired up without another Task-shape change
+//! once SMP lands.
+
+/// Highest legal priority value. Priorities are `u8` in `0..=MAX_PRIORITY`.
+pub const MAX_PRIORITY: u8 = 39;
+
+/// Priority assigned to tasks spawned without an explicit priority.
+/// Corresponds to nice 0.
+pub const DEFAULT_PRIORITY: u8 = 20;
+
+/// Number of distinct priority levels (0..=MAX_PRIORITY).
+pub const NUM_PRIORITIES: usize = MAX_PRIORITY as usize + 1;
+
+/// Lowest legal nice value — equivalent to the hottest priority.
+pub const NICE_MIN: i8 = -20;
+/// Highest legal nice value — equivalent to the coldest priority.
+pub const NICE_MAX: i8 = 19;
+
+/// All CPUs mask; default affinity for every spawned task.
+pub const AFFINITY_ALL: u64 = u64::MAX;
+
+/// Map a UNIX nice value (`-20..=19`) onto the scheduler's priority
+/// space (`0..=39`). Lower nice = higher priority. Values outside the
+/// legal range are clamped.
+pub const fn priority_from_nice(nice: i8) -> u8 {
+    let clamped = if nice < NICE_MIN {
+        NICE_MIN
+    } else if nice > NICE_MAX {
+        NICE_MAX
+    } else {
+        nice
+    };
+    // nice -20 → 39, nice 0 → 20 (DEFAULT_PRIORITY), nice 19 → 1.
+    (DEFAULT_PRIORITY as i16 - clamped as i16) as u8
+}
+
+/// Inverse of [`priority_from_nice`]: recover the nice value that would
+/// produce this priority. Priorities above [`MAX_PRIORITY`] clamp to
+/// `NICE_MIN`.
+pub const fn nice_from_priority(prio: u8) -> i8 {
+    let p = if prio > MAX_PRIORITY { MAX_PRIORITY } else { prio };
+    (DEFAULT_PRIORITY as i16 - p as i16) as i8
+}
+
+/// Clamp an arbitrary integer priority into the legal range.
+pub const fn clamp_priority(p: u8) -> u8 {
+    if p > MAX_PRIORITY {
+        MAX_PRIORITY
+    } else {
+        p
+    }
+}
+

--- a/kernel/src/task/priority.rs
+++ b/kernel/src/task/priority.rs
@@ -23,9 +23,6 @@ pub const MAX_PRIORITY: u8 = 39;
 /// priority 0.
 pub const DEFAULT_PRIORITY: u8 = 19;
 
-/// Number of distinct priority levels (0..=MAX_PRIORITY).
-pub const NUM_PRIORITIES: usize = MAX_PRIORITY as usize + 1;
-
 /// Lowest legal nice value — equivalent to the hottest priority.
 pub const NICE_MIN: i8 = -20;
 /// Highest legal nice value — equivalent to the coldest priority.

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -50,10 +50,7 @@ impl Scheduler {
 
     /// Enqueue `task` at the back of its priority's ready FIFO.
     pub fn push_ready(&mut self, task: Box<Task>) {
-        self.ready
-            .entry(task.priority)
-            .or_default()
-            .push_back(task);
+        self.ready.entry(task.priority).or_default().push_back(task);
     }
 
     /// Pop the highest-priority ready task, or `None` if nothing is

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -1,14 +1,22 @@
-//! Round-robin scheduler state. Holds the currently-running task, a
-//! FIFO ready queue, and a side-table of blocked (parked) tasks.
+//! Priority-aware scheduler state. Holds the currently-running task, a
+//! per-priority FIFO ready queue bank, and a side-table of blocked
+//! (parked) tasks.
 //!
 //! Rescheduling happens from either `preempt_tick()` (PIT ISR, on
-//! slice exhaustion) or `block_current()` (task voluntarily parking
-//! on a waitqueue). Both paths lock the scheduler, update the queues,
-//! then drop the lock before `context_switch` to avoid deadlocking
-//! the incoming task's own scheduler entry.
+//! slice exhaustion or when a higher-priority task becomes ready) or
+//! `block_current()` (task voluntarily parking on a waitqueue). Both
+//! paths lock the scheduler, update the queues, then drop the lock
+//! before `context_switch` to avoid deadlocking the incoming task's
+//! own scheduler entry.
+//!
+//! The ready bank is a `BTreeMap<u8, VecDeque<Box<Task>>>` keyed by
+//! priority. `pick_next` drains highest priority first; within a level
+//! tasks rotate in FIFO order. Empty priority queues are dropped from
+//! the map, so iteration cost scales with the number of *distinct*
+//! priorities currently runnable rather than the full 40-entry range.
 //!
 //! Blocked tasks are parked in `parked` (keyed by task id) and are
-//! invisible to the round-robin rotation. `task::wake(id)` migrates
+//! invisible to the scheduling rotation. `task::wake(id)` migrates
 //! them back to `ready`.
 
 use alloc::boxed::Box;
@@ -18,7 +26,12 @@ use super::task::Task;
 
 pub(super) struct Scheduler {
     pub current: Option<Box<Task>>,
-    pub ready: VecDeque<Box<Task>>,
+    /// Ready tasks grouped by priority. Higher keys run first; within a
+    /// level the `VecDeque` is a FIFO ring for round-robin rotation.
+    /// Invariant: every value is a non-empty `VecDeque` — an empty
+    /// queue is removed from the map so `highest_ready_priority` can
+    /// rely on the last key being actually runnable.
+    pub ready: BTreeMap<u8, VecDeque<Box<Task>>>,
     /// Tasks that have called `block_current` and are waiting to be
     /// unparked by `wake(id)`. Keyed by task id for O(log n) lookup.
     /// Blocking primitives (see `crate::sync`) move tasks in and out
@@ -30,8 +43,46 @@ impl Scheduler {
     pub const fn new() -> Self {
         Self {
             current: None,
-            ready: VecDeque::new(),
+            ready: BTreeMap::new(),
             parked: BTreeMap::new(),
         }
+    }
+
+    /// Enqueue `task` at the back of its priority's ready FIFO.
+    pub fn push_ready(&mut self, task: Box<Task>) {
+        self.ready
+            .entry(task.priority)
+            .or_default()
+            .push_back(task);
+    }
+
+    /// Pop the highest-priority ready task, or `None` if nothing is
+    /// runnable. Removes empty buckets as it goes to uphold the
+    /// non-empty invariant.
+    pub fn pop_highest(&mut self) -> Option<Box<Task>> {
+        let highest = *self.ready.keys().next_back()?;
+        let queue = self.ready.get_mut(&highest)?;
+        let task = queue.pop_front();
+        if queue.is_empty() {
+            self.ready.remove(&highest);
+        }
+        task
+    }
+
+    /// Highest priority currently runnable in the ready bank, or
+    /// `None` if the bank is empty.
+    pub fn highest_ready_priority(&self) -> Option<u8> {
+        self.ready.keys().next_back().copied()
+    }
+
+    /// Total number of ready tasks across all priority buckets.
+    pub fn ready_count(&self) -> usize {
+        self.ready.values().map(|q| q.len()).sum()
+    }
+
+    /// Iterate ready tasks in scheduling order (highest priority first,
+    /// FIFO within a level). Exposed for snapshots in `for_each_task`.
+    pub fn iter_ready(&self) -> impl Iterator<Item = &Box<Task>> {
+        self.ready.values().rev().flat_map(|q| q.iter())
     }
 }

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -117,8 +117,11 @@ impl Task {
         }
     }
 
-    /// Allocate a guard-paged stack and prime it so the first switch into
-    /// this task runs `entry` via the trampoline.
+    /// Allocate a guard-paged stack and prime it so the first switch
+    /// into this task runs `entry` via the trampoline at the given
+    /// scheduling priority. Affinity defaults to [`AFFINITY_ALL`];
+    /// callers that care about pinning call [`super::set_affinity`]
+    /// after spawning.
     ///
     /// VA layout (low → high):
     /// ```text
@@ -132,11 +135,6 @@ impl Task {
     ///   r15=0  r14=0  r13=0  r12=entry  rbp=0  rbx=0  ret=trampoline  <top>
     ///   ^ saved rsp (initial)
     /// ```
-    /// Allocate a guard-paged stack and prime it so the first switch
-    /// into this task runs `entry` via the trampoline at the given
-    /// scheduling priority. Affinity defaults to [`AFFINITY_ALL`];
-    /// callers that care about pinning call [`super::set_affinity`]
-    /// after spawning.
     pub fn new_with_priority(entry: fn() -> !, priority: u8) -> Self {
         // Bump-allocate a fresh VA slot.
         let slot_va = NEXT_STACK_VA.fetch_add(TASK_SLOT_SIZE, Ordering::Relaxed);

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -25,6 +25,7 @@ use x86_64::VirtAddr;
 
 use crate::mem::paging;
 
+use super::priority::{AFFINITY_ALL, DEFAULT_PRIORITY};
 use super::switch::task_entry_trampoline;
 use super::DEFAULT_SLICE_MS;
 
@@ -88,6 +89,15 @@ pub(super) struct Task {
     /// guards against the "wake before park" lost-wakeup race in
     /// [`crate::sync::WaitQueue::wait_while`].
     pub wake_pending: AtomicBool,
+    /// Effective scheduling priority in `0..=MAX_PRIORITY`. Higher
+    /// values preempt lower ones. See [`super::priority`] for the
+    /// priority/nice mapping.
+    pub priority: u8,
+    /// Bitmask of CPUs this task is allowed to run on (bit `n` set =
+    /// allowed on CPU `n`). Stored-but-unenforced on the single-CPU
+    /// kernel; exists so affinity APIs keep a stable shape once SMP
+    /// lands.
+    pub affinity: u64,
 }
 
 impl Task {
@@ -102,6 +112,8 @@ impl Task {
             slice_remaining_ms: DEFAULT_SLICE_MS,
             state: TaskState::Running,
             wake_pending: AtomicBool::new(false),
+            priority: DEFAULT_PRIORITY,
+            affinity: AFFINITY_ALL,
         }
     }
 
@@ -120,7 +132,12 @@ impl Task {
     ///   r15=0  r14=0  r13=0  r12=entry  rbp=0  rbx=0  ret=trampoline  <top>
     ///   ^ saved rsp (initial)
     /// ```
-    pub fn new(entry: fn() -> !) -> Self {
+    /// Allocate a guard-paged stack and prime it so the first switch
+    /// into this task runs `entry` via the trampoline at the given
+    /// scheduling priority. Affinity defaults to [`AFFINITY_ALL`];
+    /// callers that care about pinning call [`super::set_affinity`]
+    /// after spawning.
+    pub fn new_with_priority(entry: fn() -> !, priority: u8) -> Self {
         // Bump-allocate a fresh VA slot.
         let slot_va = NEXT_STACK_VA.fetch_add(TASK_SLOT_SIZE, Ordering::Relaxed);
         let guard_base = slot_va;
@@ -170,6 +187,8 @@ impl Task {
             slice_remaining_ms: DEFAULT_SLICE_MS,
             state: TaskState::Ready,
             wake_pending: AtomicBool::new(false),
+            priority: super::priority::clamp_priority(priority),
+            affinity: AFFINITY_ALL,
         }
     }
 

--- a/kernel/tests/priority.rs
+++ b/kernel/tests/priority.rs
@@ -68,6 +68,10 @@ static STOP_LO: AtomicBool = AtomicBool::new(false);
 fn hi_worker() -> ! {
     HI_HITS.fetch_add(1, Ordering::SeqCst);
     HI_FLAG.store(true, Ordering::SeqCst);
+    // Demote so the driver (priority 19) can resume and observe the
+    // flag. Strict priority scheduling would otherwise starve it —
+    // the one-shot body above already proved the scheduling property.
+    task::set_priority(task::current_id(), 1);
     loop {
         x86_64::instructions::hlt();
     }

--- a/kernel/tests/priority.rs
+++ b/kernel/tests/priority.rs
@@ -143,49 +143,54 @@ fn idle_forever() -> ! {
 fn nice_sets_visible_priority() {
     // With DEFAULT_PRIORITY=19, nice=10 maps to priority 9 and
     // nice=-5 maps to priority 24. The task list must reflect both
-    // mappings. Doesn't depend on the spawned tasks running — a
-    // lower-priority task would starve against the default-priority
-    // driver and that's the point.
-    task::spawn_with_nice(idle_forever, 10);
-    task::spawn_with_nice(idle_forever, -5);
+    // mappings.
+    //
+    // Wrap the spawn→demote window in `without_interrupts` so a PIT
+    // tick can't preempt the driver to the freshly-spawned nice=-5
+    // task (priority 24 > driver's 19) before we demote it — that
+    // would hang the test since idle_forever never yields.
+    x86_64::instructions::interrupts::without_interrupts(|| {
+        task::spawn_with_nice(idle_forever, 10);
+        task::spawn_with_nice(idle_forever, -5);
 
-    let lo_prio = task::priority_from_nice(10);
-    let hi_prio = task::priority_from_nice(-5);
-    // Round-trip across the full legal nice range.
-    for nice in task::NICE_MIN..=task::NICE_MAX {
-        let p = task::priority_from_nice(nice);
-        assert!(p <= task::MAX_PRIORITY);
-        assert_eq!(task::nice_from_priority(p), nice);
-    }
-    // Edge cases: nice extremes must not saturate before mapping.
-    assert_eq!(task::priority_from_nice(task::NICE_MIN), task::MAX_PRIORITY);
-    assert_eq!(task::priority_from_nice(task::NICE_MAX), 0);
+        let lo_prio = task::priority_from_nice(10);
+        let hi_prio = task::priority_from_nice(-5);
+        // Round-trip across the full legal nice range.
+        for nice in task::NICE_MIN..=task::NICE_MAX {
+            let p = task::priority_from_nice(nice);
+            assert!(p <= task::MAX_PRIORITY);
+            assert_eq!(task::nice_from_priority(p), nice);
+        }
+        // Edge cases: nice extremes must not saturate before mapping.
+        assert_eq!(task::priority_from_nice(task::NICE_MIN), task::MAX_PRIORITY);
+        assert_eq!(task::priority_from_nice(task::NICE_MAX), 0);
 
-    let mut saw_low = false;
-    let mut saw_high = false;
-    task::for_each_task(|info| {
-        assert!(info.priority <= task::MAX_PRIORITY);
-        assert!(info.nice >= task::NICE_MIN && info.nice <= task::NICE_MAX);
-        assert_eq!(task::nice_from_priority(info.priority), info.nice);
-        if info.nice == 10 && info.priority == lo_prio {
-            saw_low = true;
-        }
-        if info.nice == -5 && info.priority == hi_prio {
-            saw_high = true;
-        }
+        let mut saw_low = false;
+        let mut saw_high = false;
+        task::for_each_task(|info| {
+            assert!(info.priority <= task::MAX_PRIORITY);
+            assert!(info.nice >= task::NICE_MIN && info.nice <= task::NICE_MAX);
+            assert_eq!(task::nice_from_priority(info.priority), info.nice);
+            if info.nice == 10 && info.priority == lo_prio {
+                saw_low = true;
+            }
+            if info.nice == -5 && info.priority == hi_prio {
+                saw_high = true;
+            }
+        });
+        assert!(saw_low, "task list missing the nice=10 worker");
+        assert!(saw_high, "task list missing the nice=-5 worker");
+
+        // Demote every task we just spawned so the next test's driver
+        // isn't starved. The kernel doesn't support task exit yet.
+        demote_non_driver_tasks();
     });
-    assert!(saw_low, "task list missing the nice=10 worker");
-    assert!(saw_high, "task list missing the nice=-5 worker");
-
-    // Demote every task we just spawned so the next test's driver
-    // isn't starved. The kernel doesn't support task exit yet.
-    demote_non_driver_tasks();
 }
 
 /// Drop every non-driver task's priority to 1 so the bootstrap task
-/// (priority 20) gets CPU in the next test. Tasks in this test binary
-/// spawn for their lifetime — there's no exit path — so we settle for
-/// keeping them harmlessly below the driver instead.
+/// (DEFAULT_PRIORITY, 19) gets CPU in the next test. Tasks in this
+/// test binary spawn for their lifetime — there's no exit path — so
+/// we settle for keeping them harmlessly below the driver instead.
 fn demote_non_driver_tasks() {
     let driver_id = task::current_id();
     let mut ids = alloc::vec::Vec::new();
@@ -200,41 +205,47 @@ fn demote_non_driver_tasks() {
 }
 
 fn set_priority_round_trip() {
-    // Spawn a task at nice=5 (priority 15), then promote via
+    // Spawn a task at nice=5 (priority 14), then promote via
     // set_priority and verify the introspection picks up the change.
-    task::spawn_with_nice(idle_forever, 5);
-    let mut target_id = 0usize;
-    task::for_each_task(|info| {
-        if info.nice == 5 && target_id == 0 {
-            target_id = info.id;
-        }
+    // The promote lifts the target above the driver's priority; if a
+    // PIT tick lands in that window it would preempt to the target
+    // (idle_forever, hangs the test), so wrap the whole promote→demote
+    // region in without_interrupts.
+    x86_64::instructions::interrupts::without_interrupts(|| {
+        task::spawn_with_nice(idle_forever, 5);
+        let mut target_id = 0usize;
+        task::for_each_task(|info| {
+            if info.nice == 5 && target_id == 0 {
+                target_id = info.id;
+            }
+        });
+        assert!(target_id != 0, "didn't find freshly-spawned nice=5 task");
+
+        assert!(task::set_priority(target_id, 30));
+        let mut new_prio = None;
+        task::for_each_task(|info| {
+            if info.id == target_id {
+                new_prio = Some(info.priority);
+            }
+        });
+        assert_eq!(new_prio, Some(30));
+
+        assert!(!task::set_priority(usize::MAX, 10), "accepted unknown id");
+
+        // adjust_nice on the target: priority 30 -> nice -11 (with
+        // DEFAULT_PRIORITY=19). Bump by +3 → nice -8 → priority 27.
+        let new_nice = task::adjust_nice(target_id, 3);
+        assert_eq!(new_nice, Some(-8));
+        let mut adjusted_prio = None;
+        task::for_each_task(|info| {
+            if info.id == target_id {
+                adjusted_prio = Some(info.priority);
+            }
+        });
+        assert_eq!(adjusted_prio, Some(27));
+
+        demote_non_driver_tasks();
     });
-    assert!(target_id != 0, "didn't find freshly-spawned nice=5 task");
-
-    assert!(task::set_priority(target_id, 30));
-    let mut new_prio = None;
-    task::for_each_task(|info| {
-        if info.id == target_id {
-            new_prio = Some(info.priority);
-        }
-    });
-    assert_eq!(new_prio, Some(30));
-
-    assert!(!task::set_priority(usize::MAX, 10), "accepted unknown id");
-
-    // adjust_nice on the target: priority 30 -> nice -11 (with
-    // DEFAULT_PRIORITY=19). Bump by +3 → nice -8 → priority 27.
-    let new_nice = task::adjust_nice(target_id, 3);
-    assert_eq!(new_nice, Some(-8));
-    let mut adjusted_prio = None;
-    task::for_each_task(|info| {
-        if info.id == target_id {
-            adjusted_prio = Some(info.priority);
-        }
-    });
-    assert_eq!(adjusted_prio, Some(27));
-
-    demote_non_driver_tasks();
 }
 
 static AFF_RAN: AtomicBool = AtomicBool::new(false);

--- a/kernel/tests/priority.rs
+++ b/kernel/tests/priority.rs
@@ -132,15 +132,25 @@ fn idle_forever() -> ! {
 }
 
 fn nice_sets_visible_priority() {
-    // nice=10 maps to priority 10; nice=-5 maps to priority 25. The
-    // task list must reflect both mappings. Doesn't depend on the
-    // spawned tasks running — a lower-priority task would starve
-    // against the default-priority driver and that's the point.
+    // With DEFAULT_PRIORITY=19, nice=10 maps to priority 9 and
+    // nice=-5 maps to priority 24. The task list must reflect both
+    // mappings. Doesn't depend on the spawned tasks running — a
+    // lower-priority task would starve against the default-priority
+    // driver and that's the point.
     task::spawn_with_nice(idle_forever, 10);
     task::spawn_with_nice(idle_forever, -5);
 
-    assert_eq!(task::priority_from_nice(10), 10);
-    assert_eq!(task::priority_from_nice(-5), 25);
+    let lo_prio = task::priority_from_nice(10);
+    let hi_prio = task::priority_from_nice(-5);
+    // Round-trip across the full legal nice range.
+    for nice in task::NICE_MIN..=task::NICE_MAX {
+        let p = task::priority_from_nice(nice);
+        assert!(p <= task::MAX_PRIORITY);
+        assert_eq!(task::nice_from_priority(p), nice);
+    }
+    // Edge cases: nice extremes must not saturate before mapping.
+    assert_eq!(task::priority_from_nice(task::NICE_MIN), task::MAX_PRIORITY);
+    assert_eq!(task::priority_from_nice(task::NICE_MAX), 0);
 
     let mut saw_low = false;
     let mut saw_high = false;
@@ -148,10 +158,10 @@ fn nice_sets_visible_priority() {
         assert!(info.priority <= task::MAX_PRIORITY);
         assert!(info.nice >= task::NICE_MIN && info.nice <= task::NICE_MAX);
         assert_eq!(task::nice_from_priority(info.priority), info.nice);
-        if info.nice == 10 && info.priority == 10 {
+        if info.nice == 10 && info.priority == lo_prio {
             saw_low = true;
         }
-        if info.nice == -5 && info.priority == 25 {
+        if info.nice == -5 && info.priority == hi_prio {
             saw_high = true;
         }
     });
@@ -203,10 +213,10 @@ fn set_priority_round_trip() {
 
     assert!(!task::set_priority(usize::MAX, 10), "accepted unknown id");
 
-    // adjust_nice on the target: priority 30 -> nice -10. Bump by +3
-    // → nice -7 → priority 27.
+    // adjust_nice on the target: priority 30 -> nice -11 (with
+    // DEFAULT_PRIORITY=19). Bump by +3 → nice -8 → priority 27.
     let new_nice = task::adjust_nice(target_id, 3);
-    assert_eq!(new_nice, Some(-7));
+    assert_eq!(new_nice, Some(-8));
     let mut adjusted_prio = None;
     task::for_each_task(|info| {
         if info.id == target_id {

--- a/kernel/tests/priority.rs
+++ b/kernel/tests/priority.rs
@@ -1,0 +1,254 @@
+//! Integration test: the scheduler honors task priorities.
+//!
+//! Test ordering matters — tasks in this kernel don't exit, so any
+//! test that leaves a high-priority worker looping will starve tasks
+//! at lower priority in later tests. The high-priority test runs last
+//! for that reason, and the earlier tests exercise introspection and
+//! metadata APIs rather than assuming a particular task gets CPU.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use vibix::{
+    exit_qemu, serial_println, task,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("nice_sets_visible_priority", &(nice_sets_visible_priority as fn())),
+        ("set_affinity_round_trip", &(set_affinity_round_trip as fn())),
+        ("set_priority_round_trip", &(set_priority_round_trip as fn())),
+        ("high_priority_runs_before_low", &(high_priority_runs_before_low as fn())),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+static HI_FLAG: AtomicBool = AtomicBool::new(false);
+static HI_HITS: AtomicUsize = AtomicUsize::new(0);
+static LO_HITS: AtomicUsize = AtomicUsize::new(0);
+static STOP_LO: AtomicBool = AtomicBool::new(false);
+
+fn hi_worker() -> ! {
+    HI_HITS.fetch_add(1, Ordering::SeqCst);
+    HI_FLAG.store(true, Ordering::SeqCst);
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn lo_spinner() -> ! {
+    loop {
+        LO_HITS.fetch_add(1, Ordering::SeqCst);
+        if STOP_LO.load(Ordering::SeqCst) {
+            break;
+        }
+        for _ in 0..10_000 {
+            core::hint::spin_loop();
+        }
+    }
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn high_priority_runs_before_low() {
+    HI_FLAG.store(false, Ordering::SeqCst);
+    HI_HITS.store(0, Ordering::SeqCst);
+    LO_HITS.store(0, Ordering::SeqCst);
+    STOP_LO.store(false, Ordering::SeqCst);
+
+    // Spawn the low-priority spinner first so it's definitely queued
+    // before the hot task. Without priorities, round-robin would let
+    // the spinner keep hogging slices.
+    task::spawn_with_priority(lo_spinner, task::DEFAULT_PRIORITY - 5);
+    task::spawn_with_priority(hi_worker, task::DEFAULT_PRIORITY + 5);
+
+    // The hi_worker is one tick away. Give it plenty of rope.
+    for _ in 0..200 {
+        if HI_FLAG.load(Ordering::SeqCst) {
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+
+    assert!(
+        HI_FLAG.load(Ordering::SeqCst),
+        "hi_worker never ran even though it outranked the spinner"
+    );
+    assert_eq!(
+        HI_HITS.load(Ordering::SeqCst),
+        1,
+        "hi_worker's one-shot body ran the wrong number of times"
+    );
+    STOP_LO.store(true, Ordering::SeqCst);
+
+    // Let the spinner wind down before the next test reuses statics.
+    for _ in 0..50 {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn idle_forever() -> ! {
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn nice_sets_visible_priority() {
+    // nice=10 maps to priority 10; nice=-5 maps to priority 25. The
+    // task list must reflect both mappings. Doesn't depend on the
+    // spawned tasks running — a lower-priority task would starve
+    // against the default-priority driver and that's the point.
+    task::spawn_with_nice(idle_forever, 10);
+    task::spawn_with_nice(idle_forever, -5);
+
+    assert_eq!(task::priority_from_nice(10), 10);
+    assert_eq!(task::priority_from_nice(-5), 25);
+
+    let mut saw_low = false;
+    let mut saw_high = false;
+    task::for_each_task(|info| {
+        assert!(info.priority <= task::MAX_PRIORITY);
+        assert!(info.nice >= task::NICE_MIN && info.nice <= task::NICE_MAX);
+        assert_eq!(task::nice_from_priority(info.priority), info.nice);
+        if info.nice == 10 && info.priority == 10 {
+            saw_low = true;
+        }
+        if info.nice == -5 && info.priority == 25 {
+            saw_high = true;
+        }
+    });
+    assert!(saw_low, "task list missing the nice=10 worker");
+    assert!(saw_high, "task list missing the nice=-5 worker");
+
+    // Demote every task we just spawned so the next test's driver
+    // isn't starved. The kernel doesn't support task exit yet.
+    demote_non_driver_tasks();
+}
+
+/// Drop every non-driver task's priority to 1 so the bootstrap task
+/// (priority 20) gets CPU in the next test. Tasks in this test binary
+/// spawn for their lifetime — there's no exit path — so we settle for
+/// keeping them harmlessly below the driver instead.
+fn demote_non_driver_tasks() {
+    let driver_id = task::current_id();
+    let mut ids = alloc::vec::Vec::new();
+    task::for_each_task(|info| {
+        if info.id != driver_id {
+            ids.push(info.id);
+        }
+    });
+    for id in ids {
+        task::set_priority(id, 1);
+    }
+}
+
+fn set_priority_round_trip() {
+    // Spawn a task at nice=5 (priority 15), then promote via
+    // set_priority and verify the introspection picks up the change.
+    task::spawn_with_nice(idle_forever, 5);
+    let mut target_id = 0usize;
+    task::for_each_task(|info| {
+        if info.nice == 5 && target_id == 0 {
+            target_id = info.id;
+        }
+    });
+    assert!(target_id != 0, "didn't find freshly-spawned nice=5 task");
+
+    assert!(task::set_priority(target_id, 30));
+    let mut new_prio = None;
+    task::for_each_task(|info| {
+        if info.id == target_id {
+            new_prio = Some(info.priority);
+        }
+    });
+    assert_eq!(new_prio, Some(30));
+
+    assert!(!task::set_priority(usize::MAX, 10), "accepted unknown id");
+
+    // adjust_nice on the target: priority 30 -> nice -10. Bump by +3
+    // → nice -7 → priority 27.
+    let new_nice = task::adjust_nice(target_id, 3);
+    assert_eq!(new_nice, Some(-7));
+    let mut adjusted_prio = None;
+    task::for_each_task(|info| {
+        if info.id == target_id {
+            adjusted_prio = Some(info.priority);
+        }
+    });
+    assert_eq!(adjusted_prio, Some(27));
+
+    demote_non_driver_tasks();
+}
+
+static AFF_RAN: AtomicBool = AtomicBool::new(false);
+static AFF_ID: AtomicUsize = AtomicUsize::new(0);
+
+fn aff_worker() -> ! {
+    AFF_ID.store(task::current_id(), Ordering::SeqCst);
+    AFF_RAN.store(true, Ordering::SeqCst);
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn set_affinity_round_trip() {
+    AFF_RAN.store(false, Ordering::SeqCst);
+    AFF_ID.store(0, Ordering::SeqCst);
+    task::spawn(aff_worker);
+
+    for _ in 0..500 {
+        if AFF_RAN.load(Ordering::SeqCst) {
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+    assert!(AFF_RAN.load(Ordering::SeqCst), "aff_worker never ran");
+
+    let id = AFF_ID.load(Ordering::SeqCst);
+    assert!(id != 0);
+    // Pin to CPU 0 only.
+    assert!(task::set_affinity(id, 0b1), "set_affinity on live task failed");
+    // Zero mask is rejected (a task must be runnable somewhere).
+    assert!(!task::set_affinity(id, 0), "set_affinity accepted zero mask");
+    // Unknown id is rejected.
+    assert!(
+        !task::set_affinity(usize::MAX, 0b1),
+        "set_affinity accepted unknown id"
+    );
+
+    let mut saw_mask = None;
+    task::for_each_task(|info| {
+        if info.id == id {
+            saw_mask = Some(info.affinity);
+        }
+    });
+    assert_eq!(saw_mask, Some(0b1), "affinity mask didn't round-trip");
+
+    demote_non_driver_tasks();
+}

--- a/kernel/tests/priority.rs
+++ b/kernel/tests/priority.rs
@@ -36,10 +36,22 @@ fn panic(info: &PanicInfo) -> ! {
 
 fn run_tests() {
     let tests: &[(&str, &dyn Testable)] = &[
-        ("nice_sets_visible_priority", &(nice_sets_visible_priority as fn())),
-        ("set_affinity_round_trip", &(set_affinity_round_trip as fn())),
-        ("set_priority_round_trip", &(set_priority_round_trip as fn())),
-        ("high_priority_runs_before_low", &(high_priority_runs_before_low as fn())),
+        (
+            "nice_sets_visible_priority",
+            &(nice_sets_visible_priority as fn()),
+        ),
+        (
+            "set_affinity_round_trip",
+            &(set_affinity_round_trip as fn()),
+        ),
+        (
+            "set_priority_round_trip",
+            &(set_priority_round_trip as fn()),
+        ),
+        (
+            "high_priority_runs_before_low",
+            &(high_priority_runs_before_low as fn()),
+        ),
     ];
     serial_println!("running {} tests", tests.len());
     for (name, t) in tests {
@@ -233,9 +245,15 @@ fn set_affinity_round_trip() {
     let id = AFF_ID.load(Ordering::SeqCst);
     assert!(id != 0);
     // Pin to CPU 0 only.
-    assert!(task::set_affinity(id, 0b1), "set_affinity on live task failed");
+    assert!(
+        task::set_affinity(id, 0b1),
+        "set_affinity on live task failed"
+    );
     // Zero mask is rejected (a task must be runnable somewhere).
-    assert!(!task::set_affinity(id, 0), "set_affinity accepted zero mask");
+    assert!(
+        !task::set_affinity(id, 0),
+        "set_affinity accepted zero mask"
+    );
     // Unknown id is rejected.
     assert!(
         !task::set_affinity(usize::MAX, 0b1),

--- a/kernel/tests/priority.rs
+++ b/kernel/tests/priority.rs
@@ -121,6 +121,11 @@ fn high_priority_runs_before_low() {
         1,
         "hi_worker's one-shot body ran the wrong number of times"
     );
+    assert_eq!(
+        LO_HITS.load(Ordering::SeqCst),
+        0,
+        "lo_spinner ran before hi_worker finished its one-shot body"
+    );
     STOP_LO.store(true, Ordering::SeqCst);
 
     // Let the spinner wind down before the next test reuses statics.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -502,6 +502,7 @@ fn test_all() -> R<()> {
         "page_fault",
         "blocking_sync",
         "shell_smoke",
+        "priority",
     ] {
         cmd.arg("--test").arg(t);
     }


### PR DESCRIPTION
Closes #25.

## Summary

- Replace single-queue round-robin ready bank with a priority-keyed `BTreeMap<u8, VecDeque<Box<Task>>>`. `pop_highest` always picks the highest-priority ready task; FIFO rotation within a level.
- Preempt immediately when a higher-priority task becomes runnable — not just at slice exhaustion. Hooks: `spawn_with_priority`, `set_priority`, `adjust_nice`, and `wake` all shorten the current slice if the newly-ready task outranks it.
- New public API on `task::`:
  - `spawn_with_priority(entry, prio)` / `spawn_with_nice(entry, nice)`
  - `set_priority` / `set_nice` / `adjust_nice`
  - `set_affinity(id, mask)` — stored but unenforced on single-CPU; rejects `mask == 0` and unknown ids
  - `current_priority()`, priority/nice constants, and the `priority_from_nice` ↔ `nice_from_priority` mapping
- `spawn` keeps its signature and defaults to `DEFAULT_PRIORITY` (nice 0). `TaskInfo` and the shell `tasks` builtin now report priority + nice.
- Ready-queue snapshot moves to `Scheduler::iter_ready` so `for_each_task` iterates highest-priority-first.

## Out of scope (explicit non-goals in #25)

- CFS / weighted fair scheduling.
- Priority inheritance on blocking primitives — worth a follow-up alongside the sleeping-mutex work in #24.
- Enforcement of affinity (needs SMP; issue #30).

## Test plan

- [x] `cargo xtask build`
- [x] `cargo xtask test` — all integration tests green, including the new `priority` suite:
  - `nice_sets_visible_priority` — nice→priority mapping is visible via `for_each_task` in both directions
  - `set_affinity_round_trip` — affinity stored, zero/unknown-id rejected
  - `set_priority_round_trip` — `set_priority` and `adjust_nice` mutate in place and reject unknown ids
  - `high_priority_runs_before_low` — high-priority worker preempts a lower-priority spinner that never yields
- [x] `cargo xtask smoke` — all 16 boot markers present

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core scheduling behavior by replacing the ready queue with priority buckets and adding immediate preemption logic, which can impact system responsiveness and starvation behavior across all tasks. It also adds new task-mutation APIs (priority/nice/affinity) that interact with interrupt masking and scheduler invariants.
> 
> **Overview**
> Introduces **priority-based task scheduling** by replacing the single FIFO ready queue with a per-priority ready-bank and updating task selection to always run the highest-priority runnable task (FIFO rotation within the same priority).
> 
> Adds new `task::` APIs for **spawning and mutating priorities** (`spawn_with_priority`, `spawn_with_nice`, `set_priority`, `set_nice`, `adjust_nice`) plus **CPU affinity metadata** (`set_affinity`, stored but not enforced), and extends `Task`/`TaskInfo` and the shell `tasks` output to report `priority`, derived `nice`, and `affinity`.
> 
> Updates preemption paths (`preempt_tick`, `wake`, spawn, priority changes) to **trigger earlier preemption** when a higher-priority task becomes ready, and adds a new `priority` integration test (wired into `Cargo.toml` and `xtask`) to validate ordering and round-trip behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57a34b54542a9249d5ca3976688de3e14c131dad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->