### PR TITLE
mem: demand paging for AnonZero VMAs

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -103,3 +103,7 @@ harness = false
 [[test]]
 name = "per_task_cr3"
 harness = false
+
+[[test]]
+name = "demand_paging"
+harness = false

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -70,6 +70,34 @@ extern "x86-interrupt" fn page_fault(frame: InterruptStackFrame, code: PageFault
         }
     }
 
+    // Demand-paging resolver: a not-present fault inside an installed
+    // VMA is satisfied by allocating + zeroing a frame and mapping it
+    // with the VMA's flags. Protection violations (P bit set in the
+    // error code) fall through — those are real access-rights bugs,
+    // not missing-page cases.
+    if !code.contains(PageFaultErrorCode::PROTECTION_VIOLATION) {
+        if let Some((kind, flags)) = crate::task::current_vma_lookup(addr_u64 as usize) {
+            match kind {
+                crate::mem::vma::VmaKind::AnonZero => {
+                    use x86_64::structures::paging::{Page, Size4KiB};
+                    use x86_64::VirtAddr;
+                    let page = Page::<Size4KiB>::containing_address(VirtAddr::new(addr_u64));
+                    let active = x86_64::registers::control::Cr3::read().0;
+                    match crate::mem::paging::map_in_pml4(active, page, flags) {
+                        Ok(_) => return,
+                        Err(e) => {
+                            serial_println!(
+                                "#PF demand-page resolve failed addr={:#x}: {:?}",
+                                addr_u64,
+                                e
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     // Check whether the fault address lands inside a kernel task's guard
     // page — if so, this is a stack overflow, not a generic fault.
     if let Some(task_id) = crate::task::find_stack_overflow(addr_u64 as usize) {

--- a/kernel/src/mem/mod.rs
+++ b/kernel/src/mem/mod.rs
@@ -20,6 +20,8 @@ pub mod heap;
 pub mod paging;
 #[cfg(target_os = "none")]
 pub mod pat;
+#[cfg(target_os = "none")]
+pub mod vma;
 
 /// 4 KiB. The only page size we care about right now.
 pub const FRAME_SIZE: u64 = 4096;

--- a/kernel/src/mem/paging.rs
+++ b/kernel/src/mem/paging.rs
@@ -265,6 +265,40 @@ pub fn new_task_pml4() -> PhysFrame<Size4KiB> {
     new_frame
 }
 
+/// Map `page` to a freshly-allocated zeroed frame in the PML4 rooted
+/// at `pml4_frame`, with `flags`. Intended for the `#PF` demand-paging
+/// resolver: the handler runs in the faulting task's address space, so
+/// it passes `Cr3::read().0` for `pml4_frame`.
+///
+/// Flushes the TLB entry for `page` if `pml4_frame` is the currently
+/// active PML4; otherwise the new mapping only becomes visible when a
+/// later CR3 load installs this PML4 (at which point the load flushes
+/// non-global TLB entries implicitly).
+pub fn map_in_pml4(
+    pml4_frame: PhysFrame<Size4KiB>,
+    page: Page<Size4KiB>,
+    flags: PageTableFlags,
+) -> Result<PhysFrame<Size4KiB>, MapToError<Size4KiB>> {
+    let hhdm = HHDM_OFFSET
+        .lock()
+        .expect("paging::init must run before map_in_pml4");
+    let mut alloc = KernelFrameAllocator;
+    // SAFETY: just-allocated frame, zeroed through HHDM, exclusive.
+    let data_frame = unsafe { alloc_zeroed_frame(hhdm) };
+    // SAFETY: `pml4_frame` is a valid page-table frame and `hhdm` is
+    // the live HHDM offset. The temporary OffsetPageTable only lives
+    // for this call; no aliasing handle to the same PML4 escapes.
+    let l4 = unsafe { pml4_as_mut(pml4_frame, hhdm) };
+    let mut mapper = unsafe { OffsetPageTable::new(l4, hhdm) };
+    let flush = unsafe { mapper.map_to(page, data_frame, flags, &mut alloc)? };
+    if Cr3::read().0 == pml4_frame {
+        flush.flush();
+    } else {
+        flush.ignore();
+    }
+    Ok(data_frame)
+}
+
 // -- PML4 construction + CR3 swap ---------------------------------------
 
 /// Build a fresh kernel PML4 and switch CR3 to it. Drops Limine's

--- a/kernel/src/mem/vma.rs
+++ b/kernel/src/mem/vma.rs
@@ -1,0 +1,85 @@
+//! Virtual memory areas: per-task descriptors for regions that are
+//! resolved lazily by the `#PF` handler instead of eagerly mapped at
+//! spawn time.
+//!
+//! Today the only supported kind is [`VmaKind::AnonZero`] — anonymous
+//! zero-filled memory. A task installs a VMA via
+//! [`crate::task::install_vma_on_current`]; the first access to a page
+//! inside the range takes a `#PF` that the handler satisfies by
+//! allocating a zeroed frame and mapping it with the VMA's flags.
+//!
+//! This is the minimal groundwork for #51 — fork-time copy-on-write
+//! lives behind a richer VMA kind that isn't here yet.
+
+use alloc::vec::Vec;
+use x86_64::structures::paging::PageTableFlags;
+
+/// Kind of backing a VMA describes.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum VmaKind {
+    /// Anonymous, zero-filled on first touch. Each page is backed by a
+    /// freshly-allocated frame zeroed via the HHDM before it is mapped.
+    AnonZero,
+}
+
+/// A half-open `[start, end)` VA range with a backing kind and the
+/// flags the `#PF` resolver should apply when it installs a page.
+///
+/// `start` and `end` are byte addresses and must be 4 KiB-aligned; the
+/// constructor enforces that.
+#[derive(Clone, Copy, Debug)]
+pub struct Vma {
+    pub start: usize,
+    pub end: usize,
+    pub kind: VmaKind,
+    pub flags: PageTableFlags,
+}
+
+impl Vma {
+    pub fn new(start: usize, end: usize, kind: VmaKind, flags: PageTableFlags) -> Self {
+        assert!(start % 4096 == 0, "vma start must be page aligned");
+        assert!(end % 4096 == 0, "vma end must be page aligned");
+        assert!(start < end, "vma range must be non-empty");
+        Self {
+            start,
+            end,
+            kind,
+            flags,
+        }
+    }
+
+    pub fn contains(&self, addr: usize) -> bool {
+        addr >= self.start && addr < self.end
+    }
+}
+
+/// Per-task list of VMAs. Small and linear — we expect a handful of
+/// regions per task, not thousands. Lookup is O(n).
+#[derive(Default)]
+pub struct VmaList {
+    entries: Vec<Vma>,
+}
+
+impl VmaList {
+    pub const fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
+    }
+
+    /// Insert `vma` if it doesn't overlap anything already present.
+    /// Panics on overlap — overlapping VMAs are a programmer error,
+    /// not a runtime condition to recover from.
+    pub fn insert(&mut self, vma: Vma) {
+        for existing in &self.entries {
+            let overlap = vma.start < existing.end && existing.start < vma.end;
+            assert!(!overlap, "VMA overlaps existing range");
+        }
+        self.entries.push(vma);
+    }
+
+    /// Find the VMA containing `addr`, if any.
+    pub fn find(&self, addr: usize) -> Option<Vma> {
+        self.entries.iter().copied().find(|v| v.contains(addr))
+    }
+}

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -414,7 +414,10 @@ pub fn install_vma_on_current(vma: crate::mem::vma::Vma) {
 /// normally the lock is free at fault time.
 pub fn current_vma_lookup(
     addr: usize,
-) -> Option<(crate::mem::vma::VmaKind, x86_64::structures::paging::PageTableFlags)> {
+) -> Option<(
+    crate::mem::vma::VmaKind,
+    x86_64::structures::paging::PageTableFlags,
+)> {
     let sched = SCHED.try_lock()?;
     let current = sched.current.as_ref()?;
     let vma = current.vmas.find(addr)?;

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -393,6 +393,34 @@ pub fn find_stack_overflow(addr: usize) -> Option<usize> {
     }
 }
 
+/// Install a VMA on the currently-running task. The VMA is resolved
+/// lazily by the `#PF` handler on first touch of each page.
+pub fn install_vma_on_current(vma: crate::mem::vma::Vma) {
+    let mut sched = SCHED.lock();
+    let current = sched
+        .current
+        .as_mut()
+        .expect("install_vma_on_current: no running task");
+    current.vmas.insert(vma);
+}
+
+/// Consult the current task's VMA list for `addr`. Returns the VMA's
+/// backing kind and the flags the `#PF` resolver should apply.
+///
+/// Returns `None` if the scheduler lock is contended — the `#PF`
+/// handler treats that as "not a demand-page fault" and falls through
+/// to the generic hang path. In practice contention only arises when
+/// the fault hit mid-`context_switch`; for demand-paged tasks running
+/// normally the lock is free at fault time.
+pub fn current_vma_lookup(
+    addr: usize,
+) -> Option<(crate::mem::vma::VmaKind, x86_64::structures::paging::PageTableFlags)> {
+    let sched = SCHED.try_lock()?;
+    let current = sched.current.as_ref()?;
+    let vma = current.vmas.find(addr)?;
+    Some((vma.kind, vma.flags))
+}
+
 /// Called from the timer ISR after `notify_eoi`. Decrements the
 /// current task's slice; if it's exhausted and there's another task
 /// ready, rotates and context-switches. Bails on lock contention so

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -25,6 +25,7 @@ use x86_64::structures::paging::{Page, PageTableFlags, PhysFrame, Size4KiB};
 use x86_64::VirtAddr;
 
 use crate::mem::paging;
+use crate::mem::vma::VmaList;
 
 use super::priority::{AFFINITY_ALL, DEFAULT_PRIORITY};
 use super::switch::task_entry_trampoline;
@@ -108,6 +109,11 @@ pub(super) struct Task {
     /// kernel mappings and whose lower half is empty — groundwork for
     /// per-task userspace address spaces (#26).
     pub cr3: PhysFrame<Size4KiB>,
+    /// Per-task virtual-memory areas resolved lazily by the `#PF`
+    /// handler. Empty for the bootstrap task and for spawned tasks
+    /// until something installs a VMA via
+    /// [`super::install_vma_on_current`].
+    pub vmas: VmaList,
 }
 
 impl Task {
@@ -128,6 +134,7 @@ impl Task {
             // build_and_switch_kernel_pml4 installed — capture whatever
             // CR3 currently points at.
             cr3: Cr3::read().0,
+            vmas: VmaList::new(),
         }
     }
 
@@ -209,6 +216,7 @@ impl Task {
             priority: super::priority::clamp_priority(priority),
             affinity: AFFINITY_ALL,
             cr3,
+            vmas: VmaList::new(),
         }
     }
 

--- a/kernel/tests/demand_paging.rs
+++ b/kernel/tests/demand_paging.rs
@@ -1,0 +1,80 @@
+//! Integration test: an installed `VmaKind::AnonZero` region is
+//! resolved lazily by the `#PF` handler. Proves the demand-paging
+//! path for #51 — first read faults, lands zero, write-then-read
+//! preserves the sentinel across the same page.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use core::ptr;
+
+use vibix::mem::vma::{Vma, VmaKind};
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+use x86_64::structures::paging::PageTableFlags;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    vibix::task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("anon_zero_first_touch", &(anon_zero_first_touch as fn())),
+        ("anon_zero_readback", &(anon_zero_readback as fn())),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+/// Lower-half VA well clear of anything the kernel maps eagerly.
+const TEST_VA: usize = 0x0000_2000_0000_0000;
+const TEST_LEN: usize = 8 * 4096;
+
+fn install_test_vma() {
+    vibix::task::install_vma_on_current(Vma::new(
+        TEST_VA,
+        TEST_VA + TEST_LEN,
+        VmaKind::AnonZero,
+        PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE,
+    ));
+}
+
+fn anon_zero_first_touch() {
+    install_test_vma();
+    // First touch faults; handler resolves via map_in_pml4 and the
+    // read returns zero from the freshly-zeroed frame.
+    let byte = unsafe { ptr::read_volatile(TEST_VA as *const u8) };
+    assert_eq!(byte, 0, "fresh AnonZero page did not read as zero");
+}
+
+fn anon_zero_readback() {
+    // TEST_VA is now backed by a real frame (installed above). Reuse
+    // a different page in the same VMA to exercise one more fault +
+    // verify write/read persistence on the resolved mapping.
+    let va = TEST_VA + 4096;
+    let p = va as *mut u64;
+    let first = unsafe { ptr::read_volatile(p) };
+    assert_eq!(first, 0, "second AnonZero page did not read as zero");
+    unsafe { ptr::write_volatile(p, 0xDEAD_BEEF_CAFE_F00D) };
+    let back = unsafe { ptr::read_volatile(p) };
+    assert_eq!(back, 0xDEAD_BEEF_CAFE_F00D, "write/read mismatch");
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -510,6 +510,7 @@ fn test_all() -> R<()> {
         "shell_smoke",
         "priority",
         "per_task_cr3",
+        "demand_paging",
     ] {
         cmd.arg("--test").arg(t);
     }


### PR DESCRIPTION
Closes #51.

## Summary

- Adds `kernel/src/mem/vma.rs` with `VmaKind::AnonZero`, `Vma`, and a linear `VmaList`.
- `Task` gains a `vmas: VmaList` field; `task::install_vma_on_current` / `task::current_vma_lookup` are the task-side API.
- `paging::map_in_pml4(pml4, page, flags)` allocates + zeros a frame and maps it into a caller-chosen PML4, flushing only when that PML4 is the active CR3.
- `#PF` handler resolves not-present faults that land inside an installed `AnonZero` VMA by calling `map_in_pml4` on the active CR3 with the VMA's flags. Protection violations and faults outside any VMA fall through to the existing stack-overflow / hang path.

Copy-on-write and fork-level sharing are deliberately out of scope here — this is the MVP that makes the `#PF` handler a resolver and proves it end-to-end.

## Test plan

- [x] `cargo xtask build` — clean (only the two pre-existing `guard_base` / `is_guard_hit` warnings from #110).
- [x] `cargo xtask test` — all integration tests pass, including the new `demand_paging` suite:
  - `anon_zero_first_touch`: install a VMA at `0x2000_0000_0000`, read a byte, observe zero from the freshly-resolved page.
  - `anon_zero_readback`: second page in the same VMA — fault, write sentinel, read it back.
- [x] `cargo xtask smoke` — all 16 smoke markers present.

## Risk + rollback

- The resolver runs inside the `#PF` handler with the scheduler lock held briefly via `try_lock`; on contention it falls through to the generic hang path, so a faulting task that somehow holds `SCHED` (only possible mid-`context_switch`) is no worse off than before.
- Rollback is clean: both commits are additive; reverting restores the previous `#PF` handler and drops the VMA module.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core paging and the `#PF` handler to install mappings at fault time, so bugs can crash the kernel or corrupt address-space state. Also adds per-task VMA tracking and new mapping primitives, increasing surface area in memory-management paths.
> 
> **Overview**
> Adds minimal **per-task virtual memory areas (VMAs)** and wires the `#PF` handler to *resolve not-present faults* by lazily allocating/zeroing a frame and mapping it with the VMA’s `PageTableFlags` (while letting protection-violation faults fall through).
> 
> Introduces `mem::vma` (`VmaKind::AnonZero`, `Vma`, `VmaList`), stores a `VmaList` on each `Task`, and provides `task::install_vma_on_current` / `task::current_vma_lookup` for managing/querying VMAs.
> 
> Extends paging with `paging::map_in_pml4` to map into an explicit PML4 (with conditional TLB flush based on active CR3), and adds a new QEMU integration test `demand_paging` plus plumbing in `Cargo.toml` and `xtask` to run it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98ff3abc32890c9925a9efc94f88dfc8a019f172. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->