### PR TITLE
Add /usage skill for real session-quota state

### DIFF
--- a/.claude/skills/auto-engineer/SKILL.md
+++ b/.claude/skills/auto-engineer/SKILL.md
@@ -150,11 +150,11 @@ If nothing worth filing, skip silently. **Do not file speculative or "nice-to-ha
 
 ### 9. Check session quota
 
-Before compacting and kicking off the next cycle, run `/usage` and parse the session-quota remaining percentage.
+Before compacting and kicking off the next cycle, run `/usage` (the `usage` skill). It emits two machine-readable lines — `remaining_pct: <float>` and `reset_ts: <ISO>` — plus a human summary. Parse `remaining_pct`.
 
 - **≥ 10% remaining** → proceed to step 10.
 - **< 10% remaining** → don't start a new cycle; the next one could tip over mid-PR and leave an orphaned branch. Instead:
-  1. Read the quota-reset timestamp from `/usage` output.
+  1. Read `reset_ts` from `/usage` output.
   2. Compute `secondsUntilReset = reset_ts - now`. Add a 60 s buffer so the wake-up lands *after* the reset, not on its edge.
   3. **Compaction decision:**
      - If `secondsUntilReset ≤ 90 min`: skip `/compact`. The wait is short enough that one or two un-compacted hops won't burn meaningful quota, and compaction itself costs tokens we want to save.

--- a/.claude/skills/usage/SKILL.md
+++ b/.claude/skills/usage/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: usage
+description: Report real Claude Code session-quota state — percent of the 5-hour and 7-day windows used, reset times, and status (ok/warning/rejected). Same numbers Claude Code's own statusline reports. Use when the user asks about usage, quota, rate limits, or when auto-engineer's quota gate calls `/usage`.
+---
+
+# usage
+
+The authoritative source for session-quota state is the set of `anthropic-ratelimit-unified-*` response headers Anthropic attaches to every `/v1/messages` call. Claude Code reads them into memory and feeds them to its statusline — they are the real numbers, not an estimate.
+
+Since that state lives only in the running Claude Code process, this skill fetches it by making a minimal 1-token probe call and parsing the headers. Result is cached for 60s at `~/.claude/cache/usage-probe.json` so repeat invocations are free.
+
+## Primary command
+
+```sh
+bash .claude/skills/usage/probe.sh
+```
+
+(Add `--force` to bypass the 60s cache.)
+
+Output is a single-line JSON like:
+
+```json
+{"http":200,"fetched_at":1776054016,
+ "5h":{"utilization":0.38,"resets_at":1776056400,"status":"allowed"},
+ "7d":{"utilization":0.33,"resets_at":1776567600,"status":"allowed"},
+ "overage":{"utilization":0.0,"resets_at":1777593600,"status":"allowed"}}
+```
+
+Fields: `utilization` is 0..1+ (can exceed 1 when the window is over-consumed), `resets_at` is Unix epoch seconds, `status` is `allowed` / `allowed_warning` / `rejected`.
+
+## Output format
+
+Always emit these two machine-readable lines first (auto-engineer step 9 parses them):
+
+```
+remaining_pct: <max(0, 100 - 5h.utilization*100), rounded to 1 decimal>
+reset_ts: <ISO-8601 of 5h.resets_at>
+```
+
+Then a short human summary: 5h %, 7d %, overage %, each window's status, time-until-reset, and a note if `status=rejected` (Claude Code is currently blocked on that limit until reset).
+
+## Fallback
+
+If the probe returns an error (no credentials, non-200, missing headers), fall back to ccusage:
+
+```sh
+npx -y ccusage blocks --active --token-limit max --json
+```
+
+Label fallback output clearly as **estimated** — ccusage benchmarks against the user's all-time largest block, *not* the plan's real cap, so its percentage is routinely off by 2-3× vs. the probe. Use `projection.remainingMinutes` and `endTime` from `.blocks[0]`.
+
+## Other reports (on request)
+
+- `ccusage daily --json` — per-day token rollup.
+- `ccusage session --json -p <project>` — per-conversation rollup.
+- `ccusage monthly --json` — per-month rollup.
+
+These are token-count reports, not quota; run only when the user asks for historical breakdowns.
+
+## Caveats
+
+- The probe costs one tiny Haiku call (~22 in / 1 out, well under $0.001). The 60s cache keeps this negligible.
+- `overage` appears only on plans where extra-usage is enabled; absent otherwise.
+- If the user is fully rate-limited (`5h.status == "rejected"`), the probe itself still succeeds — Anthropic returns headers on 200s and rejects only subsequent inference calls. If it ever fails with 429, report `remaining_pct: 0` and surface the cached `reset_ts` from a prior probe if one exists.

