### PR TITLE
kernel: print ASCII art banner after all systems come up

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -182,6 +182,14 @@ pub extern "C" fn _start() -> ! {
     #[cfg(feature = "bench")]
     vibix::task::spawn(vibix::bench::run_all);
 
+    // ASCII art banner — shown once all subsystems and tasks are up.
+    println!("");
+    println!(r" __   _____ ____  _____  __");
+    println!(r" \ \ / /_ _| __ )|_ _\ \/ /");
+    println!(r"  \ V / | ||  _ \ | | >  < ");
+    println!(r"   \_/ |___|____/|___|/_/\_\");
+    println!("");
+
     // Bootstrap task becomes the idle loop. `hlt` with IRQs on parks
     // the CPU until the next interrupt; the PIT `preempt_tick` then
     // rotates us to any other ready task (shell, cursor_blink).


### PR DESCRIPTION
## Summary

Prints a VIBIX ASCII banner on the framebuffer as the last action of the bootstrap task, after all hardware subsystems are initialised and scheduler tasks are spawned:

```
 __   _____ ____  _____  __
 \ \ / /_ _| __ )|_ _\ \/ /
  \ V / | ||  _ \ | | >  < 
   \_/ |___|____/|___|/_/\_\
```

The banner uses only printable ASCII, so it renders correctly with the existing `BASIC_FONTS` glyph lookup in the framebuffer console.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds a few `println!` calls during boot and doesn’t change initialization, scheduling, or memory logic.
> 
> **Overview**
> Prints a VIBIX ASCII-art banner to the framebuffer console at the end of `_start`, after all subsystems are initialized and background tasks are spawned, with blank lines before/after for spacing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1042416b1734580c5473f9cc00c20be81609719d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->