### PR TITLE
mem: RFC 0001 page-fault dispatch gates (SMAP, RSVD, canonical)

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -100,7 +100,9 @@ extern "x86-interrupt" fn page_fault(frame: InterruptStackFrame, code: PageFault
     // faults fall through to the existing hang-with-diagnostic path).
     let err_raw = code.bits();
     let cpl = (frame.code_segment.0 & 0b11) as u8;
-    let rflags_ac = frame.cpu_flags.contains(x86_64::registers::rflags::RFlags::ALIGNMENT_CHECK);
+    let rflags_ac = frame
+        .cpu_flags
+        .contains(x86_64::registers::rflags::RFlags::ALIGNMENT_CHECK);
 
     if crate::mem::pf::is_smap_violation(cpl, err_raw, rflags_ac) {
         panic_smap_violation(addr_u64);

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -40,6 +40,25 @@ fn hang() -> ! {
     }
 }
 
+/// RFC 0001 Security A2: an SMAP violation is a kernel bug that could
+/// be weaponised by an attacker-controlled user page, so the diagnostic
+/// carries the faulting VA only — never PTE contents or frame physaddrs.
+#[inline(never)]
+fn panic_smap_violation(addr: u64) -> ! {
+    serial_println!("EXCEPTION: #PF SMAP violation addr={:#x}", addr);
+    hang();
+}
+
+/// RFC 0001 Security A2: a reserved-bit fault means the page-table
+/// walker saw a PTE with bits set that the current MAXPHYADDR /
+/// paging mode reserves — always a kernel-side corruption. Log the
+/// VA only; the PTE word must not reach any user-reachable sink.
+#[inline(never)]
+fn panic_rsvd_corruption(addr: u64) -> ! {
+    serial_println!("EXCEPTION: #PF RSVD corruption addr={:#x}", addr);
+    hang();
+}
+
 extern "x86-interrupt" fn divide_error(frame: InterruptStackFrame) {
     serial_println!("EXCEPTION: #DE (divide error)\n{:#?}", frame);
     hang();
@@ -72,6 +91,40 @@ extern "x86-interrupt" fn page_fault(frame: InterruptStackFrame, code: PageFault
             );
             exit_qemu(QemuExitCode::Failure);
         }
+    }
+
+    // RFC 0001 dispatch gates. Order is load-bearing: SMAP before any
+    // decision that might trust user state; RSVD before canonical
+    // because a corrupt walk could spoof a "bad address" signal; the
+    // canonical/USER_VA_END check gates user faults only (pure kernel
+    // faults fall through to the existing hang-with-diagnostic path).
+    let err_raw = code.bits();
+    let cpl = (frame.code_segment.0 & 0b11) as u8;
+    let rflags_ac = frame.cpu_flags.contains(x86_64::registers::rflags::RFlags::ALIGNMENT_CHECK);
+
+    if crate::mem::pf::is_smap_violation(cpl, err_raw, rflags_ac) {
+        panic_smap_violation(addr_u64);
+    }
+
+    // Pure kernel faults (CPL=0, supervisor page) fall through to the
+    // existing handler chain below. Nothing to do here beyond the
+    // explicit no-op — the comment documents the RFC's step 2.
+
+    if crate::mem::pf::is_rsvd_fault(err_raw) {
+        panic_rsvd_corruption(addr_u64);
+    }
+
+    // Step 4: canonical / USER_VA_END check for user-mode faults. A
+    // user fault whose cr2 lands in the kernel half (or non-canonical
+    // region) is a SIGSEGV/MAPERR; we don't have signal delivery yet
+    // so log and hang with the RFC-mandated marker.
+    if cpl != 0 && !crate::mem::pf::is_user_va(addr_u64) {
+        serial_println!(
+            "EXCEPTION: #PF user addr={:#x} outside USER_VA_END (MAPERR) code={:?}",
+            addr_u64,
+            code,
+        );
+        hang();
     }
 
     // VMA-backed resolver. Two independent paths:

