### PR TITLE
kernel: ring-0 ELF loader for the userspace_hello module

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -113,6 +113,10 @@ name = "userspace_module"
 harness = false
 
 [[test]]
+name = "userspace_loader"
+harness = false
+
+[[test]]
 name = "sleep"
 harness = false
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -10,6 +10,11 @@ use vibix::{exit_qemu, framebuffer, println, serial_println, QemuExitCode};
 /// How many PIT ticks between cursor blink toggles (~500 ms at 100 Hz).
 const CURSOR_BLINK_TICKS: u64 = 50;
 
+/// Entry point of the loaded userspace module, or 0 if no module was
+/// loaded. Set during bootstrap, read by the trampoline task after
+/// task::init().
+static USERSPACE_ENTRY: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+
 #[no_mangle]
 #[cfg_attr(
     any(feature = "ist-overflow-test", feature = "panic-test"),
@@ -148,9 +153,31 @@ pub extern "C" fn _start() -> ! {
     // see the calibrated clock from their first tick.
     vibix::time::calibrate_tsc();
 
+    // Install the userspace module's PT_LOAD segments into the shared
+    // upper-half of the kernel PML4 *before* task::init — that way
+    // new_task_pml4's upper-half copy propagates the mapping to every
+    // later-spawned task's PML4.
+    if let Some(bytes) = vibix::mem::userspace_module_elf_bytes() {
+        serial_println!("userspace: loader mapping image ({} bytes)", bytes.len());
+        match vibix::mem::loader::load(bytes) {
+            Ok(image) => {
+                serial_println!(
+                    "userspace: loader mapped entry={:#x} segments={}",
+                    image.entry.as_u64(),
+                    image.segments
+                );
+                USERSPACE_ENTRY.store(image.entry.as_u64(), core::sync::atomic::Ordering::Relaxed);
+            }
+            Err(e) => serial_println!("userspace: loader failed: {:?}", e),
+        }
+    }
+
     vibix::task::init();
     vibix::task::spawn(vibix::shell::run);
     vibix::task::spawn(cursor_blink_task);
+    if USERSPACE_ENTRY.load(core::sync::atomic::Ordering::Relaxed) != 0 {
+        vibix::task::spawn(userspace_trampoline);
+    }
 
     #[cfg(feature = "bench")]
     vibix::task::spawn(vibix::bench::run_all);
@@ -161,6 +188,20 @@ pub extern "C" fn _start() -> ! {
     loop {
         x86_64::instructions::hlt();
     }
+}
+
+/// Jump into the previously-loaded userspace ELF entry point. Runs as
+/// a regular scheduler task; the entry is invoked at ring-0 (we don't
+/// have ring-3 yet) using whatever stack the task was handed.
+fn userspace_trampoline() -> ! {
+    let entry = USERSPACE_ENTRY.load(core::sync::atomic::Ordering::Relaxed);
+    serial_println!("userspace: entering payload at {:#x}", entry);
+    // SAFETY: `entry` was produced by the loader from a parsed ELF
+    // `e_entry` and the corresponding page was installed with PRESENT
+    // flags in the shared upper half before task::init(). The payload
+    // is `extern "C" fn() -> !`, matching the type we cast to.
+    let entry_fn: extern "C" fn() -> ! = unsafe { core::mem::transmute(entry as usize) };
+    entry_fn();
 }
 
 /// Blink the framebuffer cursor at approximately 1 Hz (toggle every 500 ms).

--- a/kernel/src/mem/elf.rs
+++ b/kernel/src/mem/elf.rs
@@ -408,4 +408,50 @@ mod tests {
         put64(&mut bytes, 24, 0x0001_0000_0000_0000);
         let _ = parse_elf64(&bytes);
     }
+
+    #[test]
+    fn try_parse_rejects_filesz_exceeds_memsz() {
+        let mut bytes = sample_elf_bytes();
+        let p0 = EHDR_SIZE;
+        put64(&mut bytes, p0 + 32, 0x3000); // p_filesz > p_memsz (0x2000)
+        assert!(try_parse_elf64(&bytes).is_none());
+    }
+
+    #[test]
+    fn try_parse_rejects_file_range_overflow() {
+        let mut bytes = sample_elf_bytes();
+        let p0 = EHDR_SIZE;
+        put64(&mut bytes, p0 + 8, u64::MAX); // p_offset
+        put64(&mut bytes, p0 + 32, 1); // p_filesz (memsz already 0x2000)
+        assert!(try_parse_elf64(&bytes).is_none());
+    }
+
+    #[test]
+    fn try_parse_rejects_file_range_out_of_range() {
+        let mut bytes = sample_elf_bytes();
+        let p0 = EHDR_SIZE;
+        let len = bytes.len() as u64;
+        put64(&mut bytes, p0 + 8, len); // p_offset at end
+        put64(&mut bytes, p0 + 32, 1); // p_filesz=1 pushes past image
+        assert!(try_parse_elf64(&bytes).is_none());
+    }
+
+    #[test]
+    fn try_parse_rejects_vaddr_range_overflow() {
+        let mut bytes = sample_elf_bytes();
+        let p0 = EHDR_SIZE;
+        // Canonical upper-half vaddr close to u64::MAX so p_vaddr+p_memsz wraps.
+        put64(&mut bytes, p0 + 16, 0xFFFF_FFFF_FFFF_F000);
+        put64(&mut bytes, p0 + 40, 0x2000); // p_memsz → overflow
+                                            // Move entry into p1's range so coverage doesn't mask the overflow.
+        put64(&mut bytes, 24, 0x402000);
+        assert!(try_parse_elf64(&bytes).is_none());
+    }
+
+    #[test]
+    fn try_parse_rejects_entry_outside_load_segments() {
+        let mut bytes = sample_elf_bytes();
+        put64(&mut bytes, 24, 0x500000); // entry outside both PT_LOADs
+        assert!(try_parse_elf64(&bytes).is_none());
+    }
 }

