### PR TITLE
bench: in-kernel microbenchmark harness (kmalloc + IRQ latency)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -35,6 +35,10 @@ panic-test = []
 # of letting it silently corrupt .bss. Manual verification only —
 # successful overflow is indistinguishable from other crashes in CI.
 ist-overflow-test = []
+# Enable the in-kernel microbenchmark harness. Adds two rdtsc + an atomic
+# store to the timer ISR and spawns a bench task at boot that prints a
+# summary table over serial. Off by default so normal boots stay quiet.
+bench = []
 
 [[test]]
 name = "basic_boot"

--- a/kernel/src/arch/x86_64/interrupts.rs
+++ b/kernel/src/arch/x86_64/interrupts.rs
@@ -24,12 +24,16 @@ impl InterruptIndex {
 }
 
 pub extern "x86-interrupt" fn timer_interrupt(_frame: InterruptStackFrame) {
+    #[cfg(feature = "bench")]
+    crate::bench::irq::record_entry();
     crate::time::on_tick();
     // EOI before any attempt to preempt. If we switched to another
     // task first and *that* task ever re-entered this ISR, the PIC
     // would be carrying an un-acked IRQ and subsequent ticks would
     // stall.
     notify_eoi(InterruptIndex::Timer.as_u8());
+    #[cfg(feature = "bench")]
+    crate::bench::irq::record_exit();
     crate::task::preempt_tick();
 }
 

--- a/kernel/src/bench/alloc_bench.rs
+++ b/kernel/src/bench/alloc_bench.rs
@@ -1,0 +1,52 @@
+//! `kmalloc` / `kfree` round-trip timing for a spread of sizes.
+//!
+//! Each sample times a paired `alloc` + `dealloc` of one allocation.
+//! That bundles both halves into one measurement; the returned
+//! numbers reflect the whole round-trip cost rather than alloc alone.
+
+use alloc::alloc::{alloc, dealloc, Layout};
+
+use super::{measure, Stats};
+
+/// A spread of sizes small callers actually hit in practice: a few
+/// bytes (node-like), a cache-line, a page-and-change, and a
+/// multi-page allocation for larger working sets.
+const SIZES: &[usize] = &[16, 64, 256, 1024, 4096];
+
+const ITERS: u32 = 1024;
+
+pub fn run() -> alloc::vec::Vec<(usize, Stats)> {
+    use crate::serial_println;
+    let mut out = alloc::vec::Vec::with_capacity(SIZES.len());
+    for &size in SIZES {
+        serial_println!("bench: alloc size={}", size);
+        // Layout::from_size_align: align=8 matches the natural word
+        // alignment the linked_list_allocator hands back for small
+        // sizes anyway, and keeps the benchmark uniform across sizes.
+        let layout = Layout::from_size_align(size, 8).expect("bench: valid layout");
+        // Warm the arena: the first handful of allocs at each size
+        // hit either fresh space or the grow lock, producing outliers
+        // that skew min downward and median upward simultaneously.
+        for _ in 0..32 {
+            unsafe {
+                let p = alloc(layout);
+                if !p.is_null() {
+                    dealloc(p, layout);
+                }
+            }
+        }
+        let stats = measure(ITERS, || unsafe {
+            let p = alloc(layout);
+            // Writing the first byte forces the allocator's address
+            // range to actually be mapped — grow lock + page walk get
+            // amortised into the sample for sizes that cross the
+            // current heap tail.
+            if !p.is_null() {
+                core::ptr::write_volatile(p, 0);
+                dealloc(p, layout);
+            }
+        });
+        out.push((size, stats));
+    }
+    out
+}

