### PR TITLE
time: tick-based sleep primitive (task::sleep_ms)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -111,3 +111,7 @@ harness = false
 [[test]]
 name = "userspace_module"
 harness = false
+
+[[test]]
+name = "sleep"
+harness = false

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -449,6 +449,13 @@ pub fn preempt_tick() {
         return;
     }
 
+    // Drain any tick-deadline wakeups (see `task::sleep_ms`) and
+    // promote their targets. Runs before the preemption decision so a
+    // freshly-unparked task is visible in the highest-ready check.
+    for id in crate::time::drain_expired(crate::time::ticks()) {
+        wake_in_sched(&mut sched, id);
+    }
+
     {
         let top_ready = sched.highest_ready_priority();
         let current = sched.current.as_mut().unwrap();
@@ -628,39 +635,38 @@ pub fn wake(id: usize) {
     interrupts::disable();
 
     let mut sched = SCHED.lock();
+    wake_in_sched(&mut sched, id);
+    drop(sched);
 
-    // Parked → Ready is the happy path: move the Box across and hand
-    // the task a fresh slice so it gets a full tick the next time the
-    // scheduler rotates through.
+    if was_on {
+        interrupts::enable();
+    }
+}
+
+/// Body of [`wake`] that operates on a caller-held scheduler lock.
+/// Used by [`preempt_tick`] after draining tick-deadline wakeups so the
+/// unpark happens without re-entering the mutex.
+fn wake_in_sched(sched: &mut Scheduler, id: usize) {
+    // Parked → Ready is the happy path.
     if let Some(mut task) = sched.parked.remove(&id) {
         task.state = TaskState::Ready;
         task.slice_remaining_ms = DEFAULT_SLICE_MS;
         let prio = task.priority;
         sched.push_ready(task);
-        // If the newly-ready task outranks the current one, cut the
-        // current slice short so the next tick rotates it in.
-        maybe_preempt_current_for_priority(&mut sched, prio);
-        drop(sched);
-        if was_on {
-            interrupts::enable();
-        }
+        maybe_preempt_current_for_priority(sched, prio);
         return;
     }
 
     // Task is Running or Ready. Set wake_pending so the next
-    // block_current call on it returns immediately. This is the
-    // wake-before-park race cure — see `block_current`'s fast path.
+    // block_current call on it returns immediately — this is the
+    // wake-before-park race cure (see `block_current`'s fast path).
     if let Some(current) = sched.current.as_ref() {
         if current.id == id {
             current.wake_pending.store(true, Ordering::Release);
-            drop(sched);
-            if was_on {
-                interrupts::enable();
-            }
             return;
         }
     }
-    let ready_hit = sched.iter_ready().any(|task| {
+    let _ = sched.iter_ready().any(|task| {
         if task.id == id {
             task.wake_pending.store(true, Ordering::Release);
             true
@@ -668,18 +674,23 @@ pub fn wake(id: usize) {
             false
         }
     });
-    if ready_hit {
-        drop(sched);
-        if was_on {
-            interrupts::enable();
-        }
-        return;
-    }
+    // Unknown id — drop on the floor.
+}
 
-    // Unknown id — drop the wake on the floor. Tasks don't exit yet so
-    // this only fires if somebody handed us a stale or invented id.
-    drop(sched);
-    if was_on {
-        interrupts::enable();
-    }
+/// Park the current task for at least `ms` milliseconds.
+///
+/// Computes a deadline in PIT ticks (ceil-div against [`TICK_MS`] so a
+/// short sleep never returns early), registers the current task id
+/// with the time subsystem, and parks via [`block_current`]. The PIT
+/// ISR drains expired deadlines and unparks through the normal
+/// scheduler path.
+///
+/// Resolution is the PIT tick (10 ms at 100 Hz); callers asking for
+/// less will sleep for at least one full tick.
+pub fn sleep_ms(ms: u64) {
+    let ticks_to_wait = ms.div_ceil(crate::time::TICK_MS).max(1);
+    let deadline = crate::time::ticks().saturating_add(ticks_to_wait);
+    let id = current_id();
+    crate::time::enqueue_wakeup(deadline, id);
+    block_current();
 }

--- a/kernel/src/time.rs
+++ b/kernel/src/time.rs
@@ -4,8 +4,11 @@
 //! Separately, the CMOS RTC provides a best-effort wall-clock snapshot
 //! during boot for human-readable timestamps.
 
+use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
 use core::fmt;
 use core::sync::atomic::{AtomicU64, Ordering};
+use spin::Mutex;
 
 /// PIT oscillator frequency, in Hz. Divisor = this / desired Hz.
 #[cfg(target_os = "none")]
@@ -16,6 +19,12 @@ pub const TICK_HZ: u32 = 100;
 pub const TICK_MS: u64 = 1000 / TICK_HZ as u64;
 
 static TICKS: AtomicU64 = AtomicU64::new(0);
+
+/// Pending task wakeups keyed by deadline (in ticks). A single deadline
+/// may accumulate multiple task ids (unlikely at 100 Hz but cheap to
+/// support). Drained by `preempt_tick` each PIT IRQ; see
+/// `drain_expired`.
+static WAKEUPS: Mutex<BTreeMap<u64, Vec<usize>>> = Mutex::new(BTreeMap::new());
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct DateTime {
@@ -109,6 +118,37 @@ pub fn ticks() -> u64 {
 
 pub fn uptime_ms() -> u64 {
     ticks() * TICK_MS
+}
+
+/// Register `id` to be woken once the tick counter reaches
+/// `deadline_ticks`. Callers are task context only — uses a blocking
+/// lock. A deadline of `0` or one already in the past will be drained
+/// on the very next `preempt_tick`.
+pub fn enqueue_wakeup(deadline_ticks: u64, id: usize) {
+    WAKEUPS.lock().entry(deadline_ticks).or_default().push(id);
+}
+
+/// Pop every task id whose deadline is ≤ `now` from the wakeup list,
+/// in deadline order. Returns an empty `Vec` if the list is empty, if
+/// the lock is contended (ISR caller), or if no entry has expired.
+///
+/// Safe to call from an interrupt context: uses `try_lock` and bails
+/// cleanly on contention. A missed drain is self-healing — the next
+/// tick's call picks the same entries up.
+pub fn drain_expired(now: u64) -> Vec<usize> {
+    let Some(mut wakeups) = WAKEUPS.try_lock() else {
+        return Vec::new();
+    };
+    let mut ids: Vec<usize> = Vec::new();
+    while let Some((&deadline, _)) = wakeups.iter().next() {
+        if deadline > now {
+            break;
+        }
+        if let Some(mut bucket) = wakeups.remove(&deadline) {
+            ids.append(&mut bucket);
+        }
+    }
+    ids
 }
 
 pub fn wall_clock() -> Option<DateTime> {

--- a/kernel/tests/sleep.rs
+++ b/kernel/tests/sleep.rs
@@ -1,0 +1,163 @@
+//! Integration test: `task::sleep_ms` parks the calling task and
+//! resumes it after at least the requested interval has elapsed.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+
+use vibix::{
+    exit_qemu, serial_println, task,
+    test_harness::{test_panic_handler, Testable},
+    time, QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("sleep_ms_parks_for_interval", &(sleep_ms_parks as fn())),
+        (
+            "sleep_ms_multiple_tasks_independent",
+            &(sleep_ms_multiple as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+// --- sleep_ms_parks_for_interval ------------------------------------
+
+static SLEEP_START_MS: AtomicU64 = AtomicU64::new(0);
+static SLEEP_ELAPSED_MS: AtomicU64 = AtomicU64::new(0);
+static SLEEP_DONE: AtomicUsize = AtomicUsize::new(0);
+
+const SLEEP_MS_TARGET: u64 = 50;
+
+fn sleep_worker() -> ! {
+    let start = time::uptime_ms();
+    SLEEP_START_MS.store(start, Ordering::SeqCst);
+    task::sleep_ms(SLEEP_MS_TARGET);
+    let elapsed = time::uptime_ms().saturating_sub(start);
+    SLEEP_ELAPSED_MS.store(elapsed, Ordering::SeqCst);
+    SLEEP_DONE.fetch_add(1, Ordering::SeqCst);
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn sleep_ms_parks() {
+    SLEEP_START_MS.store(0, Ordering::SeqCst);
+    SLEEP_ELAPSED_MS.store(0, Ordering::SeqCst);
+    SLEEP_DONE.store(0, Ordering::SeqCst);
+
+    task::spawn(sleep_worker);
+
+    // Driver waits on hlt. Deadline is generous (~2 s) — a miss means
+    // the wakeup queue never drained or `block_current` wedged.
+    for _ in 0..200 {
+        if SLEEP_DONE.load(Ordering::SeqCst) == 1 {
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+
+    assert_eq!(
+        SLEEP_DONE.load(Ordering::SeqCst),
+        1,
+        "sleep_worker didn't resume — wakeup queue not drained?"
+    );
+    let elapsed = SLEEP_ELAPSED_MS.load(Ordering::SeqCst);
+    assert!(
+        elapsed >= SLEEP_MS_TARGET,
+        "sleep_ms returned early: elapsed={elapsed}ms, target={SLEEP_MS_TARGET}ms"
+    );
+    // Upper bound is loose — ten ticks of slop covers scheduling jitter
+    // on a busy QEMU host but still catches obvious runaways.
+    assert!(
+        elapsed < SLEEP_MS_TARGET + 500,
+        "sleep_ms overshot by > 500ms: elapsed={elapsed}ms"
+    );
+}
+
+// --- sleep_ms_multiple_tasks_independent ----------------------------
+//
+// Two tasks sleep for different durations concurrently. Both must
+// wake, and the shorter-sleep task must finish first.
+
+static MULTI_SHORT_DONE_AT: AtomicU64 = AtomicU64::new(0);
+static MULTI_LONG_DONE_AT: AtomicU64 = AtomicU64::new(0);
+static MULTI_DONE: AtomicUsize = AtomicUsize::new(0);
+
+fn multi_short_worker() -> ! {
+    task::sleep_ms(30);
+    MULTI_SHORT_DONE_AT.store(time::uptime_ms(), Ordering::SeqCst);
+    MULTI_DONE.fetch_add(1, Ordering::SeqCst);
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn multi_long_worker() -> ! {
+    task::sleep_ms(80);
+    MULTI_LONG_DONE_AT.store(time::uptime_ms(), Ordering::SeqCst);
+    MULTI_DONE.fetch_add(1, Ordering::SeqCst);
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn sleep_ms_multiple() {
+    MULTI_SHORT_DONE_AT.store(0, Ordering::SeqCst);
+    MULTI_LONG_DONE_AT.store(0, Ordering::SeqCst);
+    MULTI_DONE.store(0, Ordering::SeqCst);
+
+    let start = time::uptime_ms();
+    task::spawn(multi_short_worker);
+    task::spawn(multi_long_worker);
+
+    for _ in 0..200 {
+        if MULTI_DONE.load(Ordering::SeqCst) == 2 {
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+
+    assert_eq!(
+        MULTI_DONE.load(Ordering::SeqCst),
+        2,
+        "not all sleep workers finished"
+    );
+    let short = MULTI_SHORT_DONE_AT.load(Ordering::SeqCst);
+    let long = MULTI_LONG_DONE_AT.load(Ordering::SeqCst);
+    assert!(
+        short >= start + 30,
+        "short sleeper woke too early: start={start} short_done_at={short}"
+    );
+    assert!(
+        long >= start + 80,
+        "long sleeper woke too early: start={start} long_done_at={long}"
+    );
+    assert!(
+        short < long,
+        "short sleep finished after long sleep: short={short} long={long}"
+    );
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -539,6 +539,7 @@ fn test_all() -> R<()> {
         "per_task_cr3",
         "demand_paging",
         "userspace_module",
+        "sleep",
     ] {
         cmd.arg("--test").arg(t);
     }


### PR DESCRIPTION
Closes #136

## Summary
- Adds a deadline-keyed wakeup list in `time` (BTreeMap<deadline_ticks, Vec<id>>) plus `enqueue_wakeup` / `drain_expired` accessors. `drain_expired` is ISR-safe (try_lock, bails on contention — next tick re-drains).
- Adds `task::sleep_ms(ms)` that enqueues a wakeup at `ticks() + ceil_div(ms, TICK_MS)` then calls `block_current`. Resolution is one PIT tick (10 ms at 100 Hz).
- Refactors `wake`'s body into `wake_in_sched(&mut Scheduler, id)` so `preempt_tick` can unpark expired sleepers while already holding the scheduler lock — no duplicate lock acquisition, no new race surface.
- `preempt_tick` drains expired wakeups at the top of its run, before the normal preemption decision, so a freshly-unparked task is visible in the highest-ready check on the same tick.

## Out of scope
- Replacing the `RTC_MAX_READY_POLLS` busy-wait in `time::init` with `sleep_ms`: `time::init` runs *before* `task::init` during boot, so the scheduler doesn't exist when the RTC read happens. That replacement requires reordering boot init and is a separate change.

## Test plan
- [x] `cargo xtask build` — clean (only pre-existing dead-code warnings).
- [x] `cargo xtask test` — new `tests/sleep.rs` covers two cases:
  - `sleep_ms(50)` parks then resumes with `uptime_ms` delta ≥ 50 ms (upper-bounded at 550 ms for jitter).
  - Two concurrent sleepers (30 ms + 80 ms) both wake, and the short sleeper finishes first.
- [x] `cargo xtask smoke` — all 19 serial markers still present.
- [x] `cargo test --lib` — 32 host tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches kernel scheduler/timer paths by draining wakeup deadlines on each PIT tick and refactoring `wake`, which could introduce subtle scheduling/locking regressions if the wakeup queue or ISR interactions misbehave.
> 
> **Overview**
> Adds a tick-based sleep primitive `task::sleep_ms` that parks the current task until a computed PIT-tick deadline, with *tick-level resolution*.
> 
> Implements a deadline-keyed wakeup queue in `time` (`enqueue_wakeup`/`drain_expired`) and integrates it into the timer ISR path by draining expired deadlines at the start of `task::preempt_tick` and waking tasks via a new lock-reuse helper `wake_in_sched`.
> 
> Extends the QEMU integration test suite with a new `sleep` test and wires it into `Cargo.toml` and `xtask test` to validate single- and multi-sleeper behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad64a7ee2a8e0fb5619ee78b44fbb0cf953c53e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->