### PR TITLE
mem: VmaKind::Cow and VmaList::remove for fork and munmap

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -123,3 +123,7 @@ harness = false
 [[test]]
 name = "serial_rx"
 harness = false
+
+[[test]]
+name = "cow_vma"
+harness = false

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -4,6 +4,7 @@
 
 use spin::Lazy;
 use x86_64::structures::idt::{InterruptDescriptorTable, InterruptStackFrame, PageFaultErrorCode};
+use x86_64::structures::paging::PageTableFlags;
 
 use crate::arch::x86_64::gdt::DOUBLE_FAULT_IST_INDEX;
 use crate::arch::x86_64::interrupts::{
@@ -73,31 +74,63 @@ extern "x86-interrupt" fn page_fault(frame: InterruptStackFrame, code: PageFault
         }
     }
 
-    // Demand-paging resolver: a not-present fault inside an installed
-    // VMA is satisfied by allocating + zeroing a frame and mapping it
-    // with the VMA's flags. Protection violations (P bit set in the
-    // error code) fall through — those are real access-rights bugs,
-    // not missing-page cases.
-    if !code.contains(PageFaultErrorCode::PROTECTION_VIOLATION) {
-        if let Some((kind, flags)) = crate::task::current_vma_lookup(addr_u64 as usize) {
-            match kind {
-                crate::mem::vma::VmaKind::AnonZero => {
-                    use x86_64::structures::paging::{Page, Size4KiB};
-                    use x86_64::VirtAddr;
-                    let page = Page::<Size4KiB>::containing_address(VirtAddr::new(addr_u64));
-                    let active = x86_64::registers::control::Cr3::read().0;
-                    match crate::mem::paging::map_in_pml4(active, page, flags) {
-                        Ok(_) => return,
-                        Err(e) => {
-                            serial_println!(
-                                "#PF demand-page resolve failed addr={:#x}: {:?}",
-                                addr_u64,
-                                e
-                            );
-                        }
-                    }
+    // VMA-backed resolver. Two independent paths:
+    //
+    // * Not-present fault inside an installed VMA → install the page.
+    //   AnonZero: alloc+zero a frame and map it writable per the
+    //   VMA flags. Cow: map the shared source frame read-only (strip
+    //   WRITABLE) so the *next* write takes a protection fault we
+    //   resolve below.
+    //
+    // * Write protection fault on a Cow page → allocate a private
+    //   frame, memcpy the source in, remap writable.
+    //
+    // Any other protection violation (read/exec fault on a present
+    // page, or on a page outside any VMA) falls through to the
+    // generic hang path — those are real access-rights bugs.
+    if let Some((kind, flags)) = crate::task::current_vma_lookup(addr_u64 as usize) {
+        use x86_64::structures::paging::{Page, Size4KiB};
+        use x86_64::VirtAddr;
+        let page = Page::<Size4KiB>::containing_address(VirtAddr::new(addr_u64));
+        let active = x86_64::registers::control::Cr3::read().0;
+        let is_write = code.contains(PageFaultErrorCode::CAUSED_BY_WRITE);
+        let is_prot = code.contains(PageFaultErrorCode::PROTECTION_VIOLATION);
+        match (kind, is_prot, is_write) {
+            (crate::mem::vma::VmaKind::AnonZero, false, _) => {
+                match crate::mem::paging::map_in_pml4(active, page, flags) {
+                    Ok(_) => return,
+                    Err(e) => serial_println!(
+                        "#PF anon-zero resolve failed addr={:#x}: {:?}",
+                        addr_u64,
+                        e
+                    ),
                 }
             }
+            (crate::mem::vma::VmaKind::Cow { frame }, false, _) => {
+                // First touch: install the shared source read-only.
+                // Strip WRITABLE so the next write triggers the
+                // protection-fault path below.
+                let ro = flags & !PageTableFlags::WRITABLE;
+                match crate::mem::paging::map_existing_in_pml4(active, page, frame, ro) {
+                    Ok(()) => return,
+                    Err(e) => serial_println!(
+                        "#PF cow map-source failed addr={:#x}: {:?}",
+                        addr_u64,
+                        e
+                    ),
+                }
+            }
+            (crate::mem::vma::VmaKind::Cow { frame }, true, true) => {
+                match crate::mem::paging::cow_copy_and_remap(active, page, frame, flags) {
+                    Ok(_) => return,
+                    Err(e) => serial_println!(
+                        "#PF cow copy-and-remap failed addr={:#x}: {:?}",
+                        addr_u64,
+                        e
+                    ),
+                }
+            }
+            _ => {}
         }
     }
 

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -113,11 +113,9 @@ extern "x86-interrupt" fn page_fault(frame: InterruptStackFrame, code: PageFault
                 let ro = flags & !PageTableFlags::WRITABLE;
                 match crate::mem::paging::map_existing_in_pml4(active, page, frame, ro) {
                     Ok(()) => return,
-                    Err(e) => serial_println!(
-                        "#PF cow map-source failed addr={:#x}: {:?}",
-                        addr_u64,
-                        e
-                    ),
+                    Err(e) => {
+                        serial_println!("#PF cow map-source failed addr={:#x}: {:?}", addr_u64, e)
+                    }
                 }
             }
             (crate::mem::vma::VmaKind::Cow { frame }, true, true) => {

--- a/kernel/src/mem/paging.rs
+++ b/kernel/src/mem/paging.rs
@@ -299,6 +299,91 @@ pub fn map_in_pml4(
     Ok(data_frame)
 }
 
+/// Map an existing physical frame into `pml4_frame` at `page` with
+/// `flags`. Unlike [`map_in_pml4`], does not allocate a new backing
+/// frame — used by the CoW resolver to install the shared source
+/// frame read-only on first touch.
+pub fn map_existing_in_pml4(
+    pml4_frame: PhysFrame<Size4KiB>,
+    page: Page<Size4KiB>,
+    frame: PhysFrame<Size4KiB>,
+    flags: PageTableFlags,
+) -> Result<(), MapToError<Size4KiB>> {
+    let hhdm = HHDM_OFFSET
+        .lock()
+        .expect("paging::init must run before map_existing_in_pml4");
+    let mut alloc = KernelFrameAllocator;
+    let l4 = unsafe { pml4_as_mut(pml4_frame, hhdm) };
+    let mut mapper = unsafe { OffsetPageTable::new(l4, hhdm) };
+    let flush = unsafe { mapper.map_to(page, frame, flags, &mut alloc)? };
+    if Cr3::read().0 == pml4_frame {
+        flush.flush();
+    } else {
+        flush.ignore();
+    }
+    Ok(())
+}
+
+/// Copy-on-write resolve: `page` is currently mapped read-only to
+/// `source_frame` in `pml4_frame`. Allocate a fresh frame, memcpy the
+/// source into it through the HHDM, unmap the read-only PTE, then
+/// remap the page to the new frame with `flags` (caller supplies the
+/// full flag set — must include `WRITABLE`). Returns the new frame.
+///
+/// The source frame is *not* freed — it may still be aliased by other
+/// PML4s (a child post-fork, or another CoW VMA pointing to the same
+/// frame).
+pub fn cow_copy_and_remap(
+    pml4_frame: PhysFrame<Size4KiB>,
+    page: Page<Size4KiB>,
+    source_frame: PhysFrame<Size4KiB>,
+    flags: PageTableFlags,
+) -> Result<PhysFrame<Size4KiB>, MapToError<Size4KiB>> {
+    let hhdm = HHDM_OFFSET
+        .lock()
+        .expect("paging::init must run before cow_copy_and_remap");
+    let mut alloc = KernelFrameAllocator;
+    let new_frame = alloc
+        .allocate_frame()
+        .ok_or(MapToError::FrameAllocationFailed)?;
+    // SAFETY: both frames are in HHDM-covered RAM. `new_frame` was
+    // just allocated for our exclusive use; the source is read-only
+    // shared but we only copy *out* of it.
+    unsafe {
+        let src = (hhdm + source_frame.start_address().as_u64()).as_ptr::<u8>();
+        let dst = (hhdm + new_frame.start_address().as_u64()).as_mut_ptr::<u8>();
+        core::ptr::copy_nonoverlapping(src, dst, 4096);
+    }
+    let l4 = unsafe { pml4_as_mut(pml4_frame, hhdm) };
+    let mut mapper = unsafe { OffsetPageTable::new(l4, hhdm) };
+    // The page must currently be mapped — we're resolving a write
+    // protection fault on it. Any other state is a bug in the caller.
+    let (_old_frame, unmap_flush) = mapper
+        .unmap(page)
+        .expect("cow_copy_and_remap: page not mapped despite write-protection fault");
+    if Cr3::read().0 == pml4_frame {
+        unmap_flush.flush();
+    } else {
+        unmap_flush.ignore();
+    }
+    let flush = unsafe { mapper.map_to(page, new_frame, flags, &mut alloc)? };
+    if Cr3::read().0 == pml4_frame {
+        flush.flush();
+    } else {
+        flush.ignore();
+    }
+    Ok(new_frame)
+}
+
+/// HHDM offset currently in use. Panics if [`init`] hasn't run.
+/// Exposed for tests that need to poke raw frame contents via the
+/// high half.
+pub fn hhdm_offset() -> VirtAddr {
+    HHDM_OFFSET
+        .lock()
+        .expect("paging::init must run before hhdm_offset")
+}
+
 // -- PML4 construction + CR3 swap ---------------------------------------
 
 /// Build a fresh kernel PML4 and switch CR3 to it. Drops Limine's

--- a/kernel/src/mem/vma.rs
+++ b/kernel/src/mem/vma.rs
@@ -2,24 +2,27 @@
 //! resolved lazily by the `#PF` handler instead of eagerly mapped at
 //! spawn time.
 //!
-//! Today the only supported kind is [`VmaKind::AnonZero`] — anonymous
-//! zero-filled memory. A task installs a VMA via
-//! [`crate::task::install_vma_on_current`]; the first access to a page
-//! inside the range takes a `#PF` that the handler satisfies by
-//! allocating a zeroed frame and mapping it with the VMA's flags.
-//!
-//! This is the minimal groundwork for #51 — fork-time copy-on-write
-//! lives behind a richer VMA kind that isn't here yet.
+//! Two kinds today:
+//! - [`VmaKind::AnonZero`] — anonymous, zero-filled on first touch.
+//!   Each page is backed by a freshly-allocated frame zeroed via the
+//!   HHDM before it is mapped.
+//! - [`VmaKind::Cow`] — copy-on-write over a shared source frame. A
+//!   read fault maps the source read-only; a subsequent write fault
+//!   allocates a private frame, copies the source into it, and remaps
+//!   the page writable. The source frame is never freed by the CoW
+//!   resolver — other PML4s (post-`clone_for_fork`) may still alias it.
 
 use alloc::vec::Vec;
-use x86_64::structures::paging::PageTableFlags;
+use x86_64::structures::paging::{PageTableFlags, PhysFrame, Size4KiB};
 
 /// Kind of backing a VMA describes.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum VmaKind {
-    /// Anonymous, zero-filled on first touch. Each page is backed by a
-    /// freshly-allocated frame zeroed via the HHDM before it is mapped.
+    /// Anonymous, zero-filled on first touch.
     AnonZero,
+    /// Copy-on-write over `frame`. Reads map `frame` read-only; writes
+    /// trigger a private copy.
+    Cow { frame: PhysFrame<Size4KiB> },
 }
 
 /// A half-open `[start, end)` VA range with a backing kind and the
@@ -81,5 +84,30 @@ impl VmaList {
     /// Find the VMA containing `addr`, if any.
     pub fn find(&self, addr: usize) -> Option<Vma> {
         self.entries.iter().copied().find(|v| v.contains(addr))
+    }
+
+    /// Remove the VMA whose `start` matches exactly and return it.
+    /// Keyed on `start` (not an arbitrary inclusion address) so
+    /// `munmap`-style callers must name the region they installed —
+    /// partial-range unmap is out of scope here.
+    pub fn remove(&mut self, start: usize) -> Option<Vma> {
+        let idx = self.entries.iter().position(|v| v.start == start)?;
+        Some(self.entries.swap_remove(idx))
+    }
+
+    /// Duplicate this list for a child address space. Metadata is
+    /// cloned verbatim — including any `Cow { frame }` kinds, which
+    /// means the child shares the source frames with the parent until
+    /// a write fault in either address space diverges them.
+    ///
+    /// Callers that fork mapped `AnonZero` pages should convert them
+    /// to `Cow` *before* calling this — `AnonZero` carries no frame,
+    /// so copying it verbatim leaves the child with no visibility into
+    /// whatever frames the parent's page-table already backs the
+    /// region with.
+    pub fn clone_for_fork(&self) -> VmaList {
+        VmaList {
+            entries: self.entries.clone(),
+        }
     }
 }

--- a/kernel/tests/cow_vma.rs
+++ b/kernel/tests/cow_vma.rs
@@ -1,0 +1,135 @@
+//! Integration test: a `VmaKind::Cow` region resolves read faults by
+//! mapping the shared source frame read-only, and resolves write
+//! faults by allocating a private copy. Verifies that the write side
+//! diverges while the source frame retains its original content.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use core::ptr;
+
+use vibix::mem::paging::{hhdm_offset, KernelFrameAllocator};
+use vibix::mem::vma::{Vma, VmaKind};
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+use x86_64::structures::paging::{FrameAllocator, PageTableFlags};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    vibix::task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("cow_read_then_write_diverges", &(cow_read_then_write_diverges as fn())),
+        ("vma_list_remove_roundtrip", &(vma_list_remove_roundtrip as fn())),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+/// Lower-half VA well clear of anything the kernel maps eagerly and
+/// also clear of `demand_paging`'s `TEST_VA` so the two tests can
+/// coexist in the same address space without aliasing.
+const TEST_VA: usize = 0x0000_2000_1000_0000;
+
+fn cow_read_then_write_diverges() {
+    // Allocate a source frame and stamp a known pattern through the
+    // HHDM.
+    let source = KernelFrameAllocator
+        .allocate_frame()
+        .expect("failed to allocate source frame");
+    let hhdm = hhdm_offset();
+    let src_virt = hhdm + source.start_address().as_u64();
+    unsafe {
+        let p = src_virt.as_mut_ptr::<u8>();
+        for i in 0..4096 {
+            *p.add(i) = 0xAA;
+        }
+    }
+
+    vibix::task::install_vma_on_current(Vma::new(
+        TEST_VA,
+        TEST_VA + 4096,
+        VmaKind::Cow { frame: source },
+        PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE,
+    ));
+
+    // First access is a read → not-present fault → resolver maps the
+    // source frame read-only. The byte read should be 0xAA.
+    let first = unsafe { ptr::read_volatile(TEST_VA as *const u8) };
+    assert_eq!(first, 0xAA, "cow read did not see source pattern");
+
+    // Write → write-protection fault → resolver allocates a private
+    // frame, memcpys source in, remaps writable. The write then
+    // completes against the new frame.
+    unsafe { ptr::write_volatile(TEST_VA as *mut u8, 0xBB) };
+
+    // Readback reflects the write.
+    let after = unsafe { ptr::read_volatile(TEST_VA as *const u8) };
+    assert_eq!(after, 0xBB, "cow write did not land in private frame");
+
+    // The original source frame, peeked via the HHDM, is unchanged.
+    // This is the divergence property the ticket asks to verify.
+    let src_byte = unsafe { ptr::read_volatile(src_virt.as_ptr::<u8>()) };
+    assert_eq!(src_byte, 0xAA, "cow source frame was mutated by child write");
+
+    // And the rest of the private frame carries the full source
+    // pattern, not a zero fill — proves the memcpy actually happened.
+    let private_tail = unsafe { ptr::read_volatile((TEST_VA + 4095) as *const u8) };
+    assert_eq!(private_tail, 0xAA, "cow private frame missing source bytes");
+}
+
+fn vma_list_remove_roundtrip() {
+    // Covers VmaList::remove in isolation via the VMA installed by
+    // the previous test — proves `find` → `remove` → `find` returns
+    // None for that start, without disturbing other regions.
+    use vibix::mem::vma::VmaList;
+
+    let mut list = VmaList::new();
+    let a = Vma::new(
+        0x1000,
+        0x2000,
+        VmaKind::AnonZero,
+        PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
+    );
+    let b = Vma::new(
+        0x3000,
+        0x4000,
+        VmaKind::AnonZero,
+        PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
+    );
+    list.insert(a);
+    list.insert(b);
+    assert!(list.find(0x1000).is_some());
+    assert!(list.find(0x3000).is_some());
+
+    let removed = list.remove(0x1000).expect("remove returned None");
+    assert_eq!(removed.start, 0x1000);
+    assert!(list.find(0x1000).is_none(), "removed VMA still findable");
+    assert!(list.find(0x3000).is_some(), "sibling VMA lost to remove");
+
+    assert!(list.remove(0x9000).is_none(), "remove of absent start must be None");
+
+    // clone_for_fork preserves entries.
+    let child = list.clone_for_fork();
+    assert!(child.find(0x3000).is_some(), "fork clone lost an entry");
+}

--- a/kernel/tests/cow_vma.rs
+++ b/kernel/tests/cow_vma.rs
@@ -36,8 +36,14 @@ fn panic(info: &PanicInfo) -> ! {
 
 fn run_tests() {
     let tests: &[(&str, &dyn Testable)] = &[
-        ("cow_read_then_write_diverges", &(cow_read_then_write_diverges as fn())),
-        ("vma_list_remove_roundtrip", &(vma_list_remove_roundtrip as fn())),
+        (
+            "cow_read_then_write_diverges",
+            &(cow_read_then_write_diverges as fn()),
+        ),
+        (
+            "vma_list_remove_roundtrip",
+            &(vma_list_remove_roundtrip as fn()),
+        ),
     ];
     serial_println!("running {} tests", tests.len());
     for (name, t) in tests {
@@ -90,7 +96,10 @@ fn cow_read_then_write_diverges() {
     // The original source frame, peeked via the HHDM, is unchanged.
     // This is the divergence property the ticket asks to verify.
     let src_byte = unsafe { ptr::read_volatile(src_virt.as_ptr::<u8>()) };
-    assert_eq!(src_byte, 0xAA, "cow source frame was mutated by child write");
+    assert_eq!(
+        src_byte, 0xAA,
+        "cow source frame was mutated by child write"
+    );
 
     // And the rest of the private frame carries the full source
     // pattern, not a zero fill — proves the memcpy actually happened.
@@ -127,7 +136,10 @@ fn vma_list_remove_roundtrip() {
     assert!(list.find(0x1000).is_none(), "removed VMA still findable");
     assert!(list.find(0x3000).is_some(), "sibling VMA lost to remove");
 
-    assert!(list.remove(0x9000).is_none(), "remove of absent start must be None");
+    assert!(
+        list.remove(0x9000).is_none(),
+        "remove of absent start must be None"
+    );
 
     // clone_for_fork preserves entries.
     let child = list.clone_for_fork();

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -543,6 +543,7 @@ fn test_all() -> R<()> {
         "sleep",
         "pci_enum",
         "serial_rx",
+        "cow_vma",
     ] {
         cmd.arg("--test").arg(t);
     }


### PR DESCRIPTION
Closes #133

## Summary
- Add `VmaKind::Cow { frame }` to `mem::vma` for shared copy-on-write backing.
- Extend the `#PF` resolver: not-present fault on a Cow page maps the source frame read-only (WRITABLE stripped); write-protection fault allocates a private frame, memcpys the source via HHDM, and remaps writable. The source frame is never freed by the resolver — it may still be aliased by other PML4s post-fork.
- Add `VmaList::remove(start)` (keyed on exact start address, for `munmap`-style callers) and `VmaList::clone_for_fork()` for child address-space duplication.
- Add paging helpers `map_existing_in_pml4` (map a given frame, no alloc) and `cow_copy_and_remap` to back the two fault paths.

## Test plan
- [x] `cargo xtask build`
- [x] `cargo xtask test` — new `cow_vma` test covers read→write divergence (source frame bytes preserved after child's write) plus `VmaList::remove` and `clone_for_fork` behavior; all 20 existing test binaries still pass
- [x] `cargo xtask smoke` — all 20 markers present

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the page-fault handler and low-level paging/mapping paths; mistakes could cause hard-to-debug faults or memory corruption during demand paging and future fork/munmap work.
> 
> **Overview**
> Adds **copy-on-write VMAs** by introducing `VmaKind::Cow { frame }` plus `VmaList::remove(start)` and `VmaList::clone_for_fork()` to support fork-style metadata duplication and munmap-style removal.
> 
> Extends the `#PF` resolver to handle CoW pages: first-touch read faults map an existing shared frame read-only, and subsequent write-protection faults allocate a private frame, memcpy the source, and remap writable via new paging helpers (`map_existing_in_pml4`, `cow_copy_and_remap`).
> 
> Adds a new QEMU integration test `cow_vma` (wired into `Cargo.toml` and `xtask test`) to validate read→write divergence and the new VMA list behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed808d473e8a971ee8312aa6491208c0cca44c78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->