--- a/kernel/src/mem/elf.rs
+++ b/kernel/src/mem/elf.rs
@@ -52,15 +52,17 @@ struct Elf64Phdr {
 /// wants it: a virtual range plus the `PageTableFlags` derived from
 /// `p_flags` (`PF_W` → `WRITABLE`, no `PF_X` → `NO_EXECUTE`).
 #[derive(Clone, Copy)]
-pub(super) struct LoadSegment {
+pub(crate) struct LoadSegment {
     pub vaddr: VirtAddr,
     pub memsz: u64,
+    pub filesz: u64,
+    pub file_offset: u64,
     pub flags: PageTableFlags,
 }
 
 /// Parsed ELF64 image metadata for segment walking.
 #[derive(Clone, Copy)]
-pub(super) struct ParsedElf<'a> {
+pub(crate) struct ParsedElf<'a> {
     ehdr: Elf64Ehdr,
     phdr_bytes: &'a [u8],
     phnum: usize,
@@ -93,7 +95,7 @@ impl ElfParseError {
     }
 }
 
-pub(super) struct LoadSegmentIter<'a> {
+pub(crate) struct LoadSegmentIter<'a> {
     phdr_bytes: &'a [u8],
     phnum: usize,
     idx: usize,
@@ -125,6 +127,8 @@ impl<'a> Iterator for LoadSegmentIter<'a> {
             return Some(LoadSegment {
                 vaddr: VirtAddr::new(ph.p_vaddr),
                 memsz: ph.p_memsz,
+                filesz: ph.p_filesz,
+                file_offset: ph.p_offset,
                 flags,
             });
         }
@@ -133,7 +137,7 @@ impl<'a> Iterator for LoadSegmentIter<'a> {
 }
 
 impl<'a> ParsedElf<'a> {
-    pub(super) fn load_segments(self) -> LoadSegmentIter<'a> {
+    pub(crate) fn load_segments(self) -> LoadSegmentIter<'a> {
         LoadSegmentIter {
             phdr_bytes: self.phdr_bytes,
             phnum: self.phnum,
@@ -141,7 +145,7 @@ impl<'a> ParsedElf<'a> {
         }
     }
 
-    pub(super) fn entry(&self) -> VirtAddr {
+    pub(crate) fn entry(&self) -> VirtAddr {
         VirtAddr::new(self.ehdr.e_entry)
     }
 }
@@ -174,7 +178,22 @@ pub(super) fn kernel_load_segments() -> impl Iterator<Item = LoadSegment> {
 }
 
 #[cfg(target_os = "none")]
-pub(super) fn first_loaded_module_elf_summary() -> Option<(VirtAddr, usize)> {
+pub(crate) fn first_loaded_module_bytes() -> Option<&'static [u8]> {
+    let resp = crate::boot::MODULE_REQUEST.get_response()?;
+    let file = resp
+        .modules()
+        .iter()
+        .find(|f| f.path().to_bytes().ends_with(b"/boot/userspace_hello.elf"))?;
+    let base = file.addr();
+    let size = file.size() as usize;
+    // SAFETY: Limine places module payloads in EXECUTABLE_AND_MODULES
+    // memory, which is preserved across `reclaim_bootloader_memory()`.
+    // The slice stays valid for the rest of the kernel's lifetime.
+    Some(unsafe { core::slice::from_raw_parts(base, size) })
+}
+
+#[cfg(target_os = "none")]
+pub(crate) fn first_loaded_module_elf_summary() -> Option<(VirtAddr, usize)> {
     let resp = crate::boot::MODULE_REQUEST.get_response()?;
     let file = resp
         .modules()
@@ -192,11 +211,11 @@ pub(super) fn first_loaded_module_elf_summary() -> Option<(VirtAddr, usize)> {
     Some((parsed.entry(), parsed.load_segments().count()))
 }
 
-pub(super) fn try_parse_elf64(bytes: &[u8]) -> Option<ParsedElf<'_>> {
+pub(crate) fn try_parse_elf64(bytes: &[u8]) -> Option<ParsedElf<'_>> {
     parse_elf64_inner(bytes).ok()
 }
 
-pub(super) fn parse_elf64(bytes: &[u8]) -> ParsedElf<'_> {
+pub(crate) fn parse_elf64(bytes: &[u8]) -> ParsedElf<'_> {
     parse_elf64_inner(bytes).unwrap_or_else(|err| panic!("{}", err.message()))
 }
 

--- a/kernel/src/mem/elf.rs
+++ b/kernel/src/mem/elf.rs
@@ -78,6 +78,11 @@ enum ElfParseError {
     PhdrTableOutOfRange,
     NonCanonicalEntry,
     NonCanonicalLoadVaddr,
+    LoadFileszExceedsMemsz,
+    LoadFileRangeOverflow,
+    LoadFileRangeOutOfRange,
+    LoadVaddrRangeOverflow,
+    EntryOutsideLoadSegment,
 }
 
 impl ElfParseError {
@@ -91,6 +96,11 @@ impl ElfParseError {
             Self::PhdrTableOutOfRange => "ELF phdr table out of range",
             Self::NonCanonicalEntry => "ELF entry address is non-canonical",
             Self::NonCanonicalLoadVaddr => "ELF PT_LOAD virtual address is non-canonical",
+            Self::LoadFileszExceedsMemsz => "ELF PT_LOAD p_filesz exceeds p_memsz",
+            Self::LoadFileRangeOverflow => "ELF PT_LOAD file range arithmetic overflow",
+            Self::LoadFileRangeOutOfRange => "ELF PT_LOAD file range exceeds image bounds",
+            Self::LoadVaddrRangeOverflow => "ELF PT_LOAD virtual range arithmetic overflow",
+            Self::EntryOutsideLoadSegment => "ELF entry address not covered by any PT_LOAD",
         }
     }
 }
