### PR TITLE
block: legacy virtio-blk driver (step 1 of #43)

### DIFF
--- a/kernel/src/block/mod.rs
+++ b/kernel/src/block/mod.rs
@@ -1,0 +1,52 @@
+//! Block-device layer.
+//!
+//! A thin public facade over whatever backend driver probed successfully
+//! at boot. Today that's virtio-blk only; further backends would plug in
+//! the same way.
+//!
+//! Issue #43 step 1: expose `read(lba, buf)` against the first detected
+//! virtio-blk device. No writes, no caching, no interrupts — synchronous
+//! polled I/O only.
+
+#[cfg(any(test, target_os = "none"))]
+pub mod virtio_blk;
+
+/// Size of one disk sector in bytes. The virtio-blk spec fixes this at
+/// 512 regardless of the underlying medium's physical block size.
+pub const SECTOR_SIZE: usize = 512;
+
+/// Errors surfaced by the block API.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum BlkError {
+    /// No block backend was successfully brought up during init.
+    NotInitialized,
+    /// Buffer length isn't a non-zero multiple of [`SECTOR_SIZE`].
+    BadAlign,
+    /// Device reported an error completing the request.
+    DeviceError,
+    /// Bounded spin-wait for request completion elapsed.
+    Timeout,
+}
+
+/// Probe PCI and bring up the first supported block device. Called once
+/// from the main init sequence after `pci::scan()` and `mem::init()`.
+#[cfg(target_os = "none")]
+pub fn init() {
+    virtio_blk::init();
+}
+
+/// Read `buf.len() / 512` sectors starting at `lba` into `buf`.
+///
+/// `buf.len()` must be a non-zero multiple of [`SECTOR_SIZE`]. Blocks the
+/// calling task on a polled spin-wait; intended for boot-time probes and
+/// the not-yet-existent filesystem layer, not for general user traffic.
+#[cfg(target_os = "none")]
+pub fn read(lba: u64, buf: &mut [u8]) -> Result<(), BlkError> {
+    virtio_blk::read(lba, buf)
+}
+
+/// `true` once a backend has completed bring-up.
+#[cfg(target_os = "none")]
+pub fn ready() -> bool {
+    virtio_blk::ready()
+}

--- a/kernel/src/block/virtio_blk.rs
+++ b/kernel/src/block/virtio_blk.rs
@@ -13,9 +13,14 @@
 //! - Polling — no interrupt handler. The completion path spins on the
 //!   used-ring index with a bounded retry budget.
 //! - Read-only (`VIRTIO_BLK_T_IN`).
-//! - Queue size is taken from whatever the device reports. The queue is
-//!   a single heap allocation with page-size alignment so the physical
-//!   base fits the legacy `QUEUE_ADDR` register (a PFN).
+//! - Queue size is taken from whatever the device reports, capped at
+//!   [`QUEUE_MAX`] so the whole virtqueue fits in a statically-reserved
+//!   `#[repr(align(4096))]` region inside the kernel image. Limine loads
+//!   kernel segments into physically contiguous frames, which satisfies
+//!   the virtio legacy requirement that the queue be physically
+//!   contiguous (spec 0.9.5 §2.3). We verify the contiguity at init time
+//!   with `paging::translate` across each page and fail bring-up if the
+//!   mapping is not contiguous.
 //!
 //! References:
 //! - Virtio 1.0 spec §5.2 (block device).
@@ -28,6 +33,8 @@ use super::SECTOR_SIZE;
 
 #[cfg(target_os = "none")]
 use alloc::alloc::{alloc_zeroed, dealloc, Layout};
+#[cfg(target_os = "none")]
+use core::cell::UnsafeCell;
 #[cfg(target_os = "none")]
 use core::mem::size_of;
 #[cfg(target_os = "none")]
@@ -99,6 +106,37 @@ const VIRTQ_DESC_F_WRITE: u16 = 2;
 #[cfg(target_os = "none")]
 const POLL_BUDGET: u32 = 10_000_000;
 
+/// Largest queue size we're willing to drive. `queue_layout(256)` =
+/// 10248 bytes → fits in 3 pages. QEMU defaults virtio-blk to 256, so
+/// anything smaller here would force bring-up to fail rather than cap
+/// silently — legacy QUEUE_SIZE is read-only, we can't request less.
+#[cfg(target_os = "none")]
+const QUEUE_MAX: u16 = 256;
+#[cfg(target_os = "none")]
+const QUEUE_STORAGE_BYTES: usize = 4096 * 3;
+/// Minimum queue size we can drive. The submit path writes three
+/// consecutive descriptor slots computed as `slot`, `slot+1`, `slot+2`
+/// (mod qsz); with qsz < 3 those wrap and collide.
+#[cfg(target_os = "none")]
+const QUEUE_MIN: u16 = 3;
+
+/// Page-aligned storage for the single virtqueue. Lives in the kernel
+/// image's `.bss`, which Limine places into physically contiguous frames
+/// — the virtio legacy PFN in `QUEUE_ADDR` requires that. We verify the
+/// contiguity at init (see `verify_contig`).
+#[cfg(target_os = "none")]
+#[repr(C, align(4096))]
+struct QueueStorage(UnsafeCell<[u8; QUEUE_STORAGE_BYTES]>);
+
+// SAFETY: the only access is behind the DEVICE mutex (bring-up writes
+// QUEUE_ADDR once, submit_and_wait accesses descriptors while holding
+// the DEVICE lock). No concurrent CPU access occurs.
+#[cfg(target_os = "none")]
+unsafe impl Sync for QueueStorage {}
+
+#[cfg(target_os = "none")]
+static QUEUE_STORAGE: QueueStorage = QueueStorage(UnsafeCell::new([0u8; QUEUE_STORAGE_BYTES]));
+
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct VirtqDesc {
@@ -164,7 +202,6 @@ struct BlkDevice {
     queue_pa: u64,
     layout: QueueLayout,
     queue_base: *mut u8,
-    queue_alloc_layout: Layout,
     /// Our running `avail.idx` — incremented for each submission.
     avail_idx: u16,
     /// Last `used.idx` we observed; completions advance it.
@@ -229,7 +266,9 @@ pub fn init() {
 #[allow(dead_code)] // payloads are surfaced via {:?} in the init error log
 enum BringUpError {
     ZeroQueueSize,
+    QueueTooSmall(u16),
     QueueTooLarge(u16),
+    QueueNotContiguous,
     FeaturesNotOk,
 }
 
@@ -271,27 +310,35 @@ fn bring_up(dev: &pci::Device, io_base: u16) -> Result<BlkDevice, BringUpError> 
             write8(io_base, REG_DEVICE_STATUS, STATUS_FAILED);
             return Err(BringUpError::ZeroQueueSize);
         }
-        if queue_size > 256 {
-            // Cap to keep the allocation small; spec allows the driver
-            // to request a smaller queue by writing QUEUE_SIZE, but in
-            // legacy it's ROM on QEMU — easier to refuse oversized queues
-            // outright than silently half-initialize.
+        if queue_size < QUEUE_MIN {
+            // submit_and_wait writes three consecutive descriptors mod
+            // qsz; qsz<3 aliases them onto the same slot.
+            write8(io_base, REG_DEVICE_STATUS, STATUS_FAILED);
+            return Err(BringUpError::QueueTooSmall(queue_size));
+        }
+        if queue_size > QUEUE_MAX {
+            // Refuse rather than half-initialize — the static queue
+            // storage is sized for QUEUE_MAX.
             write8(io_base, REG_DEVICE_STATUS, STATUS_FAILED);
             return Err(BringUpError::QueueTooLarge(queue_size));
         }
 
         let layout = queue_layout(queue_size);
-        let alloc_layout =
-            Layout::from_size_align(layout.total, 4096).expect("virtio_blk: bad queue layout");
-        let queue_base = alloc_zeroed(alloc_layout);
-        if queue_base.is_null() {
-            write8(io_base, REG_DEVICE_STATUS, STATUS_FAILED);
-            panic!("virtio_blk: queue allocation failed");
-        }
+        debug_assert!(layout.total <= QUEUE_STORAGE_BYTES);
+        let queue_base = QUEUE_STORAGE.0.get() as *mut u8;
+        // Zero the full region — the static is zero-initialized at boot,
+        // but being defensive here costs nothing and keeps the invariant
+        // obvious if a future caller ever re-enters bring_up.
+        ptr::write_bytes(queue_base, 0, QUEUE_STORAGE_BYTES);
+
         let queue_pa = paging::translate(x86_64::VirtAddr::new(queue_base as u64))
             .expect("virtio_blk: queue not mapped")
             .as_u64();
         debug_assert_eq!(queue_pa & 0xFFF, 0, "queue must be page-aligned");
+        if !queue_phys_contiguous(queue_base, layout.total, queue_pa) {
+            write8(io_base, REG_DEVICE_STATUS, STATUS_FAILED);
+            return Err(BringUpError::QueueNotContiguous);
+        }
 
         // Legacy QUEUE_ADDR is a PFN (phys >> 12).
         write32(io_base, REG_QUEUE_ADDR, (queue_pa >> 12) as u32);
@@ -309,11 +356,31 @@ fn bring_up(dev: &pci::Device, io_base: u16) -> Result<BlkDevice, BringUpError> 
             queue_pa,
             layout,
             queue_base,
-            queue_alloc_layout: alloc_layout,
             avail_idx: 0,
             last_used_idx: 0,
         })
     }
