### PR TITLE
kernel: x87/SSE register save/restore on context switch

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -131,3 +131,7 @@ harness = false
 [[test]]
 name = "cow_vma"
 harness = false
+
+[[test]]
+name = "fpu_context_switch"
+harness = false

--- a/kernel/src/arch/x86_64/fpu.rs
+++ b/kernel/src/arch/x86_64/fpu.rs
@@ -91,6 +91,12 @@ pub fn init() {
     unsafe {
         Cr0::update(|f| {
             f.remove(Cr0Flags::EMULATE_COPROCESSOR);
+            // Clear TS so `fxsave64` / `fxrstor64` / `ldmxcsr` below
+            // (and every subsequent context-switch save/restore) don't
+            // take `#NM` if the bootloader or firmware left TS set.
+            // We eager-save; there's no lazy-FPU state machine that
+            // wants TS asserted.
+            f.remove(Cr0Flags::TASK_SWITCHED);
             f.insert(Cr0Flags::MONITOR_COPROCESSOR);
             f.insert(Cr0Flags::NUMERIC_ERROR);
         });

--- a/kernel/src/arch/x86_64/fpu.rs
+++ b/kernel/src/arch/x86_64/fpu.rs
@@ -1,0 +1,160 @@
+//! x87/SSE register state save and restore across context switches.
+//!
+//! The kernel target (`x86_64-unknown-none`) is soft-float, so kernel
+//! Rust code never emits FPU/SSE instructions itself. The reason this
+//! module exists anyway is userspace: once a ring-3 task touches XMM
+//! registers, preempting into another task would silently corrupt its
+//! FPU state without a save/restore on switch.
+//!
+//! Scope for this first cut — eager, non-lazy:
+//!
+//!  - `init()` clears `CR0.EM`, sets `CR0.MP` / `CR0.NE`, and sets
+//!    `CR4.OSFXSR` / `CR4.OSXMMEXCPT`. With those, `fxsave64` /
+//!    `fxrstor64` are legal and SSE instructions don't raise `#NM`.
+//!  - Each [`Task`](crate::task::task::Task) owns a 64-byte-aligned,
+//!    512-byte [`FpuArea`]. [`FpuArea::new_initialized`] uses `fninit`
+//!    + `fxsave64` to seed a fresh task with a canonical FPU state (no
+//!    denormals trapped, round-to-nearest, exceptions masked).
+//!  - [`save`] / [`restore`] wrap `fxsave64` / `fxrstor64` against a
+//!    Task's `FpuArea`; the scheduler (`task::mod`) calls them around
+//!    every `context_switch`.
+//!
+//! Deliberately **not in this module yet**:
+//!
+//!  - XSAVE / XRSTOR for YMM / ZMM state — tracked as a follow-up; the
+//!    kernel is soft-float and no userspace code uses AVX yet.
+//!  - Lazy save via `CR0.TS` + `#NM` — same follow-up. Correctness is
+//!    unaffected; the optimisation can land separately with its own
+//!    `#NM` handler and per-CPU FPU-owner tracking.
+//!  - `kernel_fpu_begin` / `kernel_fpu_end` guards — unused on a
+//!    soft-float kernel. Will be added when a kernel fast-path (e.g.
+//!    an AVX `memcpy`) actually wants SIMD.
+
+use alloc::boxed::Box;
+
+/// Size of an FXSAVE area, in bytes. Fixed by the ISA.
+pub const FXSAVE_SIZE: usize = 512;
+/// Required alignment for `fxsave64` / `fxrstor64`. Fixed by the ISA.
+pub const FXSAVE_ALIGN: usize = 16;
+/// Alignment used for [`FpuArea`]. Oversized relative to `FXSAVE_ALIGN`
+/// so the same storage is compatible with future XSAVE widening (which
+/// requires 64-byte alignment).
+pub const FPU_AREA_ALIGN: usize = 64;
+
+/// Per-task FPU save area. 64-byte aligned, 512 bytes — compatible with
+/// `fxsave64` / `fxrstor64`.
+#[repr(C, align(64))]
+pub struct FpuArea {
+    bytes: [u8; FXSAVE_SIZE],
+}
+
+impl FpuArea {
+    /// Allocate a fresh save area and seed it with the canonical
+    /// post-`fninit` FPU state (x87 reset: `FCW=0x037F`, `MXCSR=0x1F80`,
+    /// all data registers empty). Using the live FPU to populate the
+    /// image avoids hand-writing an FXSAVE layout.
+    ///
+    /// Must not be called before [`init`] — `fxsave64` requires
+    /// `CR4.OSFXSR` and will `#UD` otherwise.
+    pub fn new_initialized() -> Box<Self> {
+        let mut area = Box::new(Self {
+            bytes: [0u8; FXSAVE_SIZE],
+        });
+        // SAFETY: `area` is 64-byte aligned, 512 bytes, and exclusively
+        // owned by this Box. `init()` has run by the time any task is
+        // spawned, so `fninit` + `fxsave64` are legal.
+        unsafe {
+            core::arch::asm!(
+                "fninit",
+                "fxsave64 [{p}]",
+                p = in(reg) area.bytes.as_mut_ptr(),
+                options(nostack, preserves_flags),
+            );
+        }
+        area
+    }
+}
+
+/// Enable FXSAVE/FXRSTOR on this CPU.
+///
+/// Clears `CR0.EM` (so SSE instructions don't raise `#NM`), sets
+/// `CR0.MP` and `CR0.NE`, then sets `CR4.OSFXSR` and
+/// `CR4.OSXMMEXCPT`. Leaves `CR0.TS` unchanged (we eager-save for now).
+///
+/// Safe to call more than once — each bit is an idempotent set/clear.
+/// Call after [`crate::cpu::init`] and before any task is spawned.
+#[cfg(target_os = "none")]
+pub fn init() {
+    use x86_64::registers::control::{Cr0, Cr0Flags, Cr4, Cr4Flags};
+
+    // SAFETY: adjusting CR0/CR4 with paging already live is safe as
+    // long as we don't toggle paging-critical bits (PG, PE, PAE). We
+    // only touch EM/MP/NE and OSFXSR/OSXMMEXCPT.
+    unsafe {
+        Cr0::update(|f| {
+            f.remove(Cr0Flags::EMULATE_COPROCESSOR);
+            f.insert(Cr0Flags::MONITOR_COPROCESSOR);
+            f.insert(Cr0Flags::NUMERIC_ERROR);
+        });
+        Cr4::update(|f| {
+            f.insert(Cr4Flags::OSFXSR);
+            f.insert(Cr4Flags::OSXMMEXCPT_ENABLE);
+        });
+    }
+
+    crate::serial_println!("fpu: FXSAVE context switch online");
+}
+
+/// Save the current CPU FPU state into `area`.
+///
+/// # Safety
+/// - [`init`] must have run on this CPU.
+/// - `area` must not alias any other FPU save currently in flight.
+#[cfg(target_os = "none")]
+#[inline]
+pub unsafe fn save(area: &mut FpuArea) {
+    // SAFETY: caller upheld the preconditions above. The inline asm
+    // writes 512 bytes into `area.bytes`; the reference guarantees
+    // write-exclusive access and 64-byte alignment.
+    unsafe {
+        core::arch::asm!(
+            "fxsave64 [{p}]",
+            p = in(reg) area.bytes.as_mut_ptr(),
+            options(nostack, preserves_flags),
+        );
+    }
+}
+
+/// Load the FPU state stored in `area` into the current CPU.
+///
+/// # Safety
+/// - [`init`] must have run on this CPU.
+/// - `area` must hold a valid FXSAVE image (produced by [`save`] or
+///   [`FpuArea::new_initialized`]).
+#[cfg(target_os = "none")]
+#[inline]
+pub unsafe fn restore(area: &FpuArea) {
+    // SAFETY: caller upheld the preconditions above. `fxrstor64`
+    // reads 512 bytes from `area.bytes`; the reference guarantees the
+    // storage is live and 64-byte aligned.
+    unsafe {
+        core::arch::asm!(
+            "fxrstor64 [{p}]",
+            p = in(reg) area.bytes.as_ptr(),
+            options(nostack, preserves_flags),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fpu_area_layout_matches_fxsave() {
+        assert_eq!(core::mem::size_of::<FpuArea>(), FXSAVE_SIZE);
+        assert_eq!(core::mem::align_of::<FpuArea>(), FPU_AREA_ALIGN);
+        assert!(FPU_AREA_ALIGN >= FXSAVE_ALIGN);
+        assert_eq!(FXSAVE_ALIGN, 16);
+    }
+}

--- a/kernel/src/arch/x86_64/fpu.rs
+++ b/kernel/src/arch/x86_64/fpu.rs
@@ -12,9 +12,9 @@
 //!    `CR4.OSFXSR` / `CR4.OSXMMEXCPT`. With those, `fxsave64` /
 //!    `fxrstor64` are legal and SSE instructions don't raise `#NM`.
 //!  - Each [`Task`](crate::task::task::Task) owns a 64-byte-aligned,
-//!    512-byte [`FpuArea`]. [`FpuArea::new_initialized`] uses `fninit`
-//!    + `fxsave64` to seed a fresh task with a canonical FPU state (no
-//!    denormals trapped, round-to-nearest, exceptions masked).
+//!    512-byte [`FpuArea`]. [`FpuArea::new_initialized`] clones a
+//!    canonical FXSAVE image (x87 reset + `MXCSR=0x1F80`) captured
+//!    once during [`init`], so spawning never touches the live FPU.
 //!  - [`save`] / [`restore`] wrap `fxsave64` / `fxrstor64` against a
 //!    Task's `FpuArea`; the scheduler (`task::mod`) calls them around
 //!    every `context_switch`.
@@ -31,6 +31,7 @@
 //!    an AVX `memcpy`) actually wants SIMD.
 
 use alloc::boxed::Box;
+use spin::Once;
 
 /// Size of an FXSAVE area, in bytes. Fixed by the ISA.
 pub const FXSAVE_SIZE: usize = 512;
@@ -48,30 +49,27 @@ pub struct FpuArea {
     bytes: [u8; FXSAVE_SIZE],
 }
 
+/// Canonical FXSAVE image captured once in [`init`], cloned by
+/// [`FpuArea::new_initialized`] into every new task. Holding this as a
+/// template (rather than regenerating via `fninit` + `fxsave64` on each
+/// spawn) means spawning never mutates the live CPU FPU — which would
+/// otherwise clobber whatever state the spawning task was using.
+static CANONICAL_FPU_IMAGE: Once<FpuArea> = Once::new();
+
 impl FpuArea {
-    /// Allocate a fresh save area and seed it with the canonical
-    /// post-`fninit` FPU state (x87 reset: `FCW=0x037F`, `MXCSR=0x1F80`,
-    /// all data registers empty). Using the live FPU to populate the
-    /// image avoids hand-writing an FXSAVE layout.
+    /// Allocate a fresh save area pre-populated with the canonical FPU
+    /// image (x87 reset: `FCW=0x037F`, all data registers empty;
+    /// `MXCSR=0x1F80`).
     ///
-    /// Must not be called before [`init`] — `fxsave64` requires
-    /// `CR4.OSFXSR` and will `#UD` otherwise.
+    /// Must not be called before [`init`] — that's where the template
+    /// is captured.
     pub fn new_initialized() -> Box<Self> {
-        let mut area = Box::new(Self {
-            bytes: [0u8; FXSAVE_SIZE],
-        });
-        // SAFETY: `area` is 64-byte aligned, 512 bytes, and exclusively
-        // owned by this Box. `init()` has run by the time any task is
-        // spawned, so `fninit` + `fxsave64` are legal.
-        unsafe {
-            core::arch::asm!(
-                "fninit",
-                "fxsave64 [{p}]",
-                p = in(reg) area.bytes.as_mut_ptr(),
-                options(nostack, preserves_flags),
-            );
-        }
-        area
+        let template = CANONICAL_FPU_IMAGE
+            .get()
+            .expect("fpu::init must run before FpuArea::new_initialized");
+        Box::new(Self {
+            bytes: template.bytes,
+        })
     }
 }
 
@@ -101,6 +99,34 @@ pub fn init() {
             f.insert(Cr4Flags::OSXMMEXCPT_ENABLE);
         });
     }
+
+    // Capture the canonical FXSAVE image once — immediately after the
+    // FPU is enabled and before any task has had a chance to touch it.
+    // Running `fninit` + `ldmxcsr(0x1F80)` here only mutates the live
+    // FPU state that nothing has used yet, so there's no caller state
+    // to clobber. Every subsequent `FpuArea::new_initialized` clones
+    // this template without touching the CPU.
+    CANONICAL_FPU_IMAGE.call_once(|| {
+        let mut image = FpuArea {
+            bytes: [0u8; FXSAVE_SIZE],
+        };
+        let default_mxcsr: u32 = 0x1F80;
+        // SAFETY: CR0.EM is clear and CR4.OSFXSR is set by the updates
+        // above, so `fninit`, `ldmxcsr`, and `fxsave64` are all legal.
+        // `image.bytes` is 64-byte aligned and 512 bytes, satisfying
+        // `fxsave64`'s operand requirements.
+        unsafe {
+            core::arch::asm!(
+                "fninit",
+                "ldmxcsr [{m}]",
+                "fxsave64 [{p}]",
+                m = in(reg) &default_mxcsr,
+                p = in(reg) image.bytes.as_mut_ptr(),
+                options(nostack, preserves_flags),
+            );
+        }
+        image
+    });
 
     crate::serial_println!("fpu: FXSAVE context switch online");
 }

--- a/kernel/src/arch/x86_64/mod.rs
+++ b/kernel/src/arch/x86_64/mod.rs
@@ -1,5 +1,6 @@
 pub mod apic;
 pub mod backtrace;
+pub mod fpu;
 pub mod gdt;
 pub mod idt;
 pub mod interrupts;
@@ -11,6 +12,9 @@ pub mod pic;
 pub fn init() {
     // Feature detection first — everything below may query cpu::has().
     crate::cpu::init();
+    // FPU init needs CR0/CR4 writes but no heap, so it fits here —
+    // ahead of task::init() which spawns the first saving task.
+    fpu::init();
     gdt::init();
     idt::init();
     // Remap + mask the 8259 before touching ACPI/APIC. Leaving it in

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -51,6 +51,7 @@ use scheduler::Scheduler;
 use switch::context_switch;
 use task::{Task, TaskState};
 
+use crate::arch::x86_64::fpu;
 use crate::serial_println;
 use crate::time::TICK_MS;
 
@@ -490,6 +491,10 @@ pub fn preempt_tick() {
     let prev_prio = prev.priority;
     sched.current = Some(next);
     sched.current.as_mut().unwrap().slice_remaining_ms = DEFAULT_SLICE_MS;
+    // Grab a raw pointer to the incoming task's FPU area while we
+    // still hold the mutable borrow; we'll dereference it after the
+    // lock is dropped.
+    let next_fpu_ptr: *const fpu::FpuArea = &*sched.current.as_ref().unwrap().fpu;
     sched.push_ready(prev);
     // The push above put `prev` at the back of its priority's queue;
     // retrieve the pointer through the bank to keep the Box-stability
@@ -500,18 +505,22 @@ pub fn preempt_tick() {
         .and_then(|q| q.back_mut())
         .expect("just pushed");
     let prev_rsp_ptr: *mut usize = &mut prev_ref.rsp as *mut usize;
+    let prev_fpu_ptr: *mut fpu::FpuArea = &mut *prev_ref.fpu;
     drop(sched);
 
-    // SAFETY: `prev_rsp_ptr` points at the `rsp` field of a Box<Task>
-    // in the ready queue. The Box indirection pins the Task's address
-    // — a VecDeque reallocation would move the Box, not the heap-
-    // allocated Task it points at — so the pointer stays valid even
-    // though the VecDeque could mutate from under us. IRQs are already
+    // SAFETY: `prev_rsp_ptr` / `prev_fpu_ptr` / `next_fpu_ptr` point
+    // into heap-allocated `FpuArea` / `usize` fields behind Box<Task>
+    // values in the scheduler — the Box indirection pins those
+    // allocations across VecDeque or BTreeMap rebalances (rebalancing
+    // moves the Box, not the heap-allocated Task). IRQs are already
     // masked inside the ISR, so no other scheduler path can race us
     // between lock drop and the context switch. `next_cr3` is a valid
     // PML4 whose upper half mirrors the kernel PML4 (by construction
-    // in `Task::new` / `Task::bootstrap`).
+    // in `Task::new` / `Task::bootstrap`). `fpu::init()` ran during
+    // `arch::init`, so fxsave64/fxrstor64 are legal on this CPU.
     unsafe {
+        fpu::save(&mut *prev_fpu_ptr);
+        fpu::restore(&*next_fpu_ptr);
         context_switch(prev_rsp_ptr, next_rsp, next_cr3);
     }
 }
@@ -552,7 +561,7 @@ pub fn block_current() {
     let was_on = interrupts::are_enabled();
     interrupts::disable();
 
-    let (prev_rsp_ptr, next_rsp, next_cr3) = {
+    let (prev_rsp_ptr, prev_fpu_ptr, next_fpu_ptr, next_rsp, next_cr3) = {
         let mut sched = SCHED.lock();
 
         // Fast path: a prior wake() set wake_pending while we were
@@ -589,6 +598,7 @@ pub fn block_current() {
         let next_cr3 = next.cr3.start_address().as_u64();
         sched.current = Some(next);
         sched.current.as_mut().unwrap().slice_remaining_ms = DEFAULT_SLICE_MS;
+        let next_fpu_ptr: *const fpu::FpuArea = &*sched.current.as_ref().unwrap().fpu;
         sched.parked.insert(prev_id, prev);
 
         let prev_ref = sched
@@ -596,20 +606,24 @@ pub fn block_current() {
             .get_mut(&prev_id)
             .expect("just inserted into parked");
         // SAFETY: `prev_ref` is `&mut Box<Task>`; the Box heap-allocates
-        // the Task, so `&mut prev_ref.rsp` points at stable memory that
-        // survives any BTreeMap rebalance (rebalancing moves the Box,
-        // not the heap-allocated Task it points at). Same invariant as
-        // preempt_tick's ready-queue push.
+        // the Task, so `&mut prev_ref.rsp` / `&mut *prev_ref.fpu` point
+        // at stable memory that survives any BTreeMap rebalance
+        // (rebalancing moves the Box, not the heap-allocated Task it
+        // points at). Same invariant as preempt_tick's ready-queue push.
         let prev_rsp_ptr: *mut usize = &mut prev_ref.rsp as *mut usize;
+        let prev_fpu_ptr: *mut fpu::FpuArea = &mut *prev_ref.fpu;
 
-        (prev_rsp_ptr, next_rsp, next_cr3)
+        (prev_rsp_ptr, prev_fpu_ptr, next_fpu_ptr, next_rsp, next_cr3)
     };
 
     // SAFETY: IRQs are masked, the SCHED lock is dropped so the
-    // incoming task can re-enter the scheduler, and prev_rsp_ptr
-    // targets stable heap memory (see the insert comment above).
-    // `next_cr3` is a valid per-task PML4 (see preempt_tick).
+    // incoming task can re-enter the scheduler, and prev_rsp_ptr /
+    // prev_fpu_ptr / next_fpu_ptr target stable heap memory (see the
+    // insert comment above). `next_cr3` is a valid per-task PML4 (see
+    // preempt_tick). `fpu::init()` ran during `arch::init`.
     unsafe {
+        fpu::save(&mut *prev_fpu_ptr);
+        fpu::restore(&*next_fpu_ptr);
         context_switch(prev_rsp_ptr, next_rsp, next_cr3);
     }
 

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -18,12 +18,14 @@
 //! new task lands in `task_entry_trampoline`, which then calls the entry
 //! function.
 
+use alloc::boxed::Box;
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use x86_64::registers::control::Cr3;
 use x86_64::structures::paging::{Page, PageTableFlags, PhysFrame, Size4KiB};
 use x86_64::VirtAddr;
 
+use crate::arch::x86_64::fpu::FpuArea;
 use crate::mem::paging;
 use crate::mem::vma::VmaList;
 
@@ -114,6 +116,11 @@ pub(super) struct Task {
     /// until something installs a VMA via
     /// [`super::install_vma_on_current`].
     pub vmas: VmaList,
+    /// Per-task x87/SSE register image. Saved on every switch-out and
+    /// restored on switch-in. A fresh area is seeded with the
+    /// post-`fninit` canonical FPU state so a spawned task sees the
+    /// same FPU starting conditions as the bootstrap thread.
+    pub fpu: Box<FpuArea>,
 }
 
 impl Task {
@@ -135,6 +142,12 @@ impl Task {
             // CR3 currently points at.
             cr3: Cr3::read().0,
             vmas: VmaList::new(),
+            // The bootstrap task hasn't touched the FPU yet (kernel is
+            // soft-float), so seeding with the canonical `fninit` image
+            // is correct: the first switch-away from bootstrap will
+            // overwrite this buffer with whatever live FPU state exists
+            // at that moment.
+            fpu: FpuArea::new_initialized(),
         }
     }
 
@@ -217,6 +230,7 @@ impl Task {
             affinity: AFFINITY_ALL,
             cr3,
             vmas: VmaList::new(),
+            fpu: FpuArea::new_initialized(),
         }
     }
 

--- a/kernel/tests/fpu_context_switch.rs
+++ b/kernel/tests/fpu_context_switch.rs
@@ -1,0 +1,148 @@
+//! Integration test: x87/SSE register state survives preemptive context
+//! switches.
+//!
+//! Two worker tasks each load a unique 128-bit pattern into XMM0 (via
+//! inline asm — the kernel target is soft-float, so the compiler never
+//! touches XMM regs on its own). Each worker then spins reading XMM0
+//! back into a `[u64; 2]` snapshot and asserting the bits still match
+//! the pattern it loaded. Without per-task FPU save/restore on context
+//! switch the two patterns would cross-contaminate within the first
+//! preemption tick.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use vibix::{
+    exit_qemu, serial_println, task,
+    test_harness::{test_panic_handler, Testable},
+    time, QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[(
+        "fpu_state_preserved_across_preemption",
+        &(fpu_state_preserved_across_preemption as fn()),
+    )];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+const A_LO: u64 = 0xA1A1_A1A1_A1A1_A1A1;
+const A_HI: u64 = 0xA2A2_A2A2_A2A2_A2A2;
+const B_LO: u64 = 0xB1B1_B1B1_B1B1_B1B1;
+const B_HI: u64 = 0xB2B2_B2B2_B2B2_B2B2;
+
+static A_ITERS: AtomicUsize = AtomicUsize::new(0);
+static B_ITERS: AtomicUsize = AtomicUsize::new(0);
+static A_FAIL: AtomicBool = AtomicBool::new(false);
+static B_FAIL: AtomicBool = AtomicBool::new(false);
+
+#[inline(always)]
+unsafe fn load_xmm0(lo: u64, hi: u64) {
+    let pair = [lo, hi];
+    // SAFETY: caller upholds that the FPU is enabled (CR4.OSFXSR set
+    // by `arch::init` → `fpu::init`). The asm only writes XMM0.
+    unsafe {
+        core::arch::asm!(
+            "movupd xmm0, [{p}]",
+            p = in(reg) pair.as_ptr(),
+            out("xmm0") _,
+            options(nostack, preserves_flags),
+        );
+    }
+}
+
+#[inline(always)]
+unsafe fn read_xmm0() -> [u64; 2] {
+    let mut out = [0u64; 2];
+    // SAFETY: same as load_xmm0 — XMM0 is observable as soon as the
+    // FPU is enabled.
+    unsafe {
+        core::arch::asm!(
+            "movupd [{p}], xmm0",
+            p = in(reg) out.as_mut_ptr(),
+            options(nostack, preserves_flags),
+        );
+    }
+    out
+}
+
+fn worker_a() -> ! {
+    // SAFETY: FPU init ran in `vibix::init` → `arch::init`.
+    unsafe { load_xmm0(A_LO, A_HI) };
+    loop {
+        let read = unsafe { read_xmm0() };
+        if read != [A_LO, A_HI] {
+            A_FAIL.store(true, Ordering::Relaxed);
+        }
+        A_ITERS.fetch_add(1, Ordering::Relaxed);
+        // Reload to keep the test honest if a real failure already
+        // corrupted the register — we want subsequent iterations to
+        // also flag the issue, not silently pass.
+        unsafe { load_xmm0(A_LO, A_HI) };
+        core::hint::spin_loop();
+    }
+}
+
+fn worker_b() -> ! {
+    unsafe { load_xmm0(B_LO, B_HI) };
+    loop {
+        let read = unsafe { read_xmm0() };
+        if read != [B_LO, B_HI] {
+            B_FAIL.store(true, Ordering::Relaxed);
+        }
+        B_ITERS.fetch_add(1, Ordering::Relaxed);
+        unsafe { load_xmm0(B_LO, B_HI) };
+        core::hint::spin_loop();
+    }
+}
+
+fn fpu_state_preserved_across_preemption() {
+    A_ITERS.store(0, Ordering::SeqCst);
+    B_ITERS.store(0, Ordering::SeqCst);
+    A_FAIL.store(false, Ordering::SeqCst);
+    B_FAIL.store(false, Ordering::SeqCst);
+
+    task::spawn(worker_a);
+    task::spawn(worker_b);
+
+    // 200 ms = 20 PIT ticks at 100 Hz. The two 10 ms slices interleave
+    // ~10 times each over this window; without FPU save/restore the
+    // first preemption would already corrupt one task's XMM0.
+    let start = time::uptime_ms();
+    while time::uptime_ms() < start + 200 {
+        x86_64::instructions::hlt();
+    }
+
+    let a = A_ITERS.load(Ordering::Relaxed);
+    let b = B_ITERS.load(Ordering::Relaxed);
+    let af = A_FAIL.load(Ordering::Relaxed);
+    let bf = B_FAIL.load(Ordering::Relaxed);
+    serial_println!("fpu test: a_iters={a} b_iters={b} a_fail={af} b_fail={bf}");
+    assert!(a > 0, "worker_a never ran (a={a})");
+    assert!(b > 0, "worker_b never ran (b={b})");
+    assert!(!af, "worker_a saw XMM0 corruption");
+    assert!(!bf, "worker_b saw XMM0 corruption");
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -625,6 +625,7 @@ fn test_all() -> R<()> {
         "pci_enum",
         "serial_rx",
         "cow_vma",
+        "fpu_context_switch",
     ] {
         cmd.arg("--test").arg(t);
     }


### PR DESCRIPTION
Closes #115

## Summary
- Enable the FPU at boot (clear `CR0.EM`, set `CR0.MP`/`NE`, set `CR4.OSFXSR`/`OSXMMEXCPT_ENABLE`) so `fxsave64`/`fxrstor64` are legal and SSE exceptions route through `#XM`.
- Give every `Task` a heap-owned, 64-byte-aligned 512-byte `FpuArea`, seeded with a real `fninit` → `fxsave64` image so fresh tasks start with canonical FCW/MXCSR instead of a zeroed blob.
- Eagerly save the outgoing task's FPU and restore the incoming task's FPU inside `preempt_tick` and `block_current`, right before the stack/CR3 swap. Pointers into the `Box<FpuArea>` are taken while the scheduler lock is held and dereferenced after the lock drops, matching the existing `rsp` pointer pattern.
- Scope is intentionally just eager FXSAVE. Lazy save via `CR0.TS` + `#NM`, XSAVE/XSAVEOPT for AVX state, and `kernel_fpu_begin/end` guards are optimisations that aren't needed until the kernel itself adopts SIMD — captured as follow-ups.

## Test plan
- [x] `cargo xtask build`
- [x] `cargo xtask test` — new `fpu_context_switch` integration test runs two tasks that each load a unique 128-bit pattern into XMM0 and spin asserting the register still reads back correctly. Ran ~1M combined iterations across 200 ms (20 PIT ticks) with zero corruption. 54/54 tests pass.
- [x] `cargo xtask smoke` — all 26 markers present.
- [x] `cargo fmt --all --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core scheduling/context-switch paths and writes CPU control registers (CR0/CR4); bugs here can corrupt task state or crash the kernel under load.
> 
> **Overview**
> Adds eager per-task x87/SSE state preservation on x86_64 context switches.
> 
> Introduces a new `arch::x86_64::fpu` module that enables FXSAVE/FXRSTOR at boot, captures a canonical initialized FPU image, and provides `save`/`restore` helpers. Each `Task` now owns a boxed, 64-byte-aligned `FpuArea` seeded from that template, and the scheduler saves/restores FPU state around `context_switch` in both `preempt_tick` and `block_current`.
> 
> Adds a `fpu_context_switch` integration test that runs two preempted tasks with distinct `xmm0` patterns to detect corruption, and wires the test into `Cargo.toml` and `xtask test`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70ad30d18adf237096fde94e7ff956edf40fbbdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->