### PR TITLE
mem: AddressSpace struct (PML4 + VMA map + brk window)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 limine = "0.5"
-spin = { version = "0.9", default-features = false, features = ["mutex", "spin_mutex", "lazy"] }
+spin = { version = "0.9", default-features = false, features = ["mutex", "spin_mutex", "lazy", "rwlock"] }
 x86_64 = "0.15"
 uart_16550 = "0.3"
 font8x8 = { version = "0.3", default-features = false, features = ["unicode"] }
@@ -138,4 +138,8 @@ harness = false
 
 [[test]]
 name = "task_exit"
+harness = false
+
+[[test]]
+name = "addrspace"
 harness = false

--- a/kernel/src/mem/addrspace.rs
+++ b/kernel/src/mem/addrspace.rs
@@ -1,0 +1,295 @@
+//! Per-process address space — the RFC 0001 anchor for every userspace VM
+//! operation. Owns one PML4 frame, a sorted interval map of user VMAs, and
+//! a pre-reserved `brk` window. Every syscall that mutates user memory
+//! (`mmap`, `munmap`, `mprotect`, `brk`, `fork`, `exec`, `exit`) works
+//! against an `AddressSpace`; the `#PF` resolver walks it to decide how to
+//! back a faulting address.
+//!
+//! This is the skeleton introduced by RFC 0001. Richer facilities (VMA
+//! split/merge, the `VmObject` trait, the rewritten fault resolver, task
+//! integration, reclaim-on-drop) land in their own follow-up issues
+//! (#155..#161). What lives here today: the struct, kernel-half PML4 copy,
+//! the IRQ-safety contract on the lock, and the `find(addr)` lookup that
+//! every later caller will build on.
+
+use alloc::collections::BTreeMap;
+
+use spin::RwLock;
+use x86_64::VirtAddr;
+
+use crate::mem::vma::Vma;
+
+/// First address **above** the userspace canonical lower half. The legal
+/// user VA range is `[0, USER_VA_END)`; a `len`-rounded mapping that ends
+/// at `USER_VA_END` is still legal, but any address at or above it is not.
+/// Matches the RFC 0001 boundary and keeps user syscalls from touching the
+/// kernel upper half.
+pub const USER_VA_END: u64 = 0x0000_8000_0000_0000;
+
+/// Default guard distance between the top of `brk` and `mmap_base`. Stops
+/// a saturated heap from stranding later `mmap` allocations, and matches
+/// the RFC 0001 Security advisory A8 default (non-zero guard).
+pub const DEFAULT_BRK_GUARD: u64 = 1 * 1024 * 1024;
+
+/// Per-process address space.
+///
+/// All fields are `pub(crate)` rather than `pub` so later issues can
+/// evolve the representation (e.g. swap the VMA `BTreeMap` for a richer
+/// `VmaTree`, promote `brk_start`/`brk_cur` into a dedicated struct)
+/// without breaking every downstream user.
+#[allow(dead_code)] // fields consumed by follow-up issues #155..#161
+pub struct AddressSpace {
+    /// Physical frame backing this address space's PML4. The lower half
+    /// (entries `0..256`) is user-owned; the upper half (entries
+    /// `256..512`) is a verbatim copy of the canonical kernel PML4
+    /// installed at construction.
+    #[cfg(target_os = "none")]
+    pub(crate) page_table: x86_64::structures::paging::PhysFrame<
+        x86_64::structures::paging::Size4KiB,
+    >,
+
+    /// Sorted interval map of user VMAs keyed by `start`. Half-open
+    /// `[start, end)` intervals that never overlap (enforced by the
+    /// insertion path once #156 lands; for now this map is empty on
+    /// construction and read-only via [`AddressSpace::find`]).
+    pub(crate) vmas: BTreeMap<usize, Vma>,
+
+    /// First valid user VA for the initial `mmap` hint floor. Callers
+    /// that place fixed mappings may go below this.
+    pub(crate) mmap_base: VirtAddr,
+
+    /// brk window: `[brk_start, brk_cur)`, grown by `sys_brk` up to
+    /// `brk_max`.
+    pub(crate) brk_start: VirtAddr,
+    pub(crate) brk_cur: VirtAddr,
+    pub(crate) brk_max: VirtAddr,
+
+    /// Resident pages (PTE-present count). Bumped by the fault resolver
+    /// as it installs frames; decremented by `unmap_range`.
+    pub(crate) rss_pages: usize,
+    /// Virtual pages covered by VMAs, independent of whether they have
+    /// been faulted in. Bumped by `insert`, decremented by
+    /// `unmap_range`.
+    pub(crate) vm_pages: usize,
+}
+
+impl AddressSpace {
+    /// Build an empty address space: fresh PML4 with the canonical
+    /// kernel upper half copied in, no VMAs, `brk` window pinned at
+    /// `mmap_base` until a loader picks a real heap start.
+    ///
+    /// `mmap_base` defaults to `0x0000_0000_4000_0000` — a spot well
+    /// above the usual static ELF load range but far below
+    /// [`USER_VA_END`] so future `brk` and `mmap` both have room.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called before `mem::paging::init`.
+    #[cfg(target_os = "none")]
+    pub fn new_empty() -> Self {
+        let page_table = crate::mem::paging::new_task_pml4();
+        let mmap_base = VirtAddr::new(0x0000_0000_4000_0000);
+        let brk_start = mmap_base;
+        Self {
+            page_table,
+            vmas: BTreeMap::new(),
+            mmap_base,
+            brk_start,
+            brk_cur: brk_start,
+            brk_max: VirtAddr::new(mmap_base.as_u64() - DEFAULT_BRK_GUARD),
+            rss_pages: 0,
+            vm_pages: 0,
+        }
+    }
+
+    /// Test-only constructor: build an `AddressSpace` without touching
+    /// the paging subsystem. Exposed as `pub(crate)` so host tests in
+    /// this crate can exercise the [`find`](Self::find) logic.
+    #[cfg(test)]
+    pub(crate) fn new_for_test(mmap_base: u64) -> Self {
+        Self {
+            vmas: BTreeMap::new(),
+            mmap_base: VirtAddr::new(mmap_base),
+            brk_start: VirtAddr::new(mmap_base),
+            brk_cur: VirtAddr::new(mmap_base),
+            brk_max: VirtAddr::new(mmap_base - DEFAULT_BRK_GUARD),
+            rss_pages: 0,
+            vm_pages: 0,
+        }
+    }
+
+    /// Physical frame backing this address space's PML4. Stable
+    /// accessor so callers (task construction, the fork path, tests)
+    /// don't need to reach into the struct field directly.
+    #[cfg(target_os = "none")]
+    pub fn page_table_frame(
+        &self,
+    ) -> x86_64::structures::paging::PhysFrame<x86_64::structures::paging::Size4KiB> {
+        self.page_table
+    }
+
+    /// Find the VMA containing `addr`, if any. Uses a `BTreeMap::range`
+    /// walk backward from `addr` — O(log n) — so this is the intended
+    /// hot-path lookup for the page-fault resolver.
+    pub fn find(&self, addr: usize) -> Option<&Vma> {
+        self.vmas
+            .range(..=addr)
+            .next_back()
+            .map(|(_, v)| v)
+            .filter(|v| addr < v.end)
+    }
+
+    /// Returns `true` if `vma` lies entirely inside the userspace
+    /// canonical lower half and does not cross [`USER_VA_END`].
+    #[allow(dead_code)] // consumed by #156 (VmaTree::insert) and the mmap syscall
+    pub(crate) fn vma_in_user_range(vma: &Vma) -> bool {
+        (vma.end as u64) <= USER_VA_END
+    }
+}
+
+/// `AddressSpace` wrapper that enforces the RFC 0001 IRQ-safety
+/// contract. Every caller must be in task context with interrupts
+/// enabled — page fault, syscall entry, fork, exec, exit. Interrupt
+/// handlers and other IRQ-context code must defer to a task-context
+/// worker rather than taking this lock directly.
+///
+/// The wrapper exists so the assertion is centralized: a future refactor
+/// to per-CPU preempt counters (once SMP arrives) only needs to update
+/// `debug_assert_task_ctx` below, not every call site.
+pub struct AddressSpaceLock {
+    inner: RwLock<AddressSpace>,
+}
+
+impl AddressSpaceLock {
+    pub const fn new(aspace: AddressSpace) -> Self {
+        Self {
+            inner: RwLock::new(aspace),
+        }
+    }
+
+    /// Take a read lock. Panics in debug builds if called from IRQ
+    /// context (interrupts disabled); see RFC 0001 "IRQ-safety contract".
+    pub fn read(&self) -> spin::RwLockReadGuard<'_, AddressSpace> {
+        debug_assert_task_ctx();
+        self.inner.read()
+    }
+
+    /// Take a write lock. Panics in debug builds if called from IRQ
+    /// context (interrupts disabled); see RFC 0001 "IRQ-safety contract".
+    pub fn write(&self) -> spin::RwLockWriteGuard<'_, AddressSpace> {
+        debug_assert_task_ctx();
+        self.inner.write()
+    }
+}
+
+/// Panic in debug if we're running with interrupts off — a strong proxy
+/// for "we're in interrupt context" pre-SMP. Once per-CPU preempt-depth
+/// counters land this becomes `debug_assert!(!in_irq())`.
+#[cfg(target_os = "none")]
+#[inline]
+fn debug_assert_task_ctx() {
+    debug_assert!(
+        x86_64::instructions::interrupts::are_enabled(),
+        "AddressSpace lock taken from IRQ context (interrupts disabled); \
+         RFC 0001 IRQ-safety contract forbids this",
+    );
+}
+
+#[cfg(not(target_os = "none"))]
+#[inline]
+fn debug_assert_task_ctx() {
+    // Host tests have no interrupt state to check.
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mem::vma::{Vma, VmaKind};
+    use x86_64::structures::paging::PageTableFlags;
+
+    fn anon(start: usize, end: usize) -> Vma {
+        Vma::new(start, end, VmaKind::AnonZero, PageTableFlags::PRESENT)
+    }
+
+    #[test]
+    fn find_returns_none_on_empty() {
+        let aspace = AddressSpace::new_for_test(0x4000_0000);
+        assert!(aspace.find(0x1000).is_none());
+    }
+
+    #[test]
+    fn find_hits_exact_start() {
+        let mut aspace = AddressSpace::new_for_test(0x4000_0000);
+        let vma = anon(0x1_0000, 0x2_0000);
+        aspace.vmas.insert(vma.start, vma);
+        let hit = aspace.find(0x1_0000).expect("start is inclusive");
+        assert_eq!(hit.start, 0x1_0000);
+    }
+
+    #[test]
+    fn find_hits_interior() {
+        let mut aspace = AddressSpace::new_for_test(0x4000_0000);
+        let vma = anon(0x1_0000, 0x3_0000);
+        aspace.vmas.insert(vma.start, vma);
+        let hit = aspace.find(0x2_5000).expect("addr is inside the vma");
+        assert_eq!(hit.start, 0x1_0000);
+        assert_eq!(hit.end, 0x3_0000);
+    }
+
+    #[test]
+    fn find_misses_past_end() {
+        // `end` is exclusive — the very last byte is in, the end address is out.
+        let mut aspace = AddressSpace::new_for_test(0x4000_0000);
+        let vma = anon(0x1_0000, 0x2_0000);
+        aspace.vmas.insert(vma.start, vma);
+        assert!(aspace.find(0x2_0000).is_none());
+        assert!(aspace.find(0x1_ffff).is_some());
+    }
+
+    #[test]
+    fn find_misses_before_start() {
+        let mut aspace = AddressSpace::new_for_test(0x4000_0000);
+        let vma = anon(0x1_0000, 0x2_0000);
+        aspace.vmas.insert(vma.start, vma);
+        assert!(aspace.find(0x0fff).is_none());
+    }
+
+    #[test]
+    fn find_picks_the_right_neighbor_with_a_gap() {
+        let mut aspace = AddressSpace::new_for_test(0x4000_0000);
+        let a = anon(0x1_0000, 0x2_0000);
+        let b = anon(0x5_0000, 0x6_0000);
+        aspace.vmas.insert(a.start, a);
+        aspace.vmas.insert(b.start, b);
+        // In the gap: predecessor is A, but addr >= A.end → miss.
+        assert!(aspace.find(0x3_0000).is_none());
+        // Inside B.
+        assert_eq!(aspace.find(0x5_1000).unwrap().start, 0x5_0000);
+    }
+
+    #[test]
+    fn user_va_range_guard_rejects_kernel_half() {
+        let kernel_half = Vma::new(
+            USER_VA_END as usize,
+            (USER_VA_END as usize) + 0x1000,
+            VmaKind::AnonZero,
+            PageTableFlags::PRESENT,
+        );
+        assert!(!AddressSpace::vma_in_user_range(&kernel_half));
+
+        let high_user = Vma::new(
+            (USER_VA_END as usize) - 0x2000,
+            USER_VA_END as usize,
+            VmaKind::AnonZero,
+            PageTableFlags::PRESENT,
+        );
+        assert!(AddressSpace::vma_in_user_range(&high_user));
+    }
+
+    #[test]
+    fn brk_window_starts_closed_with_guard_below_mmap_base() {
+        let aspace = AddressSpace::new_for_test(0x4000_0000);
+        assert_eq!(aspace.brk_start, aspace.brk_cur);
+        assert!(aspace.brk_max.as_u64() + DEFAULT_BRK_GUARD == aspace.mmap_base.as_u64());
+    }
+}