--- a/.claude/skills/usage/probe.sh
+++ b/.claude/skills/usage/probe.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Read Claude Code session-quota state by making a 1-token probe to /v1/messages
+# and parsing the anthropic-ratelimit-unified-* response headers. This is the
+# same data Claude Code's own statusline uses.
+#
+# Output: single-line JSON on stdout. Exit 0 on success, non-zero on failure.
+#
+# Cache: ~/.claude/cache/usage-probe.json, 60s TTL. Pass --force to bypass.
+
+set -u
+CACHE="${HOME}/.claude/cache/usage-probe.json"
+TTL=60
+FORCE=0
+[[ "${1:-}" == "--force" ]] && FORCE=1
+
+if [[ $FORCE -eq 0 && -f "$CACHE" ]]; then
+  age=$(( $(date +%s) - $(stat -c %Y "$CACHE" 2>/dev/null || echo 0) ))
+  if [[ $age -lt $TTL ]]; then
+    cat "$CACHE"; exit 0
+  fi
+fi
+
+CREDS="${HOME}/.claude/.credentials.json"
+[[ -r "$CREDS" ]] || { echo '{"error":"no-credentials"}'; exit 2; }
+
+TOK=$(python3 -c "import json,sys;print(json.load(open('$CREDS'))['claudeAiOauth']['accessToken'])" 2>/dev/null) || {
+  echo '{"error":"credentials-parse-failed"}'; exit 2;
+}
+
+HDR=$(mktemp); BODY=$(mktemp)
+trap 'rm -f "$HDR" "$BODY"' EXIT
+
+http=$(curl -sS -o "$BODY" -D "$HDR" -w '%{http_code}' --max-time 10 \
+  -H "Authorization: Bearer $TOK" \
+  -H "anthropic-beta: oauth-2025-04-20" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "content-type: application/json" \
+  -X POST https://api.anthropic.com/v1/messages \
+  -d '{"model":"claude-haiku-4-5","max_tokens":1,"messages":[{"role":"user","content":"."}],"system":"You are Claude Code, Anthropic'"'"'s official CLI for Claude."}')
+
+python3 - "$HDR" "$http" <<'PY' | tee "$CACHE"
+import sys, re, json, time
+hdr_path, http = sys.argv[1], sys.argv[2]
+h = {}
+for line in open(hdr_path):
+    m = re.match(r'([^:]+):\s*(.*?)\r?$', line)
+    if m: h[m.group(1).lower()] = m.group(2)
+def g(k):
+    return h.get(f'anthropic-ratelimit-unified-{k}')
+out = {"http": int(http), "fetched_at": int(time.time())}
+for win in ('5h','7d','overage'):
+    u, r, s = g(f'{win}-utilization'), g(f'{win}-reset'), g(f'{win}-status')
+    if u is None and r is None: continue
+    out[win] = {
+        "utilization": float(u) if u is not None else None,
+        "resets_at": int(r) if r is not None else None,
+        "status": s,
+    }
+if '5h' not in out:
+    out["error"] = "no-rate-limit-headers"
+print(json.dumps(out))
+PY


### PR DESCRIPTION
## Summary
- New `/usage` skill at `.claude/skills/usage/` that reports the same session-quota numbers Claude Code's own statusline shows: 5h/7d/overage utilization, reset time, and status (`allowed` / `allowed_warning` / `rejected`).
- Implementation (`probe.sh`) makes a 1-token probe call to `/v1/messages` using the OAuth token from `~/.claude/.credentials.json` and parses the `anthropic-ratelimit-unified-*` response headers. Result is cached 60s at `~/.claude/cache/usage-probe.json`, so repeat calls are free.
- Emits two machine-readable lines (`remaining_pct:` / `reset_ts:`) so `auto-engineer` step 9 can parse the quota gate deterministically.
- Falls back to `ccusage blocks --active` if the probe can't run — clearly labeled as an *estimate*, because ccusage benchmarks against the user's all-time largest block and routinely reports 2–3× more headroom than actually exists.
- `auto-engineer` SKILL.md updated to reference the skill by name and the new field contract.

Out of scope: replacing ccusage in other places, persisting probe history for trending, or wiring a statusline hook (probe-on-demand is cheaper for now).

## Test plan
- [x] `bash .claude/skills/usage/probe.sh --force` — returns live JSON with `5h` / `7d` / `overage` blocks from real API headers (verified live: 5h hit 101% `rejected`, 7d at 33%, which matches Claude's own UI; ccusage thought 40% used).
- [x] Cached re-run within 60s returns the same JSON without hitting the network.
- [x] `auto-engineer` step 9 wording references the new field names.
- [ ] Exercise the fallback path by temporarily moving `~/.claude/.credentials.json` and confirming ccusage output is labeled as estimated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new script that reads local OAuth credentials and makes a live API call to infer quota state; mistakes could leak sensitive tokens in logs or fail in restricted environments. Otherwise changes are isolated to Claude tooling/docs and a small contract tweak for auto-engineer’s quota gate.
> 
> **Overview**
> Adds a new `/usage` Claude skill that probes Anthropic’s `anthropic-ratelimit-unified-*` response headers (via a minimal `/v1/messages` call) and caches the result for 60s to report real 5h/7d/overage quota utilization and reset times.
> 
> Updates `auto-engineer`’s quota gate (step 9) to call `/usage` and rely on a defined output contract (`remaining_pct` and `reset_ts`) instead of ad-hoc parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ce54a07bef26804d950a912b2721f04c35e5a4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->