### PR TITLE
docs: add issue prioritization playbook and file-issue skill

### DIFF
--- a/.claude/skills/auto-engineer/SKILL.md
+++ b/.claude/skills/auto-engineer/SKILL.md
@@ -11,6 +11,7 @@ Read these shared playbooks first:
 - `docs/agent-playbooks/build-run.md`
 - `docs/agent-playbooks/testing.md`
 - `docs/agent-playbooks/pr-review.md`
+- `docs/agent-playbooks/prioritization.md`
 
 Closes the full SDLC loop without prompting the user between steps. Each invocation runs **one cycle** (pick → plan → implement → PR → wait → merge), then reschedules itself via `ScheduleWakeup` with prompt `/auto-engineer` for the next cycle. Stops cleanly when it runs out of work or hits something it can't safely resolve.
 
@@ -32,6 +33,10 @@ The iteration counter is carried in the wake-up prompt itself as `/auto-engineer
 
 ### 1. Pick an unblocked issue
 
+The picking rules live in `docs/agent-playbooks/prioritization.md` — this step is the
+mechanical implementation of that policy. The north star is the minimal useful kernel:
+work P0s first, then P1s, and so on.
+
 ```sh
 gh issue list --search 'no:assignee' --state open \
   --json number,title,labels,body,assignees
