### PR TITLE
M8: HPET driver replaces the PIT as the timer source

### DIFF
--- a/kernel/src/acpi.rs
+++ b/kernel/src/acpi.rs
@@ -92,17 +92,29 @@ struct Rsdp {
 
 #[repr(C, packed)]
 #[derive(Clone, Copy)]
-struct SdtHeader {
-    signature: [u8; 4],
-    length: u32,
-    revision: u8,
-    checksum: u8,
-    oem_id: [u8; 6],
-    oem_table_id: [u8; 8],
-    oem_revision: u32,
-    creator_id: u32,
-    creator_revision: u32,
+pub struct SdtHeader {
+    pub signature: [u8; 4],
+    pub length: u32,
+    pub revision: u8,
+    pub checksum: u8,
+    pub oem_id: [u8; 6],
+    pub oem_table_id: [u8; 8],
+    pub oem_revision: u32,
+    pub creator_id: u32,
+    pub creator_revision: u32,
 }
+
+/// Cached pointer to the root table (XSDT or RSDT) plus the HHDM base.
+/// Populated by [`init`] so follow-on callers (e.g. the HPET driver)
+/// can re-walk the root looking for additional SDTs without having to
+/// re-parse the RSDP.
+struct RootTable {
+    root_phys: u64,
+    hhdm_offset: u64,
+    is_xsdt: bool,
+}
+
+static ROOT: Once<RootTable> = Once::new();
 
 const MADT_PROCESSOR_LAPIC: u8 = 0;
 const MADT_IOAPIC: u8 = 1;
@@ -143,12 +155,19 @@ pub fn init(rsdp_phys: usize, hhdm_offset: u64) {
     let xsdt_phys = rsdp.xsdt_address;
     let rsdt_phys = rsdp.rsdt_address;
 
-    let madt_ptr = if rsdp.revision >= 2 && xsdt_phys != 0 {
-        find_madt_xsdt(xsdt_phys, hhdm_offset)
+    let (root_phys, is_xsdt) = if rsdp.revision >= 2 && xsdt_phys != 0 {
+        (xsdt_phys, true)
     } else {
-        find_madt_rsdt(rsdt_phys as u64, hhdm_offset)
-    }
-    .expect("MADT not found in ACPI tables");
+        (rsdt_phys as u64, false)
+    };
+    ROOT.call_once(|| RootTable {
+        root_phys,
+        hhdm_offset,
+        is_xsdt,
+    });
+
+    let madt_ptr = find_sdt_in_root(root_phys, hhdm_offset, is_xsdt, b"APIC")
+        .expect("MADT not found in ACPI tables");
 
     let info = parse_madt(madt_ptr);
     serial_println!(
@@ -159,6 +178,65 @@ pub fn init(rsdp_phys: usize, hhdm_offset: u64) {
         info.lapic_phys
     );
     INFO.call_once(|| info);
+}
+
+/// Look up a non-MADT SDT by its 4-byte signature in the previously
+/// walked root table. Returns a pointer to the full SDT (including its
+/// header); callers cast to their own `#[repr(C, packed)]` layout.
+/// Returns `None` if [`init`] hasn't run yet or the signature is
+/// absent.
+pub fn find_sdt(signature: &[u8; 4]) -> Option<*const SdtHeader> {
+    let root = ROOT.get()?;
+    find_sdt_in_root(root.root_phys, root.hhdm_offset, root.is_xsdt, signature)
+}
+
+/// HHDM offset recorded during [`init`]. Used by drivers that map
+/// additional MMIO regions once ACPI discovery has completed.
+pub fn hhdm_offset() -> Option<u64> {
+    ROOT.get().map(|r| r.hhdm_offset)
+}
+
+fn find_sdt_in_root(
+    root_phys: u64,
+    hhdm: u64,
+    is_xsdt: bool,
+    signature: &[u8; 4],
+) -> Option<*const SdtHeader> {
+    if is_xsdt {
+        find_by_sig_xsdt(root_phys, hhdm, signature)
+    } else {
+        find_by_sig_rsdt(root_phys, hhdm, signature)
+    }
+}
+
+fn find_by_sig_xsdt(xsdt_phys: u64, hhdm: u64, signature: &[u8; 4]) -> Option<*const SdtHeader> {
+    let header = read_sdt(xsdt_phys, hhdm);
+    let entries_bytes = header.length as usize - mem::size_of::<SdtHeader>();
+    let count = entries_bytes / 8;
+    let entries_ptr = (xsdt_phys + hhdm + mem::size_of::<SdtHeader>() as u64) as *const u64;
+    for i in 0..count {
+        let phys = unsafe { entries_ptr.add(i).read_unaligned() };
+        let sdt = read_sdt(phys, hhdm);
+        if &sdt.signature == signature {
+            return Some(sdt as *const _);
+        }
+    }
+    None
+}
+
+fn find_by_sig_rsdt(rsdt_phys: u64, hhdm: u64, signature: &[u8; 4]) -> Option<*const SdtHeader> {
+    let header = read_sdt(rsdt_phys, hhdm);
+    let entries_bytes = header.length as usize - mem::size_of::<SdtHeader>();
+    let count = entries_bytes / 4;
+    let entries_ptr = (rsdt_phys + hhdm + mem::size_of::<SdtHeader>() as u64) as *const u32;
+    for i in 0..count {
+        let phys = unsafe { entries_ptr.add(i).read_unaligned() } as u64;
+        let sdt = read_sdt(phys, hhdm);
+        if &sdt.signature == signature {
+            return Some(sdt as *const _);
+        }
+    }
+    None
 }
 
 fn read_sdt(phys: u64, hhdm: u64) -> &'static SdtHeader {
@@ -190,36 +268,6 @@ fn checksum(ptr: *const u8, len: usize) -> u8 {
         sum = sum.wrapping_add(unsafe { *ptr.add(i) });
     }
     sum
-}
-
-fn find_madt_xsdt(xsdt_phys: u64, hhdm: u64) -> Option<*const SdtHeader> {
-    let header = read_sdt(xsdt_phys, hhdm);
-    let entries_bytes = header.length as usize - mem::size_of::<SdtHeader>();
-    let count = entries_bytes / 8;
-    let entries_ptr = (xsdt_phys + hhdm + mem::size_of::<SdtHeader>() as u64) as *const u64;
-    for i in 0..count {
-        let phys = unsafe { entries_ptr.add(i).read_unaligned() };
-        let sdt = read_sdt(phys, hhdm);
-        if &sdt.signature == b"APIC" {
-            return Some(sdt as *const _);
-        }
-    }
-    None
-}
-
-fn find_madt_rsdt(rsdt_phys: u64, hhdm: u64) -> Option<*const SdtHeader> {
-    let header = read_sdt(rsdt_phys, hhdm);
-    let entries_bytes = header.length as usize - mem::size_of::<SdtHeader>();
-    let count = entries_bytes / 4;
-    let entries_ptr = (rsdt_phys + hhdm + mem::size_of::<SdtHeader>() as u64) as *const u32;
-    for i in 0..count {
-        let phys = unsafe { entries_ptr.add(i).read_unaligned() } as u64;
-        let sdt = read_sdt(phys, hhdm);
-        if &sdt.signature == b"APIC" {
-            return Some(sdt as *const _);
-        }
-    }
-    None
 }
 
 fn map_phys(phys: u64, size: u64) {

--- a/kernel/src/hpet.rs
+++ b/kernel/src/hpet.rs
@@ -11,14 +11,20 @@
 //! only one ever drives it per boot.
 //!
 //! Reference: IA-PC HPET Specification Rev 1.0a, sections 2.3 / 2.4.
+#[cfg(target_os = "none")]
 use core::ptr;
 use core::sync::atomic::{AtomicBool, Ordering};
 
+#[cfg(target_os = "none")]
 use x86_64::structures::paging::PageTableFlags;
 
+#[cfg(target_os = "none")]
 use crate::acpi::{self, SdtHeader};
+#[cfg(target_os = "none")]
 use crate::mem::paging;
+#[cfg(target_os = "none")]
 use crate::serial_println;
+#[cfg(target_os = "none")]
 use crate::time::TICK_HZ;
 
 /// MMIO register offsets (bytes) within the HPET block.
@@ -41,6 +47,7 @@ const TN_VAL_SET: u64 = 1 << 6;
 /// HPET description table. The ACPI-provided address structure is
 /// inlined rather than carved out as a GAS since we only use the
 /// address + address_space_id fields.
+#[cfg(target_os = "none")]
 #[repr(C, packed)]
 struct HpetTable {
     header: SdtHeader,
@@ -83,18 +90,23 @@ pub fn active() -> bool {
 
 /// Discover, map, and start the HPET. On `Err`, callers should fall
 /// back to the PIT path; [`active`] will remain `false`.
+#[cfg(target_os = "none")]
 pub fn init() -> Result<(), HpetError> {
     let table_ptr = acpi::find_sdt(b"HPET").ok_or(HpetError::TableMissing)?;
     let hhdm = acpi::hhdm_offset().ok_or(HpetError::HhdmMissing)?;
 
     // The find_sdt helper already checked the header + checksum, so we
-    // can safely project through HpetTable here.
-    let table = unsafe { &*(table_ptr as *const HpetTable) };
-    let address_space_id = table.address_space_id;
+    // read through addr_of! to avoid forming a reference to an
+    // unaligned field — `#[repr(C, packed)]` disables alignment
+    // guarantees, so plain field access is UB even on x86_64 where
+    // the load itself would succeed.
+    let table = table_ptr as *const HpetTable;
+    let address_space_id =
+        unsafe { ptr::addr_of!((*table).address_space_id).read_unaligned() };
     if address_space_id != 0 {
         return Err(HpetError::UnsupportedAddressSpace(address_space_id));
     }
-    let base_phys = table.base_address;
+    let base_phys = unsafe { ptr::addr_of!((*table).base_address).read_unaligned() };
 
     // The register block is 1024 bytes per spec; one page covers it.
     paging::map_phys_into_hhdm(
@@ -177,10 +189,12 @@ pub fn init() -> Result<(), HpetError> {
     Ok(())
 }
 
+#[cfg(target_os = "none")]
 unsafe fn read64(base: *mut u8, offset: usize) -> u64 {
     ptr::read_volatile(base.add(offset) as *const u64)
 }
 
+#[cfg(target_os = "none")]
 unsafe fn write64(base: *mut u8, offset: usize, value: u64) {
     ptr::write_volatile(base.add(offset) as *mut u64, value);
 }
@@ -213,8 +227,8 @@ mod tests {
     #[test]
     fn handles_smaller_period() {
         // Real hardware sometimes reports ~14.3 MHz (≈69841 fs).
-        // 100 Hz → 10 ms = 10^13 fs → ~143_218_250 ticks.
+        // 100 Hz → 10 ms = 10^13 fs / 69841 ≈ 143_182_371 ticks.
         let t = ticks_for_hz(69_841, 100);
-        assert!((143_200_000..=143_300_000).contains(&t), "got {t}");
+        assert!((143_100_000..=143_300_000).contains(&t), "got {t}");
     }
 }

--- a/kernel/src/hpet.rs
+++ b/kernel/src/hpet.rs
@@ -63,7 +63,15 @@ pub enum HpetError {
     ZeroPeriod,
     PeriodTooLarge(u64),
     PeriodicUnsupported,
+    LegacyReplacementUnsupported,
 }
+
+/// Bit 15 of the General Capabilities register: set when the HPET
+/// supports LegacyReplacement routing (timer 0 → IRQ0, timer 1 → IRQ8).
+/// Without it, writing `CFG_LEG_RT` is silently ignored, so we must
+/// refuse to initialize rather than end up with a live ACTIVE flag and
+/// no timer IRQ.
+const CAPS_LEG_RT_SUPPORTED: u64 = 1 << 15;
 
 static ACTIVE: AtomicBool = AtomicBool::new(false);
 
@@ -109,6 +117,14 @@ pub fn init() -> Result<(), HpetError> {
     // Spec caps the tick period at 100 ns = 10^8 fs.
     if period_fs > 100_000_000 {
         return Err(HpetError::PeriodTooLarge(period_fs));
+    }
+    // LegacyReplacement is how we land on IRQ0; refuse to proceed if
+    // the HPET can't support it. Otherwise the CFG_LEG_RT write below
+    // is a no-op, ACTIVE still flips true, time::init skips the PIT,
+    // and calibrate_tsc spins forever waiting on a timer IRQ that
+    // never fires.
+    if caps & CAPS_LEG_RT_SUPPORTED == 0 {
+        return Err(HpetError::LegacyReplacementUnsupported);
     }
 
     let timer0_caps = unsafe { read64(base, REG_TIMER0_CONFIG) };

--- a/kernel/src/hpet.rs
+++ b/kernel/src/hpet.rs
@@ -1,0 +1,204 @@
+//! Minimal HPET driver.
+//!
+//! Discovers the HPET via its ACPI description table, maps the MMIO
+//! block, and programs comparator 0 in periodic mode at [`TICK_HZ`].
+//! LegacyReplacement routing is enabled so comparator 0 appears on
+//! IRQ0 (GSI 2 after the standard MADT override), reusing the IOAPIC
+//! redirection the APIC bring-up already installed for the PIT.
+//!
+//! The PIT stays physically present but is left unprogrammed when
+//! HPET is active — vector 0x20 is shared between the two sources and
+//! only one ever drives it per boot.
+//!
+//! Reference: IA-PC HPET Specification Rev 1.0a, sections 2.3 / 2.4.
+use core::ptr;
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use x86_64::structures::paging::PageTableFlags;
+
+use crate::acpi::{self, SdtHeader};
+use crate::mem::paging;
+use crate::serial_println;
+use crate::time::TICK_HZ;
+
+/// MMIO register offsets (bytes) within the HPET block.
+const REG_CAPS: usize = 0x00;
+const REG_CONFIG: usize = 0x10;
+const REG_MAIN_COUNTER: usize = 0xF0;
+const REG_TIMER0_CONFIG: usize = 0x100;
+const REG_TIMER0_COMPARATOR: usize = 0x108;
+
+/// General Configuration bits.
+const CFG_ENABLE: u64 = 1 << 0;
+const CFG_LEG_RT: u64 = 1 << 1;
+
+/// Timer N Configuration bits.
+const TN_INT_ENB: u64 = 1 << 2;
+const TN_TYPE_PERIODIC: u64 = 1 << 3;
+const TN_PER_INT_CAP: u64 = 1 << 4;
+const TN_VAL_SET: u64 = 1 << 6;
+
+/// HPET description table. The ACPI-provided address structure is
+/// inlined rather than carved out as a GAS since we only use the
+/// address + address_space_id fields.
+#[repr(C, packed)]
+struct HpetTable {
+    header: SdtHeader,
+    event_timer_block_id: u32,
+    address_space_id: u8,
+    reg_bit_width: u8,
+    reg_bit_offset: u8,
+    _reserved: u8,
+    base_address: u64,
+    hpet_number: u8,
+    min_tick: u16,
+    page_protection: u8,
+}
+
+#[derive(Debug)]
+pub enum HpetError {
+    TableMissing,
+    HhdmMissing,
+    UnsupportedAddressSpace(u8),
+    ZeroPeriod,
+    PeriodTooLarge(u64),
+    PeriodicUnsupported,
+}
+
+static ACTIVE: AtomicBool = AtomicBool::new(false);
+
+/// True once `init` has successfully armed comparator 0. The PIT path
+/// keys off this to avoid double-driving vector 0x20.
+pub fn active() -> bool {
+    ACTIVE.load(Ordering::Acquire)
+}
+
+/// Discover, map, and start the HPET. On `Err`, callers should fall
+/// back to the PIT path; [`active`] will remain `false`.
+pub fn init() -> Result<(), HpetError> {
+    let table_ptr = acpi::find_sdt(b"HPET").ok_or(HpetError::TableMissing)?;
+    let hhdm = acpi::hhdm_offset().ok_or(HpetError::HhdmMissing)?;
+
+    // The find_sdt helper already checked the header + checksum, so we
+    // can safely project through HpetTable here.
+    let table = unsafe { &*(table_ptr as *const HpetTable) };
+    let address_space_id = table.address_space_id;
+    if address_space_id != 0 {
+        return Err(HpetError::UnsupportedAddressSpace(address_space_id));
+    }
+    let base_phys = table.base_address;
+
+    // The register block is 1024 bytes per spec; one page covers it.
+    paging::map_phys_into_hhdm(
+        base_phys,
+        0x1000,
+        PageTableFlags::PRESENT
+            | PageTableFlags::WRITABLE
+            | PageTableFlags::NO_EXECUTE
+            | PageTableFlags::NO_CACHE,
+    )
+    .expect("failed to map HPET MMIO");
+
+    let base = (base_phys + hhdm) as *mut u8;
+    let caps = unsafe { read64(base, REG_CAPS) };
+    let period_fs = caps >> 32;
+    let num_timers = ((caps >> 8) & 0x1f) as u8 + 1;
+    if period_fs == 0 {
+        return Err(HpetError::ZeroPeriod);
+    }
+    // Spec caps the tick period at 100 ns = 10^8 fs.
+    if period_fs > 100_000_000 {
+        return Err(HpetError::PeriodTooLarge(period_fs));
+    }
+
+    let timer0_caps = unsafe { read64(base, REG_TIMER0_CONFIG) };
+    if timer0_caps & TN_PER_INT_CAP == 0 {
+        return Err(HpetError::PeriodicUnsupported);
+    }
+
+    // Disable before programming so the counter can't race our writes
+    // to the comparator accumulator.
+    let mut cfg = unsafe { read64(base, REG_CONFIG) };
+    cfg &= !CFG_ENABLE;
+    unsafe { write64(base, REG_CONFIG, cfg) };
+
+    // Zero the main counter so ticks-since-boot is meaningful from the
+    // first fire.
+    unsafe { write64(base, REG_MAIN_COUNTER, 0) };
+
+    let delta = ticks_for_hz(period_fs, TICK_HZ);
+
+    // Program comparator 0: periodic, IRQ enabled, accumulator-set.
+    // Preserve reserved bits by reading-modify-writing.
+    let mut t0_cfg = timer0_caps;
+    t0_cfg &= !(0xffff << 9); // clear int-route bits (ignored in LegacyReplacement anyway)
+    t0_cfg |= TN_INT_ENB | TN_TYPE_PERIODIC | TN_VAL_SET;
+    unsafe { write64(base, REG_TIMER0_CONFIG, t0_cfg) };
+    // With VAL_SET latched, the first write sets the comparator
+    // (first-fire deadline) and the second write sets the periodic
+    // reload interval.
+    unsafe { write64(base, REG_TIMER0_COMPARATOR, delta) };
+    unsafe { write64(base, REG_TIMER0_COMPARATOR, delta) };
+
+    // Enable LegacyReplacement so Timer 0 lands on IRQ0 (→ GSI 2 after
+    // the standard MADT override), then enable the main counter.
+    let mut cfg = unsafe { read64(base, REG_CONFIG) };
+    cfg |= CFG_LEG_RT | CFG_ENABLE;
+    unsafe { write64(base, REG_CONFIG, cfg) };
+
+    ACTIVE.store(true, Ordering::Release);
+    serial_println!(
+        "hpet: initialized (period={}fs, timers={}, base={:#x})",
+        period_fs,
+        num_timers,
+        base_phys
+    );
+    serial_println!(
+        "hpet: periodic timer armed ({} Hz, {} ticks/period)",
+        TICK_HZ,
+        delta
+    );
+    Ok(())
+}
+
+unsafe fn read64(base: *mut u8, offset: usize) -> u64 {
+    ptr::read_volatile(base.add(offset) as *const u64)
+}
+
+unsafe fn write64(base: *mut u8, offset: usize, value: u64) {
+    ptr::write_volatile(base.add(offset) as *mut u64, value);
+}
+
+/// Ticks between fires to land on `hz` Hz given `period_fs` per tick.
+/// Pulled out for host unit testing.
+fn ticks_for_hz(period_fs: u64, hz: u32) -> u64 {
+    // 10^15 fs per second; integer division rounds toward zero, which
+    // slightly over-shoots the target Hz by at most one period — fine
+    // for a coarse 100 Hz tick.
+    1_000_000_000_000_000u64 / period_fs / hz as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ticks_for_hz;
+
+    #[test]
+    fn hundred_hz_at_typical_period() {
+        // QEMU HPET reports a 10 ns period (10_000_000 fs). 100 Hz →
+        // 10 ms → 1_000_000 ticks.
+        assert_eq!(ticks_for_hz(10_000_000, 100), 1_000_000);
+    }
+
+    #[test]
+    fn thousand_hz_at_typical_period() {
+        assert_eq!(ticks_for_hz(10_000_000, 1000), 100_000);
+    }
+
+    #[test]
+    fn handles_smaller_period() {
+        // Real hardware sometimes reports ~14.3 MHz (≈69841 fs).
+        // 100 Hz → 10 ms = 10^13 fs → ~143_218_250 ticks.
+        let t = ticks_for_hz(69_841, 100);
+        assert!((143_200_000..=143_300_000).contains(&t), "got {t}");
+    }
+}

--- a/kernel/src/hpet.rs
+++ b/kernel/src/hpet.rs
@@ -101,8 +101,7 @@ pub fn init() -> Result<(), HpetError> {
     // guarantees, so plain field access is UB even on x86_64 where
     // the load itself would succeed.
     let table = table_ptr as *const HpetTable;
-    let address_space_id =
-        unsafe { ptr::addr_of!((*table).address_space_id).read_unaligned() };
+    let address_space_id = unsafe { ptr::addr_of!((*table).address_space_id).read_unaligned() };
     if address_space_id != 0 {
         return Err(HpetError::UnsupportedAddressSpace(address_space_id));
     }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -29,7 +29,7 @@ pub mod bench;
 pub mod boot;
 #[cfg(target_os = "none")]
 pub mod framebuffer;
-#[cfg(target_os = "none")]
+#[cfg(any(test, target_os = "none"))]
 pub mod hpet;
 #[cfg(target_os = "none")]
 pub mod ksymtab;

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -30,6 +30,8 @@ pub mod boot;
 #[cfg(target_os = "none")]
 pub mod framebuffer;
 #[cfg(target_os = "none")]
+pub mod hpet;
+#[cfg(target_os = "none")]
 pub mod ksymtab;
 #[cfg(target_os = "none")]
 pub mod serial;
@@ -66,6 +68,10 @@ pub fn init() {
     arch::init();
     mem::init();
     arch::init_apic(rsdp, hhdm);
+    match hpet::init() {
+        Ok(()) => {}
+        Err(e) => serial_println!("hpet: unavailable ({:?}), falling back to PIT", e),
+    }
     time::init();
 }
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -64,6 +64,10 @@ pub extern "C" fn _start() -> ! {
         serial_println!("userspace module ELF missing");
     }
     vibix::arch::init_apic(rsdp_ptr, hhdm_offset);
+    match vibix::hpet::init() {
+        Ok(()) => {}
+        Err(e) => serial_println!("hpet: unavailable ({:?}), falling back to PIT", e),
+    }
     vibix::time::init();
     vibix::pci::scan();
 

--- a/kernel/src/time.rs
+++ b/kernel/src/time.rs
@@ -108,14 +108,16 @@ const RTC_SNAPSHOT_RETRIES: usize = 4;
 pub fn init() {
     use x86_64::instructions::port::Port;
 
-    let divisor: u16 = (PIT_FREQ_HZ / TICK_HZ) as u16;
-    unsafe {
-        // Command: channel 0, access lobyte/hibyte, mode 2 (rate gen),
-        // binary counting = 0b00_11_010_0 = 0x34.
-        Port::<u8>::new(0x43).write(0x34);
-        let mut data: Port<u8> = Port::new(0x40);
-        data.write((divisor & 0xff) as u8);
-        data.write((divisor >> 8) as u8);
+    if !crate::hpet::active() {
+        let divisor: u16 = (PIT_FREQ_HZ / TICK_HZ) as u16;
+        unsafe {
+            // Command: channel 0, access lobyte/hibyte, mode 2 (rate
+            // gen), binary counting = 0b00_11_010_0 = 0x34.
+            Port::<u8>::new(0x43).write(0x34);
+            let mut data: Port<u8> = Port::new(0x40);
+            data.write((divisor & 0xff) as u8);
+            data.write((divisor >> 8) as u8);
+        }
     }
     crate::serial_println!("timer: {} Hz", TICK_HZ);
     match wall_clock() {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -60,6 +60,8 @@ const SMOKE_MARKERS: &[&str] = &[
     "apic: BSP online",
     "ioapic: initialized",
     "serial: rx irq enabled",
+    "hpet: initialized",
+    "hpet: periodic timer armed",
     "timer: 100 Hz",
     "rtc:",
     "vibix online.",


### PR DESCRIPTION
Closes #33.

## Summary
- Add `kernel/src/hpet.rs`: parses the HPET ACPI table, maps the MMIO block into HHDM, and arms comparator 0 in periodic mode at `TICK_HZ` (100 Hz) using LegacyReplacement routing so it lands on IRQ0 → GSI 2 → vec 0x20 and reuses the existing IOAPIC redirection + timer ISR unchanged.
- Generalize `kernel/src/acpi.rs` to expose `find_sdt(signature)` + `hhdm_offset()` backed by a cached root pointer, so the HPET driver (and future drivers) can walk the XSDT/RSDT without re-parsing the RSDP.
- `time::init` skips PIT programming when `hpet::active()` is true; HPET discovery failure logs a warning and falls back to the PIT silently.
- Wire `hpet::init()` into both `kernel/src/lib.rs::init` and `kernel/src/main.rs` between APIC bring-up and `time::init`.
- xtask: add `"hpet: initialized"` and `"hpet: periodic timer armed"` to the smoke marker set.

## Test plan
- [x] `cargo xtask build` — clean (pre-existing `guard_base`/`is_guard_hit` warnings unchanged).
- [x] `cargo xtask test` — all 48 integration tests green; host unit tests include three new `ticks_for_hz` cases.
- [x] `cargo xtask smoke` — all 21 markers present, including the two new HPET markers; boot log shows `hpet: initialized (period=10000000fs, timers=3, base=0xfed00000)` and `hpet: periodic timer armed (100 Hz, 1000000 ticks/period)`.
- [x] Manual: confirmed `overrides=5` MADT still produces working IRQ0 routing (timer tick test passes under HPET).

## Out of scope
- HPET timers beyond comparator 0 (oneshot, additional periodics).
- MSI / x2APIC delivery modes.
- TSC calibration against the HPET main counter (retains current PIT-tick window).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the kernel’s timer interrupt source to prefer HPET via ACPI, which can affect interrupt routing and early-boot timekeeping if hardware/firmware differs from expectations; the PIT fallback mitigates but doesn’t eliminate bring-up risk.
> 
> **Overview**
> **Switches the kernel tick source to HPET when available.** Adds a new `hpet` module that discovers the `HPET` ACPI table, maps HPET MMIO, and arms comparator 0 in periodic mode at `TICK_HZ` using LegacyReplacement routing (otherwise returns an error).
> 
> **Generalizes ACPI table discovery for other drivers.** `acpi` now caches the XSDT/RSDT root during `init`, exposes `SdtHeader`, and provides `find_sdt()` plus `hhdm_offset()` so follow-on code can locate additional SDTs without re-parsing the RSDP.
> 
> **Boot and tests now account for HPET.** `hpet::init()` is invoked after APIC bring-up (in both `lib.rs::init` and `main.rs`), `time::init()` skips PIT programming when HPET is active, and `xtask smoke` expects new HPET serial markers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eddd5621a8fd82ee5adb47fa983b3f4de915bd67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->