### PR TITLE
mem: Flusher TLB-invalidation abstraction (#157)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -143,3 +143,7 @@ harness = false
 [[test]]
 name = "addrspace"
 harness = false
+
+[[test]]
+name = "tlb_flusher"
+harness = false

--- a/kernel/src/acpi.rs
+++ b/kernel/src/acpi.rs
@@ -271,12 +271,15 @@ fn checksum(ptr: *const u8, len: usize) -> u8 {
 }
 
 fn map_phys(phys: u64, size: u64) {
+    let mut flusher = crate::mem::tlb::Flusher::new_active();
     paging::map_phys_into_hhdm(
         phys,
         size,
         PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE,
+        &mut flusher,
     )
     .expect("failed to map ACPI physical range");
+    flusher.finish();
 }
 
 fn parse_madt(madt: *const SdtHeader) -> AcpiInfo {

--- a/kernel/src/arch/x86_64/apic.rs
+++ b/kernel/src/arch/x86_64/apic.rs
@@ -18,6 +18,7 @@ use crate::mem::paging;
 use crate::serial_println;
 
 fn map_mmio(phys: u64, size: u64) {
+    let mut flusher = crate::mem::tlb::Flusher::new_active();
     paging::map_phys_into_hhdm(
         phys,
         size,
@@ -26,8 +27,10 @@ fn map_mmio(phys: u64, size: u64) {
             | PageTableFlags::NO_EXECUTE
             | PageTableFlags::NO_CACHE
             | PageTableFlags::WRITE_THROUGH,
+        &mut flusher,
     )
     .expect("failed to map APIC MMIO");
+    flusher.finish();
 }
 
 // LAPIC register offsets (all MMIO 32-bit, aligned on 16 bytes).

--- a/kernel/src/arch/x86_64/ist_guard.rs
+++ b/kernel/src/arch/x86_64/ist_guard.rs
@@ -15,6 +15,7 @@ use x86_64::structures::paging::{Page, Size4KiB};
 
 use super::gdt;
 use crate::mem::paging;
+use crate::mem::tlb::Flusher;
 use crate::serial_println;
 
 pub fn install() {
@@ -24,6 +25,8 @@ pub fn install() {
     // and unmap something that isn't the guard.
     let page: Page<Size4KiB> =
         Page::from_start_address(guard).expect("IST guard address must be page-aligned");
-    paging::unmap(page).expect("failed to unmap IST guard page");
+    let mut flusher = Flusher::new_active();
+    paging::unmap(page, &mut flusher).expect("failed to unmap IST guard page");
+    flusher.finish();
     serial_println!("paging: IST guard installed @ {:#x}", guard.as_u64());
 }

--- a/kernel/src/hpet.rs
+++ b/kernel/src/hpet.rs
@@ -108,6 +108,7 @@ pub fn init() -> Result<(), HpetError> {
     let base_phys = unsafe { ptr::addr_of!((*table).base_address).read_unaligned() };
 
     // The register block is 1024 bytes per spec; one page covers it.
+    let mut flusher = crate::mem::tlb::Flusher::new_active();
     paging::map_phys_into_hhdm(
         base_phys,
         0x1000,
@@ -115,8 +116,10 @@ pub fn init() -> Result<(), HpetError> {
             | PageTableFlags::WRITABLE
             | PageTableFlags::NO_EXECUTE
             | PageTableFlags::NO_CACHE,
+        &mut flusher,
     )
     .expect("failed to map HPET MMIO");
+    flusher.finish();
 
     let base = (base_phys + hhdm) as *mut u8;
     let caps = unsafe { read64(base, REG_CAPS) };

--- a/kernel/src/mem/heap.rs
+++ b/kernel/src/mem/heap.rs
@@ -15,6 +15,7 @@ use spin::Mutex;
 use x86_64::structures::paging::PageTableFlags;
 use x86_64::VirtAddr;
 
+use super::tlb::Flusher;
 use super::{paging, FRAME_SIZE};
 use crate::serial_println;
 
@@ -74,11 +75,13 @@ impl GrowingHeap {
         let start = VirtAddr::new((HEAP_BASE + mapped) as u64);
         let frames = (chunk as u64) / FRAME_SIZE;
         let mut grown: usize = 0;
+        let mut flusher = Flusher::new_active();
         for i in 0..frames {
             if paging::map_range(
                 start + i * FRAME_SIZE,
                 1,
                 PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
+                &mut flusher,
             )
             .is_err()
             {
@@ -86,6 +89,7 @@ impl GrowingHeap {
             }
             grown += FRAME_SIZE as usize;
         }
+        flusher.finish();
         if grown == 0 {
             return false;
         }
@@ -162,12 +166,15 @@ pub fn stats() -> HeapStats {
 /// `paging::init` to have run so `map_range` is live.
 pub fn init() {
     let frames = (INITIAL_HEAP_SIZE as u64) / FRAME_SIZE;
+    let mut flusher = Flusher::new_active();
     paging::map_range(
         VirtAddr::new(HEAP_BASE as u64),
         frames,
         PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
+        &mut flusher,
     )
     .expect("failed to map initial heap range");
+    flusher.finish();
 
     unsafe {
         ALLOCATOR

--- a/kernel/src/mem/loader.rs
+++ b/kernel/src/mem/loader.rs
@@ -25,6 +25,7 @@ use x86_64::VirtAddr;
 
 use super::elf;
 use super::paging;
+use super::tlb::Flusher;
 
 const PAGE_SIZE: u64 = 4096;
 
@@ -69,15 +70,21 @@ pub fn load(bytes: &[u8]) -> Result<LoadedImage, LoadError> {
     }
 
     let mut segments = 0usize;
+    let mut flusher = Flusher::new_active();
     for seg in parsed.load_segments() {
-        map_segment(bytes, seg)?;
+        map_segment(bytes, seg, &mut flusher)?;
         segments += 1;
     }
+    flusher.finish();
 
     Ok(LoadedImage { entry, segments })
 }
 
-fn map_segment(bytes: &[u8], seg: elf::LoadSegment) -> Result<(), LoadError> {
+fn map_segment(
+    bytes: &[u8],
+    seg: elf::LoadSegment,
+    flusher: &mut Flusher,
+) -> Result<(), LoadError> {
     if (seg.vaddr.as_u64() >> 63) != 1 {
         return Err(LoadError::SegmentNotUpperHalf);
     }
@@ -97,7 +104,7 @@ fn map_segment(bytes: &[u8], seg: elf::LoadSegment) -> Result<(), LoadError> {
     for i in 0..page_count {
         let va = seg.vaddr + i * PAGE_SIZE;
         let page = Page::<Size4KiB>::containing_address(va);
-        let frame = paging::map(page, seg.flags).map_err(LoadError::MapFailed)?;
+        let frame = paging::map(page, seg.flags, flusher).map_err(LoadError::MapFailed)?;
 
         // Fill this page through the HHDM window. The frame allocator
         // doesn't zero its output, so we clear the whole page first

--- a/kernel/src/mem/loader.rs
+++ b/kernel/src/mem/loader.rs
@@ -71,11 +71,21 @@ pub fn load(bytes: &[u8]) -> Result<LoadedImage, LoadError> {
 
     let mut segments = 0usize;
     let mut flusher = Flusher::new_active();
+    let mut err: Option<LoadError> = None;
     for seg in parsed.load_segments() {
-        map_segment(bytes, seg, &mut flusher)?;
+        if let Err(e) = map_segment(bytes, seg, &mut flusher) {
+            err = Some(e);
+            break;
+        }
         segments += 1;
     }
+    // `finish` on every path: early-returning via `?` on `map_segment`
+    // would drop the Flusher un-finished and trip its Drop-time panic,
+    // turning a graceful `LoadError` into a kernel panic.
     flusher.finish();
+    if let Some(e) = err {
+        return Err(e);
+    }
 
     Ok(LoadedImage { entry, segments })
 }

--- a/kernel/src/mem/mod.rs
+++ b/kernel/src/mem/mod.rs
@@ -12,6 +12,7 @@
 
 pub mod frame;
 pub mod refcount;
+pub mod tlb;
 
 #[cfg(any(target_os = "none", test))]
 pub(crate) mod elf;

--- a/kernel/src/mem/paging.rs
+++ b/kernel/src/mem/paging.rs
@@ -207,6 +207,15 @@ pub fn unmap(
 /// [`map`] / [`map_range`].
 pub fn unmap_and_free(page: Page<Size4KiB>, flusher: &mut Flusher) -> Result<(), UnmapError> {
     let frame = unmap(page, flusher)?;
+    // Local invlpg *before* returning the frame to the allocator. The
+    // caller's Flusher batches with other mutations and finish()
+    // happens later — in the meantime the allocator could hand this
+    // frame to someone else. A stale cached translation for `page`
+    // would then let this CPU read or write another owner's data.
+    // This is a single-CPU flush today; the SMP-shootdown follow-up
+    // will turn it into an IPI. The Flusher still carries the VA
+    // queued, so `finish` re-invalidates harmlessly.
+    x86_64::instructions::tlb::flush(page.start_address());
     // SAFETY: the caller's contract is that `page`'s frame came from
     // the global allocator — `map` is the only supported producer.
     unsafe { KernelFrameAllocator.deallocate_frame(frame) };

--- a/kernel/src/mem/paging.rs
+++ b/kernel/src/mem/paging.rs
@@ -23,6 +23,7 @@ use x86_64::structures::paging::{
 use x86_64::{PhysAddr, VirtAddr};
 
 use super::frame;
+use super::tlb::Flusher;
 use crate::serial_println;
 
 /// Frame allocator adapter: pulls 4 KiB frames from (and, via
@@ -83,9 +84,13 @@ pub fn with_mapper<R>(f: impl FnOnce(&mut OffsetPageTable<'static>) -> R) -> R {
 }
 
 /// Map `page` to a freshly-allocated physical frame with `flags`.
+/// The caller supplies a [`Flusher`]; this function queues `page` on
+/// it but does not `finish` — batch with other mutations where
+/// possible, then `finish` once.
 pub fn map(
     page: Page<Size4KiB>,
     flags: PageTableFlags,
+    flusher: &mut Flusher,
 ) -> Result<PhysFrame<Size4KiB>, MapToError<Size4KiB>> {
     let mut alloc = KernelFrameAllocator;
     let frame = alloc
@@ -93,7 +98,8 @@ pub fn map(
         .ok_or(MapToError::FrameAllocationFailed)?;
     with_mapper(|m| {
         let flush = unsafe { m.map_to(page, frame, flags, &mut alloc)? };
-        flush.flush();
+        flush.ignore();
+        flusher.invalidate(page.start_address());
         Ok(frame)
     })
 }
@@ -103,10 +109,11 @@ pub fn map_range(
     start: VirtAddr,
     count: u64,
     flags: PageTableFlags,
+    flusher: &mut Flusher,
 ) -> Result<(), MapToError<Size4KiB>> {
     for i in 0..count {
         let page = Page::<Size4KiB>::containing_address(start + i * 4096);
-        map(page, flags)?;
+        map(page, flags, flusher)?;
     }
     Ok(())
 }
@@ -123,6 +130,7 @@ pub fn map_phys_into_hhdm(
     phys: u64,
     size: u64,
     flags: PageTableFlags,
+    flusher: &mut Flusher,
 ) -> Result<(), MapToError<Size4KiB>> {
     if size == 0 {
         return Ok(());
@@ -148,7 +156,10 @@ pub fn map_phys_into_hhdm(
             // and firmware-provided ACPI tables the kernel is the sole
             // user and we never hand these pages to the frame allocator.
             match unsafe { m.map_to(page, frame, flags, &mut alloc) } {
-                Ok(flush) => flush.flush(),
+                Ok(flush) => {
+                    flush.ignore();
+                    flusher.invalidate(page.start_address());
+                }
                 // Already mapped via a 4 KiB PTE — no-op.
                 Err(MapToError::PageAlreadyMapped(_)) => {}
                 // A 2 MiB HHDM huge page already covers this address
@@ -179,10 +190,14 @@ pub fn map_phys_into_hhdm(
 /// return it to the global allocator with [`unmap_and_free`], or hold
 /// on to it (e.g. when unmapping a physical region the allocator never
 /// owned, like the IST guard page which lives in `.bss`).
-pub fn unmap(page: Page<Size4KiB>) -> Result<PhysFrame<Size4KiB>, UnmapError> {
+pub fn unmap(
+    page: Page<Size4KiB>,
+    flusher: &mut Flusher,
+) -> Result<PhysFrame<Size4KiB>, UnmapError> {
     with_mapper(|m| {
         let (frame, flush) = m.unmap(page)?;
-        flush.flush();
+        flush.ignore();
+        flusher.invalidate(page.start_address());
         Ok(frame)
     })
 }
@@ -190,8 +205,8 @@ pub fn unmap(page: Page<Size4KiB>) -> Result<PhysFrame<Size4KiB>, UnmapError> {
 /// Unmap `page` and return its backing frame to the global frame
 /// allocator. Use this for mappings whose frame originally came from
 /// [`map`] / [`map_range`].
-pub fn unmap_and_free(page: Page<Size4KiB>) -> Result<(), UnmapError> {
-    let frame = unmap(page)?;
+pub fn unmap_and_free(page: Page<Size4KiB>, flusher: &mut Flusher) -> Result<(), UnmapError> {
+    let frame = unmap(page, flusher)?;
     // SAFETY: the caller's contract is that `page`'s frame came from
     // the global allocator — `map` is the only supported producer.
     unsafe { KernelFrameAllocator.deallocate_frame(frame) };

--- a/kernel/src/mem/tlb.rs
+++ b/kernel/src/mem/tlb.rs
@@ -62,7 +62,8 @@ impl Flusher {
         self.len += 1;
     }
 
-    /// Number of queued pages (0 while in overflow mode).
+    /// Number of queued pages. Caps at [`INLINE_CAP`] once overflow
+    /// latches — further `invalidate` calls don't increment it.
     pub fn queued(&self) -> usize {
         self.len
     }

--- a/kernel/src/mem/tlb.rs
+++ b/kernel/src/mem/tlb.rs
@@ -1,0 +1,152 @@
+//! TLB-invalidation batching.
+//!
+//! Every paging mutation (`map`, `unmap`, `map_range`, ...) takes a
+//! `&mut Flusher`. Callers `invalidate(va)` on the Flusher once per
+//! modified page, then `finish()` to apply the batch — per-page
+//! `invlpg` under the inline cap, or a whole-TLB reload past it.
+//!
+//! Threading a Flusher through *now*, even as a single-CPU operation,
+//! lets the RFC-0001 SMP-shootdown follow-up slot its IPI logic into
+//! one location (`Flusher::finish`) instead of revisiting every call
+//! site.
+//!
+//! **Invariant:** every `Flusher` must be consumed by [`finish`]. The
+//! `Drop` impl panics otherwise — a Flusher dropped without `finish`
+//! means a paging mutation went live without its TLB entry being
+//! invalidated. Under `panic = "abort"` the drop-from-panic path is
+//! moot; under unwind the double-panic aborts, which is what we want
+//! for a kernel-correctness bug.
+//!
+//! [`finish`]: Flusher::finish
+
+use x86_64::VirtAddr;
+
+/// Queue depth before falling back to a whole-TLB reload. Sized to
+/// cover the single largest batch the kernel currently produces
+/// (heap grow: 16 pages) with headroom. Past the cap, per-page
+/// `invlpg` loses to a single CR3 reload anyway.
+pub const INLINE_CAP: usize = 32;
+
+/// Batched TLB invalidation. See module docs.
+pub struct Flusher {
+    pages: [u64; INLINE_CAP],
+    len: usize,
+    overflow: bool,
+    finished: bool,
+}
+
+impl Flusher {
+    /// Flusher targeting the currently-active address space. `finish`
+    /// invalidates on the CPU that calls it.
+    pub const fn new_active() -> Self {
+        Self {
+            pages: [0; INLINE_CAP],
+            len: 0,
+            overflow: false,
+            finished: false,
+        }
+    }
+
+    /// Queue `va` for invalidation. Once the queue is full, subsequent
+    /// calls latch the Flusher into overflow mode — `finish` will do a
+    /// whole-TLB reload instead of per-page `invlpg`.
+    pub fn invalidate(&mut self, va: VirtAddr) {
+        if self.overflow {
+            return;
+        }
+        if self.len == INLINE_CAP {
+            self.overflow = true;
+            return;
+        }
+        self.pages[self.len] = va.as_u64();
+        self.len += 1;
+    }
+
+    /// Number of queued pages (0 while in overflow mode).
+    pub fn queued(&self) -> usize {
+        self.len
+    }
+
+    /// True once the queue overflowed past [`INLINE_CAP`].
+    pub fn overflowed(&self) -> bool {
+        self.overflow
+    }
+
+    /// Apply queued invalidations. Consumes `self`; the `Drop` guard
+    /// trips if a caller forgets to call this.
+    pub fn finish(mut self) {
+        self.apply();
+        self.finished = true;
+    }
+
+    fn apply(&mut self) {
+        #[cfg(target_os = "none")]
+        {
+            if self.overflow {
+                use x86_64::registers::control::Cr3;
+                let (frame, flags) = Cr3::read();
+                // SAFETY: reloading the active CR3 with the same
+                // frame+flags is well-defined and flushes non-global
+                // TLB entries — exactly what we want as the overflow
+                // fallback.
+                unsafe { Cr3::write(frame, flags) };
+            } else {
+                for i in 0..self.len {
+                    x86_64::instructions::tlb::flush(VirtAddr::new(self.pages[i]));
+                }
+            }
+        }
+    }
+}
+
+impl Drop for Flusher {
+    fn drop(&mut self) {
+        assert!(
+            self.finished,
+            "Flusher dropped without finish(): {} queued, overflow={}",
+            self.len,
+            self.overflow,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_finish_is_fine() {
+        Flusher::new_active().finish();
+    }
+
+    #[test]
+    fn invalidate_accumulates() {
+        let mut f = Flusher::new_active();
+        f.invalidate(VirtAddr::new(0x1000));
+        f.invalidate(VirtAddr::new(0x2000));
+        assert_eq!(f.queued(), 2);
+        assert!(!f.overflowed());
+        f.finish();
+    }
+
+    #[test]
+    fn overflow_latches_past_cap() {
+        let mut f = Flusher::new_active();
+        for i in 0..INLINE_CAP as u64 {
+            f.invalidate(VirtAddr::new(0x1000 + i * 0x1000));
+        }
+        assert!(!f.overflowed());
+        f.invalidate(VirtAddr::new(0xdead_0000));
+        assert!(f.overflowed());
+        // Further invalidations are silent no-ops once latched.
+        f.invalidate(VirtAddr::new(0xbeef_0000));
+        assert!(f.overflowed());
+        f.finish();
+    }
+
+    #[test]
+    #[should_panic(expected = "Flusher dropped without finish()")]
+    fn drop_without_finish_panics() {
+        let _f = Flusher::new_active();
+    }
+}

--- a/kernel/src/mem/tlb.rs
+++ b/kernel/src/mem/tlb.rs
@@ -104,8 +104,7 @@ impl Drop for Flusher {
         assert!(
             self.finished,
             "Flusher dropped without finish(): {} queued, overflow={}",
-            self.len,
-            self.overflow,
+            self.len, self.overflow,
         );
     }
 }

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -183,12 +183,15 @@ impl Task {
         Page::<Size4KiB>::from_start_address(VirtAddr::new(stack_base as u64))
             .expect("task stack base must be page aligned");
         let stack_page_count = (STACK_SIZE / 4096) as u64;
+        let mut flusher = crate::mem::tlb::Flusher::new_active();
         paging::map_range(
             VirtAddr::new(stack_base as u64),
             stack_page_count,
             PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE,
+            &mut flusher,
         )
         .expect("failed to map task stack");
+        flusher.finish();
 
         // Build the per-task PML4 *after* mapping the stack — the new
         // PML4 snapshots the kernel PML4's upper half, and we want the

--- a/kernel/tests/paging.rs
+++ b/kernel/tests/paging.rs
@@ -58,7 +58,9 @@ fn map_roundtrip_unmap() {
 
     let page: Page<Size4KiB> = Page::containing_address(va);
     let flags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE;
-    let _frame = paging::map(page, flags).expect("map failed");
+    let mut flusher = vibix::mem::tlb::Flusher::new_active();
+    let _frame = paging::map(page, flags, &mut flusher).expect("map failed");
+    flusher.finish();
 
     let phys = paging::translate(va).expect("translate after map returned None");
     serial_println!("  mapped {va:?} -> {phys:?}");
@@ -69,7 +71,9 @@ fn map_roundtrip_unmap() {
         assert_eq!(ptr.read_volatile(), 0xCAFE_F00D_DEAD_BEEF);
     }
 
-    paging::unmap_and_free(page).expect("unmap failed");
+    let mut flusher = vibix::mem::tlb::Flusher::new_active();
+    paging::unmap_and_free(page, &mut flusher).expect("unmap failed");
+    flusher.finish();
     assert!(
         paging::translate(va).is_none(),
         "translate after unmap still returned Some"
@@ -90,14 +94,18 @@ fn map_unmap_loop_reclaims() {
     // (PDPT/PD/PT) that stay populated across subsequent iterations.
     // Take the baseline *after* that one-time cost so we measure pure
     // leaf-frame accounting over the loop below.
-    paging::map(page, flags).expect("warm-up map");
-    paging::unmap_and_free(page).expect("warm-up unmap");
+    let mut flusher = vibix::mem::tlb::Flusher::new_active();
+    paging::map(page, flags, &mut flusher).expect("warm-up map");
+    paging::unmap_and_free(page, &mut flusher).expect("warm-up unmap");
+    flusher.finish();
 
     let baseline = frame::global().lock().free_frames();
 
     for _ in 0..64 {
-        paging::map(page, flags).expect("map failed in loop");
-        paging::unmap_and_free(page).expect("unmap failed in loop");
+        let mut flusher = vibix::mem::tlb::Flusher::new_active();
+        paging::map(page, flags, &mut flusher).expect("map failed in loop");
+        paging::unmap_and_free(page, &mut flusher).expect("unmap failed in loop");
+        flusher.finish();
     }
 
     let after = frame::global().lock().free_frames();

--- a/kernel/tests/tlb_flusher.rs
+++ b/kernel/tests/tlb_flusher.rs
@@ -42,8 +42,9 @@ fn run_tests() {
 
 const TEST_VA: u64 = 0xFFFF_C000_F1B0_0000;
 const SENTINEL: u64 = 0xCAFE_F00D_DEAD_BEEF;
-const FLAGS_RW: PageTableFlags =
-    PageTableFlags::from_bits_truncate(PageTableFlags::PRESENT.bits() | PageTableFlags::WRITABLE.bits());
+const FLAGS_RW: PageTableFlags = PageTableFlags::from_bits_truncate(
+    PageTableFlags::PRESENT.bits() | PageTableFlags::WRITABLE.bits(),
+);
 
 /// Map a page, stash a sentinel, unmap+flush via Flusher, then remap
 /// the *same VA* to a fresh (zeroed) frame. The remap must be visible

--- a/kernel/tests/tlb_flusher.rs
+++ b/kernel/tests/tlb_flusher.rs
@@ -1,0 +1,120 @@
+//! Integration test: the `Flusher` abstraction correctly invalidates
+//! TLB entries for unmapped pages, so a remap to a different backing
+//! frame isn't shadowed by a stale cached translation.
+
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+use vibix::mem::paging;
+use vibix::mem::tlb::{Flusher, INLINE_CAP};
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+use x86_64::structures::paging::{Page, PageTableFlags, Size4KiB};
+use x86_64::VirtAddr;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("stale_tlb_invalidated", &(stale_tlb_invalidated as fn())),
+        ("overflow_path_works", &(overflow_path_works as fn())),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+const TEST_VA: u64 = 0xFFFF_C000_F1B0_0000;
+const SENTINEL: u64 = 0xCAFE_F00D_DEAD_BEEF;
+const FLAGS_RW: PageTableFlags =
+    PageTableFlags::from_bits_truncate(PageTableFlags::PRESENT.bits() | PageTableFlags::WRITABLE.bits());
+
+/// Map a page, stash a sentinel, unmap+flush via Flusher, then remap
+/// the *same VA* to a fresh (zeroed) frame. The remap must be visible
+/// — if the Flusher's finish didn't evict the old translation, the
+/// read could still hit the original frame's sentinel.
+fn stale_tlb_invalidated() {
+    let va = VirtAddr::new(TEST_VA);
+    assert!(
+        paging::translate(va).is_none(),
+        "picked test VA {va:?} is already mapped — pick another"
+    );
+
+    let page: Page<Size4KiB> = Page::from_start_address(va).expect("VA aligned");
+
+    let mut f = Flusher::new_active();
+    paging::map(page, FLAGS_RW, &mut f).expect("initial map");
+    f.finish();
+
+    let ptr = va.as_u64() as *mut u64;
+    unsafe { ptr.write_volatile(SENTINEL) };
+
+    let mut f = Flusher::new_active();
+    paging::unmap_and_free(page, &mut f).expect("unmap");
+    f.finish();
+    assert!(paging::translate(va).is_none(), "unmap left PTE behind");
+
+    let mut f = Flusher::new_active();
+    let new_frame = paging::map(page, FLAGS_RW, &mut f).expect("remap");
+    f.finish();
+
+    // Zero the new frame through HHDM so the test result doesn't
+    // depend on whether the allocator happened to hand us the same
+    // (still-sentinel-bearing) frame back.
+    let hhdm_ptr = (paging::hhdm_offset() + new_frame.start_address().as_u64()).as_mut_ptr::<u8>();
+    unsafe { core::ptr::write_bytes(hhdm_ptr, 0, 4096) };
+
+    let observed = unsafe { ptr.read_volatile() };
+    assert_eq!(
+        observed, 0,
+        "stale TLB translation survived unmap: read {observed:#x}",
+    );
+
+    let mut f = Flusher::new_active();
+    paging::unmap_and_free(page, &mut f).expect("cleanup unmap");
+    f.finish();
+}
+
+/// Queueing past the inline cap must not panic and must leave the TLB
+/// in a valid state. The Flusher latches into overflow mode and does a
+/// whole-TLB reload in `finish`. After finish, a freshly-mapped VA is
+/// readable — the CR3 reload didn't wedge the address space.
+fn overflow_path_works() {
+    let mut f = Flusher::new_active();
+    for i in 0..(INLINE_CAP as u64 + 4) {
+        f.invalidate(VirtAddr::new(0xFFFF_D000_0000_0000 + i * 0x1000));
+    }
+    assert!(f.overflowed(), "expected overflow latch");
+    f.finish();
+
+    // Address space still works end-to-end.
+    let va = VirtAddr::new(0xFFFF_C000_F1B1_0000);
+    let page: Page<Size4KiB> = Page::from_start_address(va).expect("VA aligned");
+    let mut f = Flusher::new_active();
+    paging::map(page, FLAGS_RW, &mut f).expect("post-overflow map");
+    f.finish();
+    let ptr = va.as_u64() as *mut u64;
+    unsafe {
+        ptr.write_volatile(0x1234_5678_9ABC_DEF0);
+        assert_eq!(ptr.read_volatile(), 0x1234_5678_9ABC_DEF0);
+    }
+    let mut f = Flusher::new_active();
+    paging::unmap_and_free(page, &mut f).expect("post-overflow unmap");
+    f.finish();
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -628,6 +628,7 @@ fn test_all() -> R<()> {
         "fpu_context_switch",
         "task_exit",
         "addrspace",
+        "tlb_flusher",
     ] {
         cmd.arg("--test").arg(t);
     }


### PR DESCRIPTION
Closes #157

## Summary
- New `mem::tlb::Flusher`: paging mutations queue invalidations on a caller-supplied Flusher; `finish()` emits per-page `invlpg` under the inline cap (32) and latches into a whole-TLB CR3 reload past it. `Drop` asserts the batch was finished.
- `paging::{map, map_range, unmap, unmap_and_free, map_phys_into_hhdm}` now take `&mut Flusher`; internal `MapperFlush::flush()` calls replaced with `ignore()` + `flusher.invalidate(va)`.
- Migrated call sites: heap init + grow, IST guard, ELF loader, task stack map, ACPI / HPET / APIC MMIO, paging roundtrip integration test.
- Threading a Flusher now (even as a single-CPU op) gives the future SMP-shootdown follow-up a single integration point in `Flusher::finish` instead of every call site.

`*_in_pml4` variants are intentionally out of scope — they already do correct flushing conditional on `Cr3::read() == pml4_frame`; threading a target-PML4-aware Flusher through them is a separate follow-up.

## Test plan
- [x] `cargo xtask build`
- [x] `cargo xtask test` — host unit tests for Flusher (queue, overflow latch, Drop panic) plus new `tlb_flusher` QEMU integration test (stale-TLB-after-unmap sentinel; overflow path round-trip) all green
- [x] `cargo xtask smoke` — all 26 markers present

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core paging/virtual-memory mutation paths and changes when/how TLB invalidations occur, so regressions could manifest as subtle memory-corruption or page-fault issues. Risk is mitigated by new unit + QEMU integration tests covering stale-entry and overflow/CR3-reload behavior.
> 
> **Overview**
> Introduces `mem::tlb::Flusher`, a required batching abstraction for TLB invalidations that queues per-page invalidations and falls back to a full CR3 reload after an inline cap, with a `Drop` assert to catch missing `finish()`.
> 
> Refactors paging mutation APIs (`map`, `map_range`, `unmap`, `unmap_and_free`, `map_phys_into_hhdm`) to take `&mut Flusher` and to replace immediate `MapperFlush::flush()` with `ignore()` + queued invalidations; `unmap_and_free` also adds a pre-free local `invlpg` to prevent reuse of frames with stale translations.
> 
> Updates all affected call sites (heap growth/init, ELF loader, task stack mapping, IST guard unmap, ACPI/APIC/HPET MMIO mapping, paging tests) and adds a new `tlb_flusher` QEMU integration test plus host unit tests for Flusher behavior; test runners are updated to include the new test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10506181dafaa452b67f8aa2a9799ca0969e4fcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->