--- a/kernel/src/bench/irq.rs
+++ b/kernel/src/bench/irq.rs
@@ -1,0 +1,93 @@
+//! PIT IRQ entry→exit latency.
+//!
+//! `timer_interrupt` records its entry TSC before doing any work and
+//! its exit TSC just before returning. The delta is written into a
+//! lock-free ring; the bench task drains the ring after enough
+//! samples have accumulated.
+//!
+//! Writes happen from interrupt context, so the producer side
+//! **must** be lock-free and allocation-free. A fixed array plus a
+//! wrapping `AtomicUsize` index satisfies both.
+
+use core::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+
+use super::{rdtsc_end, rdtsc_start, Stats};
+
+/// Ring capacity. Sized so collect(500) samples fit without
+/// overwrite at PIT 100 Hz for ~5 s.
+const RING_LEN: usize = 1024;
+
+/// Samples are stored as `u64` cycle deltas. Zero means "not yet
+/// written"; this is safe because a real IRQ handler round-trip is
+/// strictly positive.
+static SAMPLES: [AtomicU64; RING_LEN] = {
+    const Z: AtomicU64 = AtomicU64::new(0);
+    [Z; RING_LEN]
+};
+
+/// Monotonically-incrementing write index. `fetch_add % RING_LEN` is
+/// the slot each write claims.
+static WRITE_IDX: AtomicUsize = AtomicUsize::new(0);
+
+/// Per-CPU-ish scratchpad for the entry timestamp. With the scheduler
+/// still single-CPU this is literally "the last entry timestamp";
+/// once SMP lands the ISR will need one slot per LAPIC id, but
+/// that's #30's problem.
+static LAST_ENTRY: AtomicU64 = AtomicU64::new(0);
+
+/// Called at the top of `timer_interrupt`. Records the entry TSC so
+/// `record_exit` can compute the delta.
+#[inline(always)]
+pub fn record_entry() {
+    LAST_ENTRY.store(rdtsc_start(), Ordering::Relaxed);
+}
+
+/// Called just before the ISR returns. Pushes `now - LAST_ENTRY`
+/// into the ring.
+#[inline(always)]
+pub fn record_exit() {
+    let t0 = LAST_ENTRY.load(Ordering::Relaxed);
+    if t0 == 0 {
+        return;
+    }
+    let t1 = rdtsc_end();
+    let delta = t1.wrapping_sub(t0);
+    let idx = WRITE_IDX.fetch_add(1, Ordering::Relaxed) % RING_LEN;
+    SAMPLES[idx].store(delta, Ordering::Relaxed);
+}
+
+/// Block the calling task long enough to observe `expected` IRQ
+/// round-trips, then reduce the collected samples to [`Stats`].
+///
+/// `expected` is capped at `RING_LEN - 1` so we never wait for more
+/// samples than the ring can hold without overwrite.
+pub fn collect(expected: u32) -> Stats {
+    let expected = (expected as usize).min(RING_LEN - 1);
+    let start = WRITE_IDX.load(Ordering::Relaxed);
+
+    // Wait until the write index has advanced by `expected`. Each
+    // PIT tick (100 Hz) bumps it by one.
+    loop {
+        let written = WRITE_IDX.load(Ordering::Relaxed).saturating_sub(start);
+        if written >= expected {
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+
+    // Snapshot the most recent `expected` samples. `WRITE_IDX` may
+    // advance while we're reading; that's fine — the ring is stable
+    // under single-CPU semantics because the ISR can't preempt our
+    // read atomically between slots.
+    let end = WRITE_IDX.load(Ordering::Relaxed);
+    let taken = (end - start).min(expected);
+    let mut out = alloc::vec::Vec::with_capacity(taken);
+    for i in 0..taken {
+        let idx = (start + i) % RING_LEN;
+        let v = SAMPLES[idx].load(Ordering::Relaxed);
+        if v != 0 {
+            out.push(v);
+        }
+    }
+    Stats::from_samples(&mut out)
+}

--- a/kernel/src/bench/mod.rs
+++ b/kernel/src/bench/mod.rs
@@ -175,4 +175,3 @@ fn print_row(name: &str, s: Stats) {
         s.p99
     );
 }
-

--- a/kernel/src/bench/mod.rs
+++ b/kernel/src/bench/mod.rs
@@ -1,0 +1,178 @@
+//! In-kernel microbenchmark harness. Gated behind the `bench` cargo
+//! feature so normal boots compile the code out entirely.
+//!
+//! # Usage
+//!
+//! `cargo xtask run --bench` builds the kernel with `--features bench`
+//! and boots it under QEMU. At boot, after the scheduler and shell are
+//! up, a dedicated bench task runs each seed benchmark once, then
+//! prints a summary table over serial.
+//!
+//! # Timing
+//!
+//! Cycles come from `rdtsc` bracketed with `lfence` / `rdtscp` so the
+//! measured region isn't smeared by out-of-order execution into the
+//! surrounding code. Three aggregates per benchmark: min, median, p99.
+//! Absolute cycle counts are **not** portable across hosts — the
+//! numbers are for eyeballing regressions against a known-good run on
+//! the same machine.
+
+use alloc::vec::Vec;
+
+mod alloc_bench;
+pub(crate) mod irq;
+
+/// Summary statistics for a batch of timed samples.
+#[derive(Clone, Copy)]
+pub struct Stats {
+    pub iters: u32,
+    pub min: u64,
+    pub median: u64,
+    pub p99: u64,
+}
+
+impl Stats {
+    /// Sort the samples in place and extract min / median / p99.
+    /// Median is the `n/2`th element, p99 is `(n * 99) / 100` clamped
+    /// to the last index — both exact quantile definitions rather than
+    /// interpolated, since N is small and interpolation adds no value
+    /// for a regression eyeball.
+    pub fn from_samples(samples: &mut [u64]) -> Self {
+        if samples.is_empty() {
+            return Self {
+                iters: 0,
+                min: 0,
+                median: 0,
+                p99: 0,
+            };
+        }
+        samples.sort_unstable();
+        let n = samples.len();
+        let p99_idx = ((n * 99) / 100).min(n - 1);
+        Self {
+            iters: n as u32,
+            min: samples[0],
+            median: samples[n / 2],
+            p99: samples[p99_idx],
+        }
+    }
+}
+
+/// Start-of-region timestamp: serialize with `lfence` before sampling
+/// so prior loads / stores have retired.
+///
+/// We use `lfence; rdtsc` rather than `rdtscp` because the default
+/// QEMU CPU (`qemu64`) doesn't advertise `RDTSCP` in CPUID and hitting
+/// the instruction raises `#UD`. `lfence; rdtsc; lfence` is a
+/// well-known surrogate that's been the recommended pattern in Intel's
+/// benchmarking whitepaper since the `rdtscp`-less era.
+#[inline(always)]
+pub fn rdtsc_start() -> u64 {
+    unsafe {
+        core::arch::x86_64::_mm_lfence();
+        core::arch::x86_64::_rdtsc()
+    }
+}
+
+/// End-of-region timestamp. Symmetric with [`rdtsc_start`]: an
+/// `lfence` brackets the `rdtsc` on both sides so neither prior nor
+/// subsequent instructions can slip past the measurement.
+#[inline(always)]
+pub fn rdtsc_end() -> u64 {
+    unsafe {
+        core::arch::x86_64::_mm_lfence();
+        let v = core::arch::x86_64::_rdtsc();
+        core::arch::x86_64::_mm_lfence();
+        v
+    }
+}
+
+/// Time `body` for `iters` iterations and reduce to [`Stats`]. The
+/// closure should encapsulate exactly the region you want measured;
+/// everything else (loop bookkeeping, the `rdtsc` pair) is amortised
+/// out by the min/median/p99 reduction.
+pub fn measure<F: FnMut()>(iters: u32, mut body: F) -> Stats {
+    let mut samples: Vec<u64> = Vec::with_capacity(iters as usize);
+    for _ in 0..iters {
+        let t0 = rdtsc_start();
+        body();
+        let t1 = rdtsc_end();
+        samples.push(t1.wrapping_sub(t0));
+    }
+    Stats::from_samples(&mut samples)
+}
+
+/// Top-level bench entry point. Spawned by `main` at boot when the
+/// `bench` feature is enabled. Runs each seed benchmark, prints a
+/// summary, then parks the task on `hlt` — the kernel keeps running
+/// so the framebuffer / shell remain responsive.
+///
+/// Context-switch timing is intentionally not in this harness: a
+/// ping-pong between two tasks currently rotates through the entire
+/// ready queue (shell, cursor-blink, bootstrap), so the measurement
+/// reflects PIT-slice cost more than scheduler trip cost. Tracked as
+/// a follow-up — it needs priority-directed handoff in `task` first.
+pub fn run_all() -> ! {
+    use crate::serial_println;
+
+    // Let the shell and cursor-blink tasks settle before the irq
+    // sampling ring starts recording — the first handful of ticks
+    // after boot carry one-shot setup noise.
+    for _ in 0..20 {
+        x86_64::instructions::hlt();
+    }
+
+    serial_println!("bench: start");
+
+    let alloc_stats = alloc_bench::run();
+    // Collect across roughly 5 seconds of PIT ticks so the
+    // distribution has a few hundred samples to chew on.
+    let irq_stats = irq::collect(500);
+
+    dump(&alloc_stats, irq_stats);
+
+    serial_println!("bench: done");
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn dump(alloc_stats: &[(usize, Stats)], irq: Stats) {
+    use crate::{kinfo, serial_println};
+    serial_println!(
+        "bench: {:<16} {:>6} {:>8} {:>8} {:>8}",
+        "name",
+        "iters",
+        "min",
+        "median",
+        "p99"
+    );
+    kinfo!("bench results (cycles)");
+    for (size, s) in alloc_stats {
+        use alloc::format;
+        let name = format!("kmalloc/{size}");
+        print_row(&name, *s);
+    }
+    print_row("irq", irq);
+}
+
+fn print_row(name: &str, s: Stats) {
+    use crate::{kinfo, serial_println};
+    serial_println!(
+        "bench: {:<16} {:>6} {:>8} {:>8} {:>8}",
+        name,
+        s.iters,
+        s.min,
+        s.median,
+        s.p99
+    );
+    kinfo!(
+        "bench {} iters={} min={} median={} p99={}",
+        name,
+        s.iters,
+        s.min,
+        s.median,
+        s.p99
+    );
+}
+

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -18,10 +18,10 @@ pub mod mem;
 #[cfg(target_os = "none")]
 pub mod acpi;
 
-#[cfg(all(target_os = "none", feature = "bench"))]
-pub mod bench;
 #[cfg(target_os = "none")]
 pub mod arch;
+#[cfg(all(target_os = "none", feature = "bench"))]
+pub mod bench;
 #[cfg(target_os = "none")]
 pub mod boot;
 #[cfg(target_os = "none")]

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -17,6 +17,9 @@ pub mod mem;
 
 #[cfg(target_os = "none")]
 pub mod acpi;
+
+#[cfg(all(target_os = "none", feature = "bench"))]
+pub mod bench;
 #[cfg(target_os = "none")]
 pub mod arch;
 #[cfg(target_os = "none")]

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -125,6 +125,9 @@ pub extern "C" fn _start() -> ! {
     vibix::task::spawn(vibix::shell::run);
     vibix::task::spawn(cursor_blink_task);
 
+    #[cfg(feature = "bench")]
+    vibix::task::spawn(vibix::bench::run_all);
+
     // Bootstrap task becomes the idle loop. `hlt` with IRQs on parks
     // the CPU until the next interrupt; the PIT `preempt_tick` then
     // rotates us to any other ready task (shell, cursor_blink).

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -69,6 +69,7 @@ fn main() -> R<()> {
     let release = take_flag(&mut args, "--release");
     let fault_test = take_flag(&mut args, "--fault-test");
     let panic_test = take_flag(&mut args, "--panic-test");
+    let bench = take_flag(&mut args, "--bench");
 
     let cmd = args
         .first()
@@ -80,6 +81,7 @@ fn main() -> R<()> {
         release,
         fault_test,
         panic_test,
+        bench,
     };
 
     match cmd.as_str() {
@@ -103,7 +105,7 @@ fn main() -> R<()> {
         other => {
             eprintln!("unknown subcommand: {other}");
             eprintln!(
-                "usage: cargo xtask [build|iso|run|test|smoke|lint|clean] [--release] [--fault-test] [--panic-test]"
+                "usage: cargo xtask [build|iso|run|test|smoke|lint|clean] [--release] [--fault-test] [--panic-test] [--bench]"
             );
             std::process::exit(2);
         }
@@ -124,6 +126,7 @@ struct BuildOpts {
     release: bool,
     fault_test: bool,
     panic_test: bool,
+    bench: bool,
 }
 
 fn workspace_root() -> PathBuf {
@@ -155,6 +158,9 @@ fn build(opts: &BuildOpts) -> R<PathBuf> {
     }
     if opts.panic_test {
         cmd.arg("--features").arg("panic-test");
+    }
+    if opts.bench {
+        cmd.arg("--features").arg("bench");
     }
     check(cmd.status()?)?;
     let bin = kernel_binary(opts);


### PR DESCRIPTION
Closes #47

## Summary

- Adds a `bench` cargo feature that compiles an in-kernel microbenchmark harness; off by default, so normal boots stay quiet.
- Seed benchmarks: `kmalloc/{16,64,256,1024,4096}` (paired alloc + dealloc with a warmup pass) and `irq` (PIT entry→exit latency collected via a lock-free ring written from the timer ISR under the same feature gate).
- Timing uses `lfence; rdtsc; lfence`; `rdtscp` would be cleaner but the default `qemu64` CPU doesn't advertise it in CPUID and hitting it raises `#UD`. This is the Intel-recommended surrogate.
- Context-switch ping-pong is deliberately not included — the current round-robin scheduler rotates through the entire ready queue between `wake`/`block_current` pairs, so samples would reflect PIT-slice cost rather than scheduler trip cost. Will file a follow-up that needs priority-directed handoff in `task` first.
- Driven via `cargo xtask {build,iso,run} --bench`.

## Sample output

```
bench: name              iters      min   median      p99
bench: kmalloc/16         1024   139303   438450 73468192
bench: kmalloc/64         1024    83384   252705 72833351
bench: kmalloc/256        1024    83725   271694 73001116
bench: kmalloc/1024       1024    91466   270353   489120
bench: kmalloc/4096       1024   233738   271176   856528
bench: irq                 500    10080    29751    87785
```

Absolute cycle counts aren't portable across hosts — the numbers are for eyeballing regressions against a known-good run on the same machine.

## Test plan

- [x] `cargo xtask build` (no bench feature): clean, no new warnings.
- [x] `cargo xtask test`: all existing tests still pass.
- [x] `cargo xtask smoke`: 16/16 markers present.
- [x] `cargo xtask iso --bench` + QEMU boot: bench task runs, prints full summary table, kernel stays responsive after (shell + cursor-blink continue).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Feature-gated but touches the timer ISR and adds `rdtsc`/atomic instrumentation plus a long-running boot task, which could affect scheduling/interrupt behavior when enabled.
> 
> **Overview**
> Adds a new `bench` Cargo feature that boots an in-kernel microbenchmark task and prints cycle-based summary stats (min/median/p99) over serial.
> 
> Introduces seed benchmarks for `kmalloc`/`kfree` round-trip timing across several allocation sizes and PIT timer IRQ entry→exit latency using `rdtsc` with fence serialization. When `bench` is enabled, the timer ISR records timestamps into a lock-free ring buffer and `xtask` gains a `--bench` flag to build/run the kernel with this feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 004929d651c6d1de03aa018bf705e9974d7d6b85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->