### PR TITLE
docs: add os-researcher skill and RFC process playbook

### DIFF
--- a/.claude/skills/os-researcher/SKILL.md
+++ b/.claude/skills/os-researcher/SKILL.md
@@ -1,0 +1,380 @@
+---
+name: os-researcher
+description: Given an OS topic, deeply research it from canonical sources, draft an RFC, run it through simulated peer review, defend it, merge when approved, then break the work into tracked issues. Use when the user says "research <topic>", "write an RFC for <topic>", or invokes `/os-researcher <topic>`.
+---
+
+# os-researcher
+
+Read `docs/agent-playbooks/rfc.md` before running — RFC numbering, the document
+template, research sources, reviewer archetypes, review comment format, defense cycle
+rules, approval criteria, and post-approval issue filing all live there.
+
+Read `docs/agent-playbooks/sdlc.md` for branch, commit, and PR conventions.
+
+Read `docs/agent-playbooks/prioritization.md` before the issue-filing phase.
+
+## When to invoke
+
+- User says "research X", "write an RFC for X", "design X for vibix", or similar.
+- User types `/os-researcher <topic>` (optionally with `--skip-research` to jump
+  straight to drafting if a research summary is already in context).
+
+## Inputs
+
+| Parameter | Source |
+|---|---|
+| `<topic>` | Required. Free-form OS topic (e.g. "virtual filesystem layer", "POSIX signals", "demand paging"). |
+| `--skip-research` | Optional flag. If set, skip Phase 1 and use the research brief already in the conversation. |
+
+If the topic is ambiguous or too broad, ask the user to narrow it before proceeding.
+
+## Cycle
+
+### Phase 1 — Research
+
+*Skip if `--skip-research` is set.*
+
+#### 1a. Identify research categories
+
+For the given topic, identify 4–6 source categories from the canonical list in
+`docs/agent-playbooks/rfc.md` (OSDev Wiki, Linux kernel docs, Intel/AMD manuals,
+POSIX spec, reference OS projects, academic literature). Prune categories that clearly
+don't apply (e.g., IETF RFCs for a memory-management topic).
+
+#### 1b. Spawn parallel research sub-agents
+
+Launch one sub-agent per source category **in parallel** using the `Agent` tool
+(`subagent_type: "general-purpose"`). Each sub-agent:
+
+- Searches and fetches its assigned source(s) using `WebSearch` and `WebFetch`.
+- Returns a structured report with:
+  - **Summary** (150–300 words): what this source covers for the topic.
+  - **Key findings** (3–5 bullets): directly relevant facts, design patterns, or
+    constraints.
+  - **Citable data**: direct quotes, spec clause numbers, paper titles/authors, or
+    concrete implementation details worth including in the RFC body.
+  - **Gaps**: anything this source doesn't answer that another source might.
+
+Prompt template to pass each sub-agent (fill in `<TOPIC>` and `<SOURCE>`):
+
+```
+You are a research assistant helping write an OS kernel RFC for vibix (an x86-64
+Rust kernel) on the topic: <TOPIC>.
+
+Your assigned source: <SOURCE>
+
+Search and read that source deeply. Return a structured report:
+
+## Summary
+<150–300 words on what you found relevant to the topic>
+
+## Key Findings
+- <finding 1>
+- <finding 2>
+- <finding 3>
+
+## Citable Data
+<direct quotes, spec clauses, paper titles, concrete numbers worth citing>
+
+## Gaps
+<what this source doesn't cover that another source might>
+
+Be specific and technical. This report will be synthesized with 3–5 other source
+reports to produce an RFC for a real kernel project.
+```
+
+#### 1c. Synthesize into a research brief
+
+When all sub-agents return, combine their reports into a single **Research Brief**
+(≤ 600 words):
+
+- Unified summary of what is known about the topic.
+- Consolidated key findings (de-duplicated).
+- Conflicts or trade-offs surfaced across sources.
+- Gaps that remain unresolved (flag in the RFC's Open Questions).
+
+Keep the research brief in context — the RFC draft is written directly from it.
+
+---
+
+### Phase 2 — Assign RFC number and draft
+
+#### 2a. Assign the next RFC number
+
+```sh
+ls docs/RFC/ 2>/dev/null | sort | tail -1
+```
+
+Parse the leading digits from the filename. If the directory is empty or missing,
+start at `0001`. Increment by 1 and zero-pad to 4 digits. Create `docs/RFC/` if it
+doesn't exist.
+
+#### 2b. Choose a slug
+
+Derive a `<kebab-slug>` (≤ 5 words, lowercase, hyphens) from the topic title.
+
+#### 2c. Write the RFC file
+
+Write `docs/RFC/<NNNN>-<kebab-slug>.md` using the template from
+`docs/agent-playbooks/rfc.md`. Fill every section from the research brief:
+
+- **Abstract**: 2–4 sentences.
+- **Motivation**: grounded in actual vibix gaps surfaced during research.
+- **Background**: cite specific sources found in Phase 1.
+- **Design**: the main section — be concrete about data structures, algorithms, and
+  interfaces. Sub-sections are encouraged.
+- **Security / Performance Considerations**: drawn from reviewer-archetype focus areas
+  (pre-empt blocking findings where possible).
+- **Alternatives Considered**: document the trade-offs surfaced during research.
+- **Open Questions**: include any gaps from the research brief.
+- **Implementation Roadmap**: 4–8 independently-landable work items, ordered
+  dependency-first.
+
+Set `status: Draft` and `created: <today's date>`.
+
+---
+
+### Phase 3 — Open the RFC PR
+
+Branch and commit per `docs/agent-playbooks/sdlc.md`:
+
+```sh
+git checkout main && git pull
+git checkout -b rfc/<NNNN>-<kebab-slug>
+```
+
+Stage and commit the RFC file:
+
+```
+git add docs/RFC/<NNNN>-<kebab-slug>.md
+git commit -m "rfc(<NNNN>): <Title> [Draft]
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+Push and open the PR:
+
+```sh
+git push -u origin rfc/<NNNN>-<kebab-slug>
+```
+
+```
+mcp__github__create_pull_request(
+  owner="dburkart", repo="vibix",
+  title="RFC <NNNN>: <Title>",
+  head="rfc/<NNNN>-<kebab-slug>",
+  base="main",
+  body="""
+## Summary
+
+RFC <NNNN> proposes <1–2 sentence summary of the design>.
+
+This PR contains a design document only — no kernel code changes. The RFC will be
+reviewed by four archetype reviewers (security researcher, OS engineer, user space
+staff engineer, academic), revised until all blocking findings are addressed, then
+merged. Implementation issues will be filed from the roadmap section after merge.
+
+## RFC sections
+
+- Abstract
+- Motivation
+- Background
+- Design (with sub-sections)
+- Security Considerations
+- Performance Considerations
+- Alternatives Considered
+- Open Questions
+- Implementation Roadmap
+
+## Test plan
+
+- [ ] All four archetype reviewers post a review comment.
+- [ ] All blocking findings are addressed in at most 2 defense cycles.
+- [ ] RFC frontmatter updated to `status: Accepted` before merge.
+"""
+)
+```
+
+Record the PR number. Update the RFC frontmatter to `status: In Review`, commit, and
+push.
+
+---
+
+### Phase 4 — Peer review
+
+Spawn all four reviewer sub-agents **in parallel** using `Agent`
+(`subagent_type: "general-purpose"`). Pass each:
+
+- The full RFC content (read the file and include it verbatim in the prompt).
+- Their archetype persona, focus areas, and what constitutes a blocking finding
+  (from `docs/agent-playbooks/rfc.md`).
+- The PR number and repo (`dburkart/vibix`).
+- The exact review comment format required (from `docs/agent-playbooks/rfc.md`).
+- Instructions to post the review via `mcp__github__add_issue_comment` with
+  `owner="dburkart"`, `repo="vibix"`, `issue_number=<PR>`.
+
+Prompt template (fill in `<ARCHETYPE>`, `<FOCUS>`, `<BLOCKS_ON>`, `<RFC_CONTENT>`,
+`<PR_NUMBER>`):
+
+```
+You are a <ARCHETYPE> reviewing an OS kernel RFC for vibix (an x86-64 Rust kernel).
+
+Your focus areas: <FOCUS>
+
+You block on (i.e., must issue CHANGES REQUESTED for): <BLOCKS_ON>
+
+Read the RFC below and post a structured review comment on GitHub PR #<PR_NUMBER>
+in the repo dburkart/vibix. Use mcp__github__add_issue_comment with
+owner="dburkart", repo="vibix", issue_number=<PR_NUMBER>.
+
+Your comment MUST follow this exact format:
+
+### Review: <ARCHETYPE>
+
+**Summary:** <1–2 sentence overall assessment.>
+
+**Blocking findings:**
+- [B1] <short label> — <explanation>
+
+**Advisory findings:**
+- [A1] <short label> — <explanation>
+
+**Verdict:** CHANGES REQUESTED | LGTM
+
+---
+
+RFC content:
+
+<RFC_CONTENT>
+```
+
+After all four sub-agents complete, fetch the PR comments to confirm all four review
+comments were posted:
+
+```
+mcp__github__pull_request_read(owner="dburkart", repo="vibix", pullNumber=<PR>)
+```
+
+---
+
+### Phase 5 — Defense cycle
+
+This phase repeats up to **2 times**. Track the cycle count.
+
+#### 5a. Collect blocking findings
+
+Fetch all PR comments. Extract every `[B*]` finding from comments whose header
+matches `### Review: <Archetype Name>`. Group by archetype.
+
+If zero blocking findings across all archetypes → skip to Phase 6 (Approval).
+
+#### 5b. Update the RFC
+
+For each blocking finding:
+
+1. Decide: address in the RFC (add mitigations, redesign, justify with evidence) or
+   classify as out-of-scope (requires clear reasoning).
+2. Edit `docs/RFC/<NNNN>-<kebab-slug>.md` directly.
+3. Prefer addressing over deferring — the RFC should be as complete as possible.
+
+#### 5c. Commit and push the updated RFC
+
+```
+git add docs/RFC/<NNNN>-<kebab-slug>.md
+git commit -m "rfc(<NNNN>): address review findings (defense cycle N)
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+git push
+```
+
+#### 5d. Post a defense comment
+
+Post a **single comment** on the PR via `mcp__github__add_issue_comment` listing:
+
+- Which `[Bx]` findings were addressed and the specific change made.
+- Which (if any) were classified as out-of-scope and why.
+
+#### 5e. Re-spawn blocking-archetype reviewers
+
+Only re-spawn the archetypes that had blocking findings. Provide them with the updated
+RFC content and ask them to post a **new** review comment (same format) reflecting
+the updated design. Their new `LGTM` or `CHANGES REQUESTED` supersedes the old one.
+
+#### 5f. Check cycle count
+
+- Cycle 1 complete → re-evaluate blocking findings from the new reviews (return to 5a).
+- Cycle 2 complete with remaining blockers → **stop** (see Stopping).
+
+---
+
+### Phase 6 — Approval and merge
+
+All four archetypes have issued `LGTM`. Proceed:
+
+1. Update `docs/RFC/<NNNN>-<kebab-slug>.md` frontmatter: `status: Accepted`.
+2. Update the **Open Questions** section: mark resolved ones answered, flag any
+   remaining as "deferred to implementation."
+3. Commit and push:
+   ```
+   git commit -m "rfc(<NNNN>): mark Accepted
+
+   Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+   git push
+   ```
+4. Merge via squash:
+   ```
+   mcp__github__merge_pull_request(
+     owner="dburkart", repo="vibix",
+     pullNumber=<PR>, mergeMethod="squash"
+   )
+   ```
+5. Post-merge cleanup:
+   ```sh
+   git checkout main && git pull
+   git branch -d rfc/<NNNN>-<kebab-slug>
+   ```
+
+---
+
+### Phase 7 — Break out work
+
+For each `- [ ]` item in the **Implementation Roadmap** section of the merged RFC,
+invoke the `file-issue` skill. Pass:
+
+- **Title:** the work item text, ≤ 72 chars, imperative form.
+- **Motivation:** "Implements RFC <NNNN> — <RFC title>. <one sentence on why this
+  item matters or what it unblocks.>"
+- **Work:** sub-tasks inferred from the RFC's Design section, specific enough to act
+  on cold in a week.
+- **Context:** `docs/RFC/<NNNN>-<slug>.md`, merged PR number.
+- **Labels:** follow `docs/agent-playbooks/prioritization.md` — exactly one
+  `priority:*`, one or more `area:*`, optional `track:*`.
+
+File all issues and report the full list of URLs to the user.
+
+---
+
+## Stopping
+
+If the defense cycle limit (2 cycles) is exhausted with remaining blocking findings:
+
+1. Update RFC frontmatter `status: Withdrawn`.
+2. Commit and push: `"rfc(<NNNN>): withdraw — unresolved blocking findings"`.
+3. Close the PR via `mcp__github__update_pull_request` with `state: "closed"`.
+4. Post a closing comment listing the unresolved `[Bx]` items and which archetype
+   raised each.
+5. Invoke `file-issue` to create a follow-up issue titled
+   `"Resolve blocked RFC <NNNN>: <Title>"` with `priority:P2`, appropriate `area:*`
+   labels, and the list of unresolved findings as work items.
+6. Report to the user with the issue URL.
+
+## Never
+
+- Open a PR to `main` directly (all RFC PRs use `rfc/<NNNN>-<slug>` branches).
+- Skip the research phase unless `--skip-research` is explicitly set.
+- Write the RFC before the research brief is complete — synthesis before drafting.
+- Merge without all four archetypes posting `LGTM`.
+- File implementation issues before the RFC is merged and `Accepted`.
+- Invent new `priority:*` or `area:*` labels when filing issues — update the
+  prioritization playbook first.
+- Re-use or skip an RFC number.

--- a/.claude/skills/os-researcher/SKILL.md
+++ b/.claude/skills/os-researcher/SKILL.md
@@ -316,6 +316,7 @@ All four archetypes have issued `LGTM`. Proceed:
    remaining as "deferred to implementation."
 3. Commit and push:
    ```
+   git add docs/RFC/<NNNN>-<kebab-slug>.md
    git commit -m "rfc(<NNNN>): mark Accepted
 
    Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"

--- a/docs/agent-playbooks/rfc.md
+++ b/docs/agent-playbooks/rfc.md
@@ -1,0 +1,280 @@
+# RFC Process
+
+RFCs (Requests for Comments) are the primary mechanism for designing and socializing
+significant changes to vibix **before** implementation begins. An RFC is not a commit
+message or a GitHub issue — it is a design document that captures motivation,
+architecture, trade-offs, and the shape of the work stream so that bad assumptions are
+caught early, not mid-implementation.
+
+## When to write an RFC
+
+Write an RFC for changes that are:
+
+- **New subsystems** — a scheduler, a filesystem, a device class, or any new kernel
+  abstraction with its own state machine and public API.
+- **Cross-cutting** — changes that touch ≥ 3 subsystems or alter a fundamental
+  invariant (e.g., the interrupt-safety contract, the virtual memory layout, the syscall ABI).
+- **ABI-visible** — new or changed syscall interfaces, `/proc`/`/sys` layouts, or binary
+  formats that userspace will depend on.
+- **Architecturally uncertain** — design points where two or more viable approaches
+  exist and the choice has lasting consequences.
+
+You do **not** need an RFC for:
+
+- Bug fixes, performance improvements, or refactors within a single subsystem.
+- Documentation-only changes.
+- Feature additions with an obvious design that fits cleanly within an existing
+  subsystem's API.
+
+## Numbering
+
+RFCs are numbered monotonically, zero-padded to four digits: `0001`, `0002`, etc.
+
+To assign the next number:
+
+1. List `docs/RFC/` and find the highest-numbered file (`NNNN-*.md`).
+2. Next RFC = `NNNN + 1`, formatted as `%04d`.
+3. If `docs/RFC/` is empty or does not exist, start at `0001`.
+
+Never reuse or skip a number. If an RFC is abandoned, leave the file with
+`status: Withdrawn` rather than deleting it.
+
+## File location
+
+```
+docs/RFC/<NNNN>-<kebab-slug>.md
+```
+
+`<kebab-slug>` is a short (≤ 5 words), lowercase, hyphen-separated description.
+
+Examples:
+- `docs/RFC/0001-virtual-memory-map.md`
+- `docs/RFC/0002-ext2-filesystem-driver.md`
+- `docs/RFC/0003-posix-signals.md`
+
+## Document template
+
+Every RFC uses this template verbatim. Fill every section. If a section genuinely has
+nothing to say, write `N/A — <one sentence explaining why>` rather than leaving it
+blank. A blank section signals an incomplete design.
+
+```markdown
+---
+rfc: <NNNN>
+title: <Title Case Title>
+status: Draft
+created: <YYYY-MM-DD>
+---
+
+# RFC <NNNN>: <Title>
+
+## Abstract
+
+<2–4 sentences. What is being proposed and what does it achieve?>
+
+## Motivation
+
+<Why is this needed? What is currently broken or missing? What does vibix gain?>
+
+## Background
+
+<Prior art: relevant subsystems already in vibix, analogous designs in other OS
+projects (Linux, SerenityOS, Redox), academic literature.>
+
+## Design
+
+<The architecture and technical specification. Use sub-sections freely.>
+
+### Overview
+
+### Key Data Structures
+
+### Algorithms and Protocols
+
+### Kernel–Userspace Interface
+
+<Syscall numbers, argument layout, return values, errno codes, /proc or /sys layout.
+Write N/A if the change is kernel-internal only.>
+
+## Security Considerations
+
+<Privilege model impact, new attack surface, information-disclosure risks, mitigations.>
+
+## Performance Considerations
+
+<Hot-path impact, memory overhead, lock contention, SMP scalability.>
+
+## Alternatives Considered
+
+<What else was considered and why it was rejected or deferred.>
+
+## Open Questions
+
+<Unresolved design points that need decisions before or during implementation.>
+
+## Implementation Roadmap
+
+<Independently-landable work items. These become GitHub issues when the RFC is
+accepted.>
+
+- [ ] <work item 1>
+- [ ] <work item 2>
+```
+
+## Status lifecycle
+
+| Status | Meaning |
+|---|---|
+| `Draft` | Being written; not ready for review. |
+| `In Review` | PR open; peer review in progress. |
+| `Accepted` | All blocking reviewer concerns addressed; PR merged. |
+| `Implemented` | All implementation roadmap items closed. |
+| `Withdrawn` | Abandoned; file kept for reference. |
+
+Update the frontmatter `status` field at each transition. Do **not** retroactively
+edit the `created` date.
+
+## Research methodology
+
+Before drafting an RFC, gather information from these canonical sources:
+
+| Source | What it covers |
+|---|---|
+| `wiki.osdev.org` | Practical x86 kernel dev knowledge; hardware quirks; community-vetted patterns |
+| `kernel.org/doc/html/latest/` | Linux subsystem design; locking discipline; driver model |
+| Intel SDM (`intel.com`) | x86-64 instruction reference; MSR definitions; paging structures |
+| AMD APM (`amd.com`) | AMD-specific extensions; SVM; IOMMU |
+| `pubs.opengroup.org/onlinepubs/9699919799/` | POSIX.1-2017; syscall semantics; error codes |
+| SerenityOS (`github.com/SerenityOS/serenity`) | C++ x86 kernel patterns; userspace-facing API design |
+| Redox OS (`github.com/redox-os/redox`) | Rust kernel patterns; capability-based approach |
+| Google Scholar / Semantic Scholar | Academic papers on OS design, scheduling, formal verification |
+| `rfc-editor.org` | IETF RFCs for networking and protocol topics |
+
+Delegate each source category to a **separate research sub-agent** running in parallel.
+Each sub-agent should return:
+
+- A 150–300 word summary of what it found.
+- 3–5 key findings directly relevant to the topic.
+- Direct quotes or data points worth citing in the RFC body.
+- Gaps or contradictions across sources worth calling out.
+
+The main agent synthesizes all sub-agent summaries before writing the RFC draft.
+
+## Peer review archetypes
+
+The `os-researcher` skill spawns four reviewer sub-agents in parallel after the RFC PR
+is opened. Each reads the RFC and posts a structured PR comment identifying itself by
+archetype.
+
+### Security Researcher
+
+**Focus:** Privilege model, attack surface, side-channels, memory-safety invariants,
+TOCTOU, kernel-to-user data flows.
+
+**Asks:** Can a user process trigger this path maliciously? What happens at bounds
+violations? Are there information-disclosure risks in error codes or timing? Does the
+design create a new privilege-escalation surface?
+
+**Blocks on:** Any finding that could allow unprivileged code to gain elevated access,
+corrupt kernel state, or leak kernel addresses/data.
+
+### OS Engineer
+
+**Focus:** Kernel correctness, interrupt safety, memory ordering, lock discipline, SMP
+correctness, ABI stability, resource lifecycle (allocation/free symmetry).
+
+**Asks:** Is this IRQ-safe? Does it hold under SMP? What is the locking order? Are
+there hidden races? Is the data layout cache-friendly?
+
+**Blocks on:** Any concurrency bug, undefined behaviour, or violation of the project's
+existing invariants (interrupt-safety contract, memory model).
+
+### User Space Staff Engineer
+
+**Focus:** Syscall API ergonomics, POSIX compliance, composability with existing
+interfaces, application developer experience, error reporting.
+
+**Asks:** What is the exact syscall interface? How does this compose with `select` /
+`poll` / `epoll`? What do errno values mean to a userspace programmer? Is this API
+idiomatic for C and Rust callers?
+
+**Blocks on:** Any interface that breaks POSIX semantics without a documented
+exception, or that is impossible to implement correctly from userspace.
+
+### Academic
+
+**Focus:** Theoretical foundations, comparison to published research, formal
+properties, correctness invariants, novelty vs. duplication of prior work.
+
+**Asks:** Has this been studied formally? Which papers are directly relevant? Does the
+design maintain the right formal invariants (deadlock-freedom, liveness, isolation)?
+Is there a simpler or more principled approach in the literature?
+
+**Blocks on:** A known published result that directly contradicts the design's safety
+or liveness claims.
+
+## Review comment format
+
+Each reviewer sub-agent posts a **single PR comment** in this format. The opening
+`### Review: …` header is load-bearing — the defense cycle uses it to attribute
+findings to the right archetype.
+
+```
+### Review: <Archetype Name>
+
+**Summary:** <1–2 sentence overall assessment.>
+
+**Blocking findings:**
+- [B1] <short label> — <explanation>
+
+**Advisory findings:**
+- [A1] <short label> — <explanation>
+
+**Verdict:** CHANGES REQUESTED | LGTM
+```
+
+`CHANGES REQUESTED` means ≥ 1 blocking finding exists. `LGTM` means no blocking
+findings (advisory findings are fine to ship with).
+
+If the archetype finds nothing noteworthy, a `LGTM` with an empty blocking list is a
+valid and complete review — do not pad it.
+
+## Defense cycle
+
+After all four reviewer comments are posted:
+
+1. Collect every `[B*]` blocking finding across all archetypes.
+2. For each blocking finding, update the RFC: add mitigations, redesign the affected
+   section, or justify the original approach with cited evidence.
+3. Commit and push the updated RFC to the PR branch.
+4. Post a **single reply comment** listing which `[Bx]` items were addressed and how.
+5. Re-spawn **only** the archetypes that had blocking findings; they re-read the
+   updated RFC and post a new review comment replacing their previous verdict.
+
+**Maximum 2 defense cycles.** After the 2nd cycle, if blocking findings remain, update
+the RFC `status` to `Withdrawn`, close the PR with a comment explaining the unresolved
+issues, and file a follow-up issue (via `file-issue`) for a human to resolve them.
+
+## Approval criteria
+
+An RFC is approved — and ready to merge — when **all** are true:
+
+- All four archetype reviewers have issued `LGTM` (or never had blocking findings).
+- The RFC's frontmatter `status` is updated to `Accepted`.
+- The **Open Questions** section is updated: answered questions resolved, remaining
+  ones explicitly flagged as "deferred to implementation."
+
+## Post-approval
+
+After merging:
+
+1. Confirm `status: Accepted` is in the merged file.
+2. For each `- [ ]` item in the **Implementation Roadmap** section, invoke the
+   `file-issue` skill:
+   - **Title:** the work item text, imperative phrase, ≤ 72 chars.
+   - **Motivation:** "Implements RFC NNNN — <title>. <1 sentence on why this item matters.>"
+   - **Work:** sub-tasks inferred from the RFC's Design section.
+   - **Context:** `docs/RFC/NNNN-<slug>.md`, PR number, any related open issues.
+   - **Labels:** follow `docs/agent-playbooks/prioritization.md` — exactly one
+     `priority:*`, one or more `area:*`, optional `track:*`.
+3. Report all filed issue URLs to the user.


### PR DESCRIPTION
Introduces the /os-researcher skill, which drives a full RFC lifecycle:

1. Deep parallel research across canonical OS dev sources (OSDev Wiki,
   Linux kernel docs, Intel/AMD manuals, POSIX spec, SerenityOS, Redox,
   academic literature) via delegated sub-agents.
2. RFC drafting using a monotonically-numbered template under docs/RFC/.
3. Automated peer review via four archetype sub-agents (security
   researcher, OS engineer, user space staff engineer, academic), each
   posting structured CHANGES REQUESTED / LGTM comments directly on the PR.
4. Defense cycle: the skill addresses blocking findings, pushes revisions,
   and re-triggers only the archetypes that had blockers (max 2 cycles).
5. Merge on unanimous LGTM, then breaks the Implementation Roadmap into
   labeled GitHub issues via the file-issue skill.

Also adds docs/agent-playbooks/rfc.md, the shared policy document that
codifies RFC numbering, the document template, research source list,
reviewer archetype definitions, review comment format, defense cycle
rules, approval criteria, and post-approval issue-filing protocol. The
skill is a thin Claude-specific wrapper around this playbook, following
the same shared-playbook pattern used by auto-engineer and wait-for-pr.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds documentation/playbooks and a new Claude skill spec only, with no changes to kernel/runtime behavior. Main risk is process churn (new RFC workflow expectations) rather than code correctness.
> 
> **Overview**
> Introduces a new Claude skill, `os-researcher`, that standardizes an end-to-end RFC workflow: parallel research, RFC numbering/creation under `docs/RFC/`, PR opening, structured multi-archetype review, up to two defense cycles, and post-merge issue filing from the roadmap.
> 
> Adds `docs/agent-playbooks/rfc.md` to codify the shared RFC process (when RFCs are required, numbering rules, document template, canonical research sources, reviewer archetypes + blocking criteria, review comment format, and acceptance/withdrawal rules).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dab93a3c008c1a02d62c178050002ea77eb722c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->