@@ -41,10 +46,19 @@ Filter out:
 - Issues labeled `blocked`, `needs-discussion`, `question`, `wontfix`.
 - Issues whose body references an unresolved dependency (e.g. "blocked on #NN" where #NN is still open).
 
-Sort preference:
-1. Lowest-numbered issue labeled `enhancement` or `milestone-*`.
-2. Otherwise lowest-numbered `bug`.
-3. Otherwise lowest-numbered remaining issue.
+Sort preference (apply in order — do **not** fall back to "oldest first" until you have
+exhausted the priority ordering):
+
+1. `priority:P0` before `priority:P1` before `priority:P2` before `priority:P3`. Issues with
+   no `priority:*` label rank **after** `priority:P3` — they are un-triaged.
+2. Within a priority bucket, prefer `track:userspace`, then `track:filesystem`, then
+   `track:terminal`, then `track:posix`, then untracked.
+3. Within a (priority, track) bucket, lowest-numbered first.
+
+If the top candidate's prerequisites are still open, skip it and try the next one rather
+than starting work that cannot land. If a candidate is un-triaged (no `priority:*` label),
+prefer triaging it via the `file-issue` skill's label rules before working it — don't mine
+the un-triaged tail for "easy" work and bypass the priority queue.
 
 If the candidate list is empty → **stop** (see Stopping below) with message *"no unblocked issues — auto-engineer idle."*
 
@@ -145,17 +159,16 @@ Before reloading the next issue, scan for work that surfaced during this cycle b
 - Build/test warnings observed during step 4 that weren't blocking but deserve follow-up.
 - Anything the sub-agent's plan (step 2) explicitly listed as "out of scope" or "risks."
 
-For each distinct follow-up, before filing, **dedupe against existing issues**:
+For each distinct follow-up, **invoke the `file-issue` skill** — do not call
+`mcp__github__issue_write` directly. The `file-issue` skill handles dedupe against existing
+issues, enforces the label taxonomy from `docs/agent-playbooks/prioritization.md`, and
+produces a body in the canonical template. Feed it:
 
-```sh
-gh issue list --state open --search '<keywords>' --json number,title
-```
-
-If no match, file via `mcp__github__create_issue` per the `sdlc` "capture out-of-scope ideas" rule:
-- Specific title.
-- Body explaining *what* and *why* with enough context to act on cold in a week.
-- Reference the merged PR (`discovered while merging #<PR>`).
-- Labels that fit (`bug`, `enhancement`, `tech-debt`, `milestone-N`).
+- A specific title.
+- A 1–3 sentence motivation, including `discovered while merging #<PR>` so the origin is
+  recoverable later.
+- Concrete work items.
+- Context (file paths, commit SHAs, related issue numbers).
 
 If nothing worth filing, skip silently. **Do not file speculative or "nice-to-have" issues** — only things with concrete motivation. Over-filing clutters the backlog and degrades the `no:assignee` candidate set that step 1 depends on.
 

--- a/.claude/skills/file-issue/SKILL.md
+++ b/.claude/skills/file-issue/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: file-issue
+description: File a new vibix GitHub issue with the correct priority/area/track labels applied up front. Use whenever an agent needs to capture a new unit of work — follow-ups from a merged PR, TODOs discovered while coding, or manually-requested issues. Invoked as `/file-issue`.
+---
+
+# file-issue
+
+Files a single GitHub issue against `dburkart/vibix` with priority, area, and (when
+applicable) track labels applied on creation. Keeps the backlog triaged in one step instead
+of leaving un-labeled issues that pollute the auto-engineer candidate set.
+
+Read `docs/agent-playbooks/prioritization.md` before running — the label taxonomy, the P0
+critical path, and the triage rules all live there. This skill is the mechanical front-end
+for that policy.
+
+## When to invoke
+
+- A merged PR surfaced out-of-scope follow-up work that needs its own issue (auto-engineer
+  step 8, or a human reviewer deferring a nit).
+- A `TODO`/`FIXME`/`unimplemented!()` was introduced that deserves tracking.
+- The user says "file an issue for …" or invokes `/file-issue` directly.
+- The issue-backfill workflow proposes new items during periodic triage.
+
+Do **not** use this skill to edit an existing issue — use `mcp__github__issue_write` with
+`method: "update"` for that.
+
+## Inputs
+
+Either accept them as free-form arguments after `/file-issue`, or infer from the invoking
+context:
+
+- **title** — imperative phrase, ≤ 72 chars, no emoji.
+- **motivation** — 1–3 sentences on why this matters and what it unblocks.
+- **work** — bulleted sub-tasks, concrete enough to act on cold in a week (file paths,
+  struct names, function signatures when known).
+- **context** — relevant commit SHAs, file paths, existing issue numbers, or the PR that
+  surfaced the follow-up.
+
+If any of those are missing and cannot be reasonably inferred, ask the user before filing.
+
+## Cycle
+
+### 1. Dedupe
+
+Search open issues for overlap before filing:
+
+```
+mcp__github__search_issues(
+  query="repo:dburkart/vibix is:open <keywords from title>",
+)
+```
+
+If a strong duplicate exists, **do not** file. Instead, add a comment on the existing issue
+linking the new context (via `mcp__github__add_issue_comment`) and return its URL.
+
+### 2. Decide labels
+
+Follow the triage rules in `docs/agent-playbooks/prioritization.md`:
+
+1. Assign exactly one `priority:P0` / `P1` / `P2` / `P3` label. The rule of thumb:
+   - Blocks PID 1 / first useful userspace → `priority:P0`.
+   - Required for POSIX readiness, real FS, or usable terminal → `priority:P1`.
+   - Polish / QoL / hardening → `priority:P2`.
+   - SMP / advanced / optimization → `priority:P3`.
+2. Assign one or more `area:*` labels matching the subsystem(s): `area:userspace`,
+   `area:mem`, `area:fs`, `area:driver`, `area:console`, `area:smp`, `area:debug`,
+   `area:perf`, `area:security`, `area:time`.
+3. Add a `track:*` label **only** when the issue directly unblocks one of the named
+   milestones (`track:userspace`, `track:filesystem`, `track:terminal`, `track:posix`).
+4. If the issue is a bug rather than new work, also add `bug`. Otherwise prefer
+   `enhancement` when the issue adds a capability.
+5. Never invent a new label from this skill. If the taxonomy is missing a dimension, stop
+   and update `docs/agent-playbooks/prioritization.md` in a separate PR first.
+
+### 3. Compose the body
+
+Use the canonical template — identical to the one used by the issue-backfill workflow so the
+backlog stays uniform:
+
+```
+## Motivation
+<1-3 sentences>
+
+## Work
+- [ ] <concrete sub-task 1>
+- [ ] <concrete sub-task 2>
+
+## Context
+<PR/commit/issue references and file paths>
+```
+
+### 4. File
+
+```
+mcp__github__issue_write(
+  method="create",
+  owner="dburkart",
+  repo="vibix",
+  title="<title>",
+  body="<templated body>",
+  labels=["priority:PN", "area:...", "track:...", ...],
+)
+```
+
+Report the new issue number and URL back to the caller.
+
+### 5. Record
+
+If the issue was filed from auto-engineer's follow-up capture pass (step 8), include it in
+the "captured follow-ups" summary that auto-engineer emits before re-entering its loop.
+
+## Never
+
+- File an issue without at least one `priority:*` and one `area:*` label.
+- File an issue that duplicates an open one.
+- Invent new priority/area/track label values in-flight. Update the playbook first.
+- File speculative "nice-to-have" items with no concrete motivation — they clutter the
+  backlog and degrade the auto-engineer candidate set.
+- Close, reassign, or relabel issues other than the one being filed.

--- a/.cursor/skills/cursor-cloud-auto-engineer/SKILL.md
+++ b/.cursor/skills/cursor-cloud-auto-engineer/SKILL.md
@@ -16,6 +16,7 @@ Read these shared playbooks first:
 - `docs/agent-playbooks/build-run.md`
 - `docs/agent-playbooks/testing.md`
 - `docs/agent-playbooks/pr-review.md`
+- `docs/agent-playbooks/prioritization.md`
 
 This is the Cursor Cloud companion to `.claude/skills/auto-engineer/SKILL.md`. Keep the same
 core loop — pick work, plan, implement, validate, push, and open a PR — but adapt it to Cursor
@@ -64,8 +65,11 @@ gh issue list --search 'no:assignee' --state open \
 ```
 
 Filter out issues labeled `blocked`, `needs-discussion`, `question`, or `wontfix`, plus issues
-whose body clearly references an unresolved dependency. Prefer the lowest-numbered
-`enhancement`/`milestone-*`, then `bug`, then the next remaining issue.
+whose body clearly references an unresolved dependency. Apply the pick-order policy from
+`docs/agent-playbooks/prioritization.md`: sort `priority:P0` → `P1` → `P2` → `P3`, preferring
+`track:userspace` / `track:filesystem` / `track:terminal` / `track:posix` in that order within a
+priority bucket, and only fall back to lowest-numbered first inside a (priority, track) bucket.
+Issues missing a `priority:*` label rank after `priority:P3`.
 
 Cursor Cloud's `gh` access is read-only in this repo, so do not try to assign the issue. If
 issue assignment matters, note that limitation in the final handoff or PR body.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,5 +46,5 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh pr:*)" "Bash(gh issue create:*)"'
+          claude_args: '--allowed-tools "Bash(gh pr:*)" "Bash(gh issue create:*)" "Skill(file-issue)"'
 

--- a/.github/workflows/issue-backfill.yml
+++ b/.github/workflows/issue-backfill.yml
@@ -43,12 +43,27 @@ jobs:
             "Bash(grep:*)"
             "Bash(head:*)"
             "Bash(gh issue list:*)"
-            "Bash(gh issue create:*)"
+            "Skill(file-issue)"
           prompt: |
             You are a technical project manager for the vibix kernel — a hobby OS kernel written in Rust.
 
             Your job: propose and file up to 5 GitHub issues that represent the most valuable
-            near-term work, based on recent project momentum and what is already tracked.
+            near-term work, based on recent project momentum and what is already tracked. The
+            north star is the minimal useful kernel defined in the prioritization playbook —
+            getting to PID 1 loading a real userspace program from the ramdisk — so favor gaps
+            that advance that goal over unrelated polish.
+
+            ## Step 0 — read the prioritization playbook
+
+            Read `docs/agent-playbooks/prioritization.md` end-to-end. It defines:
+
+            - The `priority:P0..P3` / `area:*` / `track:*` label taxonomy.
+            - The current P0 critical path to PID 1.
+            - The triage rules every new issue must follow.
+
+            Every issue you file in this run must land with the correct labels applied on
+            creation. Un-labeled issues pollute the auto-engineer candidate set and defeat the
+            whole point of triage.
 
             ## Step 1 — understand recent progress
 
@@ -73,6 +88,9 @@ jobs:
             gh issue list --state open --limit 100 --json number,title,labels,body
             ```
 
+            Pay attention to existing labels — the triaged backlog is your map of what's
+            already covered and where the gaps are.
+
             ## Step 3 — identify gaps
 
             Cross-reference what was recently merged with what is already filed.
@@ -86,33 +104,28 @@ jobs:
 
             Avoid filing anything that duplicates an open issue (check titles and bodies carefully).
 
-            ## Step 4 — file up to 5 issues
+            ## Step 4 — file up to 5 issues via the `file-issue` skill
 
-            For each issue run:
-            ```
-            gh issue create --title "<title>" --body "<body>"
-            ```
+            For each gap, invoke the `file-issue` skill (`/file-issue`). The skill handles
+            dedupe, enforces the label taxonomy from `docs/agent-playbooks/prioritization.md`,
+            and writes the canonical body template. Do **not** call `gh issue create` or
+            `mcp__github__issue_write` directly — go through the skill so every filed issue
+            is triaged on creation.
 
-            Each issue body must follow this template:
+            Feed the skill, per issue:
 
-            ```
-            ## Motivation
-            <1-3 sentences: why this matters and what it unblocks>
-
-            ## Work
-            - [ ] <concrete sub-task 1>
-            - [ ] <concrete sub-task 2>
-            - [ ] ...
-
-            ## Context
-            <relevant commit hashes, file paths, or existing issue numbers that informed this>
-            ```
+            - A concise imperative title (≤ 72 chars, no emoji).
+            - A 1–3 sentence motivation: why this matters and what it unblocks.
+            - Concrete work items, naming files / structs / functions where known.
+            - Context: commit SHAs, file paths, and existing issue numbers that informed
+              the gap.
 
             Guidelines:
-            - Titles should be concise imperative phrases (≤ 72 chars), no emoji.
-            - Prefer specificity over vagueness — name files, structs, and functions where known.
+            - Prefer specificity over vagueness.
             - Cover a spread of concerns (correctness, performance, testing, docs, next subsystem).
+            - Weight your picks toward P0 / P1 work that advances the minimal useful kernel.
             - Do NOT create duplicate issues. If you cannot find 5 distinct gaps, file fewer.
 
-            After filing all issues, print a one-line summary of each issue number and title
-            so it appears in the workflow log.
+            After filing all issues, print a one-line summary of each issue number, title,
+            and the priority/area/track labels the skill applied so it appears in the
+            workflow log.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Read these repo-level playbooks before acting in the corresponding area:
 - `docs/agent-playbooks/testing.md` for host, QEMU, and smoke testing
 - `docs/agent-playbooks/sdlc.md` for branch, commit, push, and PR policy
 - `docs/agent-playbooks/pr-review.md` for CI readiness and review classification
+- `docs/agent-playbooks/prioritization.md` for issue labels, triage rules, and pick-order policy
 
 ## Cursor Cloud runtime notes
 

--- a/docs/agent-playbooks/prioritization.md
+++ b/docs/agent-playbooks/prioritization.md
@@ -1,0 +1,109 @@
+# Issue prioritization playbook
+
+This playbook defines the label taxonomy used across the vibix issue tracker and the rules
+agents follow when triaging new issues or picking the next one to work on.
+
+The north star is a **minimal useful kernel** — the earliest point at which vibix can load
+a real userspace program off disk, drop it to ring 3, and service its syscalls. Everything
+P0 exists to unblock that moment; everything else is ordered by how directly it supports the
+four post-userspace milestones: userspace, filesystem, terminal, POSIX readiness.
+
+## Label taxonomy
+
+Every tracked issue should carry exactly one `priority:*` label and at least one `area:*`
+label. `track:*` labels are optional and mark alignment to a named milestone.
+
+### Priority — usefulness toward the minimal useful kernel
+
+| Label | Meaning |
+|---|---|
+| `priority:P0` | On the critical path to the first useful userspace process. Blocks PID 1. |
+| `priority:P1` | Required for POSIX readiness, real filesystem semantics, or a usable terminal. |
+| `priority:P2` | Polish, quality-of-life, hardening — valuable but not blocking. |
+| `priority:P3` | SMP, advanced hardware, optimization, benchmarks, long-term work. |
+
+Pick the **highest** priority the issue honestly supports. When in doubt, go one step lower —
+over-prioritizing P0 defeats the point of the ordering.
+
+### Area — subsystem
+
+`area:userspace`, `area:mem`, `area:fs`, `area:driver`, `area:console`, `area:smp`,
+`area:debug`, `area:perf`, `area:security`, `area:time`. Multiple areas are fine when the
+work genuinely spans subsystems (e.g. SMEP/SMAP is `area:security` + `area:mem`).
+
+### Track — milestone alignment (optional)
+
+| Label | What it marks |
+|---|---|
+| `track:userspace` | Required to land PID 1 loading `/init` from the ramdisk. |
+| `track:filesystem` | Needed for real multi-level, writable, permission-aware filesystem. |
+| `track:terminal` | Needed for a usable interactive shell/terminal experience. |
+| `track:posix` | Needed for POSIX-compatible userspace (signals, threads, fd semantics, dynamic linking). |
+
+An issue can carry more than one track label when it genuinely unblocks multiple milestones.
+
+## P0 critical path (as of this writing)
+
+The chain from today's kernel to PID 1 executing a statically-linked userspace binary:
+
+1. **Discovery** — `#42` PCI enumeration.
+2. **Storage** — `#43` virtio-blk driver + read-only ramdisk.
+3. **Loading** — `#44` ELF64 loader (ring 0).
+4. **Context safety** — `#115` x87/SSE/AVX save-restore on context switch (must land before
+   any ring-3 task is allowed to run).
+5. **Address-space plumbing** — `#132` task exit + resource reclaim; `#133` `VmaKind::Cow`
+   + `VmaList::remove` (both required for fork and clean teardown).
+6. **Process model** — `#123` process table + fork/exec/wait; `#124` per-process fd table;
+   `#125` expanded syscall table (exit, read, open, close, mmap).
+7. **Capstone** — `#121` PID 1 launches `/init` from the ramdisk.
+
+Anything not on that chain is P1 or lower.
+
+## Triage rules for new issues
+
+When filing an issue (by hand or via an agent), the author must set labels before the issue
+is considered triaged.
+
+1. **Determine priority by asking, in order:**
+   - Does this block PID 1 loading and running a userspace binary? → `priority:P0`.
+   - Is it required for POSIX readiness, a real FS, or a usable terminal? → `priority:P1`.
+   - Is it a polish / hardening / QoL improvement on already-working code? → `priority:P2`.
+   - Is it SMP, advanced hardware, optimization, or benchmarks? → `priority:P3`.
+2. **Pick one or more areas** that match the subsystem boundaries in
+   `docs/README.md`.
+3. **Add a track label** only if the issue directly unblocks one of the four named
+   milestones. Do not add speculative track labels.
+4. **Cross-reference existing issues.** If the new issue is a follow-up of an open P0
+   prerequisite, it almost certainly inherits that prerequisite's priority or lower. It
+   rarely out-prioritizes the thing it depends on.
+5. **Do not invent new priority or area labels.** If a new axis is genuinely needed, update
+   this playbook in the same PR that introduces the label.
+
+## Picking rules for agents
+
+When an agent (auto-engineer, human, sub-skill) picks the next issue to work on, the
+selection order is:
+
+1. Filter to `state:open`, `no:assignee`, and **not** labeled `blocked`, `needs-discussion`,
+   `question`, or `wontfix`.
+2. Exclude issues whose body references an unresolved dependency (e.g. "blocked on `#NN`"
+   where `#NN` is still open).
+3. Sort the remainder by priority: `priority:P0` first, then `P1`, `P2`, `P3`. Issues with
+   no priority label rank **after** `P3` — they are un-triaged and should be labeled before
+   being worked.
+4. Within a priority bucket, prefer issues with a `track:userspace` label, then
+   `track:filesystem`, then `track:terminal`, then `track:posix`, then untracked.
+5. Within an (priority, track) bucket, fall back to lowest-numbered first (oldest).
+
+If the top candidate's prerequisites are all still open, move to the next candidate rather
+than starting something that cannot land.
+
+## Maintenance
+
+This playbook — and the P0 critical path section specifically — goes stale as P0 work lands.
+Whenever a P0 issue merges, the closing PR or the next triage pass should:
+
+- Remove the merged item from the critical-path list above.
+- Promote any `priority:P1` issue that now directly blocks the next P0 to `priority:P0`.
+- If a new dependency is discovered, file it and label it immediately rather than letting it
+  sit un-triaged.


### PR DESCRIPTION
## Summary

- Add `docs/agent-playbooks/prioritization.md` defining the `priority:P0..P3` / `area:*` / `track:*` label taxonomy, the current P0 critical path toward a minimal useful kernel (PID 1 loading `/init` from the ramdisk), and the triage + pick-order rules every agent follows.
- Add a new `.claude/skills/file-issue` skill as the mechanical front-end for that policy: it dedupes against existing issues, applies the correct labels on creation, and writes the canonical body template so every filed issue lands triaged.
- Rewire callers to the new policy:
  - `auto-engineer` now sorts candidate issues `P0 > P1 > P2 > P3`, then by `track:*`, then by issue number (instead of the old "lowest-numbered `enhancement` or `milestone-*`"), and delegates follow-up issue creation in step 8 to the `file-issue` skill.
  - `cursor-cloud-auto-engineer` adopts the same pick-order policy.
  - `.github/workflows/issue-backfill.yml` invokes the `file-issue` skill instead of calling `gh issue create` directly, so scheduled triage runs produce labeled issues.
  - `AGENTS.md` lists the new playbook alongside the existing ones.

Companion to the label backfill pass that triaged every open issue into this scheme.

## Test plan

- [x] `cargo xtask build` — green (pre-existing `guard_base` / `is_guard_hit` dead-code warnings only)
- [x] `git grep "milestone-\*\|lowest-numbered.*enhancement"` — no stale pick-order references remain
- [x] Manual inspection: auto-engineer step 1 and step 8, cursor-cloud-auto-engineer step 1, and the issue-backfill workflow prompt all point at the new playbook / skill

Closes — none; this only changes policy and tooling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes automation behavior for issue selection and issue creation in agent workflows and GitHub Actions, which could affect backlog hygiene and what work gets picked next. No runtime/kernel code paths are modified.
> 
> **Overview**
> Adds a new `docs/agent-playbooks/prioritization.md` that defines the `priority:*`/`area:*`/`track:*` taxonomy plus the label-driven pick-order and triage rules.
> 
> Introduces a new `.claude/skills/file-issue` skill to dedupe and file issues with the required labels and canonical body template, and updates `auto-engineer` (including follow-up capture), `cursor-cloud-auto-engineer`, and the scheduled `issue-backfill` workflow to route issue filing through this skill and to select work by `priority`/`track` ordering. GitHub Actions config is updated to allow `Skill(file-issue)`, and `AGENTS.md` now references the new prioritization playbook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ab813df2a7f59e087208c532a83a0d8055db946. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->