@@ -251,14 +261,38 @@ fn parse_elf64_inner(bytes: &[u8]) -> Result<ParsedElf<'_>, ElfParseError> {
         return Err(ElfParseError::NonCanonicalEntry);
     }
 
+    let mut entry_covered = false;
     for i in 0..phnum {
         let off = phoff + i * phsz;
         // SAFETY: `phdr_table_end` bounds-check above guarantees every
         // header read in this loop stays within `bytes`.
         let ph = unsafe { core::ptr::read_unaligned(bytes.as_ptr().add(off).cast::<Elf64Phdr>()) };
-        if ph.p_type == PT_LOAD && ph.p_memsz != 0 && VirtAddr::try_new(ph.p_vaddr).is_err() {
+        if ph.p_type != PT_LOAD || ph.p_memsz == 0 {
+            continue;
+        }
+        if VirtAddr::try_new(ph.p_vaddr).is_err() {
             return Err(ElfParseError::NonCanonicalLoadVaddr);
         }
+        if ph.p_filesz > ph.p_memsz {
+            return Err(ElfParseError::LoadFileszExceedsMemsz);
+        }
+        let file_end = ph
+            .p_offset
+            .checked_add(ph.p_filesz)
+            .ok_or(ElfParseError::LoadFileRangeOverflow)?;
+        if file_end > bytes.len() as u64 {
+            return Err(ElfParseError::LoadFileRangeOutOfRange);
+        }
+        let vaddr_end = ph
+            .p_vaddr
+            .checked_add(ph.p_memsz)
+            .ok_or(ElfParseError::LoadVaddrRangeOverflow)?;
+        if ehdr.e_entry >= ph.p_vaddr && ehdr.e_entry < vaddr_end {
+            entry_covered = true;
+        }
+    }
+    if !entry_covered {
+        return Err(ElfParseError::EntryOutsideLoadSegment);
     }
 
     Ok(ParsedElf {

--- a/kernel/src/mem/loader.rs
+++ b/kernel/src/mem/loader.rs
@@ -19,6 +19,7 @@
 //! be applied at map time (e.g. read-only .text) without a separate
 //! read-only → writable → read-only dance.
 
+use x86_64::structures::paging::mapper::MapToError;
 use x86_64::structures::paging::{Page, Size4KiB};
 use x86_64::VirtAddr;
 
@@ -27,7 +28,7 @@ use super::paging;
 
 const PAGE_SIZE: u64 = 4096;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum LoadError {
     /// `bytes` failed ELF64 parsing (bad magic, wrong class, bad phdr
     /// table, non-canonical addresses, entry outside PT_LOAD, etc.).
@@ -41,7 +42,9 @@ pub enum LoadError {
     /// segments to that boundary.
     SegmentNotPageAligned,
     /// Frame allocation or page-table install failed mid-segment.
-    MapFailed,
+    /// Wraps the underlying `paging::map` error so callers can tell
+    /// `FrameAllocationFailed` from `PageAlreadyMapped` etc.
+    MapFailed(MapToError<Size4KiB>),
 }
 
 /// Result of a successful load: the entry point and the number of
@@ -94,7 +97,7 @@ fn map_segment(bytes: &[u8], seg: elf::LoadSegment) -> Result<(), LoadError> {
     for i in 0..page_count {
         let va = seg.vaddr + i * PAGE_SIZE;
         let page = Page::<Size4KiB>::containing_address(va);
-        let frame = paging::map(page, seg.flags).map_err(|_| LoadError::MapFailed)?;
+        let frame = paging::map(page, seg.flags).map_err(LoadError::MapFailed)?;
 
         // Fill this page through the HHDM window. The frame allocator
         // doesn't zero its output, so we clear the whole page first

--- a/kernel/src/mem/loader.rs
+++ b/kernel/src/mem/loader.rs
@@ -29,11 +29,18 @@ const PAGE_SIZE: u64 = 4096;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LoadError {
+    /// `bytes` failed ELF64 parsing (bad magic, wrong class, bad phdr
+    /// table, non-canonical addresses, entry outside PT_LOAD, etc.).
     NotElf64,
-    NonCanonicalEntry,
+    /// A `PT_LOAD` segment (or the entry) is in the lower half of the
+    /// virtual address space. The loader only installs upper-half
+    /// mappings so they propagate through `new_task_pml4`.
     SegmentNotUpperHalf,
+    /// A `PT_LOAD` segment's `p_vaddr` isn't 4 KiB-aligned. We only
+    /// install 4 KiB PTEs so the caller's linker script has to align
+    /// segments to that boundary.
     SegmentNotPageAligned,
-    SegmentFileTooShort,
+    /// Frame allocation or page-table install failed mid-segment.
     MapFailed,
 }
 
@@ -75,13 +82,10 @@ fn map_segment(bytes: &[u8], seg: elf::LoadSegment) -> Result<(), LoadError> {
         return Err(LoadError::SegmentNotPageAligned);
     }
 
-    let file_end = seg
-        .file_offset
-        .checked_add(seg.filesz)
-        .ok_or(LoadError::SegmentFileTooShort)?;
-    if (file_end as usize) > bytes.len() {
-        return Err(LoadError::SegmentFileTooShort);
-    }
+    // The parser already rejects PT_LOAD segments where
+    // `p_offset + p_filesz` overflows or exceeds the image, so this
+    // slice is just a sanity restatement of that invariant.
+    let file_end = seg.file_offset + seg.filesz;
     let src = &bytes[seg.file_offset as usize..file_end as usize];
 
     let page_count = seg.memsz.div_ceil(PAGE_SIZE);

--- a/kernel/src/mem/loader.rs
+++ b/kernel/src/mem/loader.rs
@@ -1,0 +1,126 @@
+//! Minimal ELF64 image loader.
+//!
+//! Walks `PT_LOAD` segments of an ELF payload, allocates and maps 4 KiB
+//! pages at each segment's `p_vaddr`, and copies `p_filesz` bytes from
+//! the source image (zero-filling `p_memsz - p_filesz` for .bss). The
+//! target range must land in the **upper half** of the virtual address
+//! space so the mapping lands in PML4 slots 256-511, which are shared
+//! across every task PML4 that `new_task_pml4` constructs. The loader
+//! must therefore run before `task::init()`; later-spawned tasks will
+//! inherit the mapping automatically.
+//!
+//! Scope: enough to prove end-to-end control transfer into a separately
+//! linked ELF image. No ring-3, no per-process address spaces, no user
+//! stack allocation — the entry is called at ring-0 with the kernel's
+//! current stack still active.
+//!
+//! The loader writes segment contents through the HHDM window rather
+//! than through the just-installed PTE, so the final mapping flags can
+//! be applied at map time (e.g. read-only .text) without a separate
+//! read-only → writable → read-only dance.
+
+use x86_64::structures::paging::{Page, Size4KiB};
+use x86_64::VirtAddr;
+
+use super::elf;
+use super::paging;
+
+const PAGE_SIZE: u64 = 4096;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoadError {
+    NotElf64,
+    NonCanonicalEntry,
+    SegmentNotUpperHalf,
+    SegmentNotPageAligned,
+    SegmentFileTooShort,
+    MapFailed,
+}
+
+/// Result of a successful load: the entry point and the number of
+/// `PT_LOAD` segments that were mapped.
+#[derive(Debug, Clone, Copy)]
+pub struct LoadedImage {
+    pub entry: VirtAddr,
+    pub segments: usize,
+}
+
+/// Parse `bytes` as an ELF64 image and install its `PT_LOAD` segments
+/// into the active page tables. Returns the entry point so the caller
+/// can jump into it once the kernel is otherwise ready.
+pub fn load(bytes: &[u8]) -> Result<LoadedImage, LoadError> {
+    let parsed = elf::try_parse_elf64(bytes).ok_or(LoadError::NotElf64)?;
+
+    let entry = parsed.entry();
+    // Upper-half check: PML4 slots 256-511 are the shared kernel half.
+    // A canonical upper-half address has bit 63 set.
+    if (entry.as_u64() >> 63) != 1 {
+        return Err(LoadError::SegmentNotUpperHalf);
+    }
+
+    let mut segments = 0usize;
+    for seg in parsed.load_segments() {
+        map_segment(bytes, seg)?;
+        segments += 1;
+    }
+
+    Ok(LoadedImage { entry, segments })
+}
+
+fn map_segment(bytes: &[u8], seg: elf::LoadSegment) -> Result<(), LoadError> {
+    if (seg.vaddr.as_u64() >> 63) != 1 {
+        return Err(LoadError::SegmentNotUpperHalf);
+    }
+    if seg.vaddr.as_u64() & (PAGE_SIZE - 1) != 0 {
+        return Err(LoadError::SegmentNotPageAligned);
+    }
+
+    let file_end = seg
+        .file_offset
+        .checked_add(seg.filesz)
+        .ok_or(LoadError::SegmentFileTooShort)?;
+    if (file_end as usize) > bytes.len() {
+        return Err(LoadError::SegmentFileTooShort);
+    }
+    let src = &bytes[seg.file_offset as usize..file_end as usize];
+
+    let page_count = seg.memsz.div_ceil(PAGE_SIZE);
+    let hhdm = paging::hhdm_offset();
+
+    for i in 0..page_count {
+        let va = seg.vaddr + i * PAGE_SIZE;
+        let page = Page::<Size4KiB>::containing_address(va);
+        let frame = paging::map(page, seg.flags).map_err(|_| LoadError::MapFailed)?;
+
+        // Fill this page through the HHDM window. The frame allocator
+        // doesn't zero its output, so we clear the whole page first
+        // (covers .bss tail and any slack past filesz), then overlay
+        // the file bytes that fall inside this page.
+        let dst_base = hhdm + frame.start_address().as_u64();
+        // SAFETY: `frame` was just allocated by `paging::map` for our
+        // exclusive use and is reachable writable via the HHDM window.
+        unsafe {
+            core::ptr::write_bytes(dst_base.as_mut_ptr::<u8>(), 0, PAGE_SIZE as usize);
+        }
+
+        let offset_in_seg = i * PAGE_SIZE;
+        if offset_in_seg < seg.filesz {
+            let copy_off = offset_in_seg as usize;
+            let remaining = (seg.filesz - offset_in_seg) as usize;
+            let n = remaining.min(PAGE_SIZE as usize);
+            // SAFETY: same HHDM frame as the zero-fill above. `n` is
+            // clamped to stay inside one page, and `src[copy_off..]` is
+            // bounded by `filesz` which the caller checked against
+            // `bytes.len()`.
+            unsafe {
+                core::ptr::copy_nonoverlapping(
+                    src.as_ptr().add(copy_off),
+                    dst_base.as_mut_ptr::<u8>(),
+                    n,
+                );
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/kernel/src/mem/mod.rs
+++ b/kernel/src/mem/mod.rs
@@ -13,9 +13,11 @@
 pub mod frame;
 
 #[cfg(any(target_os = "none", test))]
-mod elf;
+pub(crate) mod elf;
 #[cfg(target_os = "none")]
 pub mod heap;
+#[cfg(target_os = "none")]
+pub mod loader;
 #[cfg(target_os = "none")]
 pub mod paging;
 #[cfg(target_os = "none")]
@@ -28,6 +30,9 @@ use spin::Once;
 
 #[cfg(target_os = "none")]
 static USERSPACE_MODULE_ELF_SUMMARY: Once<Option<(x86_64::VirtAddr, usize)>> = Once::new();
+
+#[cfg(target_os = "none")]
+static USERSPACE_MODULE_ELF_BYTES: Once<Option<&'static [u8]>> = Once::new();
 
 /// 4 KiB. The only page size we care about right now.
 pub const FRAME_SIZE: u64 = 4096;
@@ -67,6 +72,11 @@ pub fn init() {
 
     // Snapshot Limine module metadata before reclaiming BOOTLOADER_RECLAIMABLE
     // memory; the response structs themselves live there.
+    // Snapshot both the parsed summary and the raw file slice before
+    // BOOTLOADER_RECLAIMABLE is released. The bytes themselves live in
+    // EXECUTABLE_AND_MODULES (preserved) so the &'static slice stays
+    // valid after reclaim; only Limine's response structs go away.
+    USERSPACE_MODULE_ELF_BYTES.call_once(elf::first_loaded_module_bytes);
     USERSPACE_MODULE_ELF_SUMMARY.call_once(elf::first_loaded_module_elf_summary);
 
     heap::init();
@@ -88,4 +98,11 @@ pub fn init() {
 #[cfg(target_os = "none")]
 pub fn userspace_module_elf_summary() -> Option<(x86_64::VirtAddr, usize)> {
     USERSPACE_MODULE_ELF_SUMMARY.get().copied().flatten()
+}
+
+/// Raw bytes of the first Limine-delivered userspace module ELF file,
+/// snapshotted during `init()` before BOOTLOADER_RECLAIMABLE is freed.
+#[cfg(target_os = "none")]
+pub fn userspace_module_elf_bytes() -> Option<&'static [u8]> {
+    USERSPACE_MODULE_ELF_BYTES.get().copied().flatten()
 }

--- a/kernel/tests/userspace_loader.rs
+++ b/kernel/tests/userspace_loader.rs
@@ -1,0 +1,103 @@
+//! Integration test: the ELF loader maps the userspace_hello image
+//! into the active upper-half of the kernel PML4 and the mapped pages
+//! hold the expected ELF contents.
+
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "loader_maps_upper_half_segments",
+            &(loader_maps_upper_half_segments as fn()),
+        ),
+        (
+            "loader_entry_page_matches_file_image",
+            &(loader_entry_page_matches_file_image as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+fn loader_maps_upper_half_segments() {
+    let bytes = vibix::mem::userspace_module_elf_bytes().expect("hello module bytes missing");
+    let image = vibix::mem::loader::load(bytes).expect("loader failed to map segments");
+    assert!(
+        image.entry.as_u64() >> 63 == 1,
+        "entry {:#x} must be upper-half",
+        image.entry.as_u64()
+    );
+    assert!(image.segments > 0, "at least one PT_LOAD must map");
+    serial_println!(
+        "loader mapped entry={:#x} segments={}",
+        image.entry.as_u64(),
+        image.segments
+    );
+}
+
+fn loader_entry_page_matches_file_image() {
+    // The loader runs once during `vibix::init()`; the first four bytes
+    // at the entry point should be whatever the file image holds at the
+    // corresponding file offset. Use the ELF Ehdr-reported entry plus
+    // the first PT_LOAD's (offset, vaddr) to locate the right file
+    // bytes, then memcmp against the live mapping.
+    let bytes = vibix::mem::userspace_module_elf_bytes().unwrap();
+    let (entry, _) = vibix::mem::userspace_module_elf_summary().unwrap();
+
+    // Minimal hand-rolled re-parse: first PT_LOAD's p_offset / p_vaddr
+    // give us the mapping from virtual address to file offset.
+    let phoff = u64::from_le_bytes(bytes[32..40].try_into().unwrap()) as usize;
+    let phentsize = u16::from_le_bytes(bytes[54..56].try_into().unwrap()) as usize;
+    let phnum = u16::from_le_bytes(bytes[56..58].try_into().unwrap()) as usize;
+
+    let mut located = None;
+    for i in 0..phnum {
+        let off = phoff + i * phentsize;
+        let p_type = u32::from_le_bytes(bytes[off..off + 4].try_into().unwrap());
+        if p_type != 1 {
+            continue;
+        }
+        let p_offset = u64::from_le_bytes(bytes[off + 8..off + 16].try_into().unwrap());
+        let p_vaddr = u64::from_le_bytes(bytes[off + 16..off + 24].try_into().unwrap());
+        let p_filesz = u64::from_le_bytes(bytes[off + 32..off + 40].try_into().unwrap());
+        if entry.as_u64() >= p_vaddr && entry.as_u64() < p_vaddr + p_filesz {
+            located = Some((p_offset, p_vaddr));
+            break;
+        }
+    }
+    let (p_offset, p_vaddr) = located.expect("entry not inside a PT_LOAD filesz range");
+    let file_off = (entry.as_u64() - p_vaddr + p_offset) as usize;
+    let expected = &bytes[file_off..file_off + 16];
+    // SAFETY: the loader mapped this virtual address PRESENT during
+    // `vibix::init()`; reading 16 bytes stays within the first page of
+    // the text segment.
+    let live: &[u8] = unsafe { core::slice::from_raw_parts(entry.as_u64() as *const u8, 16) };
+    assert_eq!(live, expected, "mapped entry bytes differ from file image");
+    serial_println!(
+        "loader entry page matches file image ({} bytes)",
+        live.len()
+    );
+}

--- a/userspace/hello/link.ld
+++ b/userspace/hello/link.ld
@@ -1,0 +1,55 @@
+/* Linker script for the userspace hello ELF loaded by the kernel.
+ *
+ * Virtual base: 0xffff_ffff_c000_0000 — 1 GiB into the top 2 GiB kernel
+ * region. The kernel itself lives at 0xffff_ffff_8000_0000 and is at
+ * most a few megabytes, leaving the rest of the -2 GiB window free.
+ * The range is canonical, falls within `code-model=kernel`'s ±2 GiB
+ * reach, and sits in the upper half of the address space — upper-half
+ * PML4 slots are shared by every task PML4 via paging::new_task_pml4,
+ * so a mapping installed in the kernel PML4 before task::init() is
+ * visible to any task that later runs this code.
+ */
+
+OUTPUT_FORMAT(elf64-x86-64)
+OUTPUT_ARCH(i386:x86-64)
+ENTRY(_start)
+
+PHDRS
+{
+    text   PT_LOAD;
+    rodata PT_LOAD;
+    data   PT_LOAD;
+}
+
+SECTIONS
+{
+    . = 0xffffffffc0000000;
+
+    .text : {
+        *(.text .text.*)
+    } :text
+
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
+
+    .rodata : {
+        *(.rodata .rodata.*)
+    } :rodata
+
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
+
+    .data : {
+        *(.data .data.*)
+    } :data
+
+    .bss : {
+        *(COMMON)
+        *(.bss .bss.*)
+    } :data
+
+    /DISCARD/ : {
+        *(.eh_frame*)
+        *(.note.*)
+        *(.comment)
+        *(.dynamic)
+    }
+}

--- a/userspace/hello/src/main.rs
+++ b/userspace/hello/src/main.rs
@@ -1,18 +1,48 @@
+//! Tiny userspace ELF payload for the ring-0 loader smoke test.
+//!
+//! Runs with the kernel's descriptors still active (we don't yet have
+//! ring-3). The only contract is: write the "USRHELLO\n" marker to the
+//! COM1 serial port so `xtask smoke` can observe control transfer, then
+//! park via `hlt`.
+
 #![no_std]
 #![no_main]
 
 use core::panic::PanicInfo;
 
+const COM1: u16 = 0x3F8;
+const MARKER: &[u8] = b"USRHELLO\n";
+
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
-    loop {
-        core::hint::spin_loop();
+    for &b in MARKER {
+        unsafe {
+            // Spin on the THR-empty bit (LSR.5) so bytes don't get
+            // dropped if the UART isn't drained yet.
+            while (inb(COM1 + 5) & 0x20) == 0 {}
+            outb(COM1, b);
+        }
     }
+    loop {
+        unsafe { core::arch::asm!("hlt", options(nomem, nostack)) };
+    }
+}
+
+#[inline(always)]
+unsafe fn outb(port: u16, val: u8) {
+    core::arch::asm!("out dx, al", in("dx") port, in("al") val, options(nomem, nostack, preserves_flags));
+}
+
+#[inline(always)]
+unsafe fn inb(port: u16) -> u8 {
+    let val: u8;
+    core::arch::asm!("in al, dx", out("al") val, in("dx") port, options(nomem, nostack, preserves_flags));
+    val
 }
 
 #[panic_handler]
 fn panic(_info: &PanicInfo) -> ! {
     loop {
-        core::hint::spin_loop();
+        unsafe { core::arch::asm!("hlt", options(nomem, nostack)) };
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -70,6 +70,8 @@ const SMOKE_MARKERS: &[&str] = &[
     "interrupts enabled",
     "tasks: scheduler online",
     "userspace module ELF entry=",
+    "userspace: loader mapping image",
+    "USRHELLO",
 ];
 
 fn main() -> R<()> {
@@ -209,8 +211,22 @@ fn userspace_hello_binary() -> PathBuf {
 }
 
 fn build_userspace_hello() -> R<PathBuf> {
+    // Setting RUSTFLAGS wholesale overrides the workspace
+    // `[target.x86_64-unknown-none] rustflags` from .cargo/config.toml,
+    // so we must re-supply every flag the kernel target still needs —
+    // only the linker script differs (userspace payload maps at
+    // 0xffffffffc0000000, not the kernel's 0xffffffff80000000).
+    let rustflags = [
+        "-C link-arg=-Tuserspace/hello/link.ld",
+        "-C relocation-model=static",
+        "-C code-model=kernel",
+        "-C no-redzone=yes",
+        "-C force-frame-pointers=yes",
+    ]
+    .join(" ");
     let mut cmd = Command::new("cargo");
     cmd.current_dir(workspace_root())
+        .env("RUSTFLAGS", rustflags)
         .args(["build", "--package", "userspace_hello"])
         .args(KERNEL_BUILD_STD_ARGS);
     check(cmd.status()?)?;
@@ -604,6 +620,7 @@ fn test_all() -> R<()> {
         "per_task_cr3",
         "demand_paging",
         "userspace_module",
+        "userspace_loader",
         "sleep",
         "pci_enum",
         "serial_rx",


### PR DESCRIPTION
Closes #44

## Summary
- Give `userspace_hello` its own linker script placing it at `0xffffffffc0000000` — 1 GiB above the kernel text at `0xffffffff80000000`, still in the upper half so a pre-`task::init()` mapping propagates through `new_task_pml4`'s upper-half copy to every later-spawned task. Override the workspace's kernel-linker rustflags via `RUSTFLAGS` env so the two binaries can share the `x86_64-unknown-none` target.
- Replace the payload's spin-loop with a COM1 write of `"USRHELLO\n"` so the smoke test can observe end-to-end control transfer.
- Add `kernel::mem::loader::load()` that walks `PT_LOAD` segments, allocates + maps 4 KiB pages with each segment's final flags, copies `p_filesz` bytes through the HHDM window, and zero-fills `memsz - filesz` for `.bss`. Widen `LoadSegment` with `p_offset` / `p_filesz` and bump visibility from `pub(super)` to `pub(crate)`.
- Snapshot the module's raw `&'static [u8]` in `mem::init` before `reclaim_bootloader_memory` runs (module bytes live in `EXECUTABLE_AND_MODULES`, preserved; Limine's response metadata does not).
- Wire `loader::load()` into `_start` between `mem::init` and `task::init`, stash the entry in a static `AtomicU64`, and spawn a trampoline task that calls into it (still ring-0 — ring-3 is deferred).

## Test plan
- [x] `cargo xtask build` — clean
- [x] `cargo xtask test` — 49 host unit + all QEMU integration tests pass, including a new `kernel/tests/userspace_loader.rs` that asserts upper-half mapping and byte-for-byte parity at the entry page
- [x] `cargo xtask smoke` — all 26 markers present, including the new `userspace: loader mapping image` and `USRHELLO` markers proving the trampoline jumped into the payload and the payload reached COM1
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy -p xtask --all-targets -- -D warnings` — clean (matches CI scope)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a new ELF loader that maps arbitrary module segments into the kernel address space and transfers control to the loaded entry point, which is paging- and memory-safety critical. Failures could corrupt page tables or execute unintended code if validation/mapping assumptions are wrong.
> 
> **Overview**
> Adds a minimal in-kernel ELF64 `PT_LOAD` loader (`mem::loader`) that maps an embedded module’s segments into the shared upper-half page tables, copies file bytes, and zero-fills `.bss`.
> 
> Boot now snapshots the module’s raw bytes during `mem::init()`, loads/maps it before `task::init()`, and spawns a trampoline task that jumps to the loaded entry (still ring-0). ELF parsing is tightened (filesz/memsz and range/overflow checks, entry coverage validation) and exposed for loader use.
> 
> Introduces a new QEMU integration test (`userspace_loader`) to validate mappings and byte-for-byte correctness at the entry page, updates `userspace_hello` to link at an upper-half base and emit a `USRHELLO` serial marker, and extends `xtask smoke/test` expectations accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba51baa486816a73e65abcf9a13301761ff47201. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->