--- a/kernel/src/mem/mod.rs
+++ b/kernel/src/mem/mod.rs
@@ -32,6 +32,9 @@ pub mod vmatree;
 pub mod vmobject;
 
 #[cfg(any(target_os = "none", test))]
+pub mod pf;
+
+#[cfg(any(target_os = "none", test))]
 pub mod addrspace;
 
 #[cfg(target_os = "none")]

--- a/kernel/src/mem/pf.rs
+++ b/kernel/src/mem/pf.rs
@@ -1,0 +1,185 @@
+//! Page-fault pure logic. Hosts the RFC 0001 dispatch gates
+//! (SMAP violation, reserved-bit corruption, canonical/`USER_VA_END`
+//! check, `prot_user` permission check) as pure functions so the host
+//! unit tests can drive them without a live IDT.
+//!
+//! The actual page-fault handler in `arch::x86_64::idt::page_fault`
+//! composes these gates in the order mandated by the RFC
+//! ("Algorithms and Protocols", page-fault dispatch pseudocode):
+//!
+//!   1. SMAP violation (CPL=0, U/S=1, AC=0)      → panic, VA only
+//!   2. Pure kernel fault (CPL=0, U/S=0)          → existing kernel path
+//!   3. RSVD=1                                    → panic, VA only
+//!   4. `cr2` not canonical or ≥ `USER_VA_END`    → SIGSEGV (MAPERR)
+//!   5. VMA lookup; SIGSEGV on miss               → resolve_growsdown_or_segv
+//!   6. `prot_user.allows(access)`                → SIGSEGV (ACCERR)
+//!   7. Dispatch (demand / CoW / racy present)    → resolve_*
+//!
+//! This module owns 1, 3, 4, 6. Steps 2, 5, 7 stay in `idt.rs` /
+//! follow-ups (#159 and #160) because they need task/addrspace state
+//! that isn't reachable from pure logic.
+//!
+//! Security note on the panic paths: both `panic_smap_violation` and
+//! `panic_rsvd_corruption` must **log the faulting VA only**, never the
+//! PTE word or the frame's physaddr. A reserved-bit fault often means
+//! the kernel's own page tables were corrupted; echoing back the PTE
+//! contents to a user-reachable sink hands an attacker a free peek at
+//! kernel state (RFC 0001 Security advisory A2).
+
+use crate::mem::addrspace::USER_VA_END;
+use crate::mem::vmatree::ProtUser;
+use crate::mem::vmobject::Access;
+
+/// User-visible `PROT_*` bits, mirrored out of `mman.h`. Width and
+/// values match the Linux ABI so future file-backed `mmap` can take
+/// them straight from userspace without re-encoding.
+pub const PROT_NONE: ProtUser = 0;
+pub const PROT_READ: ProtUser = 1;
+pub const PROT_WRITE: ProtUser = 2;
+pub const PROT_EXEC: ProtUser = 4;
+
+// Raw bit positions in the x86 #PF error code. Kept as numeric
+// constants (not `PageFaultErrorCode` flags) so the module stays
+// host-compilable — the `x86_64` crate is target-only.
+const ERR_P: u64 = 1 << 0;
+const ERR_WR: u64 = 1 << 1;
+const ERR_US: u64 = 1 << 2;
+const ERR_RSVD: u64 = 1 << 3;
+#[allow(dead_code)] // reserved for the future XD-bit / exec-fault gate
+const ERR_ID: u64 = 1 << 4;
+
+/// Decode the access kind from the raw `#PF` error code. Write is any
+/// fault with `W/R=1`; everything else is a read (instruction fetch
+/// and data read share the read permission bit in our `prot_user`
+/// model, mirroring Linux).
+pub fn access_from_error_code(err: u64) -> Access {
+    if err & ERR_WR != 0 {
+        Access::Write
+    } else {
+        Access::Read
+    }
+}
+
+/// True if `prot` grants `access`. `PROT_WRITE` without `PROT_READ` is
+/// accepted as the user's request but the PTE is installed with `R|W`
+/// anyway (see RFC 0001 "PROT bits"), so a read on a write-only VMA is
+/// legal at the `prot_user` layer.
+pub fn prot_user_allows(prot: ProtUser, access: Access) -> bool {
+    match access {
+        Access::Read => prot & (PROT_READ | PROT_WRITE) != 0,
+        Access::Write => prot & PROT_WRITE != 0,
+    }
+}
+
+/// True if `va` is a valid 48-bit canonical userspace address: bits
+/// `[47..64]` must all be zero (lower half) and `va` must be strictly
+/// below [`USER_VA_END`]. Rejects both non-canonical addresses and
+/// kernel-half addresses in one check.
+pub fn is_user_va(va: u64) -> bool {
+    va < USER_VA_END
+}
+
+/// True if this fault is an SMAP violation: the CPU was in ring 0
+/// (`cpl == 0`), the faulting address was a user page (`U/S=1`), and
+/// `RFLAGS.AC` was clear (no explicit `stac` / `clac` bracket around
+/// the user touch). See RFC 0001 Security advisory B5; the handler
+/// **must** panic — a return would let a kernel bug corrupt user
+/// state.
+pub fn is_smap_violation(cpl: u8, err: u64, rflags_ac: bool) -> bool {
+    cpl == 0 && (err & ERR_US != 0) && !rflags_ac
+}
+
+/// True if the CPU reported a reserved-bit violation in a page-table
+/// entry along the walk. Always a kernel bug (userspace cannot
+/// author kernel PTEs) — the RFC mandates panic with no PTE content
+/// in the logged output.
+pub fn is_rsvd_fault(err: u64) -> bool {
+    err & ERR_RSVD != 0
+}
+
+/// True if the fault came from ring 0 against a *kernel* page (U/S=0).
+/// The RFC routes these to the existing kernel-fault diagnostic
+/// instead of the user-VM dispatch.
+pub fn is_pure_kernel_fault(cpl: u8, err: u64) -> bool {
+    cpl == 0 && (err & ERR_US == 0)
+}
+
+/// True if the fault hit an already-present page (typical for CoW or
+/// protection-widening paths); false for demand-fault (not present).
+pub fn is_present_fault(err: u64) -> bool {
+    err & ERR_P != 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn access_decodes_read_and_write() {
+        // Error code layout: bit 0 P, 1 W/R, 2 U/S, 3 RSVD, 4 I/D.
+        assert_eq!(access_from_error_code(0b0000_0100), Access::Read); // user read
+        assert_eq!(access_from_error_code(0b0000_0110), Access::Write); // user write
+        assert_eq!(access_from_error_code(0b0000_0000), Access::Read); // kernel read
+    }
+
+    #[test]
+    fn prot_user_allows_matches_mman_semantics() {
+        assert!(prot_user_allows(PROT_READ, Access::Read));
+        assert!(!prot_user_allows(PROT_READ, Access::Write));
+        assert!(prot_user_allows(PROT_READ | PROT_WRITE, Access::Write));
+        // PROT_WRITE without PROT_READ: read is allowed because the
+        // PTE round-trip installs R|W anyway.
+        assert!(prot_user_allows(PROT_WRITE, Access::Read));
+        assert!(prot_user_allows(PROT_WRITE, Access::Write));
+        assert!(!prot_user_allows(PROT_NONE, Access::Read));
+        assert!(!prot_user_allows(PROT_NONE, Access::Write));
+        assert!(!prot_user_allows(PROT_EXEC, Access::Write));
+    }
+
+    #[test]
+    fn user_va_rejects_kernel_half_and_non_canonical() {
+        assert!(is_user_va(0x0000_0000_4000_0000));
+        assert!(is_user_va(USER_VA_END - 1));
+        // Exactly at USER_VA_END is the lowest non-canonical address.
+        assert!(!is_user_va(USER_VA_END));
+        // Kernel half is trivially rejected.
+        assert!(!is_user_va(0xffff_8000_0000_0000));
+        // The first address after USER_VA_END (non-canonical region).
+        assert!(!is_user_va(0x0000_8000_0000_1000));
+    }
+
+    #[test]
+    fn smap_violation_requires_all_three_signals() {
+        // Ring-0 touches a user page with AC clear → violation.
+        assert!(is_smap_violation(0, ERR_US, false));
+        // Same fault but AC set (explicit stac) → allowed.
+        assert!(!is_smap_violation(0, ERR_US, true));
+        // Ring-3 fault on user page → not an SMAP concern.
+        assert!(!is_smap_violation(3, ERR_US, false));
+        // Ring-0 touching kernel page → not SMAP.
+        assert!(!is_smap_violation(0, 0, false));
+    }
+
+    #[test]
+    fn rsvd_fault_detects_bit_3() {
+        assert!(is_rsvd_fault(ERR_RSVD));
+        assert!(is_rsvd_fault(ERR_P | ERR_US | ERR_RSVD));
+        assert!(!is_rsvd_fault(ERR_P | ERR_WR | ERR_US));
+    }
+
+    #[test]
+    fn pure_kernel_fault_detects_supervisor_page_in_ring0() {
+        assert!(is_pure_kernel_fault(0, 0));
+        assert!(is_pure_kernel_fault(0, ERR_P));
+        assert!(!is_pure_kernel_fault(0, ERR_US));
+        assert!(!is_pure_kernel_fault(3, 0));
+    }
+
+    #[test]
+    fn present_fault_flag() {
+        assert!(is_present_fault(ERR_P));
+        assert!(is_present_fault(ERR_P | ERR_WR | ERR_US));
+        assert!(!is_present_fault(ERR_US));
+        assert!(!is_present_fault(0));
+    }
+}


