### PR TITLE
task: per-task PML4 with CR3 swap on context switch

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -99,3 +99,7 @@ harness = false
 [[test]]
 name = "priority"
 harness = false
+
+[[test]]
+name = "per_task_cr3"
+harness = false

--- a/kernel/src/mem/paging.rs
+++ b/kernel/src/mem/paging.rs
@@ -223,6 +223,48 @@ pub fn active_pml4_phys() -> PhysAddr {
     Cr3::read().0.start_address()
 }
 
+/// Build a fresh PML4 for a new task, sharing the kernel's upper half.
+///
+/// The returned frame holds a page table whose lower half (entries
+/// `0..256`) is zero and whose upper half (entries `256..512`) is a
+/// verbatim copy of the currently-active PML4's upper half. That gives
+/// the task its own lower-half VA space while all kernel mappings
+/// (HHDM, heap, IST, kernel image, task stacks, framebuffer) remain
+/// reachable at the same VAs.
+///
+/// # Invariant
+///
+/// Kernel upper-half L4 entries must be fully populated before this is
+/// called for the first time, and must not subsequently gain *new* L4
+/// entries. The kernel populates L4 entries 256 (HHDM), 384 (heap),
+/// 416 (task stacks — populated when the first task stack is mapped),
+/// and 511 (kernel image) during boot and first-task construction.
+/// Further kernel mappings only populate lower levels below those L4
+/// entries, which are shared by alias across all task PML4s. A future
+/// feature that installs a brand-new upper-half L4 entry after tasks
+/// exist would leave the older PML4s blind to it — that's the
+/// groundwork #61/SMP-level TLB-shootdown will have to take care of.
+pub fn new_task_pml4() -> PhysFrame<Size4KiB> {
+    let hhdm = HHDM_OFFSET
+        .lock()
+        .expect("paging::init must run before new_task_pml4");
+    // SAFETY: freshly allocated, exclusively owned, zeroed through HHDM.
+    let new_frame = unsafe { alloc_zeroed_frame(hhdm) };
+    let active = Cr3::read().0;
+
+    // SAFETY: `active` is the live PML4 (CR3), which is always mapped in
+    // the HHDM. `new_frame` was just allocated for our exclusive use.
+    // PageTable is repr(C) `[PageTableEntry; 512]` and PageTableEntry is
+    // repr(transparent) u64 — copy the raw 64-bit slots to avoid
+    // depending on the entry type's Clone impl.
+    unsafe {
+        let src = pml4_as_mut(active, hhdm) as *const PageTable as *const u64;
+        let dst = pml4_as_mut(new_frame, hhdm) as *mut PageTable as *mut u64;
+        core::ptr::copy_nonoverlapping(src.add(256), dst.add(256), 256);
+    }
+    new_frame
+}
+
 // -- PML4 construction + CR3 swap ---------------------------------------
 
 /// Build a fresh kernel PML4 and switch CR3 to it. Drops Limine's

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -448,6 +448,7 @@ pub fn preempt_tick() {
     prev.state = TaskState::Ready;
     next.state = TaskState::Running;
     let next_rsp = next.rsp;
+    let next_cr3 = next.cr3.start_address().as_u64();
     let prev_prio = prev.priority;
     sched.current = Some(next);
     sched.current.as_mut().unwrap().slice_remaining_ms = DEFAULT_SLICE_MS;
@@ -469,9 +470,11 @@ pub fn preempt_tick() {
     // allocated Task it points at — so the pointer stays valid even
     // though the VecDeque could mutate from under us. IRQs are already
     // masked inside the ISR, so no other scheduler path can race us
-    // between lock drop and the context switch.
+    // between lock drop and the context switch. `next_cr3` is a valid
+    // PML4 whose upper half mirrors the kernel PML4 (by construction
+    // in `Task::new` / `Task::bootstrap`).
     unsafe {
-        context_switch(prev_rsp_ptr, next_rsp);
+        context_switch(prev_rsp_ptr, next_rsp, next_cr3);
     }
 }
 
@@ -511,7 +514,7 @@ pub fn block_current() {
     let was_on = interrupts::are_enabled();
     interrupts::disable();
 
-    let (prev_rsp_ptr, next_rsp) = {
+    let (prev_rsp_ptr, next_rsp, next_cr3) = {
         let mut sched = SCHED.lock();
 
         // Fast path: a prior wake() set wake_pending while we were
@@ -545,6 +548,7 @@ pub fn block_current() {
         next.state = TaskState::Running;
         let prev_id = prev.id;
         let next_rsp = next.rsp;
+        let next_cr3 = next.cr3.start_address().as_u64();
         sched.current = Some(next);
         sched.current.as_mut().unwrap().slice_remaining_ms = DEFAULT_SLICE_MS;
         sched.parked.insert(prev_id, prev);
@@ -560,14 +564,15 @@ pub fn block_current() {
         // preempt_tick's ready-queue push.
         let prev_rsp_ptr: *mut usize = &mut prev_ref.rsp as *mut usize;
 
-        (prev_rsp_ptr, next_rsp)
+        (prev_rsp_ptr, next_rsp, next_cr3)
     };
 
     // SAFETY: IRQs are masked, the SCHED lock is dropped so the
     // incoming task can re-enter the scheduler, and prev_rsp_ptr
     // targets stable heap memory (see the insert comment above).
+    // `next_cr3` is a valid per-task PML4 (see preempt_tick).
     unsafe {
-        context_switch(prev_rsp_ptr, next_rsp);
+        context_switch(prev_rsp_ptr, next_rsp, next_cr3);
     }
 
     if was_on {

--- a/kernel/src/task/switch.rs
+++ b/kernel/src/task/switch.rs
@@ -16,14 +16,24 @@ use core::arch::global_asm;
 
 unsafe extern "C" {
     /// Save the outgoing task's callee-saved regs + rsp into
-    /// `*prev_rsp`, then load `next_rsp` and the incoming task's regs.
+    /// `*prev_rsp`, then load `next_rsp` and the incoming task's regs,
+    /// then load `next_cr3` into CR3.
+    ///
+    /// The CR3 write happens after the stack swap — kernel task stacks
+    /// live in the shared upper half, so the new stack is reachable
+    /// through either PML4 and the ordering is symmetric.
     ///
     /// # Safety
     /// - `prev_rsp` must be a valid, aligned, writable `*mut usize`
     ///   pointing at stable storage that outlives this call.
     /// - `next_rsp` must be a valid saved rsp produced either by a
     ///   prior `context_switch` or by `Task::new`'s stack priming.
-    pub fn context_switch(prev_rsp: *mut usize, next_rsp: usize);
+    /// - `next_cr3` must be the physical address of a PML4 whose upper
+    ///   half mirrors the current kernel PML4 (i.e. produced by
+    ///   `paging::new_task_pml4` or captured from the kernel PML4
+    ///   itself). A PML4 with a stale kernel upper half will fault on
+    ///   the next kernel-space access.
+    pub fn context_switch(prev_rsp: *mut usize, next_rsp: usize, next_cr3: u64);
 
     /// First-entry trampoline for a freshly primed task. The entry fn
     /// pointer is passed in `r12`; the trampoline just `call`s it.
@@ -37,7 +47,7 @@ global_asm!(
     .global task_entry_trampoline
 
 context_switch:
-    // rdi = prev_rsp (*mut usize), rsi = next_rsp (usize)
+    // rdi = prev_rsp (*mut usize), rsi = next_rsp (usize), rdx = next_cr3 (u64)
     push rbx
     push rbp
     push r12
@@ -46,6 +56,11 @@ context_switch:
     push r15
     mov [rdi], rsp
     mov rsp, rsi
+    // Load the incoming task's PML4. Non-global kernel mappings are
+    // flushed by the CR3 write; we use no PTE_GLOBAL today so this
+    // alone is sufficient. New stack is already live; both PML4s agree
+    // on upper-half mappings so the ongoing `ret` walk keeps working.
+    mov cr3, rdx
     pop r15
     pop r14
     pop r13

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -20,7 +20,8 @@
 
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
-use x86_64::structures::paging::{Page, PageTableFlags, Size4KiB};
+use x86_64::registers::control::Cr3;
+use x86_64::structures::paging::{Page, PageTableFlags, PhysFrame, Size4KiB};
 use x86_64::VirtAddr;
 
 use crate::mem::paging;
@@ -98,6 +99,15 @@ pub(super) struct Task {
     /// kernel; exists so affinity APIs keep a stable shape once SMP
     /// lands.
     pub affinity: u64,
+    /// Physical frame holding this task's PML4. Loaded into CR3 on
+    /// every `context_switch` into this task. The bootstrap task's
+    /// PML4 is the kernel PML4 built by
+    /// [`crate::mem::paging::build_and_switch_kernel_pml4`]; spawned
+    /// tasks get a fresh PML4 from
+    /// [`crate::mem::paging::new_task_pml4`] whose upper half shares
+    /// kernel mappings and whose lower half is empty — groundwork for
+    /// per-task userspace address spaces (#26).
+    pub cr3: PhysFrame<Size4KiB>,
 }
 
 impl Task {
@@ -114,6 +124,10 @@ impl Task {
             wake_pending: AtomicBool::new(false),
             priority: DEFAULT_PRIORITY,
             affinity: AFFINITY_ALL,
+            // The bootstrap task runs on the kernel PML4 that
+            // build_and_switch_kernel_pml4 installed — capture whatever
+            // CR3 currently points at.
+            cr3: Cr3::read().0,
         }
     }
 
@@ -156,6 +170,13 @@ impl Task {
         )
         .expect("failed to map task stack");
 
+        // Build the per-task PML4 *after* mapping the stack — the new
+        // PML4 snapshots the kernel PML4's upper half, and we want the
+        // fresh stack's L4 entry to already be in place. Later tasks'
+        // stacks fall under the same L4 entry and propagate by alias
+        // through the shared L3 subtree.
+        let cr3 = paging::new_task_pml4();
+
         let top = stack_base + STACK_SIZE;
 
         // Seven 8-byte slots: [r15, r14, r13, r12, rbp, rbx, ret].
@@ -187,6 +208,7 @@ impl Task {
             wake_pending: AtomicBool::new(false),
             priority: super::priority::clamp_priority(priority),
             affinity: AFFINITY_ALL,
+            cr3,
         }
     }
 

--- a/kernel/tests/per_task_cr3.rs
+++ b/kernel/tests/per_task_cr3.rs
@@ -1,0 +1,116 @@
+//! Integration test: each spawned task gets its own PML4 and
+//! `context_switch` reloads CR3 on every rotation. Proves the
+//! groundwork for per-task address spaces (#26) — different PML4s,
+//! kernel upper half still reachable from each.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+
+use vibix::{
+    exit_qemu, serial_println, task,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+use x86_64::registers::control::Cr3;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    task::init();
+    // Preemption drives task rotation — without IF=1 the workers never
+    // run and we deadlock on the atomics below.
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("distinct_pml4_per_task", &(distinct_pml4_per_task as fn())),
+        ("kernel_upper_half_shared", &(kernel_upper_half_shared as fn())),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+static A_CR3: AtomicU64 = AtomicU64::new(0);
+static B_CR3: AtomicU64 = AtomicU64::new(0);
+static DONE: AtomicUsize = AtomicUsize::new(0);
+
+fn task_a() -> ! {
+    A_CR3.store(Cr3::read().0.start_address().as_u64(), Ordering::SeqCst);
+    DONE.fetch_add(1, Ordering::SeqCst);
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn task_b() -> ! {
+    B_CR3.store(Cr3::read().0.start_address().as_u64(), Ordering::SeqCst);
+    DONE.fetch_add(1, Ordering::SeqCst);
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn distinct_pml4_per_task() {
+    let boot_cr3 = Cr3::read().0.start_address().as_u64();
+    A_CR3.store(0, Ordering::SeqCst);
+    B_CR3.store(0, Ordering::SeqCst);
+    DONE.store(0, Ordering::SeqCst);
+
+    task::spawn(task_a);
+    task::spawn(task_b);
+
+    // Bounded wait so a scheduling regression fails the test in ~1s
+    // instead of hanging CI.
+    for _ in 0..1_000 {
+        if DONE.load(Ordering::SeqCst) >= 2 {
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+
+    let a = A_CR3.load(Ordering::SeqCst);
+    let b = B_CR3.load(Ordering::SeqCst);
+    assert_ne!(a, 0, "task A never ran");
+    assert_ne!(b, 0, "task B never ran");
+    assert_ne!(
+        a, boot_cr3,
+        "task A shares bootstrap CR3 — new_task_pml4 regressed"
+    );
+    assert_ne!(
+        b, boot_cr3,
+        "task B shares bootstrap CR3 — new_task_pml4 regressed"
+    );
+    assert_ne!(a, b, "tasks A and B share CR3 — PML4 alloc regressed");
+    serial_println!("  boot=0x{boot_cr3:x} a=0x{a:x} b=0x{b:x}");
+}
+
+fn kernel_upper_half_shared() {
+    // If the kernel upper half weren't mirrored in task PML4s, task A
+    // would have faulted the instant it touched A_CR3 (a .bss static
+    // in the kernel image) — the fact that distinct_pml4_per_task
+    // above reached DONE=2 already proves it. Re-assert explicitly so
+    // a future test ordering change doesn't silently skip the check.
+    use vibix::mem::paging;
+    use x86_64::VirtAddr;
+    let marker_va = VirtAddr::new(&raw const A_CR3 as u64);
+    paging::translate(marker_va).expect("kernel .bss unreachable after task rotation");
+    let fn_ptr: fn() = kernel_upper_half_shared;
+    let fn_va = VirtAddr::new(fn_ptr as usize as u64);
+    paging::translate(fn_va).expect("kernel .text unreachable after task rotation");
+}

--- a/kernel/tests/per_task_cr3.rs
+++ b/kernel/tests/per_task_cr3.rs
@@ -37,7 +37,10 @@ fn panic(info: &PanicInfo) -> ! {
 fn run_tests() {
     let tests: &[(&str, &dyn Testable)] = &[
         ("distinct_pml4_per_task", &(distinct_pml4_per_task as fn())),
-        ("kernel_upper_half_shared", &(kernel_upper_half_shared as fn())),
+        (
+            "kernel_upper_half_shared",
+            &(kernel_upper_half_shared as fn()),
+        ),
     ];
     serial_println!("running {} tests", tests.len());
     for (name, t) in tests {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -509,6 +509,7 @@ fn test_all() -> R<()> {
         "blocking_sync",
         "shell_smoke",
         "priority",
+        "per_task_cr3",
     ] {
         cmd.arg("--test").arg(t);
     }


### PR DESCRIPTION
Closes #26

## Summary

- Every kernel task now owns its own PML4 whose upper half (L4 entries 256..512) is a verbatim copy of the live kernel PML4 and whose lower half is zero — groundwork for loading ELF userspace binaries into a task-private lower half without disturbing the kernel.
- `context_switch` gains a third argument (`next_cr3`) and loads CR3 after the stack swap; task stacks live in the shared upper half so either order is sound.
- Task stacks are mapped into the kernel PML4 *before* the task's own PML4 is snapshotted, so the L4 entry covering `TASK_STACKS_VA_BASE` (index 0x1A0) is present in every task PML4 from the moment it's created. Later tasks only extend lower levels inside that L4 entry, which all existing task PML4s see by alias.
- Relies on the invariant that no kernel upper-half L4 entry is added *after* a task PML4 exists. The kernel populates L4 256 (HHDM), 384 (heap), 416 (task stacks), and 511 (kernel image); further kernel mappings live below those L4 entries. Documented in the `new_task_pml4` doc comment.

Non-goals (per #26): ELF loading, ASLR/KASLR, SMEP/SMAP, shared memory / mmap, per-task lower-half mapping API (follow-up when userspace lands).

## Test plan

- [x] `cargo xtask build` — clean
- [x] `cargo xtask test` — 34 `[ok]` across every integration test, including the new `per_task_cr3` suite which asserts:
  - Two spawned tasks observe distinct `Cr3::read()` values that differ from the bootstrap task's CR3.
  - Kernel `.bss` and `.text` remain translatable after task rotation, proving the upper-half mirror is live.
- [x] `cargo xtask smoke` — all 16 markers present

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes low-level paging and context-switch mechanics (CR3 loads), where mistakes can cause hard faults, memory corruption, or hard-to-debug scheduling crashes.
> 
> **Overview**
> Adds per-task address-space scaffolding by creating a `paging::new_task_pml4()` helper that allocates a fresh PML4 with a zeroed lower half and a copied kernel upper half, and stores that frame in each `Task`.
> 
> Updates task creation to snapshot the PML4 after mapping the task stack, and extends `context_switch` (Rust + asm) to accept `next_cr3` and write CR3 on every switch; scheduler switch paths (`preempt_tick`, `block_current`) now pass the incoming task’s CR3.
> 
> Adds a new `per_task_cr3` integration test and wires it into `Cargo.toml` and `xtask test` to assert tasks observe distinct CR3 values while kernel upper-half mappings remain accessible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 807e0fc9e21caae50d2c8f9679094dc20dc06b81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->