### PR TITLE
task: AddressSpace::drop reclaims VMAs, page tables, PML4 (#161)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -145,5 +145,9 @@ name = "addrspace"
 harness = false
 
 [[test]]
+name = "addrspace_drop"
+harness = false
+
+[[test]]
 name = "tlb_flusher"
 harness = false

--- a/kernel/src/mem/addrspace.rs
+++ b/kernel/src/mem/addrspace.rs
@@ -70,6 +70,13 @@ pub struct AddressSpace {
     /// been faulted in. Bumped by `insert`, decremented by
     /// `unmap_range`.
     pub(crate) vm_pages: usize,
+
+    /// `true` for the bootstrap task's address space, whose `page_table`
+    /// is the live kernel PML4. `Drop` skips reclaim entirely in that
+    /// case — freeing the kernel PML4 (or walking its lower half, which
+    /// is empty anyway) would brick the system. All other constructors
+    /// set this to `false`.
+    pub(crate) bootstrap: bool,
 }
 
 impl AddressSpace {
@@ -93,6 +100,7 @@ impl AddressSpace {
             brk_max: VirtAddr::new(mmap_base.as_u64() - DEFAULT_BRK_GUARD),
             rss_pages: 0,
             vm_pages: 0,
+            bootstrap: true,
         }
     }
 
@@ -121,6 +129,7 @@ impl AddressSpace {
             brk_max: VirtAddr::new(mmap_base.as_u64() - DEFAULT_BRK_GUARD),
             rss_pages: 0,
             vm_pages: 0,
+            bootstrap: false,
         }
     }
 
@@ -137,6 +146,7 @@ impl AddressSpace {
             brk_max: VirtAddr::new(mmap_base - DEFAULT_BRK_GUARD),
             rss_pages: 0,
             vm_pages: 0,
+            bootstrap: false,
         }
     }
 
@@ -199,6 +209,78 @@ impl AddressSpace {
     #[allow(dead_code)] // consumed by #156 (VmaTree::insert) and the mmap syscall
     pub(crate) fn vma_in_user_range(vma: &Vma) -> bool {
         (vma.end as u64) <= USER_VA_END
+    }
+}
+
+/// Reclaim the address space when the last `Arc<RwLock<AddressSpace>>`
+/// is dropped — closes #161 (and the leak documented in #146):
+///
+/// 1. Walk every VMA, unmap each page from this PML4, free the leaf
+///    frame (`AnonZero` always; `Cow` only when the mapped frame is the
+///    private post-write copy, never the shared source).
+/// 2. Free every intermediate L3/L2/L1 page-table frame in the user
+///    half via [`paging::free_user_page_tables`].
+/// 3. Free the PML4 frame itself.
+///
+/// The bootstrap task's address space is exempt: its `page_table` is
+/// the live kernel PML4 and its lower half is empty.
+///
+/// Runs from whatever context drops the last `Arc` — today that's the
+/// `preempt_tick` reaper (timer ISR, IRQs masked). The reclaim path is
+/// lock-free apart from the `HHDM_OFFSET` mutex, which is set once at
+/// boot and only briefly read here, so it cannot deadlock the ISR.
+///
+/// TODO(#159 follow-up): once the legacy `VmaKind::AnonZero`/`Cow`
+/// reclaim is replaced by `VmObject::release` + `PageRefcount` book-
+/// keeping, add `debug_assert_eq!(self.rss_pages, 0)` after the VMA
+/// pass to catch refcount leaks.
+#[cfg(target_os = "none")]
+impl Drop for AddressSpace {
+    fn drop(&mut self) {
+        if self.bootstrap {
+            return;
+        }
+
+        use crate::mem::paging;
+        use crate::mem::vma::VmaKind;
+        use x86_64::structures::paging::{FrameDeallocator, Page, Size4KiB};
+
+        let pml4 = self.page_table;
+
+        for vma in self.vmas.values() {
+            let mut va = vma.start;
+            while va < vma.end {
+                let page = Page::<Size4KiB>::from_start_address(VirtAddr::new(va as u64))
+                    .expect("vma page VA aligned by construction");
+                match vma.kind {
+                    VmaKind::AnonZero => {
+                        let _ = paging::unmap_and_free_in_pml4(pml4, page);
+                    }
+                    VmaKind::Cow { frame: source } => {
+                        if let Ok(frame) = paging::unmap_in_pml4(pml4, page) {
+                            if frame != source {
+                                // SAFETY: private CoW copy allocated from the
+                                // global allocator by the #PF resolver; no
+                                // other PML4 references it.
+                                unsafe {
+                                    paging::KernelFrameAllocator.deallocate_frame(frame);
+                                }
+                            }
+                        }
+                    }
+                }
+                va += 4096;
+            }
+        }
+
+        // SAFETY: this PML4 is no longer the active CR3 on any CPU
+        // (the reaper switched away before dropping the Box<Task>),
+        // every leaf VMA frame has just been unmapped above, and no
+        // outstanding `&mut` references to its tables exist.
+        unsafe {
+            paging::free_user_page_tables(pml4);
+            paging::free_pml4_frame(pml4);
+        }
     }
 }
 