### PR DESCRIPTION
Closes #158

## Summary

- New `kernel/src/mem/pf.rs` module with pure-logic page-fault dispatch gates: `is_smap_violation`, `is_rsvd_fault`, `is_user_va` (canonical + `USER_VA_END`), `access_from_error_code`, `prot_user_allows`, `is_pure_kernel_fault`, `is_present_fault`. Host-testable — no `x86_64` crate types in the public surface.
- `PROT_NONE/READ/WRITE/EXEC` constants (Linux ABI values) anchored in the new module.
- `idt.rs::page_fault` restructured to run the gates in RFC 0001 order before the existing VMA resolver: SMAP → pure-kernel fallthrough → RSVD → canonical/USER_VA_END. Two new `panic_smap_violation` / `panic_rsvd_corruption` helpers log the faulting VA only (RFC Security A2) — PTE word must never reach a user-reachable sink.
- The `resolve_demand_page` / `resolve_cow` dispatch bodies (#158 items 3/4) are intentionally deferred; they need AddressSpace plumbed through tasks (#159) before they can run live. The pure gates ship here so SMAP / RSVD safety lands immediately and the dispatch wiring follows in #159.

## Test plan

- [x] `cargo test --lib mem::pf` — 7 host unit tests green (error-code decode, prot/access matrix, `USER_VA_END` and canonical rejection, SMAP/RSVD/kernel-fault/present-fault classification).
- [x] `cargo xtask build` — green, no new warnings.
- [x] `cargo xtask test` — full integration suite green.
- [x] `cargo xtask smoke` — all 26 markers present.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the kernel `#PF` handler and introduces new fault-classification logic; incorrect gating could misclassify faults or cause unexpected panics/hangs in critical memory-management paths.
> 
> **Overview**
> Implements RFC 0001 early page-fault dispatch gates by adding a new `mem::pf` pure-logic module (with unit tests) to classify `#PF` causes, decode access/protection bits, and validate userspace VAs against `USER_VA_END`.
> 
> Updates `arch/x86_64/idt.rs::page_fault` to run the gates in a fixed order before the existing VMA resolver: **panic on SMAP violations**, **panic on RSVD-bit faults** (both logging *only* the faulting VA), and **reject non-canonical/kernel-half addresses for user faults** with an explicit MAPERR marker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f916c56f20b7721ca7b80e4a35dc1702aaa39c5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->