### PR TITLE
serial: UART RX via IOAPIC IRQ4

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -119,3 +119,7 @@ harness = false
 [[test]]
 name = "pci_enum"
 harness = false
+
+[[test]]
+name = "serial_rx"
+harness = false

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -6,7 +6,9 @@ use spin::Lazy;
 use x86_64::structures::idt::{InterruptDescriptorTable, InterruptStackFrame, PageFaultErrorCode};
 
 use crate::arch::x86_64::gdt::DOUBLE_FAULT_IST_INDEX;
-use crate::arch::x86_64::interrupts::{keyboard_interrupt, timer_interrupt, InterruptIndex};
+use crate::arch::x86_64::interrupts::{
+    keyboard_interrupt, serial_interrupt, timer_interrupt, InterruptIndex,
+};
 use crate::serial_println;
 
 static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
@@ -23,6 +25,7 @@ static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
     }
     idt[InterruptIndex::Timer.as_u8()].set_handler_fn(timer_interrupt);
     idt[InterruptIndex::Keyboard.as_u8()].set_handler_fn(keyboard_interrupt);
+    idt[InterruptIndex::Serial.as_u8()].set_handler_fn(serial_interrupt);
     idt
 });
 

--- a/kernel/src/arch/x86_64/interrupts.rs
+++ b/kernel/src/arch/x86_64/interrupts.rs
@@ -15,6 +15,7 @@ use crate::arch::x86_64::pic::{notify_eoi, PIC_1_OFFSET};
 pub enum InterruptIndex {
     Timer = PIC_1_OFFSET,
     Keyboard = PIC_1_OFFSET + 1,
+    Serial = PIC_1_OFFSET + 4,
 }
 
 impl InterruptIndex {
@@ -41,4 +42,12 @@ pub extern "x86-interrupt" fn keyboard_interrupt(_frame: InterruptStackFrame) {
     let code: u8 = unsafe { Port::new(0x60).read() };
     crate::input::push_scancode_from_isr(code);
     notify_eoi(InterruptIndex::Keyboard.as_u8());
+}
+
+pub extern "x86-interrupt" fn serial_interrupt(_frame: InterruptStackFrame) {
+    // Draining RBR until LSR.DR clears acks the Received-Data-Available
+    // condition in IIR, so no separate register read is needed to
+    // dismiss the IRQ.
+    crate::serial::drain_rx_hardware();
+    notify_eoi(InterruptIndex::Serial.as_u8());
 }

--- a/kernel/src/arch/x86_64/mod.rs
+++ b/kernel/src/arch/x86_64/mod.rs
@@ -29,4 +29,8 @@ pub fn init_apic(rsdp_phys: usize, hhdm_offset: u64) {
     apic::ioapic_init(hhdm_offset);
     apic::route_legacy_irq(0, interrupts::InterruptIndex::Timer.as_u8());
     apic::route_legacy_irq(1, interrupts::InterruptIndex::Keyboard.as_u8());
+    apic::route_legacy_irq(4, interrupts::InterruptIndex::Serial.as_u8());
+    // Enable RX IER only after the IOAPIC redirection for IRQ4 is in
+    // place — otherwise the first byte raises against a masked vector.
+    crate::serial::enable_rx_interrupts();
 }

--- a/kernel/src/serial.rs
+++ b/kernel/src/serial.rs
@@ -1,10 +1,49 @@
-//! COM1 16550 UART — our primary log sink during early boot.
+//! COM1 16550 UART — our primary log sink during early boot, plus an
+//! interrupt-driven RX path that feeds the shell's input loop.
+//!
+//! Write side uses the `uart_16550` crate's `SerialPort` behind a
+//! `Mutex`. RX side runs out of the IRQ4 ISR (`serial_interrupt` in
+//! `arch::x86_64::interrupts`): the ISR drains the UART FIFO into
+//! `RX_RING`, consumers pop via [`try_read_byte`]. Ring overflow
+//! increments [`rx_overflows`] and drops the new byte — mirrors the
+//! keyboard scancode path in `input.rs`.
 
 use core::fmt::{self, Write};
+use core::sync::atomic::{AtomicU64, Ordering};
+
 use spin::Mutex;
 use uart_16550::SerialPort;
+use x86_64::instructions::interrupts::without_interrupts;
+use x86_64::instructions::port::Port;
 
-static COM1: Mutex<SerialPort> = Mutex::new(unsafe { SerialPort::new(0x3F8) });
+use crate::input::RingBuffer;
+
+/// COM1 IO base. Individual registers are named offsets off of this.
+pub const COM1_BASE: u16 = 0x3F8;
+
+const UART_REG_RBR: u16 = 0; // R: receive buffer (DLAB=0)
+const UART_REG_IER: u16 = 1; // R/W: interrupt enable (DLAB=0)
+const UART_REG_LCR: u16 = 3; // R/W: line control (bit 7 = DLAB)
+const UART_REG_MCR: u16 = 4; // R/W: modem control
+const UART_REG_LSR: u16 = 5; // R: line status
+
+/// IER bit 0 — Received Data Available interrupt.
+const IER_RDA: u8 = 0x01;
+/// MCR bit 3 — OUT2. Required to gate the UART's interrupt line to the
+/// IOAPIC; without it, enabling IER alone produces no IRQ.
+const MCR_OUT2: u8 = 0x08;
+/// LSR bit 0 — Data Ready (one or more bytes in RBR).
+const LSR_DR: u8 = 0x01;
+
+static COM1: Mutex<SerialPort> = Mutex::new(unsafe { SerialPort::new(COM1_BASE) });
+
+/// RX bytes pushed here from the IRQ4 ISR. Sized to match the keyboard
+/// scancode ring (128) — human typing can't overflow it; the only way
+/// it fills is a stuck consumer, which [`rx_overflows`] reports.
+static RX_RING: Mutex<RingBuffer<u8, 128>> = Mutex::new(RingBuffer::new());
+
+/// Count of bytes the ISR dropped because `RX_RING` was full.
+static RX_OVERFLOWS: AtomicU64 = AtomicU64::new(0);
 
 pub fn init() {
     COM1.lock().init();
@@ -27,4 +66,59 @@ macro_rules! serial_print {
 macro_rules! serial_println {
     () => ($crate::serial_print!("\n"));
     ($($arg:tt)*) => ($crate::serial_print!("{}\n", format_args!($($arg)*)));
+}
+
+/// Enable the Received-Data-Available interrupt on COM1 and assert
+/// MCR.OUT2 so the UART's IRQ line actually reaches the IOAPIC.
+///
+/// Call *after* `route_legacy_irq(4, ...)` — the ISR vector must exist
+/// before an IRQ can fire into it. The `uart_16550` init path leaves
+/// IER=0, so enabling it here is safe against double-init.
+pub fn enable_rx_interrupts() {
+    unsafe {
+        let mut lcr: Port<u8> = Port::new(COM1_BASE + UART_REG_LCR);
+        // Force DLAB=0 so offset 1 addresses IER (not divisor latch
+        // high). `uart_16550::init` already did this, but defend in
+        // depth: any future re-entry that toggled DLAB would otherwise
+        // silently scribble the baud divisor.
+        let cur_lcr = lcr.read() & 0x7F;
+        lcr.write(cur_lcr);
+
+        let mut ier: Port<u8> = Port::new(COM1_BASE + UART_REG_IER);
+        ier.write(IER_RDA);
+
+        let mut mcr: Port<u8> = Port::new(COM1_BASE + UART_REG_MCR);
+        let cur_mcr = mcr.read();
+        mcr.write(cur_mcr | MCR_OUT2);
+    }
+    crate::serial_println!("serial: rx irq enabled");
+}
+
+/// Drain the UART receive FIFO into [`RX_RING`]. Called from the IRQ4
+/// ISR; also safe to call from test code after TX-loopback.
+///
+/// Loops while LSR.DR is set so a single IRQ can pull a burst out of
+/// the FIFO in one shot, avoiding spurious re-entries on consecutive
+/// bytes.
+pub(crate) fn drain_rx_hardware() {
+    unsafe {
+        let mut lsr: Port<u8> = Port::new(COM1_BASE + UART_REG_LSR);
+        let mut rbr: Port<u8> = Port::new(COM1_BASE + UART_REG_RBR);
+        while lsr.read() & LSR_DR != 0 {
+            let b = rbr.read();
+            if !RX_RING.lock().push(b) {
+                RX_OVERFLOWS.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+}
+
+/// Pop the next received byte, or `None` if the ring is empty.
+pub fn try_read_byte() -> Option<u8> {
+    without_interrupts(|| RX_RING.lock().pop())
+}
+
+/// Count of bytes dropped by the ISR because `RX_RING` was full.
+pub fn rx_overflows() -> u64 {
+    RX_OVERFLOWS.load(Ordering::Relaxed)
 }

--- a/kernel/src/shell/mod.rs
+++ b/kernel/src/shell/mod.rs
@@ -1,12 +1,10 @@
 //! Tiny kernel shell, spawned as its own preemptively-scheduled task.
 //!
-//! Reads a line from the PS/2 keyboard, dispatches it against a small
-//! table of builtins, and loops. When no input is pending the task
-//! `hlt`s — the keyboard ISR wakes the CPU on the next keypress, and
-//! the PIT preempt tick rotates other tasks in meanwhile.
-//!
-//! The input path is PS/2-only for now. Serial RX is orthogonal (needs
-//! IOAPIC IRQ4 routing) and deliberately out of scope for this module.
+//! Reads a line from either the PS/2 keyboard or COM1 serial input,
+//! dispatches it against a small table of builtins, and loops. When no
+//! input is pending the task `hlt`s — the keyboard or UART ISR wakes
+//! the CPU on the next byte, and the PIT preempt tick rotates other
+//! tasks in meanwhile.
 
 use alloc::string::String;
 use core::sync::atomic::{AtomicBool, Ordering};
@@ -15,7 +13,7 @@ use pc_keyboard::DecodedKey;
 
 use crate::mem::{frame, heap, FRAME_SIZE};
 use crate::task::TaskStateView;
-use crate::{input, pci, serial_print, serial_println, task, time};
+use crate::{input, pci, serial, serial_print, serial_println, task, time};
 
 /// Flipped to `true` the first time the shell's `run` enters its main
 /// loop. Integration tests poll this to confirm the shell actually
@@ -36,33 +34,53 @@ pub fn run() -> ! {
 
     let mut line = String::new();
     loop {
-        match input::try_read_key() {
-            Some(DecodedKey::Unicode('\r')) | Some(DecodedKey::Unicode('\n')) => {
-                serial_print!("\r\n");
-                // Only strip leading whitespace so `echo` can round-trip
-                // user-entered trailing spaces.
-                dispatch(line.trim_start());
-                line.clear();
-                prompt();
-            }
-            // Backspace (0x08) or DEL (0x7f) — both map to "erase one char".
-            Some(DecodedKey::Unicode('\x08')) | Some(DecodedKey::Unicode('\x7f')) => {
-                if line.pop().is_some() {
-                    serial_print!("\x08 \x08");
-                }
-            }
-            Some(DecodedKey::Unicode(c)) if !c.is_control() => {
-                if line.len() + c.len_utf8() <= MAX_LINE_LEN {
-                    line.push(c);
-                    serial_print!("{}", c);
-                }
-            }
-            Some(_) => {}
-            // Nothing in the scancode ring. Halt until the next IRQ
-            // (keyboard press wakes us; PIT rotates us out on slice
-            // expiry).
-            None => x86_64::instructions::hlt(),
+        if let Some(c) = next_char() {
+            on_char(c, &mut line);
+        } else {
+            // Nothing in either input ring. Halt until the next IRQ
+            // (keyboard or UART byte wakes us; PIT rotates us out on
+            // slice expiry).
+            x86_64::instructions::hlt();
         }
+    }
+}
+
+/// Pull the next character from whichever input source has one ready.
+/// Serial is polled first so headless operation feels responsive even
+/// when both rings accumulate simultaneously.
+fn next_char() -> Option<char> {
+    if let Some(b) = serial::try_read_byte() {
+        return Some(b as char);
+    }
+    match input::try_read_key()? {
+        DecodedKey::Unicode(c) => Some(c),
+        _ => None,
+    }
+}
+
+fn on_char(c: char, line: &mut String) {
+    match c {
+        '\r' | '\n' => {
+            serial_print!("\r\n");
+            // Only strip leading whitespace so `echo` can round-trip
+            // user-entered trailing spaces.
+            dispatch(line.trim_start());
+            line.clear();
+            prompt();
+        }
+        // Backspace (0x08) or DEL (0x7f) — both map to "erase one char".
+        '\x08' | '\x7f' => {
+            if line.pop().is_some() {
+                serial_print!("\x08 \x08");
+            }
+        }
+        c if !c.is_control() => {
+            if line.len() + c.len_utf8() <= MAX_LINE_LEN {
+                line.push(c);
+                serial_print!("{}", c);
+            }
+        }
+        _ => {}
     }
 }
 

--- a/kernel/tests/serial_rx.rs
+++ b/kernel/tests/serial_rx.rs
@@ -1,0 +1,92 @@
+//! Integration test: COM1 RX IRQ path delivers bytes into `RX_RING`.
+//!
+//! Drives the test entirely in-guest by flipping the 16550 into
+//! loopback mode (MCR.LOOP | MCR.OUT2), transmitting a byte, and
+//! waiting for IRQ4 → `serial_interrupt` → `drain_rx_hardware` to
+//! push it to the software ring. MCR is restored before the test
+//! emits its result so serial output leaves the chip again.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+
+use vibix::{
+    exit_qemu, serial, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+use x86_64::instructions::port::Port;
+
+const COM1_BASE: u16 = 0x3F8;
+const UART_REG_THR: u16 = 0;
+const UART_REG_MCR: u16 = 4;
+const MCR_LOOPBACK_BITS: u8 = 0x1A; // LOOP (bit4) | OUT2 (bit3) | RTS (bit1)
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[(
+        "serial_loopback_irq_delivers_byte",
+        &(serial_loopback_irq_delivers_byte as fn()),
+    )];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+fn serial_loopback_irq_delivers_byte() {
+    // Drop any stray bytes that landed in the ring during boot/init.
+    while serial::try_read_byte().is_some() {}
+    let overflows_before = serial::rx_overflows();
+
+    let mut mcr: Port<u8> = Port::new(COM1_BASE + UART_REG_MCR);
+    let mut thr: Port<u8> = Port::new(COM1_BASE + UART_REG_THR);
+    let saved_mcr = unsafe { mcr.read() };
+
+    // Enter loopback and transmit the probe byte.
+    unsafe {
+        mcr.write(MCR_LOOPBACK_BITS);
+        thr.write(b'X');
+    }
+
+    // Wait up to ~1 s for IRQ4 to push the looped byte into the ring.
+    let mut observed: Option<u8> = None;
+    for _ in 0..200 {
+        if let Some(b) = serial::try_read_byte() {
+            observed = Some(b);
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+
+    // Restore MCR *before* any serial output so logs leave the chip
+    // again. Assertions come after so a failure message is visible.
+    unsafe { mcr.write(saved_mcr) };
+
+    assert_eq!(
+        observed,
+        Some(b'X'),
+        "IRQ4 didn't deliver loopback byte — ring stayed empty"
+    );
+    assert_eq!(
+        serial::rx_overflows(),
+        overflows_before,
+        "RX ring overflowed during single-byte loopback test"
+    );
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -59,6 +59,7 @@ const SMOKE_MARKERS: &[&str] = &[
     "acpi: MADT parsed",
     "apic: BSP online",
     "ioapic: initialized",
+    "serial: rx irq enabled",
     "timer: 100 Hz",
     "rtc:",
     "vibix online.",
@@ -541,6 +542,7 @@ fn test_all() -> R<()> {
         "userspace_module",
         "sleep",
         "pci_enum",
+        "serial_rx",
     ] {
         cmd.arg("--test").arg(t);
     }


### PR DESCRIPTION
Closes #111

## Summary
- Route IRQ4 (COM1) through the IOAPIC to a new `InterruptIndex::Serial` vector and register the ISR in the IDT.
- `serial::enable_rx_interrupts()` sets IER.RDA and asserts MCR.OUT2 so UART IRQs actually reach the IOAPIC. Called from `arch::init_apic` right after the IRQ4 redirection is programmed.
- RX ISR drains the UART FIFO (loops on LSR.DR) into a 128-byte `RX_RING` built on the existing `RingBuffer`; overflow drops the byte and bumps `rx_overflows()`.
- Shell's idle loop now polls `serial::try_read_byte()` alongside `input::try_read_key()`, so typing in the QEMU serial console drives the prompt end-to-end.

## Test plan
- [x] New `kernel/tests/serial_rx.rs` drives the hardware path via UART loopback (MCR.LOOP|OUT2) — TX'ing `'X'` raises IRQ4, the ISR pushes it to the ring, test pops it and asserts `rx_overflows == 0`. MCR is restored before logs so assertion output still reaches the host.
- [x] `cargo xtask build` — clean (pre-existing dead-code warnings unchanged).
- [x] `cargo test --lib` — 36 passed.
- [x] `cargo xtask test` — all integration tests green, including new `serial_loopback_irq_delivers_byte` and the existing `shell_smoke`.
- [x] `cargo xtask smoke` — 20/20 markers (added `serial: rx irq enabled`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches low-level interrupt/APIC routing and UART port programming; mistakes could wedge IRQ handling or drop input, but the change is localized and covered by a new integration test.
> 
> **Overview**
> Adds **interrupt-driven COM1 RX** by introducing `InterruptIndex::Serial`, registering `serial_interrupt` in the IDT, and routing legacy IRQ4 through the IOAPIC during `arch::init_apic`.
> 
> Extends `serial` with an RX ring buffer (`try_read_byte`, `rx_overflows`), UART register programming to enable RX interrupts (`enable_rx_interrupts`), and an ISR-side FIFO drain (`drain_rx_hardware`), then updates the shell input loop to accept characters from serial as well as the keyboard.
> 
> Adds a new `serial_rx` QEMU integration test (UART loopback) and updates `xtask` smoke markers and test list accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d6fedfbb0e9db31c4b8326194b1216722e7c7b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->