--- a/kernel/src/mem/paging.rs
+++ b/kernel/src/mem/paging.rs
@@ -448,6 +448,89 @@ pub unsafe fn free_pml4_frame(pml4_frame: PhysFrame<Size4KiB>) {
     KernelFrameAllocator.deallocate_frame(pml4_frame);
 }
 
+/// Walk the user (lower) half of `pml4_frame` and free every intermediate
+/// L3/L2/L1 page-table frame. Does **not** free leaf data frames (those
+/// are VMA-owned and freed by the AddressSpace VMA-reclaim pass) and does
+/// **not** free the PML4 frame itself (caller calls [`free_pml4_frame`]
+/// last). The kernel upper half (entries `256..512`) is skipped — its
+/// L3 subtrees are shared with the kernel PML4 and outlive this address
+/// space.
+///
+/// Closes the leak documented in #146 and is the main reclaim primitive
+/// behind `Drop for AddressSpace` (#161).
+///
+/// # Safety
+/// * `pml4_frame` must be a per-task PML4 that no CPU is using as its
+///   active page table and that has no outstanding `&mut PageTable` /
+///   `OffsetPageTable` references.
+/// * Callers must already have unmapped every leaf VMA frame so that
+///   the L1 entries this walker frees are decoupled from any owned
+///   data; freeing an L1 frame whose PTEs still point at live data
+///   leaks those frames silently.
+pub unsafe fn free_user_page_tables(pml4_frame: PhysFrame<Size4KiB>) {
+    let hhdm = HHDM_OFFSET
+        .lock()
+        .expect("paging::init must run before free_user_page_tables");
+
+    let l4_virt = hhdm + pml4_frame.start_address().as_u64();
+    // SAFETY: per fn safety contract.
+    let l4: &mut PageTable = unsafe { &mut *(l4_virt.as_mut_ptr::<PageTable>()) };
+
+    let mut alloc = KernelFrameAllocator;
+
+    // Lower half only — entries 0..256 cover the userspace canonical
+    // half. Entries 256..512 alias the shared kernel PML4 subtrees and
+    // must not be touched here.
+    for l4_idx in 0..256 {
+        let l4_entry = &mut l4[l4_idx];
+        if !l4_entry.flags().contains(PageTableFlags::PRESENT) {
+            continue;
+        }
+        let Ok(l3_frame) = l4_entry.frame() else {
+            continue;
+        };
+        let l3_virt = hhdm + l3_frame.start_address().as_u64();
+        // SAFETY: l3 frame reachable via HHDM, exclusively owned by this PML4.
+        let l3: &mut PageTable = unsafe { &mut *(l3_virt.as_mut_ptr::<PageTable>()) };
+
+        for l3_entry in l3.iter_mut() {
+            if !l3_entry.flags().contains(PageTableFlags::PRESENT) {
+                continue;
+            }
+            // 1 GiB huge leaf: no L2 child to free.
+            if l3_entry.flags().contains(PageTableFlags::HUGE_PAGE) {
+                continue;
+            }
+            let Ok(l2_frame) = l3_entry.frame() else {
+                continue;
+            };
+            let l2_virt = hhdm + l2_frame.start_address().as_u64();
+            let l2: &mut PageTable = unsafe { &mut *(l2_virt.as_mut_ptr::<PageTable>()) };
+
+            for l2_entry in l2.iter_mut() {
+                if !l2_entry.flags().contains(PageTableFlags::PRESENT) {
+                    continue;
+                }
+                // 2 MiB huge leaf: no L1 child to free.
+                if l2_entry.flags().contains(PageTableFlags::HUGE_PAGE) {
+                    continue;
+                }
+                if let Ok(l1_frame) = l2_entry.frame() {
+                    // SAFETY: per fn contract — leaf VMA frames already freed
+                    // by the AddressSpace reclaim pass; this L1 frame holds
+                    // only PTEs and is itself the intermediate table.
+                    unsafe { alloc.deallocate_frame(l1_frame) };
+                }
+            }
+            // SAFETY: every L1 child of this L2 has been freed above.
+            unsafe { alloc.deallocate_frame(l2_frame) };
+        }
+        // SAFETY: every L2 child of this L3 has been freed above.
+        unsafe { alloc.deallocate_frame(l3_frame) };
+        l4_entry.set_unused();
+    }
+}
+
 /// HHDM offset currently in use. Panics if [`init`] hasn't run.
 /// Exposed for tests that need to poke raw frame contents via the
 /// high half.

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -522,26 +522,29 @@ pub fn exit() -> ! {
     unreachable!("task::exit returned from context_switch");
 }
 