--- a/kernel/src/mem/addrspace.rs
+++ b/kernel/src/mem/addrspace.rs
@@ -44,9 +44,8 @@ pub struct AddressSpace {
     /// `256..512`) is a verbatim copy of the canonical kernel PML4
     /// installed at construction.
     #[cfg(target_os = "none")]
-    pub(crate) page_table: x86_64::structures::paging::PhysFrame<
-        x86_64::structures::paging::Size4KiB,
-    >,
+    pub(crate) page_table:
+        x86_64::structures::paging::PhysFrame<x86_64::structures::paging::Size4KiB>,
 
     /// Sorted interval map of user VMAs keyed by `start`. Half-open
     /// `[start, end)` intervals that never overlap (enforced by the

--- a/kernel/src/mem/mod.rs
+++ b/kernel/src/mem/mod.rs
@@ -22,8 +22,11 @@ pub mod loader;
 pub mod paging;
 #[cfg(target_os = "none")]
 pub mod pat;
-#[cfg(target_os = "none")]
+#[cfg(any(target_os = "none", test))]
 pub mod vma;
+
+#[cfg(any(target_os = "none", test))]
+pub mod addrspace;
 
 #[cfg(target_os = "none")]
 use spin::Once;

--- a/kernel/tests/addrspace.rs
+++ b/kernel/tests/addrspace.rs
@@ -1,0 +1,98 @@
+//! Integration test: `AddressSpace::new_empty` allocates a fresh PML4
+//! whose upper half (entries 256..512) matches the active kernel PML4
+//! verbatim and whose lower half (entries 0..256) is empty. Two
+//! consecutive calls produce distinct physical frames.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+
+use vibix::mem::addrspace::AddressSpace;
+use vibix::mem::paging::{active_pml4_phys, hhdm_offset};
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "new_empty_produces_distinct_pml4s",
+            &(new_empty_produces_distinct_pml4s as fn()),
+        ),
+        (
+            "new_empty_kernel_half_matches_active",
+            &(new_empty_kernel_half_matches_active as fn()),
+        ),
+        (
+            "new_empty_lower_half_is_empty",
+            &(new_empty_lower_half_is_empty as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+fn new_empty_produces_distinct_pml4s() {
+    let a = AddressSpace::new_empty();
+    let b = AddressSpace::new_empty();
+    assert_ne!(
+        a.page_table_frame().start_address(),
+        b.page_table_frame().start_address(),
+        "two independent AddressSpaces must own distinct PML4 frames",
+    );
+}
+
+/// Read the 512 raw PTE slots of a PML4 through the HHDM.
+unsafe fn pml4_slots(phys: u64) -> &'static [u64; 512] {
+    let virt = hhdm_offset().as_u64() + phys;
+    &*(virt as *const [u64; 512])
+}
+
+fn new_empty_kernel_half_matches_active() {
+    let aspace = AddressSpace::new_empty();
+    let new_phys = aspace.page_table_frame().start_address().as_u64();
+    let active_phys = active_pml4_phys().as_u64();
+
+    let new_slots = unsafe { pml4_slots(new_phys) };
+    let active_slots = unsafe { pml4_slots(active_phys) };
+
+    for i in 256..512 {
+        assert_eq!(
+            new_slots[i], active_slots[i],
+            "PML4 entry {i} (upper/kernel half) must match active PML4",
+        );
+    }
+}
+
+fn new_empty_lower_half_is_empty() {
+    let aspace = AddressSpace::new_empty();
+    let new_phys = aspace.page_table_frame().start_address().as_u64();
+    let new_slots = unsafe { pml4_slots(new_phys) };
+    for i in 0..256 {
+        assert_eq!(
+            new_slots[i], 0,
+            "PML4 entry {i} (lower/user half) must be zeroed in a fresh AddressSpace",
+        );
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -627,6 +627,7 @@ fn test_all() -> R<()> {
         "cow_vma",
         "fpu_context_switch",
         "task_exit",
+        "addrspace",
     ] {
         cmd.arg("--test").arg(t);
     }


### PR DESCRIPTION
Closes #154

## Summary

- First step of RFC 0001. Introduces `AddressSpace` — the per-process anchor every userspace VM syscall and the rewritten `#PF` resolver will hang off of.
- `new_empty()` allocates a fresh PML4 via `paging::new_task_pml4()` (which copies the canonical kernel upper half), initializes an empty `BTreeMap<usize, Vma>`, and opens a `brk` window with a 1 MiB guard below `mmap_base` (RFC Security advisory A8).
- `find(addr)` is the hot-path lookup: `BTreeMap::range(..=addr).next_back()` + end check. O(log n).
- `AddressSpaceLock` wraps `spin::RwLock<AddressSpace>` and enforces the RFC's IRQ-safety contract via a `debug_assert!` that interrupts are enabled at lock entry. Enables spin's `rwlock` feature.
- Constants: `USER_VA_END = 0x0000_8000_0000_0000`, `DEFAULT_BRK_GUARD = 1 MiB`.
- Fields are `pub(crate)` (some `#[allow(dead_code)]`) while follow-up issues #155..#161 evolve VMA insert/split/merge, `VmObject`, the fault resolver, task integration, and `AddressSpace::drop` reclaim.

## Test plan

- [x] `cargo xtask build` — clean.
- [x] `cargo xtask test` — all 62 host unit tests pass, including 7 new `mem::addrspace::tests::*` covering empty/exact-start/interior/past-end/before-start/gap lookups and the brk guard invariant. The new `kernel/tests/addrspace.rs` QEMU integration test passes all three cases (`new_empty_produces_distinct_pml4s`, `new_empty_kernel_half_matches_active`, `new_empty_lower_half_is_empty`).
- [x] `cargo xtask smoke` — all 26 markers present.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new address-space primitives and a locking contract around VM metadata, touching kernel paging setup and test infrastructure; while mostly additive, mistakes here could impact future fault handling and mapping safety.
> 
> **Overview**
> Introduces a new `mem::addrspace` module implementing `AddressSpace` as the per-process VM anchor: it allocates a fresh task PML4 (kernel upper-half copied, user half empty), tracks user VMAs in a sorted map, and pre-reserves a `brk` window with a default guard below `mmap_base`.
> 
> Adds `AddressSpaceLock` (a `spin::RwLock`) with a debug IRQ-safety assertion (interrupts must be enabled when taking the lock), plus constants like `USER_VA_END`/`DEFAULT_BRK_GUARD` and unit tests for `find()`/range checks.
> 
> Enables spin’s `rwlock` feature, exports `vma`/`addrspace` for host tests, and adds a new QEMU integration test (`kernel/tests/addrspace.rs`) that validates the new PML4’s kernel-half mirroring and user-half zeroing; `xtask` now runs this test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcd9bebd34e01814a680de895a37ef8d13122ddd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->