### PR TITLE
task: exit path with stack, VMA, and PML4 reclaim

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -127,3 +127,7 @@ harness = false
 [[test]]
 name = "cow_vma"
 harness = false
+
+[[test]]
+name = "task_exit"
+harness = false

--- a/kernel/src/mem/paging.rs
+++ b/kernel/src/mem/paging.rs
@@ -375,6 +375,53 @@ pub fn cow_copy_and_remap(
     Ok(new_frame)
 }
 
+/// Unmap `page` from `pml4_frame` and return its backing frame. Unlike
+/// [`unmap`], scopes to a specific PML4 — the reaper path in
+/// `task::exit` uses this to clean up a dead task's private mappings
+/// while running on a different (live) PML4.
+pub fn unmap_in_pml4(
+    pml4_frame: PhysFrame<Size4KiB>,
+    page: Page<Size4KiB>,
+) -> Result<PhysFrame<Size4KiB>, UnmapError> {
+    let hhdm = HHDM_OFFSET
+        .lock()
+        .expect("paging::init must run before unmap_in_pml4");
+    let l4 = unsafe { pml4_as_mut(pml4_frame, hhdm) };
+    let mut mapper = unsafe { OffsetPageTable::new(l4, hhdm) };
+    let (frame, flush) = mapper.unmap(page)?;
+    if Cr3::read().0 == pml4_frame {
+        flush.flush();
+    } else {
+        flush.ignore();
+    }
+    Ok(frame)
+}
+
+/// Unmap `page` from `pml4_frame` and return its backing frame to the
+/// global allocator. Mirrors [`unmap_and_free`] for the
+/// arbitrary-PML4 case.
+pub fn unmap_and_free_in_pml4(
+    pml4_frame: PhysFrame<Size4KiB>,
+    page: Page<Size4KiB>,
+) -> Result<(), UnmapError> {
+    let frame = unmap_in_pml4(pml4_frame, page)?;
+    // SAFETY: caller asserts the frame came from the global allocator.
+    unsafe { KernelFrameAllocator.deallocate_frame(frame) };
+    Ok(())
+}
+
+/// Return `pml4_frame` to the global frame allocator.
+///
+/// # Safety
+/// The caller must guarantee that no CPU is using `pml4_frame` as its
+/// active page table and that no outstanding reference (PTE alias,
+/// OffsetPageTable, cached `&mut PageTable`) still exists. Kernel
+/// upper-half entries reference shared L3 tables owned by the kernel
+/// PML4 — freeing this L4 frame does not affect them.
+pub unsafe fn free_pml4_frame(pml4_frame: PhysFrame<Size4KiB>) {
+    KernelFrameAllocator.deallocate_frame(pml4_frame);
+}
+
 /// HHDM offset currently in use. Panics if [`init`] hasn't run.
 /// Exposed for tests that need to poke raw frame contents via the
 /// high half.

--- a/kernel/src/mem/paging.rs
+++ b/kernel/src/mem/paging.rs
@@ -389,11 +389,15 @@ pub fn unmap_in_pml4(
     let l4 = unsafe { pml4_as_mut(pml4_frame, hhdm) };
     let mut mapper = unsafe { OffsetPageTable::new(l4, hhdm) };
     let (frame, flush) = mapper.unmap(page)?;
-    if Cr3::read().0 == pml4_frame {
-        flush.flush();
-    } else {
-        flush.ignore();
-    }
+    // Always flush this CPU's TLB for `page`. `Cr3::read().0 ==
+    // pml4_frame` isn't sufficient: upper-half L3 subtrees are aliased
+    // into every PML4 (shared kernel window), so an unmap performed
+    // through the victim PML4 invalidates entries that the active CR3's
+    // TLB may have cached. Leaving them behind lets freed frames be
+    // reallocated while stale translations still point at them.
+    // `invlpg` is a single-CPU op; multi-CPU shootdown is a follow-up
+    // once we have >1 AP online.
+    flush.flush();
     Ok(frame)
 }
 