-/// Reclaim the stack pages, VMA-backed frames, and PML4 frame of a
-/// task that called [`exit`]. Called from [`preempt_tick`] on a stack
-/// that is *not* the victim's — the victim already context-switched
-/// away, so unmapping its stack is safe.
+/// Reclaim the stack pages of a task that called [`exit`], then drop
+/// the `Box<Task>`. Called from [`preempt_tick`] on a stack that is
+/// *not* the victim's — the victim already context-switched away, so
+/// unmapping its stack is safe.
+///
+/// VMA-backed leaf frames, intermediate page tables, and the PML4 are
+/// reclaimed by `Drop for AddressSpace`, which fires when the last
+/// `Arc<RwLock<AddressSpace>>` is released as the `Box<Task>` is
+/// dropped at the end of this function (#161).
 fn reap_pending(victim: alloc::boxed::Box<Task>) {
     use crate::mem::paging;
-    use crate::mem::vma::VmaKind;
-    use x86_64::structures::paging::{FrameDeallocator, Page, Size4KiB};
+    use x86_64::structures::paging::{Page, Size4KiB};
     use x86_64::VirtAddr;
 
-    // 1. Unmap + free stack pages. Stack pages live in the shared
-    //    upper-half kernel window (L4 entry 416) — the L3 subtree under
-    //    that entry is aliased into every per-task PML4, so unmapping
-    //    via the victim's PML4 propagates to every PML4.
+    // Unmap + free stack pages. Stack pages live in the shared
+    // upper-half kernel window (L4 entry 416) — the L3 subtree under
+    // that entry is aliased into every per-task PML4, so unmapping via
+    // the victim's PML4 propagates to every PML4.
     //
-    //    We deliberately route through `unmap_in_pml4` (temporary
-    //    mapper) rather than `unmap_and_free` (global `MAPPER` lock):
-    //    `reap_pending` runs inside `preempt_tick`, a timer ISR. If the
-    //    interrupted task held `MAPPER`, spinning on it here would
-    //    deadlock with IRQs masked.
+    // We deliberately route through `unmap_in_pml4` (temporary mapper)
+    // rather than `unmap_and_free` (global `MAPPER` lock): `reap_pending`
+    // runs inside `preempt_tick`, a timer ISR. If the interrupted task
+    // held `MAPPER`, spinning on it here would deadlock with IRQs masked.
     let stack_base = victim.stack_base();
     if stack_base != 0 {
         for i in 0..victim.stack_page_count() {
@@ -550,57 +553,8 @@ fn reap_pending(victim: alloc::boxed::Box<Task>) {
                 .expect("stack page VA aligned by construction");
             let _ = paging::unmap_and_free_in_pml4(victim.cr3, page);
         }
-    }
 
-    // 2. Walk VMAs. For each VA in each VMA, unmap from the victim's
-    //    private PML4. AnonZero: free the frame. Cow: free only when
-    //    the backing frame is not the shared source (the private
-    //    post-write copy).
-    // `reap_pending` runs from the timer ISR with IRQs masked, so a
-    // blocking `read()` would deadlock the moment the address space is
-    // contended. Today every task owns its address space outright (no
-    // CLONE_VM), so the lock is uncontended at reap time — `try_read`
-    // succeeds. The `expect` will fire loudly the first time a future
-    // refactor introduces shared address spaces; better a panic with
-    // a clear message than a silent ISR hang.
-    let aspace = victim
-        .address_space
-        .try_read()
-        .expect("reap_pending: address-space lock contended in ISR");
-    for vma in aspace.iter() {
-        let mut va = vma.start;
-        while va < vma.end {
-            let page = Page::<Size4KiB>::from_start_address(VirtAddr::new(va as u64))
-                .expect("vma page VA aligned by construction");
-            match vma.kind {
-                VmaKind::AnonZero => {
-                    let _ = paging::unmap_and_free_in_pml4(victim.cr3, page);
-                }
-                VmaKind::Cow { frame: source } => {
-                    if let Ok(frame) = paging::unmap_in_pml4(victim.cr3, page) {
-                        if frame != source {
-                            // SAFETY: private copy allocated from the
-                            // global allocator by the #PF resolver.
-                            unsafe {
-                                paging::KernelFrameAllocator.deallocate_frame(frame);
-                            }
-                        }
-                    }
-                }
-            }
-            va += 4096;
-        }
-    }
-    drop(aspace);
-
-    // 3. Return the PML4 frame itself.
-    // SAFETY: victim is no longer on any CPU; we're running on a
-    //         different CR3 and no other reference to its PML4
-    //         survives — the Box<Task> is about to be dropped.
-    unsafe { paging::free_pml4_frame(victim.cr3) };
-
-    // 4. Log the leaked stack VA slot for diagnostics.
-    if stack_base != 0 {
+        // Log the leaked stack VA slot for diagnostics.
         serial_println!(
             "tasks: reaped task {} (stack VA slot {:#x}..{:#x} leaked)",
             victim.id,
@@ -609,7 +563,10 @@ fn reap_pending(victim: alloc::boxed::Box<Task>) {
         );
     }
 
-    // 5. Drop the Box<Task>, returning its heap memory.
+    // Drop the Box<Task>. The Arc<RwLock<AddressSpace>> goes with it;
+    // when the strong count reaches zero, `Drop for AddressSpace`
+    // walks the VMAs, frees every leaf frame, frees the user-half
+    // intermediate page tables, and frees the PML4 itself.
     drop(victim);
 }
 

--- a/kernel/tests/addrspace_drop.rs
+++ b/kernel/tests/addrspace_drop.rs
@@ -1,0 +1,130 @@
+//! Integration test for #161: dropping the last `Arc<RwLock<AddressSpace>>`
+//! returns every leaf VMA frame, every intermediate page-table frame in
+//! the user half, and the PML4 frame itself to the global allocator.
+//!
+//! The signal is `mem::frame::free_frames()` returning to (or above)
+//! its pre-spawn baseline after a worker that allocates, faults, and
+//! exits has been reaped. A leaky `Drop for AddressSpace` would leave
+//! the VMA leaves, intermediate L3/L2/L1 tables, and/or PML4 stranded.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use core::ptr;
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use vibix::mem::frame;
+use vibix::mem::vma::{Vma, VmaKind};
+use vibix::{
+    exit_qemu, serial_println, task,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+use x86_64::structures::paging::PageTableFlags;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[(
+        "drop_releases_vma_pages_pml4",
+        &(drop_releases_vma_pages_pml4 as fn()),
+    )];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+/// Lower-half VA chosen to land in an L4 entry the bootstrap kernel
+/// PML4 doesn't touch — keeps the worker's intermediate tables wholly
+/// owned by its private PML4 so that `Drop` reclaim can be observed
+/// in isolation.
+const WORKER_VMA_BASE: usize = 0x0000_3000_0000_0000;
+const WORKER_VMA_PAGES: usize = 8;
+
+static WORKER_DONE: AtomicUsize = AtomicUsize::new(0);
+
+fn worker() -> ! {
+    task::install_vma_on_current(Vma::new(
+        WORKER_VMA_BASE,
+        WORKER_VMA_BASE + WORKER_VMA_PAGES * 4096,
+        VmaKind::AnonZero,
+        PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE,
+    ));
+
+    // Touch every page so the resolver installs a leaf frame for each.
+    for i in 0..WORKER_VMA_PAGES {
+        let va = WORKER_VMA_BASE + i * 4096;
+        unsafe { ptr::write_volatile(va as *mut u8, 0xCD) };
+    }
+
+    WORKER_DONE.fetch_add(1, Ordering::SeqCst);
+    task::exit();
+}
+
+fn drop_releases_vma_pages_pml4() {
+    // Run a couple of warm-up cycles so any one-shot allocations
+    // (per-task FPU areas grown into a slab, etc.) settle before the
+    // baseline measurement.
+    for _ in 0..2 {
+        WORKER_DONE.store(0, Ordering::SeqCst);
+        task::spawn(worker);
+        wait_for_worker();
+    }
+
+    let baseline = frame::free_frames();
+
+    const ITERATIONS: usize = 16;
+    for i in 0..ITERATIONS {
+        WORKER_DONE.store(0, Ordering::SeqCst);
+        task::spawn(worker);
+        wait_for_worker();
+        assert_eq!(
+            WORKER_DONE.load(Ordering::SeqCst),
+            1,
+            "worker {i} never reached exit()"
+        );
+    }
+
+    let after = frame::free_frames();
+
+    // After all reaps complete, the free-frame count must not have
+    // dropped below baseline: every VMA leaf, every L3/L2/L1
+    // intermediate table, and every PML4 must have been returned.
+    assert!(
+        after >= baseline,
+        "frame leak across {ITERATIONS} spawn/exit cycles: \
+         baseline={baseline}, after={after}, delta={}",
+        baseline as isize - after as isize,
+    );
+}
+
+fn wait_for_worker() {
+    for _ in 0..200 {
+        if WORKER_DONE.load(Ordering::SeqCst) == 1 {
+            // Extra ticks so pending_exit drains and Drop runs.
+            for _ in 0..10 {
+                x86_64::instructions::hlt();
+            }
+            return;
+        }
+        x86_64::instructions::hlt();
+    }
+    panic!("worker never reached exit()");
+}

--- a/kernel/tests/addrspace_drop.rs
+++ b/kernel/tests/addrspace_drop.rs
@@ -118,7 +118,11 @@ fn drop_releases_vma_pages_pml4() {
 fn wait_for_worker() {
     for _ in 0..200 {
         if WORKER_DONE.load(Ordering::SeqCst) == 1 {
-            // Extra ticks so pending_exit drains and Drop runs.
+            // Worker hit `task::exit`, but the actual reap (and the
+            // `Drop for AddressSpace` that releases its frames) happens
+            // on the next `preempt_tick` that drains `pending_exit`.
+            // At 100 Hz, 10 `hlt` cycles ≈ 100 ms — ample slack for the
+            // timer ISR to fire and run the reaper.
             for _ in 0..10 {
                 x86_64::instructions::hlt();
             }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -629,6 +629,7 @@ fn test_all() -> R<()> {
         "fpu_context_switch",
         "task_exit",
         "addrspace",
+        "addrspace_drop",
         "tlb_flusher",
     ] {
         cmd.arg("--test").arg(t);


### PR DESCRIPTION
Closes #161.

## Summary
- New `paging::free_user_page_tables(pml4)` walks lower-half PML4 entries (0..256) and frees every intermediate L3/L2/L1 frame, respecting HUGE_PAGE leaves at L3/L2 so huge-page leaves are not mistaken for child tables. Closes the leak documented in #146.
- `Drop for AddressSpace` (gated `#[cfg(target_os = "none")]`) walks every VMA freeing leaf frames (AnonZero unconditionally; Cow only when the mapped frame is the private post-write copy), then frees user-half intermediate page tables, then frees the PML4. A new `bootstrap: bool` field exempts the bootstrap task — its `page_table` is the live kernel PML4.
- `reap_pending` shrinks to its remaining job: unmap the victim's stack pages and `drop(victim)`. Arc drop now triggers the full address-space reclaim through `Drop for AddressSpace`.

The reclaim path runs from `preempt_tick` (timer ISR, IRQs masked) and is lock-free apart from the `HHDM_OFFSET` mutex, which is set once at boot and only briefly read here, so it cannot deadlock the ISR.

## Test plan
- [x] `cargo xtask build` — clean.
- [x] `cargo xtask test` — host unit tests + every QEMU integration test pass, including the new `addrspace_drop` test that records a `frame::free_frames()` baseline, runs 16 spawn → fault → exit cycles of a worker that installs an 8-page AnonZero VMA and faults each page in, and asserts `free_frames` returns to (or above) baseline.
- [x] `cargo xtask smoke` — all 27 markers present.

## Follow-ups
- Once the legacy `VmaKind::AnonZero`/`Cow` reclaim is replaced by `VmObject::release` + `PageRefcount` bookkeeping (#159 follow-ups), add `debug_assert_eq!(self.rss_pages, 0)` after the VMA pass to catch refcount leaks. Marked with a TODO in `addrspace.rs`.
- Stack-VA-slot leak still logged on every reap — `NEXT_STACK_VA` is monotonic; recycling those slots is its own ticket.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches low-level paging teardown and introduces new `unsafe` frame reclamation paths that run during task reaping; mistakes could cause leaks or corrupt page tables. Scope is contained to address-space teardown and is covered by a new QEMU integration test.
> 
> **Overview**
> Fixes a per-task memory leak by making `AddressSpace` teardown reclaim its mappings and page-table structures when the last `Arc<RwLock<AddressSpace>>` is dropped.
> 
> Adds `Drop for AddressSpace` (skipping the bootstrap/kernel PML4 via a new `bootstrap` flag) that walks VMAs to unmap and free leaf frames (including CoW private copies), then frees all user-half intermediate page tables via new `paging::free_user_page_tables`, and finally frees the task PML4 frame.
> 
> Simplifies the task reaper (`reap_pending`) to only free stack pages and then rely on `AddressSpace` drop for the rest of address-space cleanup. Adds the `addrspace_drop` QEMU integration test and wires it into the test lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e776874f867fee0a942d14004e61d1ca7ca50f4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->