+}
+
+/// Walk each 4 KiB page of `[base, base+len)` and assert that successive
+/// pages map to successive physical frames starting from `base_pa`.
+/// Legacy virtio-blk's QUEUE_ADDR is a single PFN and the device
+/// interprets the whole queue as contiguous physical memory.
+#[cfg(target_os = "none")]
+unsafe fn queue_phys_contiguous(base: *const u8, len: usize, base_pa: u64) -> bool {
+    let mut off = 4096usize;
+    while off < len {
+        let va = x86_64::VirtAddr::new(base as u64 + off as u64);
+        let pa = match paging::translate(va) {
+            Some(p) => p.as_u64(),
+            None => return false,
+        };
+        if pa != base_pa + off as u64 {
+            return false;
+        }
+        off += 4096;
+    }
+    true
 }
 
 #[cfg(target_os = "none")]
@@ -321,11 +388,19 @@ pub fn read(lba: u64, buf: &mut [u8]) -> Result<(), BlkError> {
     if buf.is_empty() || buf.len() % SECTOR_SIZE != 0 {
         return Err(BlkError::BadAlign);
     }
+    // Single-page bounce buffer: guarantees the data descriptor covers
+    // one physically-contiguous frame regardless of the caller's buffer
+    // alignment. Capping at one page keeps this step-1 driver simple;
+    // multi-page transfers can split into per-page descriptors later.
+    if buf.len() > 4096 {
+        return Err(BlkError::BadAlign);
+    }
     let mut guard = DEVICE.lock();
     let dev = guard.as_mut().ok_or(BlkError::NotInitialized)?;
 
-    // Per-request scratch: header + status byte, sitting in the heap
-    // (HHDM-backed, so translate works identically to the queue).
+    // Per-request scratch: header + status byte + page-aligned data
+    // bounce buffer, sitting in the heap (HHDM-backed, so translate
+    // works identically to the queue).
     let header = VirtioBlkReqHeader {
         ty: VIRTIO_BLK_T_IN,
         reserved: 0,
@@ -333,10 +408,12 @@ pub fn read(lba: u64, buf: &mut [u8]) -> Result<(), BlkError> {
     };
     let header_layout = Layout::from_size_align(size_of::<VirtioBlkReqHeader>(), 8).unwrap();
     let status_layout = Layout::from_size_align(1, 1).unwrap();
-    // SAFETY: both layouts are valid and non-zero-sized.
+    let data_layout = Layout::from_size_align(4096, 4096).unwrap();
+    // SAFETY: all layouts are valid and non-zero-sized.
     let header_ptr = unsafe { alloc_zeroed(header_layout) } as *mut VirtioBlkReqHeader;
     let status_ptr = unsafe { alloc_zeroed(status_layout) };
-    assert!(!header_ptr.is_null() && !status_ptr.is_null());
+    let data_ptr = unsafe { alloc_zeroed(data_layout) };
+    assert!(!header_ptr.is_null() && !status_ptr.is_null() && !data_ptr.is_null());
     // SAFETY: just allocated, exclusive.
     unsafe {
         ptr::write(header_ptr, header);
@@ -345,25 +422,41 @@ pub fn read(lba: u64, buf: &mut [u8]) -> Result<(), BlkError> {
     let header_pa = paging::translate(x86_64::VirtAddr::new(header_ptr as u64))
         .expect("virtio_blk: header not mapped")
         .as_u64();
-    let buf_pa = paging::translate(x86_64::VirtAddr::new(buf.as_mut_ptr() as u64))
-        .expect("virtio_blk: buffer not mapped")
+    let data_pa = paging::translate(x86_64::VirtAddr::new(data_ptr as u64))
+        .expect("virtio_blk: data not mapped")
         .as_u64();
     let status_pa = paging::translate(x86_64::VirtAddr::new(status_ptr as u64))
         .expect("virtio_blk: status not mapped")
         .as_u64();
 
-    let result = unsafe { submit_and_wait(dev, header_pa, buf_pa, buf.len() as u32, status_pa) };
-    // SAFETY: these allocations are no longer referenced by the device
-    // once submit_and_wait has seen the used-ring entry (or timed out).
-    // On timeout we deliberately leak rather than risk the device
-    // scribbling into freed memory.
-    if result.is_ok() {
-        unsafe {
-            dealloc(header_ptr as *mut u8, header_layout);
-            dealloc(status_ptr, status_layout);
+    let result = unsafe { submit_and_wait(dev, header_pa, data_pa, buf.len() as u32, status_pa) };
+    // The device is only still looking at our buffers if submit_and_wait
+    // timed out — on any completed status (Ok or DeviceError) it's safe
+    // to free. Timeout deliberately leaks to avoid freeing memory the
+    // device may still DMA into.
+    match result {
+        Ok(()) => {
+            // SAFETY: data_ptr points to a live 4 KiB allocation.
+            unsafe {
+                ptr::copy_nonoverlapping(data_ptr, buf.as_mut_ptr(), buf.len());
+            }
+            unsafe {
+                dealloc(header_ptr as *mut u8, header_layout);
+                dealloc(status_ptr, status_layout);
+                dealloc(data_ptr, data_layout);
+            }
+            Ok(())
+        }
+        Err(BlkError::Timeout) => Err(BlkError::Timeout),
+        Err(e) => {
+            unsafe {
+                dealloc(header_ptr as *mut u8, header_layout);
+                dealloc(status_ptr, status_layout);
+                dealloc(data_ptr, data_layout);
+            }
+            Err(e)
         }
     }
-    result
 }
 
 #[cfg(target_os = "none")]

--- a/kernel/src/block/virtio_blk.rs
+++ b/kernel/src/block/virtio_blk.rs
@@ -1,0 +1,567 @@
+//! Minimal legacy virtio-blk driver.
+//!
+//! Probes the first PCI function matching the transitional (legacy)
+//! virtio block device (vendor `0x1AF4`, device `0x1001`), negotiates
+//! zero features, wires up a single virtqueue, and exposes polled reads
+//! via [`read`].
+//!
+//! Scope is deliberately narrow (issue #43 step 1):
+//!
+//! - Legacy PCI transport only. Modern (`0x1042`) devices are logged and
+//!   skipped; QEMU is pinned to legacy via `disable-modern=on` in the
+//!   xtask command line.
+//! - Polling — no interrupt handler. The completion path spins on the
+//!   used-ring index with a bounded retry budget.
+//! - Read-only (`VIRTIO_BLK_T_IN`).
+//! - Queue size is taken from whatever the device reports. The queue is
+//!   a single heap allocation with page-size alignment so the physical
+//!   base fits the legacy `QUEUE_ADDR` register (a PFN).
+//!
+//! References:
+//! - Virtio 1.0 spec §5.2 (block device).
+//! - Virtio 0.9.5 (legacy) §2.3, §2.4 (virtqueue layout, notification).
+
+#[cfg(target_os = "none")]
+use super::BlkError;
+#[cfg(target_os = "none")]
+use super::SECTOR_SIZE;
+
+#[cfg(target_os = "none")]
+use alloc::alloc::{alloc_zeroed, dealloc, Layout};
+#[cfg(target_os = "none")]
+use core::mem::size_of;
+#[cfg(target_os = "none")]
+use core::ptr;
+#[cfg(target_os = "none")]
+use core::sync::atomic::{fence, Ordering};
+
+#[cfg(target_os = "none")]
+use spin::Mutex;
+#[cfg(target_os = "none")]
+use x86_64::instructions::port::Port;
+
+#[cfg(target_os = "none")]
+use crate::mem::paging;
+use crate::pci;
+#[cfg(target_os = "none")]
+use crate::serial_println;
+
+/// Transitional virtio PCI vendor ID.
+const VIRTIO_VENDOR: u16 = 0x1AF4;
+/// Transitional (legacy) virtio-blk device ID.
+const DEVICE_ID_LEGACY: u16 = 0x1001;
+/// Modern-only virtio-blk device ID. Skipped in this driver.
+const DEVICE_ID_MODERN: u16 = 0x1042;
+
+// Legacy virtio PCI I/O-register offsets (from BAR0 base). Only referenced
+// from the target-only bring-up/submit path; gated on target_os = "none"
+// so host test builds stay warning-clean.
+#[cfg(target_os = "none")]
+const REG_HOST_FEATURES: u16 = 0x00;
+#[cfg(target_os = "none")]
+const REG_GUEST_FEATURES: u16 = 0x04;
+#[cfg(target_os = "none")]
+const REG_QUEUE_ADDR: u16 = 0x08;
+#[cfg(target_os = "none")]
+const REG_QUEUE_SIZE: u16 = 0x0C;
+#[cfg(target_os = "none")]
+const REG_QUEUE_SELECT: u16 = 0x0E;
+#[cfg(target_os = "none")]
+const REG_QUEUE_NOTIFY: u16 = 0x10;
+#[cfg(target_os = "none")]
+const REG_DEVICE_STATUS: u16 = 0x12;
+
+/// `Device Status` bits (virtio §2.1).
+#[cfg(target_os = "none")]
+const STATUS_ACKNOWLEDGE: u8 = 1;
+#[cfg(target_os = "none")]
+const STATUS_DRIVER: u8 = 2;
+#[cfg(target_os = "none")]
+const STATUS_DRIVER_OK: u8 = 4;
+#[cfg(target_os = "none")]
+const STATUS_FEATURES_OK: u8 = 8;
+#[cfg(target_os = "none")]
+const STATUS_FAILED: u8 = 128;
+
+/// `type` values in the block request header.
+#[cfg(target_os = "none")]
+const VIRTIO_BLK_T_IN: u32 = 0;
+
+/// `flags` bits in a virtqueue descriptor.
+#[cfg(target_os = "none")]
+const VIRTQ_DESC_F_NEXT: u16 = 1;
+#[cfg(target_os = "none")]
+const VIRTQ_DESC_F_WRITE: u16 = 2;
+
+/// Completion spin-budget. At ~1 GHz worth of `in`/pause iterations the
+/// outer bound is generous — a real request finishes in microseconds; a
+/// hung device should not hang the boot forever.
+#[cfg(target_os = "none")]
+const POLL_BUDGET: u32 = 10_000_000;
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct VirtqDesc {
+    pub addr: u64,
+    pub len: u32,
+    pub flags: u16,
+    pub next: u16,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct VirtioBlkReqHeader {
+    pub ty: u32,
+    pub reserved: u32,
+    pub sector: u64,
+}
+
+/// Byte layout of a virtqueue with `size` descriptors, per legacy spec:
+/// `desc[size]` then `avail` then a 4096-byte alignment pad then `used`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct QueueLayout {
+    pub desc_off: usize,
+    pub avail_off: usize,
+    pub used_off: usize,
+    pub total: usize,
+}
+
+/// Compute the virtqueue layout for a given queue `size`.
+///
+/// Host-testable — it's pure integer arithmetic.
+pub const fn queue_layout(size: u16) -> QueueLayout {
+    let sz = size as usize;
+    let desc_bytes = 16 * sz;
+    let avail_bytes = 6 + 2 * sz;
+    let avail_end = desc_bytes + avail_bytes;
+    let used_off = (avail_end + 4095) & !4095;
+    let used_bytes = 8 + 8 * sz;
+    QueueLayout {
+        desc_off: 0,
+        avail_off: desc_bytes,
+        used_off,
+        total: used_off + used_bytes,
+    }
+}
+
+/// Whittle the host-feature bitmap down to the subset we accept. Today
+/// that's an empty set — no FEATURES_OK contract beyond "I acked nothing".
+pub const fn negotiate(_host: u64) -> u64 {
+    0
+}
+
+/// PCI probe predicate. Pulled out for host-test coverage against
+/// `pci::Device` fixtures.
+pub fn is_virtio_blk_legacy(d: &pci::Device) -> bool {
+    d.vendor_id == VIRTIO_VENDOR && d.device_id == DEVICE_ID_LEGACY
+}
+
+#[cfg(target_os = "none")]
+#[allow(dead_code)] // several fields are held for future teardown / debug paths
+struct BlkDevice {
+    io_base: u16,
+    queue_size: u16,
+    queue_pa: u64,
+    layout: QueueLayout,
+    queue_base: *mut u8,
+    queue_alloc_layout: Layout,
+    /// Our running `avail.idx` — incremented for each submission.
+    avail_idx: u16,
+    /// Last `used.idx` we observed; completions advance it.
+    last_used_idx: u16,
+}
+
+// SAFETY: the device is kept inside a Mutex; the raw pointer is only
+// dereferenced while the mutex is held. Legacy virtio has no per-CPU
+// state, so sharing across threads is sound.
+#[cfg(target_os = "none")]
+unsafe impl Send for BlkDevice {}
+
+#[cfg(target_os = "none")]
+static DEVICE: Mutex<Option<BlkDevice>> = Mutex::new(None);
+
+#[cfg(target_os = "none")]
+pub fn ready() -> bool {
+    DEVICE.lock().is_some()
+}
+
+#[cfg(target_os = "none")]
+pub fn init() {
+    for d in pci::devices() {
+        if d.vendor_id == VIRTIO_VENDOR && d.device_id == DEVICE_ID_MODERN {
+            serial_println!(
+                "block: skipping modern virtio-blk at {:02x}:{:02x}.{:x} (legacy-only driver)",
+                d.addr.bus,
+                d.addr.device,
+                d.addr.function
+            );
+            continue;
+        }
+        if !is_virtio_blk_legacy(d) {
+            continue;
+        }
+        let bar0 = d.bars[0];
+        if !bar0.is_io() {
+            serial_println!("block: virtio-blk BAR0 not an I/O BAR ({:#x})", bar0.0);
+            continue;
+        }
+        let io_base = bar0.addr() as u16;
+        match bring_up(d, io_base) {
+            Ok(dev) => {
+                let queue_size = dev.queue_size;
+                *DEVICE.lock() = Some(dev);
+                serial_println!(
+                    "block: virtio-blk ready (io_base={:#06x}, queue_size={})",
+                    io_base,
+                    queue_size
+                );
+                return;
+            }
+            Err(e) => {
+                serial_println!("block: virtio-blk bring-up failed: {:?}", e);
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "none")]
+#[derive(Debug)]
+#[allow(dead_code)] // payloads are surfaced via {:?} in the init error log
+enum BringUpError {
+    ZeroQueueSize,
+    QueueTooLarge(u16),
+    FeaturesNotOk,
+}
+
+#[cfg(target_os = "none")]
+fn bring_up(dev: &pci::Device, io_base: u16) -> Result<BlkDevice, BringUpError> {
+    // Command-register bus-mastering: the device DMAs our queue memory,
+    // which a strict root complex won't allow without bit 2 set. QEMU is
+    // lenient here but the spec is explicit, so set it regardless.
+    pci::enable_bus_master(dev.addr);
+
+    unsafe {
+        // Reset.
+        write8(io_base, REG_DEVICE_STATUS, 0);
+        // ACK + DRIVER.
+        write8(io_base, REG_DEVICE_STATUS, STATUS_ACKNOWLEDGE);
+        write8(
+            io_base,
+            REG_DEVICE_STATUS,
+            STATUS_ACKNOWLEDGE | STATUS_DRIVER,
+        );
+        // Feature negotiation: accept nothing (step 1).
+        let host = read32(io_base, REG_HOST_FEATURES) as u64;
+        let guest = negotiate(host);
+        write32(io_base, REG_GUEST_FEATURES, guest as u32);
+        write8(
+            io_base,
+            REG_DEVICE_STATUS,
+            STATUS_ACKNOWLEDGE | STATUS_DRIVER | STATUS_FEATURES_OK,
+        );
+        if read8(io_base, REG_DEVICE_STATUS) & STATUS_FEATURES_OK == 0 {
+            write8(io_base, REG_DEVICE_STATUS, STATUS_FAILED);
+            return Err(BringUpError::FeaturesNotOk);
+        }
+
+        // Select queue 0 ("requestq").
+        write16(io_base, REG_QUEUE_SELECT, 0);
+        let queue_size = read16(io_base, REG_QUEUE_SIZE);
+        if queue_size == 0 {
+            write8(io_base, REG_DEVICE_STATUS, STATUS_FAILED);
+            return Err(BringUpError::ZeroQueueSize);
+        }
+        if queue_size > 256 {
+            // Cap to keep the allocation small; spec allows the driver
+            // to request a smaller queue by writing QUEUE_SIZE, but in
+            // legacy it's ROM on QEMU — easier to refuse oversized queues
+            // outright than silently half-initialize.
+            write8(io_base, REG_DEVICE_STATUS, STATUS_FAILED);
+            return Err(BringUpError::QueueTooLarge(queue_size));
+        }
+
+        let layout = queue_layout(queue_size);
+        let alloc_layout =
+            Layout::from_size_align(layout.total, 4096).expect("virtio_blk: bad queue layout");
+        let queue_base = alloc_zeroed(alloc_layout);
+        if queue_base.is_null() {
+            write8(io_base, REG_DEVICE_STATUS, STATUS_FAILED);
+            panic!("virtio_blk: queue allocation failed");
+        }
+        let queue_pa = paging::translate(x86_64::VirtAddr::new(queue_base as u64))
+            .expect("virtio_blk: queue not mapped")
+            .as_u64();
+        debug_assert_eq!(queue_pa & 0xFFF, 0, "queue must be page-aligned");
+
+        // Legacy QUEUE_ADDR is a PFN (phys >> 12).
+        write32(io_base, REG_QUEUE_ADDR, (queue_pa >> 12) as u32);
+
+        // DRIVER_OK — device is live.
+        write8(
+            io_base,
+            REG_DEVICE_STATUS,
+            STATUS_ACKNOWLEDGE | STATUS_DRIVER | STATUS_FEATURES_OK | STATUS_DRIVER_OK,
+        );
+
+        Ok(BlkDevice {
+            io_base,
+            queue_size,
+            queue_pa,
+            layout,
+            queue_base,
+            queue_alloc_layout: alloc_layout,
+            avail_idx: 0,
+            last_used_idx: 0,
+        })
+    }
+}
+
+#[cfg(target_os = "none")]
+pub fn read(lba: u64, buf: &mut [u8]) -> Result<(), BlkError> {
+    if buf.is_empty() || buf.len() % SECTOR_SIZE != 0 {
+        return Err(BlkError::BadAlign);
+    }
+    let mut guard = DEVICE.lock();
+    let dev = guard.as_mut().ok_or(BlkError::NotInitialized)?;
+
+    // Per-request scratch: header + status byte, sitting in the heap
+    // (HHDM-backed, so translate works identically to the queue).
+    let header = VirtioBlkReqHeader {
+        ty: VIRTIO_BLK_T_IN,
+        reserved: 0,
+        sector: lba,
+    };
+    let header_layout = Layout::from_size_align(size_of::<VirtioBlkReqHeader>(), 8).unwrap();
+    let status_layout = Layout::from_size_align(1, 1).unwrap();
+    // SAFETY: both layouts are valid and non-zero-sized.
+    let header_ptr = unsafe { alloc_zeroed(header_layout) } as *mut VirtioBlkReqHeader;
+    let status_ptr = unsafe { alloc_zeroed(status_layout) };
+    assert!(!header_ptr.is_null() && !status_ptr.is_null());
+    // SAFETY: just allocated, exclusive.
+    unsafe {
+        ptr::write(header_ptr, header);
+    }
+
+    let header_pa = paging::translate(x86_64::VirtAddr::new(header_ptr as u64))
+        .expect("virtio_blk: header not mapped")
+        .as_u64();
+    let buf_pa = paging::translate(x86_64::VirtAddr::new(buf.as_mut_ptr() as u64))
+        .expect("virtio_blk: buffer not mapped")
+        .as_u64();
+    let status_pa = paging::translate(x86_64::VirtAddr::new(status_ptr as u64))
+        .expect("virtio_blk: status not mapped")
+        .as_u64();
+
+    let result = unsafe { submit_and_wait(dev, header_pa, buf_pa, buf.len() as u32, status_pa) };
+    // SAFETY: these allocations are no longer referenced by the device
+    // once submit_and_wait has seen the used-ring entry (or timed out).
+    // On timeout we deliberately leak rather than risk the device
+    // scribbling into freed memory.
+    if result.is_ok() {
+        unsafe {
+            dealloc(header_ptr as *mut u8, header_layout);
+            dealloc(status_ptr, status_layout);
+        }
+    }
+    result
+}
+
+#[cfg(target_os = "none")]
+unsafe fn submit_and_wait(
+    dev: &mut BlkDevice,
+    header_pa: u64,
+    buf_pa: u64,
+    buf_len: u32,
+    status_pa: u64,
+) -> Result<(), BlkError> {
+    let qsz = dev.queue_size as u16;
+    let slot = dev.avail_idx % qsz;
+    let desc_base = dev.queue_base.add(dev.layout.desc_off) as *mut VirtqDesc;
+
+    // Three descriptors: header (RO), data (WO), status (WO).
+    let d0 = slot;
+    let d1 = (slot + 1) % qsz;
+    let d2 = (slot + 2) % qsz;
+    ptr::write_volatile(
+        desc_base.add(d0 as usize),
+        VirtqDesc {
+            addr: header_pa,
+            len: size_of::<VirtioBlkReqHeader>() as u32,
+            flags: VIRTQ_DESC_F_NEXT,
+            next: d1,
+        },
+    );
+    ptr::write_volatile(
+        desc_base.add(d1 as usize),
+        VirtqDesc {
+            addr: buf_pa,
+            len: buf_len,
+            flags: VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE,
+            next: d2,
+        },
+    );
+    ptr::write_volatile(
+        desc_base.add(d2 as usize),
+        VirtqDesc {
+            addr: status_pa,
+            len: 1,
+            flags: VIRTQ_DESC_F_WRITE,
+            next: 0,
+        },
+    );
+
+    // Avail ring: [flags: u16, idx: u16, ring[qsz]: u16, used_event: u16].
+    let avail_base = dev.queue_base.add(dev.layout.avail_off);
+    let avail_ring_ptr = (avail_base as *mut u16).add(2); // skip flags+idx
+    let ring_slot = (dev.avail_idx % qsz) as isize;
+    ptr::write_volatile(avail_ring_ptr.offset(ring_slot), d0);
+    // Ensure the ring write is visible before the index bump.
+    fence(Ordering::Release);
+    dev.avail_idx = dev.avail_idx.wrapping_add(1);
+    ptr::write_volatile((avail_base as *mut u16).add(1), dev.avail_idx);
+    fence(Ordering::Release);
+
+    // Kick the device. Value written is the queue index (we're on queue 0).
+    write16(dev.io_base, REG_QUEUE_NOTIFY, 0);
+
+    // Poll the used-ring index until it catches up to our submission.
+    let used_base = dev.queue_base.add(dev.layout.used_off);
+    let expected = dev.avail_idx;
+    for _ in 0..POLL_BUDGET {
+        fence(Ordering::Acquire);
+        let used_idx = ptr::read_volatile((used_base as *const u16).add(1));
+        if used_idx == expected {
+            dev.last_used_idx = used_idx;
+            // Status byte: 0 = OK, 1 = IOERR, 2 = UNSUPP.
+            let status =
+                ptr::read_volatile((paging::hhdm_offset().as_u64() + status_pa) as *const u8);
+            return if status == 0 {
+                Ok(())
+            } else {
+                Err(BlkError::DeviceError)
+            };
+        }
+        core::hint::spin_loop();
+    }
+    Err(BlkError::Timeout)
+}
+
+#[cfg(target_os = "none")]
+unsafe fn read8(base: u16, reg: u16) -> u8 {
+    let mut p: Port<u8> = Port::new(base + reg);
+    p.read()
+}
+#[cfg(target_os = "none")]
+unsafe fn read16(base: u16, reg: u16) -> u16 {
+    let mut p: Port<u16> = Port::new(base + reg);
+    p.read()
+}
+#[cfg(target_os = "none")]
+unsafe fn read32(base: u16, reg: u16) -> u32 {
+    let mut p: Port<u32> = Port::new(base + reg);
+    p.read()
+}
+#[cfg(target_os = "none")]
+unsafe fn write8(base: u16, reg: u16, v: u8) {
+    let mut p: Port<u8> = Port::new(base + reg);
+    p.write(v);
+}
+#[cfg(target_os = "none")]
+unsafe fn write16(base: u16, reg: u16, v: u16) {
+    let mut p: Port<u16> = Port::new(base + reg);
+    p.write(v);
+}
+#[cfg(target_os = "none")]
+unsafe fn write32(base: u16, reg: u16, v: u32) {
+    let mut p: Port<u32> = Port::new(base + reg);
+    p.write(v);
+}
+
+#[cfg(all(test, not(target_os = "none")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn queue_layout_small_fits_one_page() {
+        let l = queue_layout(64);
+        assert_eq!(l.desc_off, 0);
+        assert_eq!(l.avail_off, 16 * 64);
+        // avail = 6 + 2*64 = 134 bytes; ends at 1024 + 134 = 1158 → next
+        // 4 KiB boundary is 4096.
+        assert_eq!(l.used_off, 4096);
+        // used = 8 + 8*64 = 520 bytes.
+        assert_eq!(l.total, 4096 + 520);
+    }
+
+    #[test]
+    fn queue_layout_256_spans_two_pages() {
+        let l = queue_layout(256);
+        assert_eq!(l.avail_off, 16 * 256);
+        // 16*256 = 4096; avail = 6 + 512 = 518; avail_end = 4614 → 8192.
+        assert_eq!(l.used_off, 8192);
+        // used = 8 + 8*256 = 2056.
+        assert_eq!(l.total, 8192 + 2056);
+    }
+
+    #[test]
+    fn layout_sizes_match_spec() {
+        assert_eq!(size_of_desc(), 16);
+        assert_eq!(size_of_header(), 16);
+    }
+
+    const fn size_of_desc() -> usize {
+        core::mem::size_of::<VirtqDesc>()
+    }
+    const fn size_of_header() -> usize {
+        core::mem::size_of::<VirtioBlkReqHeader>()
+    }
+
+    #[test]
+    fn header_field_offsets() {
+        let h = VirtioBlkReqHeader {
+            ty: 0,
+            reserved: 0,
+            sector: 0,
+        };
+        let base = &h as *const _ as usize;
+        assert_eq!(&h.ty as *const _ as usize - base, 0);
+        assert_eq!(&h.reserved as *const _ as usize - base, 4);
+        assert_eq!(&h.sector as *const _ as usize - base, 8);
+    }
+
+    #[test]
+    fn negotiate_accepts_nothing() {
+        assert_eq!(negotiate(0xFFFF_FFFF_FFFF_FFFF), 0);
+        assert_eq!(negotiate(0), 0);
+    }
+
+    #[test]
+    fn probe_matches_only_legacy() {
+        let legacy = pci::Device::from_raw(
+            pci::Address::new(0, 1, 0),
+            (DEVICE_ID_LEGACY as u32) << 16 | VIRTIO_VENDOR as u32,
+            0x0100_0000, // class=01, subclass=00
+            0,
+            [0xC001, 0, 0, 0, 0, 0],
+        );
+        assert!(is_virtio_blk_legacy(&legacy));
+
+        let modern = pci::Device::from_raw(
+            pci::Address::new(0, 1, 0),
+            (DEVICE_ID_MODERN as u32) << 16 | VIRTIO_VENDOR as u32,
+            0x0100_0000,
+            0,
+            [0; 6],
+        );
+        assert!(!is_virtio_blk_legacy(&modern));
+
+        let other = pci::Device::from_raw(
+            pci::Address::new(0, 0, 0),
+            0x1237_8086,
+            0x0600_0000,
+            0,
+            [0; 6],
+        );
+        assert!(!is_virtio_blk_legacy(&other));
+    }
+}

--- a/kernel/src/block/virtio_blk.rs
+++ b/kernel/src/block/virtio_blk.rs
@@ -86,8 +86,6 @@ const STATUS_DRIVER: u8 = 2;
 #[cfg(target_os = "none")]
 const STATUS_DRIVER_OK: u8 = 4;
 #[cfg(target_os = "none")]
-const STATUS_FEATURES_OK: u8 = 8;
-#[cfg(target_os = "none")]
 const STATUS_FAILED: u8 = 128;
 
 /// `type` values in the block request header.
@@ -170,10 +168,12 @@ pub struct QueueLayout {
 pub const fn queue_layout(size: u16) -> QueueLayout {
     let sz = size as usize;
     let desc_bytes = 16 * sz;
+    // avail: flags(u16) + idx(u16) + ring(u16 * size) + used_event(u16)
     let avail_bytes = 6 + 2 * sz;
     let avail_end = desc_bytes + avail_bytes;
     let used_off = (avail_end + 4095) & !4095;
-    let used_bytes = 8 + 8 * sz;
+    // used: flags(u16) + idx(u16) + ring(u32+u32 * size) + avail_event(u16)
+    let used_bytes = 6 + 8 * sz;
     QueueLayout {
         desc_off: 0,
         avail_off: desc_bytes,
@@ -269,7 +269,6 @@ enum BringUpError {
     QueueTooSmall(u16),
     QueueTooLarge(u16),
     QueueNotContiguous,
-    FeaturesNotOk,
 }
 
 #[cfg(target_os = "none")]
@@ -289,19 +288,13 @@ fn bring_up(dev: &pci::Device, io_base: u16) -> Result<BlkDevice, BringUpError> 
             REG_DEVICE_STATUS,
             STATUS_ACKNOWLEDGE | STATUS_DRIVER,
         );
-        // Feature negotiation: accept nothing (step 1).
+        // Feature negotiation: accept nothing (step 1). Legacy virtio
+        // (0.9.5) has no FEATURES_OK bit — that's a v1.0 addition. We
+        // write GUEST_FEATURES and move on; the transitional device
+        // accepts an empty feature set unconditionally.
         let host = read32(io_base, REG_HOST_FEATURES) as u64;
         let guest = negotiate(host);
         write32(io_base, REG_GUEST_FEATURES, guest as u32);
-        write8(
-            io_base,
-            REG_DEVICE_STATUS,
-            STATUS_ACKNOWLEDGE | STATUS_DRIVER | STATUS_FEATURES_OK,
-        );
-        if read8(io_base, REG_DEVICE_STATUS) & STATUS_FEATURES_OK == 0 {
-            write8(io_base, REG_DEVICE_STATUS, STATUS_FAILED);
-            return Err(BringUpError::FeaturesNotOk);
-        }
 
         // Select queue 0 ("requestq").
         write16(io_base, REG_QUEUE_SELECT, 0);
@@ -347,7 +340,7 @@ fn bring_up(dev: &pci::Device, io_base: u16) -> Result<BlkDevice, BringUpError> 
         write8(
             io_base,
             REG_DEVICE_STATUS,
-            STATUS_ACKNOWLEDGE | STATUS_DRIVER | STATUS_FEATURES_OK | STATUS_DRIVER_OK,
+            STATUS_ACKNOWLEDGE | STATUS_DRIVER | STATUS_DRIVER_OK,
         );
 
         Ok(BlkDevice {
@@ -540,11 +533,6 @@ unsafe fn submit_and_wait(
 }
 
 #[cfg(target_os = "none")]
-unsafe fn read8(base: u16, reg: u16) -> u8 {
-    let mut p: Port<u8> = Port::new(base + reg);
-    p.read()
-}
-#[cfg(target_os = "none")]
 unsafe fn read16(base: u16, reg: u16) -> u16 {
     let mut p: Port<u16> = Port::new(base + reg);
     p.read()
@@ -582,8 +570,8 @@ mod tests {
         // avail = 6 + 2*64 = 134 bytes; ends at 1024 + 134 = 1158 → next
         // 4 KiB boundary is 4096.
         assert_eq!(l.used_off, 4096);
-        // used = 8 + 8*64 = 520 bytes.
-        assert_eq!(l.total, 4096 + 520);
+        // used = 6 + 8*64 = 518 bytes.
+        assert_eq!(l.total, 4096 + 518);
     }
 
     #[test]
@@ -592,8 +580,8 @@ mod tests {
         assert_eq!(l.avail_off, 16 * 256);
         // 16*256 = 4096; avail = 6 + 512 = 518; avail_end = 4614 → 8192.
         assert_eq!(l.used_off, 8192);
-        // used = 8 + 8*256 = 2056.
-        assert_eq!(l.total, 8192 + 2056);
+        // used = 6 + 8*256 = 2054.
+        assert_eq!(l.total, 8192 + 2054);
     }
 
     #[test]

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -11,6 +11,8 @@
 
 extern crate alloc;
 
+#[cfg(any(test, target_os = "none"))]
+pub mod block;
 pub mod cpu;
 pub mod input;
 pub mod klog;

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -70,6 +70,14 @@ pub extern "C" fn _start() -> ! {
     }
     vibix::time::init();
     vibix::pci::scan();
+    vibix::block::init();
+    if vibix::block::ready() {
+        let mut sector = [0u8; vibix::block::SECTOR_SIZE];
+        match vibix::block::read(0, &mut sector) {
+            Ok(()) => serial_println!("block: lba0[0..16]={:02x?}", &sector[..16]),
+            Err(e) => serial_println!("block: lba0 read failed: {:?}", e),
+        }
+    }
 
     // Console init must come after mem::init() — the character grid and
     // scrollback buffer are heap-allocated inside Console::new().

--- a/kernel/src/pci.rs
+++ b/kernel/src/pci.rs
@@ -256,6 +256,35 @@ mod target {
         value
     }
 
+    /// Write a 32-bit word to the PCI config space at `addr + offset`.
+    /// Same locking contract as [`config_read32`].
+    ///
+    /// # Safety
+    /// Issues raw OUT to 0xCF8/0xCFC. Caller is responsible for the
+    /// semantic validity of writes (e.g. enabling bus mastering).
+    pub unsafe fn config_write32(addr: Address, offset: u8, value: u32) {
+        x86_64::instructions::interrupts::without_interrupts(|| {
+            let _guard = CFG_LOCK.lock();
+            let mut a: Port<u32> = Port::new(CONFIG_ADDRESS);
+            let mut d: Port<u32> = Port::new(CONFIG_DATA);
+            a.write(addr.config_dword(offset));
+            d.write(value);
+        });
+    }
+
+    /// Set the `Bus Master` bit (bit 2) in the device's Command register
+    /// (config offset 0x04). Required before the device is allowed to
+    /// DMA driver-managed memory.
+    pub fn enable_bus_master(addr: Address) {
+        // SAFETY: the Command/Status dword at 0x04 is a well-known
+        // config-space slot; we only OR in bit 2 without clobbering the
+        // status half.
+        unsafe {
+            let dw = config_read32(addr, 0x04);
+            config_write32(addr, 0x04, dw | 0x0000_0004);
+        }
+    }
+
     fn read_device(addr: Address) -> Option<Device> {
         // SAFETY: see config_read32 — the fixed hardware interface.
         let dw0 = unsafe { config_read32(addr, 0x00) };
@@ -329,7 +358,7 @@ mod target {
 }
 
 #[cfg(target_os = "none")]
-pub use target::{config_read32, scan};
+pub use target::{config_read32, config_write32, enable_bus_master, scan};
 
 // -- host unit tests ----------------------------------------------------
 

--- a/kernel/src/pci.rs
+++ b/kernel/src/pci.rs
@@ -276,12 +276,14 @@ mod target {
     /// (config offset 0x04). Required before the device is allowed to
     /// DMA driver-managed memory.
     pub fn enable_bus_master(addr: Address) {
-        // SAFETY: the Command/Status dword at 0x04 is a well-known
-        // config-space slot; we only OR in bit 2 without clobbering the
-        // status half.
+        // The high 16 bits of this dword are the Status register, which
+        // is write-1-to-clear: writing back any bit currently set would
+        // ack-and-clear it. Mask to just the Command half (low 16) before
+        // ORing in bit 2.
         unsafe {
             let dw = config_read32(addr, 0x04);
-            config_write32(addr, 0x04, dw | 0x0000_0004);
+            let command = (dw & 0x0000_FFFF) | 0x0000_0004;
+            config_write32(addr, 0x04, command);
         }
     }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -64,6 +64,8 @@ const SMOKE_MARKERS: &[&str] = &[
     "hpet: periodic timer armed",
     "timer: 100 Hz",
     "rtc:",
+    "block: virtio-blk ready",
+    "block: lba0[0..16]=[56, 49, 42, 49, 58, 42, 4c, 4b, 30",
     "vibix online.",
     "interrupts enabled",
     "tasks: scheduler online",
@@ -140,6 +142,49 @@ fn workspace_root() -> PathBuf {
         .parent()
         .unwrap()
         .to_path_buf()
+}
+
+/// Magic bytes at LBA 0 of the test disk. The kernel's smoke-path
+/// readback logs the first 16 bytes, which `SMOKE_MARKERS` assert on.
+const TEST_DISK_MAGIC: &[u8] = b"VIBIXBLK0";
+/// 1 MiB scratch disk — enough for any step-1 smoke test; the file is
+/// regenerated if absent or the wrong size so it's safe to `rm -rf`.
+const TEST_DISK_SIZE: u64 = 1024 * 1024;
+
+fn test_disk_path() -> PathBuf {
+    workspace_root().join("target").join("test-disk.img")
+}
+
+/// Create or refresh the test disk image. Idempotent: if the file is
+/// already present and the right size, we leave it alone.
+fn ensure_test_disk() -> R<PathBuf> {
+    let path = test_disk_path();
+    let needs_write = match fs::metadata(&path) {
+        Ok(m) => m.len() != TEST_DISK_SIZE,
+        Err(_) => true,
+    };
+    if needs_write {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let mut data = vec![0u8; TEST_DISK_SIZE as usize];
+        data[..TEST_DISK_MAGIC.len()].copy_from_slice(TEST_DISK_MAGIC);
+        fs::write(&path, &data)?;
+    }
+    Ok(path)
+}
+
+/// QEMU args attaching the generated test disk as legacy virtio-blk.
+/// `disable-modern=on,disable-legacy=off` pins the transport so the
+/// step-1 legacy-only driver actually matches the device.
+fn virtio_blk_args(disk: &Path) -> Vec<String> {
+    let drive = format!("file={},if=none,id=vd0,format=raw", disk.display());
+    vec![
+        "-drive".to_string(),
+        drive,
+        "-device".to_string(),
+        "virtio-blk-pci,drive=vd0,disable-modern=on,disable-legacy=off".to_string(),
+    ]
 }
 
 fn userspace_hello_binary() -> PathBuf {
@@ -425,6 +470,7 @@ fn iso(opts: &BuildOpts) -> R<PathBuf> {
 
 fn run(opts: &BuildOpts) -> R<()> {
     let iso = iso(opts)?;
+    let disk = ensure_test_disk()?;
     let status = Command::new("qemu-system-x86_64")
         .args([
             "-M",
@@ -438,6 +484,7 @@ fn run(opts: &BuildOpts) -> R<()> {
             "-device",
             "isa-debug-exit,iobase=0xf4,iosize=0x04",
         ])
+        .args(virtio_blk_args(&disk))
         .arg("-cdrom")
         .arg(&iso)
         .status()?;
@@ -467,6 +514,7 @@ fn test_runner(kernel: &Path) -> R<()> {
     eprintln!("▶ {}", name);
     // Note: no `-no-shutdown` here — it would prevent `isa-debug-exit`
     // from actually terminating QEMU, defeating the exit-code protocol.
+    let disk = ensure_test_disk()?;
     let mut child = Command::new("qemu-system-x86_64")
         .args([
             "-M",
@@ -481,6 +529,7 @@ fn test_runner(kernel: &Path) -> R<()> {
             "-device",
             "isa-debug-exit,iobase=0xf4,iosize=0x04",
         ])
+        .args(virtio_blk_args(&disk))
         .arg("-cdrom")
         .arg(&iso)
         .stdout(Stdio::inherit())
@@ -556,6 +605,7 @@ fn test_all() -> R<()> {
 
 fn smoke(opts: &BuildOpts) -> R<()> {
     let iso = iso(opts)?;
+    let disk = ensure_test_disk()?;
 
     // We run QEMU with serial to stdio, capture output, then kill after
     // a short delay — the kernel halts in hlt_loop forever.
@@ -574,6 +624,7 @@ fn smoke(opts: &BuildOpts) -> R<()> {
             "-device",
             "isa-debug-exit,iobase=0xf4,iosize=0x04",
         ])
+        .args(virtio_blk_args(&disk))
         .arg("-cdrom")
         .arg(&iso)
         .stdout(Stdio::piped())

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -159,9 +159,22 @@ fn test_disk_path() -> PathBuf {
 /// already present and the right size, we leave it alone.
 fn ensure_test_disk() -> R<PathBuf> {
     let path = test_disk_path();
+    // Rebuild if absent, wrong size, or the magic prefix doesn't match.
+    // Size alone isn't a strong enough check — an old disk image of the
+    // right length but stale contents would silently fail the smoke
+    // marker assertion, which is noisier to diagnose than a fresh write.
     let needs_write = match fs::metadata(&path) {
-        Ok(m) => m.len() != TEST_DISK_SIZE,
-        Err(_) => true,
+        Ok(m) if m.len() == TEST_DISK_SIZE => {
+            let mut head = vec![0u8; TEST_DISK_MAGIC.len()];
+            match fs::File::open(&path).and_then(|mut f| {
+                use std::io::Read as _;
+                f.read_exact(&mut head)
+            }) {
+                Ok(()) => head != TEST_DISK_MAGIC,
+                Err(_) => true,
+            }
+        }
+        _ => true,
     };
     if needs_write {
         if let Some(parent) = path.parent() {


### PR DESCRIPTION
Closes #43 (step 1 only — step 2 ramdisk + VFS is a follow-up).

## Summary

- **`kernel/src/block/`** — new module with a `block::read(lba, buf)` facade, backed by `virtio_blk::` which probes PCI for the transitional virtio block device (vendor `0x1AF4`, device `0x1001`), negotiates zero features, allocates a 4 KiB-aligned virtqueue on the heap, and submits `VIRTIO_BLK_T_IN` requests via polled avail/used rings. Modern (`0x1042`) IDs are logged and skipped.
- **`kernel/src/pci.rs`** — added `config_write32` + `enable_bus_master`; the driver needs bit 2 of the Command register set before the device is allowed to DMA our queue.
- **`kernel/src/main.rs`** — calls `block::init()` after `pci::scan()` and logs the first 16 bytes of LBA 0 on success.
- **`xtask/src/main.rs`** — regenerates `target/test-disk.img` (1 MiB, `VIBIXBLK0` magic at offset 0) on demand and attaches it to `run`, `smoke`, and `test-runner` via `virtio-blk-pci,disable-modern=on,disable-legacy=off`. Two new smoke markers: `"block: virtio-blk ready"` and the `[56, 49, 42, 49, 58, 42, 4c, 4b, 30` hex prefix of `VIBIXBLK0`.

## Scope (deliberately narrow)

- Legacy PCI transport only.
- Polling — no interrupt handler; bounded spin on `used.idx` with a `Timeout` fallback.
- Read-only (`VIRTIO_BLK_T_IN`). No caching, no writes, no multi-queue.

Step 2 (`block::read` → a tiny VFS → `cat /hello.txt` in the shell) is the natural follow-up; filed as a separate issue if not landed by the next cycle.

## Test plan

- [x] `cargo xtask build` clean (only pre-existing `task.rs` dead-code warnings remain).
- [x] `cargo xtask test` — all host unit tests (54 passing, 6 new in `virtio_blk::tests`) + QEMU integration suite green.
- [x] `cargo xtask smoke` — all 24 markers present, including the two new `block:` lines and the `VIBIXBLK0` hex prefix.
- [x] `cargo fmt --all -- --check`.
- [x] `cargo clippy -p xtask --all-targets -- -D warnings`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a new polled virtio-blk driver that performs PCI config writes and device DMA, plus new boot-time I/O; mistakes here can hang boot or corrupt memory on real hardware/emulators.
> 
> **Overview**
> Introduces a new `block` module with a minimal **read-only** API (`init`, `ready`, `read`) backed by a legacy PCI `virtio-blk` driver that probes PCI, sets up a single virtqueue, and performs synchronous polled reads with bounded timeout handling.
> 
> Extends PCI support with `config_write32` and `enable_bus_master` to allow devices to DMA driver-managed memory.
> 
> Updates the kernel boot path to initialize the block layer after PCI scan and log a small LBA0 read, and updates `xtask` to provision and attach a deterministic test disk to QEMU runs/tests while asserting new smoke markers for block bring-up and readback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdf9764ab9a14df7fb321925c60fd186309a8e8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->