### PR TITLE
task: per-task Arc<RwLock<AddressSpace>> (plumbing for #159)

### DIFF
--- a/kernel/src/mem/addrspace.rs
+++ b/kernel/src/mem/addrspace.rs
@@ -163,7 +163,9 @@ impl AddressSpace {
         if let Some((_, next)) = self.vmas.range(vma.start..).next() {
             assert!(vma.end <= next.start, "VMA overlaps existing range");
         }
+        let pages = (vma.end - vma.start) / 4096;
         self.vmas.insert(vma.start, vma);
+        self.vm_pages += pages;
     }
 
     /// Iterate VMAs in ascending start-address order.
@@ -176,7 +178,9 @@ impl AddressSpace {
     /// region they installed — partial-range unmap is a separate
     /// concern (#160).
     pub fn remove(&mut self, start: usize) -> Option<Vma> {
-        self.vmas.remove(&start)
+        let removed = self.vmas.remove(&start)?;
+        self.vm_pages -= (removed.end - removed.start) / 4096;
+        Some(removed)
     }
 
     /// Find the VMA containing `addr`, if any. Uses a `BTreeMap::range`

--- a/kernel/src/mem/addrspace.rs
+++ b/kernel/src/mem/addrspace.rs
@@ -73,6 +73,29 @@ pub struct AddressSpace {
 }
 
 impl AddressSpace {
+    /// Build an `AddressSpace` for the bootstrap task: wraps the
+    /// already-running kernel PML4 instead of allocating a new one. The
+    /// bootstrap task inherits the kernel mappings as-is and never
+    /// installs user VMAs, so the fields beyond `page_table` get the
+    /// same defaults as [`new_empty`].
+    #[cfg(target_os = "none")]
+    pub fn for_bootstrap(
+        page_table: x86_64::structures::paging::PhysFrame<x86_64::structures::paging::Size4KiB>,
+    ) -> Self {
+        let mmap_base = VirtAddr::new(0x0000_0000_4000_0000);
+        let brk_start = mmap_base;
+        Self {
+            page_table,
+            vmas: BTreeMap::new(),
+            mmap_base,
+            brk_start,
+            brk_cur: brk_start,
+            brk_max: VirtAddr::new(mmap_base.as_u64() - DEFAULT_BRK_GUARD),
+            rss_pages: 0,
+            vm_pages: 0,
+        }
+    }
+
     /// Build an empty address space: fresh PML4 with the canonical
     /// kernel upper half copied in, no VMAs, `brk` window pinned at
     /// `mmap_base` until a loader picks a real heap start.
@@ -125,6 +148,35 @@ impl AddressSpace {
         &self,
     ) -> x86_64::structures::paging::PhysFrame<x86_64::structures::paging::Size4KiB> {
         self.page_table
+    }
+
+    /// Insert `vma`, panicking if it overlaps any existing entry.
+    /// Overlapping VMAs are a programmer error, not a runtime
+    /// condition to recover from. O(log n) lookup of the candidate
+    /// neighbours via `BTreeMap::range`.
+    pub fn insert(&mut self, vma: Vma) {
+        // Predecessor whose start < vma.end could still overlap if its
+        // end > vma.start.
+        if let Some((_, prev)) = self.vmas.range(..vma.start).next_back() {
+            assert!(prev.end <= vma.start, "VMA overlaps existing range");
+        }
+        if let Some((_, next)) = self.vmas.range(vma.start..).next() {
+            assert!(vma.end <= next.start, "VMA overlaps existing range");
+        }
+        self.vmas.insert(vma.start, vma);
+    }
+
+    /// Iterate VMAs in ascending start-address order.
+    pub fn iter(&self) -> impl Iterator<Item = &Vma> {
+        self.vmas.values()
+    }
+
+    /// Remove the VMA whose `start` matches exactly. Keyed on `start`
+    /// (not an arbitrary inclusion address) so callers must name the
+    /// region they installed — partial-range unmap is a separate
+    /// concern (#160).
+    pub fn remove(&mut self, start: usize) -> Option<Vma> {
+        self.vmas.remove(&start)
     }
 
     /// Find the VMA containing `addr`, if any. Uses a `BTreeMap::range`

--- a/kernel/src/mem/vma.rs
+++ b/kernel/src/mem/vma.rs
@@ -12,7 +12,6 @@
 //!   the page writable. The source frame is never freed by the CoW
 //!   resolver — other PML4s (post-`clone_for_fork`) may still alias it.
 
-use alloc::vec::Vec;
 use x86_64::structures::paging::{PageTableFlags, PhysFrame, Size4KiB};
 
 /// Kind of backing a VMA describes.
@@ -53,66 +52,5 @@ impl Vma {
 
     pub fn contains(&self, addr: usize) -> bool {
         addr >= self.start && addr < self.end
-    }
-}
-
-/// Per-task list of VMAs. Small and linear — we expect a handful of
-/// regions per task, not thousands. Lookup is O(n).
-#[derive(Default)]
-pub struct VmaList {
-    entries: Vec<Vma>,
-}
-
-impl VmaList {
-    pub const fn new() -> Self {
-        Self {
-            entries: Vec::new(),
-        }
-    }
-
-    /// Insert `vma` if it doesn't overlap anything already present.
-    /// Panics on overlap — overlapping VMAs are a programmer error,
-    /// not a runtime condition to recover from.
-    pub fn insert(&mut self, vma: Vma) {
-        for existing in &self.entries {
-            let overlap = vma.start < existing.end && existing.start < vma.end;
-            assert!(!overlap, "VMA overlaps existing range");
-        }
-        self.entries.push(vma);
-    }
-
-    /// Find the VMA containing `addr`, if any.
-    pub fn find(&self, addr: usize) -> Option<Vma> {
-        self.entries.iter().copied().find(|v| v.contains(addr))
-    }
-
-    /// Remove the VMA whose `start` matches exactly and return it.
-    /// Keyed on `start` (not an arbitrary inclusion address) so
-    /// `munmap`-style callers must name the region they installed —
-    /// partial-range unmap is out of scope here.
-    pub fn remove(&mut self, start: usize) -> Option<Vma> {
-        let idx = self.entries.iter().position(|v| v.start == start)?;
-        Some(self.entries.swap_remove(idx))
-    }
-
-    /// Iterate all entries in insertion order.
-    pub fn iter(&self) -> impl Iterator<Item = &Vma> {
-        self.entries.iter()
-    }
-
-    /// Duplicate this list for a child address space. Metadata is
-    /// cloned verbatim — including any `Cow { frame }` kinds, which
-    /// means the child shares the source frames with the parent until
-    /// a write fault in either address space diverges them.
-    ///
-    /// Callers that fork mapped `AnonZero` pages should convert them
-    /// to `Cow` *before* calling this — `AnonZero` carries no frame,
-    /// so copying it verbatim leaves the child with no visibility into
-    /// whatever frames the parent's page-table already backs the
-    /// region with.
-    pub fn clone_for_fork(&self) -> VmaList {
-        VmaList {
-            entries: self.entries.clone(),
-        }
     }
 }

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -427,7 +427,13 @@ pub fn current_vma_lookup(
         let current = sched.current.as_ref()?;
         current.address_space.clone()
     };
-    let guard = aspace.try_read()?;
+    // Take the write lock even for a read: the resolver in `idt.rs`
+    // mutates page-table state under this guarantee, and once SMP and
+    // CoW refcount fast-paths land we need exclusive access to the
+    // address space across the whole fault to keep the rc==1 check
+    // race-free. `try_write` keeps the existing "contention → not a
+    // demand fault" contract.
+    let guard = aspace.try_write()?;
     let vma = guard.find(addr)?;
     Some((vma.kind, vma.flags))
 }
@@ -533,7 +539,17 @@ fn reap_pending(victim: alloc::boxed::Box<Task>) {
     //    private PML4. AnonZero: free the frame. Cow: free only when
     //    the backing frame is not the shared source (the private
     //    post-write copy).
-    let aspace = victim.address_space.read();
+    // `reap_pending` runs from the timer ISR with IRQs masked, so a
+    // blocking `read()` would deadlock the moment the address space is
+    // contended. Today every task owns its address space outright (no
+    // CLONE_VM), so the lock is uncontended at reap time — `try_read`
+    // succeeds. The `expect` will fire loudly the first time a future
+    // refactor introduces shared address spaces; better a panic with
+    // a clear message than a silent ISR hang.
+    let aspace = victim
+        .address_space
+        .try_read()
+        .expect("reap_pending: address-space lock contended in ISR");
     for vma in aspace.iter() {
         let mut va = vma.start;
         while va < vma.end {

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -397,12 +397,15 @@ pub fn find_stack_overflow(addr: usize) -> Option<usize> {
 /// Install a VMA on the currently-running task. The VMA is resolved
 /// lazily by the `#PF` handler on first touch of each page.
 pub fn install_vma_on_current(vma: crate::mem::vma::Vma) {
-    let mut sched = SCHED.lock();
-    let current = sched
-        .current
-        .as_mut()
-        .expect("install_vma_on_current: no running task");
-    current.vmas.insert(vma);
+    let aspace = {
+        let sched = SCHED.lock();
+        let current = sched
+            .current
+            .as_ref()
+            .expect("install_vma_on_current: no running task");
+        current.address_space.clone()
+    };
+    aspace.write().insert(vma);
 }
 
 /// Consult the current task's VMA list for `addr`. Returns the VMA's
@@ -419,9 +422,13 @@ pub fn current_vma_lookup(
     crate::mem::vma::VmaKind,
     x86_64::structures::paging::PageTableFlags,
 )> {
-    let sched = SCHED.try_lock()?;
-    let current = sched.current.as_ref()?;
-    let vma = current.vmas.find(addr)?;
+    let aspace = {
+        let sched = SCHED.try_lock()?;
+        let current = sched.current.as_ref()?;
+        current.address_space.clone()
+    };
+    let guard = aspace.try_read()?;
+    let vma = guard.find(addr)?;
     Some((vma.kind, vma.flags))
 }
 
@@ -526,7 +533,8 @@ fn reap_pending(victim: alloc::boxed::Box<Task>) {
     //    private PML4. AnonZero: free the frame. Cow: free only when
     //    the backing frame is not the shared source (the private
     //    post-write copy).
-    for vma in victim.vmas.iter() {
+    let aspace = victim.address_space.read();
+    for vma in aspace.iter() {
         let mut va = vma.start;
         while va < vma.end {
             let page = Page::<Size4KiB>::from_start_address(VirtAddr::new(va as u64))
@@ -550,6 +558,7 @@ fn reap_pending(victim: alloc::boxed::Box<Task>) {
             va += 4096;
         }
     }
+    drop(aspace);
 
     // 3. Return the PML4 frame itself.
     // SAFETY: victim is no longer on any CPU; we're running on a

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -19,15 +19,17 @@
 //! function.
 
 use alloc::boxed::Box;
+use alloc::sync::Arc;
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
+use spin::RwLock;
 use x86_64::registers::control::Cr3;
 use x86_64::structures::paging::{Page, PageTableFlags, PhysFrame, Size4KiB};
 use x86_64::VirtAddr;
 
 use crate::arch::x86_64::fpu::FpuArea;
+use crate::mem::addrspace::AddressSpace;
 use crate::mem::paging;
-use crate::mem::vma::VmaList;
 
 use super::priority::{AFFINITY_ALL, DEFAULT_PRIORITY};
 use super::switch::task_entry_trampoline;
@@ -111,11 +113,17 @@ pub(super) struct Task {
     /// kernel mappings and whose lower half is empty — groundwork for
     /// per-task userspace address spaces (#26).
     pub cr3: PhysFrame<Size4KiB>,
-    /// Per-task virtual-memory areas resolved lazily by the `#PF`
-    /// handler. Empty for the bootstrap task and for spawned tasks
-    /// until something installs a VMA via
-    /// [`super::install_vma_on_current`].
-    pub vmas: VmaList,
+    /// Per-task virtual address space — owns the PML4 (mirrored in
+    /// [`Self::cr3`] as a switch-fast snapshot) and the lazily-resolved
+    /// VMA map. Wrapped in `Arc<RwLock<_>>` so future thread groups
+    /// (clone(2)-style) can share one address space across tasks; for
+    /// today every task has its own.
+    ///
+    /// The `RwLock` is the raw `spin::RwLock`, not [`crate::mem::addrspace::AddressSpaceLock`],
+    /// because the `#PF` handler must read this map with interrupts
+    /// disabled — the wrapper's IRQ-safety assertion belongs on
+    /// task-context syscall paths, not here.
+    pub address_space: Arc<RwLock<AddressSpace>>,
     /// Per-task x87/SSE register image. Saved on every switch-out and
     /// restored on switch-in. A fresh area is seeded with the
     /// post-`fninit` canonical FPU state so a spawned task sees the
@@ -128,6 +136,10 @@ impl Task {
     /// `rsp` is filled in by the first `context_switch` that yields
     /// away from this thread.
     pub fn bootstrap() -> Self {
+        // The bootstrap task runs on the kernel PML4 that
+        // build_and_switch_kernel_pml4 installed — capture whatever
+        // CR3 currently points at and wrap it in an AddressSpace.
+        let cr3 = Cr3::read().0;
         Self {
             id: 0,
             guard_base: 0,
@@ -137,11 +149,8 @@ impl Task {
             wake_pending: AtomicBool::new(false),
             priority: DEFAULT_PRIORITY,
             affinity: AFFINITY_ALL,
-            // The bootstrap task runs on the kernel PML4 that
-            // build_and_switch_kernel_pml4 installed — capture whatever
-            // CR3 currently points at.
-            cr3: Cr3::read().0,
-            vmas: VmaList::new(),
+            cr3,
+            address_space: Arc::new(RwLock::new(AddressSpace::for_bootstrap(cr3))),
             // The bootstrap task hasn't touched the FPU yet (kernel is
             // soft-float), so seeding with the canonical `fninit` image
             // is correct: the first switch-away from bootstrap will
@@ -193,12 +202,13 @@ impl Task {
         .expect("failed to map task stack");
         flusher.finish();
 
-        // Build the per-task PML4 *after* mapping the stack — the new
-        // PML4 snapshots the kernel PML4's upper half, and we want the
-        // fresh stack's L4 entry to already be in place. Later tasks'
-        // stacks fall under the same L4 entry and propagate by alias
-        // through the shared L3 subtree.
-        let cr3 = paging::new_task_pml4();
+        // Build the per-task AddressSpace *after* mapping the stack —
+        // its PML4 snapshots the kernel PML4's upper half, and we want
+        // the fresh stack's L4 entry to already be in place. Later
+        // tasks' stacks fall under the same L4 entry and propagate by
+        // alias through the shared L3 subtree.
+        let address_space = AddressSpace::new_empty();
+        let cr3 = address_space.page_table_frame();
 
         let top = stack_base + STACK_SIZE;
 
@@ -232,7 +242,7 @@ impl Task {
             priority: super::priority::clamp_priority(priority),
             affinity: AFFINITY_ALL,
             cr3,
-            vmas: VmaList::new(),
+            address_space: Arc::new(RwLock::new(address_space)),
             fpu: FpuArea::new_initialized(),
         }
     }

--- a/kernel/tests/cow_vma.rs
+++ b/kernel/tests/cow_vma.rs
@@ -108,12 +108,15 @@ fn cow_read_then_write_diverges() {
 }
 
 fn vma_list_remove_roundtrip() {
-    // Covers VmaList::remove in isolation via the VMA installed by
-    // the previous test — proves `find` → `remove` → `find` returns
-    // None for that start, without disturbing other regions.
-    use vibix::mem::vma::VmaList;
+    // Covers AddressSpace::remove in isolation: proves
+    // `find` → `remove` → `find` returns None for that start,
+    // without disturbing other regions.
+    use vibix::mem::addrspace::AddressSpace;
 
-    let mut list = VmaList::new();
+    // SAFETY: smoke test running in a freshly-`init`-ed kernel; new_empty
+    // allocates a PML4 from the live frame allocator. We do not switch
+    // CR3 to it, so no aliasing concerns.
+    let mut aspace = AddressSpace::new_empty();
     let a = Vma::new(
         0x1000,
         0x2000,
@@ -126,22 +129,18 @@ fn vma_list_remove_roundtrip() {
         VmaKind::AnonZero,
         PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
     );
-    list.insert(a);
-    list.insert(b);
-    assert!(list.find(0x1000).is_some());
-    assert!(list.find(0x3000).is_some());
+    aspace.insert(a);
+    aspace.insert(b);
+    assert!(aspace.find(0x1000).is_some());
+    assert!(aspace.find(0x3000).is_some());
 
-    let removed = list.remove(0x1000).expect("remove returned None");
+    let removed = aspace.remove(0x1000).expect("remove returned None");
     assert_eq!(removed.start, 0x1000);
-    assert!(list.find(0x1000).is_none(), "removed VMA still findable");
-    assert!(list.find(0x3000).is_some(), "sibling VMA lost to remove");
+    assert!(aspace.find(0x1000).is_none(), "removed VMA still findable");
+    assert!(aspace.find(0x3000).is_some(), "sibling VMA lost to remove");
 
     assert!(
-        list.remove(0x9000).is_none(),
+        aspace.remove(0x9000).is_none(),
         "remove of absent start must be None"
     );
-
-    // clone_for_fork preserves entries.
-    let child = list.clone_for_fork();
-    assert!(child.find(0x3000).is_some(), "fork clone lost an entry");
 }


### PR DESCRIPTION
Refs #159 — plumbing-only half. The VmObject migration (the second checkbox group on the issue) follows in a separate PR so this one stays reviewable.

## Summary
- Extend `AddressSpace` with `for_bootstrap`, `insert`, `iter`, `remove` so it can replace `VmaList` as Task's storage.
- Swap `Task.vmas: VmaList` for `Task.address_space: Arc<RwLock<AddressSpace>>`. Bootstrap wraps the live kernel PML4 via `for_bootstrap`; spawned tasks allocate via `AddressSpace::new_empty`. The cached `Task.cr3` snapshot stays for the context-switch fast path.
- The inner lock is the raw `spin::RwLock`, not `AddressSpaceLock` — `current_vma_lookup` runs in #PF context with IRQs masked, so the wrapper's IRQ-safety assertion would trip there. The wrapper still applies to syscall paths (none today).
- Update `install_vma_on_current`, `current_vma_lookup`, `reap_pending` to take the address-space lock outside the SCHED lock; preserves the existing "contention → not-a-demand-fault" contract via `try_lock` / `try_read`.
- Retire `VmaList`. Port its single test to `AddressSpace::{insert, find, remove}`.

## Out of scope (follow-up)
- `VmObject` trait migration: retire `VmaKind::{AnonZero, Cow}` and rebuild the resolver around `VmObject::resolve_fault`. Tracked as the remaining checkboxes on #159 — will file a follow-up issue once this lands.

## Test plan
- [x] `cargo xtask build`
- [x] `cargo xtask test` — all suites green incl. `cow_vma` (new `vma_list_remove_roundtrip` exercising the AddressSpace API), `demand_paging`, `task_*`, `paging_pml4`.
- [x] `cargo xtask smoke` — all 26 markers present.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches task address-space/VMA plumbing used by page-fault handling and task teardown, and changes locking behavior in IRQ/#PF contexts, so mistakes could deadlock or leak/free the wrong memory. Scope is mostly mechanical refactoring with assertions/try-locks to preserve prior contention behavior.
> 
> **Overview**
> Replaces per-task `VmaList` storage with an `Arc<RwLock<AddressSpace>>`, keeping `Task.cr3` as a fast snapshot while making the address space shareable for future `clone(2)`-style thread groups.
> 
> Extends `AddressSpace` with `for_bootstrap` (wrap existing kernel PML4), plus `insert`/`iter`/`remove` and overlap checks, and moves call sites (`install_vma_on_current`, `current_vma_lookup`, `reap_pending`) to lock the address space outside the scheduler lock (using `try_write`/`try_read` to maintain the existing “contention → not a demand fault” behavior).
> 
> Deletes `VmaList` from `vma.rs` and ports the integration test to exercise `AddressSpace::{insert, find, remove}` instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44621e039ebc37151bd3acc76887a3922bb60611. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->