--- a/kernel/src/mem/vma.rs
+++ b/kernel/src/mem/vma.rs
@@ -95,6 +95,11 @@ impl VmaList {
         Some(self.entries.swap_remove(idx))
     }
 
+    /// Iterate all entries in insertion order.
+    pub fn iter(&self) -> impl Iterator<Item = &Vma> {
+        self.entries.iter()
+    }
+
     /// Duplicate this list for a child address space. Metadata is
     /// cloned verbatim — including any `Cow { frame }` kinds, which
     /// means the child shares the source frames with the parent until

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -501,16 +501,23 @@ fn reap_pending(victim: alloc::boxed::Box<Task>) {
     use x86_64::structures::paging::{FrameDeallocator, Page, Size4KiB};
     use x86_64::VirtAddr;
 
-    // 1. Unmap + free stack pages. These live in the shared upper-half
-    //    kernel window (L4 entry 416), so a single unmap via the
-    //    active PML4 propagates through aliasing to every PML4.
+    // 1. Unmap + free stack pages. Stack pages live in the shared
+    //    upper-half kernel window (L4 entry 416) — the L3 subtree under
+    //    that entry is aliased into every per-task PML4, so unmapping
+    //    via the victim's PML4 propagates to every PML4.
+    //
+    //    We deliberately route through `unmap_in_pml4` (temporary
+    //    mapper) rather than `unmap_and_free` (global `MAPPER` lock):
+    //    `reap_pending` runs inside `preempt_tick`, a timer ISR. If the
+    //    interrupted task held `MAPPER`, spinning on it here would
+    //    deadlock with IRQs masked.
     let stack_base = victim.stack_base();
     if stack_base != 0 {
         for i in 0..victim.stack_page_count() {
             let va = stack_base + i * 4096;
             let page = Page::<Size4KiB>::from_start_address(VirtAddr::new(va as u64))
                 .expect("stack page VA aligned by construction");
-            let _ = paging::unmap_and_free(page);
+            let _ = paging::unmap_and_free_in_pml4(victim.cr3, page);
         }
     }
 

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -440,18 +440,12 @@ pub fn current_vma_lookup(
 /// # Panics
 /// - No other ready task exists (exiting the last runnable task would
 ///   halt the kernel).
-/// - A prior `task::exit` has not yet been reaped. At most one task
-///   may be awaiting reap at a time; with reaping on every tick this
-///   only trips if the scheduler lock is so contended that no tick
-///   ever reaps — i.e. never, in practice.
+/// - The bootstrap task calls `exit` — it owns the kernel PML4 and the
+///   inherited boot stack, neither of which the reaper may reclaim.
 pub fn exit() -> ! {
     interrupts::disable();
     let (prev_rsp_ptr, next_rsp, next_cr3) = {
         let mut sched = SCHED.lock();
-        assert!(
-            sched.pending_exit.is_none(),
-            "task::exit: prior exit not yet reaped"
-        );
         // Exiting the bootstrap task would reap the kernel PML4 and
         // the inherited boot stack — neither of which we own. Reject
         // it up-front rather than relying on per-field guards deeper
@@ -474,12 +468,14 @@ pub fn exit() -> ! {
         let next_cr3 = next.cr3.start_address().as_u64();
         sched.current = Some(next);
         sched.current.as_mut().unwrap().slice_remaining_ms = DEFAULT_SLICE_MS;
-        sched.pending_exit = Some(prev);
-        let prev_ref = sched.pending_exit.as_mut().unwrap();
-        // SAFETY: prev_ref is a stable Box<Task> in pending_exit; the
-        // heap-allocated Task it points at does not move while the
-        // Box lives, and context_switch only writes to this location
-        // once (we never read it back — the task is doomed).
+        // Enqueue the doomed task; the next `preempt_tick` drains the
+        // whole queue. Back-to-back exits between ticks just append.
+        sched.pending_exit.push_back(prev);
+        let prev_ref = sched.pending_exit.back_mut().unwrap();
+        // SAFETY: `prev_ref` is a stable `Box<Task>` in the queue tail.
+        // We never push in front of it (push_back only) and never
+        // reap it until a later tick, so the heap location remains
+        // valid for this context_switch's single write.
         let prev_rsp_ptr: *mut usize = &mut prev_ref.rsp as *mut usize;
         (prev_rsp_ptr, next_rsp, next_cr3)
     };
@@ -589,10 +585,11 @@ pub fn preempt_tick() {
         return;
     };
 
-    // Reap a task that called `task::exit` on a prior tick, before
+    // Reap any task that called `task::exit` on a prior tick, before
     // touching the ready bank — keeps this tick's rotation consistent
-    // and bounds pending_exit to at most one tick of latency.
-    if let Some(victim) = sched.pending_exit.take() {
+    // and bounds reap latency to one tick per exit. Multiple exits
+    // between ticks drain here in FIFO order.
+    while let Some(victim) = sched.pending_exit.pop_front() {
         drop(sched);
         reap_pending(victim);
         let Some(s) = SCHED.try_lock() else {

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -424,6 +424,135 @@ pub fn current_vma_lookup(
     Some((vma.kind, vma.flags))
 }
 
+/// Terminate the currently-running task. Reclaims the task's mapped
+/// stack pages, VMA-backed frames, and PML4 frame on the next
+/// scheduler tick, then drops the `Box<Task>`.
+///
+/// The actual reclaim runs from [`preempt_tick`] rather than here
+/// because it unmaps the very stack we're executing on — we have to
+/// context-switch away first. The exiting task is parked in
+/// `Scheduler::pending_exit` for the next tick to reap.
+///
+/// The stack VA slot (`NEXT_STACK_VA`'s bump-allocated range) is *not*
+/// reclaimed — that would require a free-list on `NEXT_STACK_VA`
+/// which is out of scope for this pass. The VA is logged as leaked.
+///
+/// # Panics
+/// - No other ready task exists (exiting the last runnable task would
+///   halt the kernel).
+/// - A prior `task::exit` has not yet been reaped. At most one task
+///   may be awaiting reap at a time; with reaping on every tick this
+///   only trips if the scheduler lock is so contended that no tick
+///   ever reaps — i.e. never, in practice.
+pub fn exit() -> ! {
+    interrupts::disable();
+    let (prev_rsp_ptr, next_rsp, next_cr3) = {
+        let mut sched = SCHED.lock();
+        assert!(
+            sched.pending_exit.is_none(),
+            "task::exit: prior exit not yet reaped"
+        );
+        let Some(mut next) = sched.pop_highest() else {
+            panic!("task::exit: no ready task to switch to");
+        };
+        let prev = sched
+            .current
+            .take()
+            .expect("task::exit before task::init");
+        next.state = TaskState::Running;
+        let next_rsp = next.rsp;
+        let next_cr3 = next.cr3.start_address().as_u64();
+        sched.current = Some(next);
+        sched.current.as_mut().unwrap().slice_remaining_ms = DEFAULT_SLICE_MS;
+        sched.pending_exit = Some(prev);
+        let prev_ref = sched.pending_exit.as_mut().unwrap();
+        // SAFETY: prev_ref is a stable Box<Task> in pending_exit; the
+        // heap-allocated Task it points at does not move while the
+        // Box lives, and context_switch only writes to this location
+        // once (we never read it back — the task is doomed).
+        let prev_rsp_ptr: *mut usize = &mut prev_ref.rsp as *mut usize;
+        (prev_rsp_ptr, next_rsp, next_cr3)
+    };
+    // SAFETY: IRQs are masked, SCHED is dropped, prev_rsp_ptr targets
+    // a stable heap location, next_cr3 is a valid per-task PML4.
+    unsafe {
+        context_switch(prev_rsp_ptr, next_rsp, next_cr3);
+    }
+    unreachable!("task::exit returned from context_switch");
+}
+
+/// Reclaim the stack pages, VMA-backed frames, and PML4 frame of a
+/// task that called [`exit`]. Called from [`preempt_tick`] on a stack
+/// that is *not* the victim's — the victim already context-switched
+/// away, so unmapping its stack is safe.
+fn reap_pending(victim: alloc::boxed::Box<Task>) {
+    use crate::mem::paging;
+    use crate::mem::vma::VmaKind;
+    use x86_64::structures::paging::{FrameDeallocator, Page, Size4KiB};
+    use x86_64::VirtAddr;
+
+    // 1. Unmap + free stack pages. These live in the shared upper-half
+    //    kernel window (L4 entry 416), so a single unmap via the
+    //    active PML4 propagates through aliasing to every PML4.
+    let stack_base = victim.stack_base();
+    if stack_base != 0 {
+        for i in 0..victim.stack_page_count() {
+            let va = stack_base + i * 4096;
+            let page = Page::<Size4KiB>::from_start_address(VirtAddr::new(va as u64))
+                .expect("stack page VA aligned by construction");
+            let _ = paging::unmap_and_free(page);
+        }
+    }
+
+    // 2. Walk VMAs. For each VA in each VMA, unmap from the victim's
+    //    private PML4. AnonZero: free the frame. Cow: free only when
+    //    the backing frame is not the shared source (the private
+    //    post-write copy).
+    for vma in victim.vmas.iter() {
+        let mut va = vma.start;
+        while va < vma.end {
+            let page = Page::<Size4KiB>::from_start_address(VirtAddr::new(va as u64))
+                .expect("vma page VA aligned by construction");
+            match vma.kind {
+                VmaKind::AnonZero => {
+                    let _ = paging::unmap_and_free_in_pml4(victim.cr3, page);
+                }
+                VmaKind::Cow { frame: source } => {
+                    if let Ok(frame) = paging::unmap_in_pml4(victim.cr3, page) {
+                        if frame != source {
+                            // SAFETY: private copy allocated from the
+                            // global allocator by the #PF resolver.
+                            unsafe {
+                                paging::KernelFrameAllocator.deallocate_frame(frame);
+                            }
+                        }
+                    }
+                }
+            }
+            va += 4096;
+        }
+    }
+
+    // 3. Return the PML4 frame itself.
+    // SAFETY: victim is no longer on any CPU; we're running on a
+    //         different CR3 and no other reference to its PML4
+    //         survives — the Box<Task> is about to be dropped.
+    unsafe { paging::free_pml4_frame(victim.cr3) };
+
+    // 4. Log the leaked stack VA slot for diagnostics.
+    if stack_base != 0 {
+        serial_println!(
+            "tasks: reaped task {} (stack VA slot {:#x}..{:#x} leaked)",
+            victim.id,
+            victim.guard_base,
+            victim.guard_base + task::TASK_SLOT_SIZE
+        );
+    }
+
+    // 5. Drop the Box<Task>, returning its heap memory.
+    drop(victim);
+}
+
 /// Called from the timer ISR after `notify_eoi`. Decrements the
 /// current task's slice; if it's exhausted and there's another task
 /// ready, rotates and context-switches. Bails on lock contention so
@@ -442,6 +571,18 @@ pub fn preempt_tick() {
     let Some(mut sched) = SCHED.try_lock() else {
         return;
     };
+
+    // Reap a task that called `task::exit` on a prior tick, before
+    // touching the ready bank — keeps this tick's rotation consistent
+    // and bounds pending_exit to at most one tick of latency.
+    if let Some(victim) = sched.pending_exit.take() {
+        drop(sched);
+        reap_pending(victim);
+        let Some(s) = SCHED.try_lock() else {
+            return;
+        };
+        sched = s;
+    }
 
     // No task::init yet (or a non-task integration test) — nothing to
     // preempt. Forces Lazy init, but that's allocation-free.

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -452,6 +452,19 @@ pub fn exit() -> ! {
             sched.pending_exit.is_none(),
             "task::exit: prior exit not yet reaped"
         );
+        // Exiting the bootstrap task would reap the kernel PML4 and
+        // the inherited boot stack — neither of which we own. Reject
+        // it up-front rather than relying on per-field guards deeper
+        // in the reaper.
+        assert!(
+            sched
+                .current
+                .as_ref()
+                .expect("task::exit before task::init")
+                .id
+                != 0,
+            "task::exit: bootstrap task may not exit"
+        );
         let Some(mut next) = sched.pop_highest() else {
             panic!("task::exit: no ready task to switch to");
         };

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -455,10 +455,7 @@ pub fn exit() -> ! {
         let Some(mut next) = sched.pop_highest() else {
             panic!("task::exit: no ready task to switch to");
         };
-        let prev = sched
-            .current
-            .take()
-            .expect("task::exit before task::init");
+        let prev = sched.current.take().expect("task::exit before task::init");
         next.state = TaskState::Running;
         let next_rsp = next.rsp;
         let next_cr3 = next.cr3.start_address().as_u64();

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -445,7 +445,7 @@ pub fn current_vma_lookup(
 ///   inherited boot stack, neither of which the reaper may reclaim.
 pub fn exit() -> ! {
     interrupts::disable();
-    let (prev_rsp_ptr, next_rsp, next_cr3) = {
+    let (prev_rsp_ptr, next_rsp, next_cr3, next_fpu_ptr) = {
         let mut sched = SCHED.lock();
         // Exiting the bootstrap task would reap the kernel PML4 and
         // the inherited boot stack — neither of which we own. Reject
@@ -469,6 +469,7 @@ pub fn exit() -> ! {
         let next_cr3 = next.cr3.start_address().as_u64();
         sched.current = Some(next);
         sched.current.as_mut().unwrap().slice_remaining_ms = DEFAULT_SLICE_MS;
+        let next_fpu_ptr: *const fpu::FpuArea = &*sched.current.as_ref().unwrap().fpu;
         // Enqueue the doomed task; the next `preempt_tick` drains the
         // whole queue. Back-to-back exits between ticks just append.
         sched.pending_exit.push_back(prev);
@@ -478,11 +479,14 @@ pub fn exit() -> ! {
         // reap it until a later tick, so the heap location remains
         // valid for this context_switch's single write.
         let prev_rsp_ptr: *mut usize = &mut prev_ref.rsp as *mut usize;
-        (prev_rsp_ptr, next_rsp, next_cr3)
+        (prev_rsp_ptr, next_rsp, next_cr3, next_fpu_ptr)
     };
     // SAFETY: IRQs are masked, SCHED is dropped, prev_rsp_ptr targets
-    // a stable heap location, next_cr3 is a valid per-task PML4.
+    // a stable heap location, next_cr3 is a valid per-task PML4,
+    // next_fpu_ptr points into a Box<FpuArea> pinned by the scheduler.
+    // We intentionally skip `fpu::save` — the exiting task is doomed.
     unsafe {
+        fpu::restore(&*next_fpu_ptr);
         context_switch(prev_rsp_ptr, next_rsp, next_cr3);
     }
     unreachable!("task::exit returned from context_switch");

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -37,13 +37,13 @@ pub(super) struct Scheduler {
     /// Blocking primitives (see `crate::sync`) move tasks in and out
     /// of here via the task-level API.
     pub parked: BTreeMap<usize, Box<Task>>,
-    /// A task that has called `task::exit` and is awaiting reaping on
-    /// the next scheduler tick. At most one at a time — `task::exit`
-    /// refuses to enter if the slot is occupied. The reaper runs from
+    /// Tasks that have called `task::exit` and are awaiting reaping on
+    /// the next scheduler tick. FIFO: back-to-back exits between ticks
+    /// queue here rather than panicking. The reaper drains this on every
     /// `preempt_tick` (so it executes on a stack that isn't about to be
-    /// unmapped) and drops the `Box<Task>` after reclaiming the stack
+    /// unmapped) and drops each `Box<Task>` after reclaiming the stack
     /// pages, VMA-backed frames, and PML4 frame.
-    pub pending_exit: Option<Box<Task>>,
+    pub pending_exit: VecDeque<Box<Task>>,
 }
 
 impl Scheduler {
@@ -52,7 +52,7 @@ impl Scheduler {
             current: None,
             ready: BTreeMap::new(),
             parked: BTreeMap::new(),
-            pending_exit: None,
+            pending_exit: VecDeque::new(),
         }
     }
 

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -37,6 +37,13 @@ pub(super) struct Scheduler {
     /// Blocking primitives (see `crate::sync`) move tasks in and out
     /// of here via the task-level API.
     pub parked: BTreeMap<usize, Box<Task>>,
+    /// A task that has called `task::exit` and is awaiting reaping on
+    /// the next scheduler tick. At most one at a time — `task::exit`
+    /// refuses to enter if the slot is occupied. The reaper runs from
+    /// `preempt_tick` (so it executes on a stack that isn't about to be
+    /// unmapped) and drops the `Box<Task>` after reclaiming the stack
+    /// pages, VMA-backed frames, and PML4 frame.
+    pub pending_exit: Option<Box<Task>>,
 }
 
 impl Scheduler {
@@ -45,6 +52,7 @@ impl Scheduler {
             current: None,
             ready: BTreeMap::new(),
             parked: BTreeMap::new(),
+            pending_exit: None,
         }
     }
 

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -220,6 +220,21 @@ impl Task {
         }
     }
 
+    /// Base VA of the mapped stack pages (guard page excluded). Zero
+    /// for the bootstrap task, which has no separate stack allocation.
+    pub fn stack_base(&self) -> usize {
+        if self.guard_base == 0 {
+            0
+        } else {
+            self.guard_base + GUARD_SIZE
+        }
+    }
+
+    /// Number of 4 KiB stack pages owned by this task.
+    pub fn stack_page_count(&self) -> usize {
+        STACK_SIZE / 4096
+    }
+
     /// Returns `true` if `addr` falls within this task's guard page.
     ///
     /// Always returns `false` for the bootstrap task (`guard_base == 0`).

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -230,9 +230,15 @@ impl Task {
         }
     }
 
-    /// Number of 4 KiB stack pages owned by this task.
+    /// Number of 4 KiB stack pages owned by this task. Zero for the
+    /// bootstrap task (mirrors `stack_base() == 0`) so cleanup paths
+    /// can loop `0..stack_page_count()` without a separate guard.
     pub fn stack_page_count(&self) -> usize {
-        STACK_SIZE / 4096
+        if self.guard_base == 0 {
+            0
+        } else {
+            STACK_SIZE / 4096
+        }
     }
 
     /// Returns `true` if `addr` falls within this task's guard page.

--- a/kernel/tests/task_exit.rs
+++ b/kernel/tests/task_exit.rs
@@ -1,0 +1,123 @@
+//! Integration test: `task::exit()` removes the running task from the
+//! scheduler and its stack pages, VMA-backed frames, and PML4 frame
+//! are returned to the global allocator. Validated by running many
+//! spawn→exit cycles in a single boot without exhausting free frames.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use vibix::{
+    exit_qemu, serial_println, task,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("exit_removes_task", &(exit_removes_task as fn())),
+        ("exit_loop_no_leak", &(exit_loop_no_leak as fn())),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+static EXIT_REACHED: AtomicUsize = AtomicUsize::new(0);
+
+fn exit_worker() -> ! {
+    EXIT_REACHED.fetch_add(1, Ordering::SeqCst);
+    task::exit();
+}
+
+fn exit_removes_task() {
+    // Baseline: only the bootstrap task is live.
+    let mut baseline = 0usize;
+    task::for_each_task(|_| baseline += 1);
+    assert_eq!(baseline, 1, "unexpected tasks before spawn");
+
+    EXIT_REACHED.store(0, Ordering::SeqCst);
+    task::spawn(exit_worker);
+
+    // Wait for the worker to run and then be reaped. One tick (10 ms)
+    // is enough to reap; give it generous slack.
+    for _ in 0..50 {
+        if EXIT_REACHED.load(Ordering::SeqCst) == 1 {
+            // Extra ticks so pending_exit drains through preempt_tick.
+            for _ in 0..10 {
+                x86_64::instructions::hlt();
+            }
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+
+    assert_eq!(
+        EXIT_REACHED.load(Ordering::SeqCst),
+        1,
+        "worker never reached exit()"
+    );
+
+    let mut after = 0usize;
+    task::for_each_task(|_| after += 1);
+    assert_eq!(
+        after, baseline,
+        "task count didn't return to baseline after exit (leak in scheduler)"
+    );
+}
+
+fn exit_loop_no_leak() {
+    // Spawn-and-exit many times. If the PML4 / stack frames were not
+    // being returned to the global allocator, `new_task_pml4` or the
+    // stack-page map calls would eventually fail — the kernel has a
+    // small pool of usable frames and 64 unreaped PML4s + stacks would
+    // comfortably exhaust it.
+    //
+    // The strong signal here is "kernel still boots tests through this
+    // loop without panicking in the allocator path." A leak panics;
+    // a clean reap survives.
+    const ITERATIONS: usize = 64;
+
+    for i in 0..ITERATIONS {
+        EXIT_REACHED.store(0, Ordering::SeqCst);
+        task::spawn(exit_worker);
+        for _ in 0..50 {
+            if EXIT_REACHED.load(Ordering::SeqCst) == 1 {
+                for _ in 0..4 {
+                    x86_64::instructions::hlt();
+                }
+                break;
+            }
+            x86_64::instructions::hlt();
+        }
+        assert_eq!(
+            EXIT_REACHED.load(Ordering::SeqCst),
+            1,
+            "worker {i} didn't reach exit()"
+        );
+    }
+
+    let mut live = 0usize;
+    task::for_each_task(|_| live += 1);
+    assert_eq!(live, 1, "tasks leaking across exit loop");
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -546,6 +546,7 @@ fn test_all() -> R<()> {
         "pci_enum",
         "serial_rx",
         "cow_vma",
+        "task_exit",
     ] {
         cmd.arg("--test").arg(t);
     }


### PR DESCRIPTION
Closes #132

## Summary
- Add `task::exit() -> !` that parks the current task in a new `Scheduler::pending_exit` slot and context-switches to the next ready task (never returns).
- Reap from the top of `preempt_tick`: unmap + free the victim's stack pages (shared upper-half), walk its `VmaList` to unmap + free per-PML4 private frames (`AnonZero` returns frames to the allocator; `Cow` only frees when the mapped frame differs from the shared source), free the PML4 frame, then drop the `Box<Task>`.
- Stack VA slots from the bump allocator stay leaked — logged per reap. Reclaiming the VA range would need a free-list on `NEXT_STACK_VA` and is out of scope.

## Test plan
- [x] `cargo xtask build` — clean
- [x] `cargo xtask test` — new `task_exit` integration test passes
  - `exit_removes_task`: spawn → exit → task count returns to baseline.
  - `exit_loop_no_leak`: 64 spawn/exit cycles without allocator exhaustion.
- [x] `cargo xtask smoke` — all 22 markers present

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core scheduler and paging teardown logic and frees page-table frames; bugs could leak memory or free mappings still in use (TLB/aliasing), though changes are scoped and covered by a new integration test.
> 
> **Overview**
> Adds `task::exit() -> !` to terminate the current task by immediately context-switching to another runnable task and enqueueing the exiting `Task` for deferred cleanup.
> 
> On the next timer tick, `preempt_tick` now drains `Scheduler::pending_exit` and reaps each victim by unmapping/freeing its stack pages and VMA-backed frames (including special handling for `Cow` source vs private copies), then freeing the task’s PML4 frame.
> 
> Paging gains arbitrary-PML4 unmap helpers (`unmap_in_pml4`, `unmap_and_free_in_pml4`) with unconditional local TLB invalidation, plus `free_pml4_frame`; VMAs add `VmaList::iter()` to support the reaper. A new `task_exit` QEMU integration test validates tasks are removed and repeated spawn/exit cycles don’t exhaust frames, and `xtask test` now includes it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1aa505eb94659b89116ebe3b30aa7e7ef9c47efb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->