### PR TITLE
kernel: SMEP/SMAP enforcement + copy_from_user/copy_to_user helpers

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -151,3 +151,7 @@ harness = false
 [[test]]
 name = "tlb_flusher"
 harness = false
+
+[[test]]
+name = "smep_smap"
+harness = false

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -75,6 +75,19 @@ extern "x86-interrupt" fn general_protection(frame: InterruptStackFrame, code: u
 }
 
 extern "x86-interrupt" fn page_fault(frame: InterruptStackFrame, code: PageFaultErrorCode) {
+    // Clear RFLAGS.AC immediately so the handler runs with SMAP live,
+    // even if we entered mid-`stac` bracket from `uaccess::copy_*`. The
+    // IRET at exit restores the saved RFLAGS (and therefore AC) from
+    // `frame`, so a legitimate user access inside the bracket retries
+    // correctly. The `is_smap_violation` check below still inspects the
+    // saved `frame.cpu_flags` AC bit — that's the ring-0 caller's AC,
+    // which is what the RFC needs.
+    //
+    // SAFETY: `clac` is a single-instruction flag clear with no memory
+    // effects; it's a no-op on CPUs without SMAP.
+    if crate::cpu::has(crate::cpu::Feature::Smap) {
+        unsafe { core::arch::asm!("clac", options(nomem, nostack)) };
+    }
     let addr_u64 = x86_64::registers::control::Cr2::read_raw();
 
     if let Some(expected) = crate::test_hook::take_page_fault_expectation() {

--- a/kernel/src/arch/x86_64/mod.rs
+++ b/kernel/src/arch/x86_64/mod.rs
@@ -7,12 +7,17 @@ pub mod interrupts;
 pub mod ist_guard;
 pub mod pic;
 pub mod syscall;
+pub mod uaccess;
 
 /// Bring up arch-specific interrupt plumbing that doesn't depend on
 /// the kernel mapper. Interrupts stay disabled throughout.
 pub fn init() {
     // Feature detection first — everything below may query cpu::has().
     crate::cpu::init();
+    // SMEP/SMAP enforcement: blocks ring-0 fetch/access of user pages
+    // outside a `stac`/`clac` bracket. Must precede `syscall::init` so
+    // the first SYSCALL fires with enforcement already live.
+    uaccess::enable_smep_smap();
     // FPU init needs CR0/CR4 writes but no heap, so it fits here —
     // ahead of task::init() which spawns the first saving task.
     fpu::init();

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -166,15 +166,16 @@ pub unsafe extern "C" fn syscall_dispatch(nr: u64, a0: u64, a1: u64, a2: u64) ->
             let fd = a0;
             let buf_va = a1 as usize;
             let len = a2 as usize;
-            if fd == 1 && len > 0 {
-                // Validate the whole `[buf_va, buf_va + len)` range up
-                // front so a cross-boundary buffer fails with -EFAULT
-                // *before* any bytes hit the UART. Per-chunk validation
-                // alone would emit partial output on a later-chunk
-                // failure — non-atomic observable side effects.
+            // Validate the whole `[buf_va, buf_va + len)` range up
+            // front regardless of fd, so a kernel-half or wrapping
+            // pointer returns -EFAULT even for unsupported fds.
+            // Zero-length writes skip the check (no pointer access).
+            if len > 0 {
                 if let Err(e) = uaccess::check_user_range(buf_va, len) {
                     return e.as_errno();
                 }
+            }
+            if fd == 1 && len > 0 {
                 // Chunk through a small kernel-stack bounce buffer so the
                 // ring-0 access window stays short and bounded — a single
                 // STAC/CLAC bracket per chunk, not per byte.

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -150,48 +150,38 @@ pub unsafe fn jump_to_ring3(entry: u64, stack_top: u64) -> ! {
     );
 }
 
-/// First canonical upper-half address — same boundary as `loader::UPPER_HALF_START`.
-/// Any `buf` pointer at or above this is a kernel address and must be rejected.
-const USER_VA_END: u64 = 0x0000_8000_0000_0000;
-
-/// `-EFAULT` — returned when a user pointer fails the bounds check.
-const EFAULT: i64 = -14;
+use super::uaccess;
 
 /// Syscall handler called from the `syscall_entry` trampoline.
 ///
 /// # Safety
 /// Called only from `syscall_entry` with the kernel stack active and
-/// interrupts disabled. User-supplied pointer arguments (`a1` for `write`)
-/// are validated against `USER_VA_END` before any dereference.
+/// interrupts disabled. User pointer arguments are validated and
+/// marshalled via `uaccess::copy_from_user` before any dereference.
 #[no_mangle]
 pub unsafe extern "C" fn syscall_dispatch(nr: u64, a0: u64, a1: u64, a2: u64) -> i64 {
     match nr {
         // write(fd, buf, len) — fd=1 (stdout/stderr) → serial
         1 => {
             let fd = a0;
-            let buf_va = a1;
+            let buf_va = a1 as usize;
             let len = a2 as usize;
-            // Reject kernel-space or obviously wrapping buf pointers.
-            // A zero-length write is a no-op; skip the pointer check.
-            if len > 0 {
-                let end = buf_va.saturating_add(len as u64);
-                if buf_va >= USER_VA_END || end > USER_VA_END {
-                    return EFAULT;
-                }
-            }
             if fd == 1 && len > 0 {
-                let buf = buf_va as *const u8;
-                // Write each byte via direct port I/O. Avoids acquiring the
-                // COM1 spinlock (which could deadlock if another task holds
-                // it while IF=0 during a syscall) and avoids the Rust
-                // fmt machinery with its associated stack depth.
-                //
-                // Safety: `buf` is a validated user-space VA in the active
-                // PML4 (checked against USER_VA_END above). IF is cleared
-                // (SFMASK) so no context switch can invalidate the mapping.
-                for i in 0..len {
-                    let b = unsafe { core::ptr::read_volatile(buf.add(i)) };
-                    uart_putc(b);
+                // Chunk through a small kernel-stack bounce buffer so the
+                // ring-0 access window stays short and bounded — a single
+                // STAC/CLAC bracket per chunk, not per byte.
+                let mut chunk = [0u8; 256];
+                let mut off = 0;
+                while off < len {
+                    let n = core::cmp::min(chunk.len(), len - off);
+                    match uaccess::copy_from_user(&mut chunk[..n], buf_va + off) {
+                        Ok(()) => {}
+                        Err(e) => return e.as_errno(),
+                    }
+                    for &b in &chunk[..n] {
+                        uart_putc(b);
+                    }
+                    off += n;
                 }
             }
             len as i64

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -167,6 +167,14 @@ pub unsafe extern "C" fn syscall_dispatch(nr: u64, a0: u64, a1: u64, a2: u64) ->
             let buf_va = a1 as usize;
             let len = a2 as usize;
             if fd == 1 && len > 0 {
+                // Validate the whole `[buf_va, buf_va + len)` range up
+                // front so a cross-boundary buffer fails with -EFAULT
+                // *before* any bytes hit the UART. Per-chunk validation
+                // alone would emit partial output on a later-chunk
+                // failure — non-atomic observable side effects.
+                if let Err(e) = uaccess::check_user_range(buf_va, len) {
+                    return e.as_errno();
+                }
                 // Chunk through a small kernel-stack bounce buffer so the
                 // ring-0 access window stays short and bounded — a single
                 // STAC/CLAC bracket per chunk, not per byte.

--- a/kernel/src/arch/x86_64/uaccess.rs
+++ b/kernel/src/arch/x86_64/uaccess.rs
@@ -21,10 +21,9 @@ use core::sync::atomic::{AtomicBool, Ordering};
 use x86_64::registers::control::{Cr4, Cr4Flags};
 
 use crate::cpu::{self, Feature};
-
-/// First canonical upper-half address. Any user pointer at or above this
-/// is a kernel address and must be rejected.
-pub const USER_VA_END: u64 = 0x0000_8000_0000_0000;
+// Single source of truth for the lower/upper canonical-half boundary.
+// Re-exported so callers in this module can use the short name.
+pub use crate::mem::addrspace::USER_VA_END;
 
 /// Cached so `stac`/`clac` can skip the SMAP ops on CPUs that don't
 /// implement them (e.g. `qemu64` without `-cpu max`).
@@ -82,7 +81,7 @@ pub fn enable_smep_smap() {
 #[inline(always)]
 unsafe fn stac() {
     if SMAP_ON.load(Ordering::Relaxed) {
-        core::arch::asm!("stac", options(nomem, preserves_flags));
+        core::arch::asm!("stac", options(nomem, nostack));
     }
 }
 
@@ -90,19 +89,22 @@ unsafe fn stac() {
 #[inline(always)]
 unsafe fn clac() {
     if SMAP_ON.load(Ordering::Relaxed) {
-        core::arch::asm!("clac", options(nomem, preserves_flags));
+        core::arch::asm!("clac", options(nomem, nostack));
     }
 }
 
 /// Validate `[uva, uva + len)` lies entirely within the lower canonical
 /// half. Returns `Efault` on overflow or kernel-half overlap.
+///
+/// Exposed so syscall handlers can reject a bad range up front before
+/// any observable side effect (e.g. emitting bytes to the UART).
 #[inline]
-fn check_range(uva: u64, len: usize) -> Result<(), Efault> {
+pub fn check_user_range(uva: usize, len: usize) -> Result<(), Efault> {
     if len == 0 {
         return Ok(());
     }
-    let end = uva.checked_add(len as u64).ok_or(Efault)?;
-    if uva >= USER_VA_END || end > USER_VA_END {
+    let end = (uva as u64).checked_add(len as u64).ok_or(Efault)?;
+    if uva as u64 >= USER_VA_END || end > USER_VA_END {
         return Err(Efault);
     }
     Ok(())
@@ -121,7 +123,7 @@ fn check_range(uva: u64, len: usize) -> Result<(), Efault> {
 /// per-CPU AC bit; a context switch clobbers it). Syscalls already
 /// run with IF=0 via the SFMASK we install.
 pub unsafe fn copy_from_user(dst: &mut [u8], src_uva: usize) -> Result<(), Efault> {
-    check_range(src_uva as u64, dst.len())?;
+    check_user_range(src_uva, dst.len())?;
     let src = src_uva as *const u8;
     stac();
     for i in 0..dst.len() {
@@ -137,7 +139,7 @@ pub unsafe fn copy_from_user(dst: &mut [u8], src_uva: usize) -> Result<(), Efaul
 /// Same constraints as `copy_from_user` but the user range must be
 /// mapped writable.
 pub unsafe fn copy_to_user(dst_uva: usize, src: &[u8]) -> Result<(), Efault> {
-    check_range(dst_uva as u64, src.len())?;
+    check_user_range(dst_uva, src.len())?;
     let dst = dst_uva as *mut u8;
     stac();
     for i in 0..src.len() {

--- a/kernel/src/arch/x86_64/uaccess.rs
+++ b/kernel/src/arch/x86_64/uaccess.rs
@@ -81,7 +81,11 @@ pub fn enable_smep_smap() {
 #[inline(always)]
 unsafe fn stac() {
     if SMAP_ON.load(Ordering::Relaxed) {
-        core::arch::asm!("stac", options(nomem, nostack));
+        // `nostack` only — omitting `nomem` makes this a compiler memory
+        // barrier so LLVM cannot hoist volatile loads/stores (in the
+        // copy_*_user callers) past this instruction and out of the
+        // STAC/CLAC bracket.
+        core::arch::asm!("stac", options(nostack));
     }
 }
 
@@ -89,7 +93,10 @@ unsafe fn stac() {
 #[inline(always)]
 unsafe fn clac() {
     if SMAP_ON.load(Ordering::Relaxed) {
-        core::arch::asm!("clac", options(nomem, nostack));
+        // Same reasoning as `stac`: no `nomem` so this acts as a compiler
+        // memory barrier, preventing the volatile accesses from sinking
+        // past the bracket.
+        core::arch::asm!("clac", options(nostack));
     }
 }
 

--- a/kernel/src/arch/x86_64/uaccess.rs
+++ b/kernel/src/arch/x86_64/uaccess.rs
@@ -1,0 +1,148 @@
+//! Ring-0 user-memory access primitives with SMEP/SMAP enforcement.
+//!
+//! ## SMEP (CR4.20)
+//! Blocks ring-0 fetch of instructions from user (U=1) pages. No software
+//! bracket — once enabled it's always on. Mitigates ret2user exploits.
+//!
+//! ## SMAP (CR4.21)
+//! Blocks ring-0 read/write of user pages unless RFLAGS.AC is set. The
+//! `STAC`/`CLAC` instructions toggle AC without touching other flag bits.
+//! Accesses outside a `stac()`/`clac()` bracket take a `#PF` with the
+//! user bit set — exactly what we want if the kernel accidentally chases
+//! a user pointer.
+//!
+//! `copy_from_user` / `copy_to_user` are the only sanctioned way to cross
+//! the ring-0/ring-3 boundary from kernel code. They bounds-check the
+//! user VA against the lower canonical half, bracket the byte-copy with
+//! STAC/CLAC, and return `Efault` on range failure.
+
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use x86_64::registers::control::{Cr4, Cr4Flags};
+
+use crate::cpu::{self, Feature};
+
+/// First canonical upper-half address. Any user pointer at or above this
+/// is a kernel address and must be rejected.
+pub const USER_VA_END: u64 = 0x0000_8000_0000_0000;
+
+/// Cached so `stac`/`clac` can skip the SMAP ops on CPUs that don't
+/// implement them (e.g. `qemu64` without `-cpu max`).
+static SMAP_ON: AtomicBool = AtomicBool::new(false);
+
+/// `-EFAULT`.
+pub const EFAULT: i64 = -14;
+
+/// Zero-sized error type for `copy_from_user` / `copy_to_user`.
+#[derive(Debug, Clone, Copy)]
+pub struct Efault;
+
+impl Efault {
+    pub const fn as_errno(self) -> i64 {
+        EFAULT
+    }
+}
+
+/// Read CR4 and set SMEP / SMAP bits iff the CPU supports them.
+///
+/// Call after `cpu::init()` so feature detection has populated the
+/// global `FEATURES`. Safe to call once; subsequent calls are a no-op
+/// because setting the bit again is idempotent.
+pub fn enable_smep_smap() {
+    let have_smep = cpu::has(Feature::Smep);
+    let have_smap = cpu::has(Feature::Smap);
+
+    let mut flags = Cr4::read();
+    if have_smep {
+        flags |= Cr4Flags::SUPERVISOR_MODE_EXECUTION_PROTECTION;
+    }
+    if have_smap {
+        flags |= Cr4Flags::SUPERVISOR_MODE_ACCESS_PREVENTION;
+    }
+    // SAFETY: We're only asserting bits we've proven the CPU implements.
+    // SMEP/SMAP enforcement is exactly the protection we want; no other
+    // CR4 bits are being touched.
+    unsafe { Cr4::write(flags) };
+
+    SMAP_ON.store(have_smap, Ordering::Relaxed);
+
+    crate::serial_println!(
+        "uaccess: smep={} smap={}",
+        if have_smep { "on" } else { "unavailable" },
+        if have_smap { "on" } else { "unavailable" },
+    );
+}
+
+/// Set RFLAGS.AC so ring-0 loads/stores of user pages are permitted.
+/// No-op if the CPU lacks SMAP.
+///
+/// # Safety
+/// Must be paired with a `clac()` before returning to arbitrary kernel
+/// code. Leaving AC=1 defeats SMAP for the rest of the thread.
+#[inline(always)]
+unsafe fn stac() {
+    if SMAP_ON.load(Ordering::Relaxed) {
+        core::arch::asm!("stac", options(nomem, preserves_flags));
+    }
+}
+
+/// Clear RFLAGS.AC. Pair with a prior `stac()`.
+#[inline(always)]
+unsafe fn clac() {
+    if SMAP_ON.load(Ordering::Relaxed) {
+        core::arch::asm!("clac", options(nomem, preserves_flags));
+    }
+}
+
+/// Validate `[uva, uva + len)` lies entirely within the lower canonical
+/// half. Returns `Efault` on overflow or kernel-half overlap.
+#[inline]
+fn check_range(uva: u64, len: usize) -> Result<(), Efault> {
+    if len == 0 {
+        return Ok(());
+    }
+    let end = uva.checked_add(len as u64).ok_or(Efault)?;
+    if uva >= USER_VA_END || end > USER_VA_END {
+        return Err(Efault);
+    }
+    Ok(())
+}
+
+/// Copy `dst.len()` bytes from user VA `src_uva` into `dst`.
+///
+/// Bounds-checks the user range against `USER_VA_END`, then brackets the
+/// byte-wise copy with `stac`/`clac`. On SMEP/SMAP-capable CPUs a stray
+/// kernel pointer or an unmapped user page surfaces as a `#PF` rather
+/// than silent data corruption.
+///
+/// # Safety
+/// The active PML4 must map `[src_uva, src_uva + dst.len())` as user
+/// pages. Interrupts must be disabled for the duration (SMAP is a
+/// per-CPU AC bit; a context switch clobbers it). Syscalls already
+/// run with IF=0 via the SFMASK we install.
+pub unsafe fn copy_from_user(dst: &mut [u8], src_uva: usize) -> Result<(), Efault> {
+    check_range(src_uva as u64, dst.len())?;
+    let src = src_uva as *const u8;
+    stac();
+    for i in 0..dst.len() {
+        dst[i] = core::ptr::read_volatile(src.add(i));
+    }
+    clac();
+    Ok(())
+}
+
+/// Copy `src.len()` bytes from `src` into user VA `dst_uva`.
+///
+/// # Safety
+/// Same constraints as `copy_from_user` but the user range must be
+/// mapped writable.
+pub unsafe fn copy_to_user(dst_uva: usize, src: &[u8]) -> Result<(), Efault> {
+    check_range(dst_uva as u64, src.len())?;
+    let dst = dst_uva as *mut u8;
+    stac();
+    for i in 0..src.len() {
+        core::ptr::write_volatile(dst.add(i), src[i]);
+    }
+    clac();
+    Ok(())
+}

--- a/kernel/tests/smep_smap.rs
+++ b/kernel/tests/smep_smap.rs
@@ -1,0 +1,117 @@
+//! Integration test for #116: SMEP/SMAP enforcement is live on the CPU
+//! and `copy_from_user` / `copy_to_user` gate ring-0 access to user
+//! pages behind STAC/CLAC.
+//!
+//! Verifies:
+//! 1. CR4.SMEP / CR4.SMAP are set after `vibix::init()`.
+//! 2. `copy_from_user` / `copy_to_user` reject kernel-half and wrapping
+//!    pointers with `Efault`.
+//! 3. A round-trip through a real user VMA copies the expected bytes
+//!    (implicitly exercising the STAC/CLAC bracket — without it the
+//!    access would take a `#PF` with the SMAP bit set).
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+
+use vibix::arch::x86_64::uaccess::{self, USER_VA_END};
+use vibix::mem::vma::{Vma, VmaKind};
+use vibix::{
+    exit_qemu, serial_println, task,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+use x86_64::registers::control::{Cr4, Cr4Flags};
+use x86_64::structures::paging::PageTableFlags;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("cr4_smep_smap_bits_set", &(cr4_smep_smap_bits_set as fn())),
+        ("copy_rejects_kernel_half", &(copy_rejects_kernel_half as fn())),
+        ("copy_rejects_wrap", &(copy_rejects_wrap as fn())),
+        ("copy_roundtrip_user", &(copy_roundtrip_user as fn())),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+fn cr4_smep_smap_bits_set() {
+    let flags = Cr4::read();
+    assert!(
+        flags.contains(Cr4Flags::SUPERVISOR_MODE_EXECUTION_PROTECTION),
+        "CR4.SMEP not set — SMEP enforcement is off"
+    );
+    assert!(
+        flags.contains(Cr4Flags::SUPERVISOR_MODE_ACCESS_PREVENTION),
+        "CR4.SMAP not set — SMAP enforcement is off"
+    );
+}
+
+fn copy_rejects_kernel_half() {
+    let mut buf = [0u8; 8];
+    let kernel_va = USER_VA_END as usize;
+    unsafe {
+        assert!(uaccess::copy_from_user(&mut buf, kernel_va).is_err());
+        assert!(uaccess::copy_to_user(kernel_va, &buf).is_err());
+    }
+}
+
+fn copy_rejects_wrap() {
+    let mut buf = [0u8; 8];
+    unsafe {
+        // A near-max usize pointer + non-trivial length overflows — must
+        // be rejected, not silently wrap past 0 into the low user VA.
+        assert!(uaccess::copy_from_user(&mut buf, usize::MAX - 3).is_err());
+    }
+}
+
+/// Install an AnonZero VMA on the current task, fault the pages in by
+/// touching them, then exercise `copy_to_user` / `copy_from_user` through
+/// that real user mapping. On an SMAP-on CPU, missing STAC/CLAC brackets
+/// inside the helpers would `#PF` here.
+fn copy_roundtrip_user() {
+    const BASE: usize = 0x0000_3000_0010_0000;
+    const PAGES: usize = 2;
+
+    task::install_vma_on_current(Vma::new(
+        BASE,
+        BASE + PAGES * 4096,
+        VmaKind::AnonZero,
+        PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE,
+    ));
+
+    // Fault each page in by touching it. We're still running in ring-0
+    // and this task's PML4 — this is a demand-paging trigger, not a
+    // user-pointer-from-kernel access.
+    for i in 0..PAGES {
+        unsafe { core::ptr::write_volatile((BASE + i * 4096) as *mut u8, 0) };
+    }
+
+    let payload: [u8; 16] = *b"smep_smap_rtrip!";
+    let mut readback = [0u8; 16];
+    unsafe {
+        uaccess::copy_to_user(BASE + 32, &payload).expect("copy_to_user ok");
+        uaccess::copy_from_user(&mut readback, BASE + 32).expect("copy_from_user ok");
+    }
+    assert_eq!(readback, payload);
+}

--- a/kernel/tests/smep_smap.rs
+++ b/kernel/tests/smep_smap.rs
@@ -96,20 +96,26 @@ fn copy_roundtrip_user() {
     const BASE: usize = 0x0000_3000_0010_0000;
     const PAGES: usize = 2;
 
+    // USER_ACCESSIBLE is load-bearing here: without it the pages are
+    // mapped supervisor-only (U/S=0), SMAP wouldn't block ring-0 access,
+    // and the copy_*_user helpers would appear to work even if their
+    // STAC/CLAC bracket were broken. With U/S=1 the round-trip only
+    // succeeds when SMAP is actually toggled inside the helpers.
     task::install_vma_on_current(Vma::new(
         BASE,
         BASE + PAGES * 4096,
         VmaKind::AnonZero,
-        PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE,
+        PageTableFlags::PRESENT
+            | PageTableFlags::WRITABLE
+            | PageTableFlags::USER_ACCESSIBLE
+            | PageTableFlags::NO_EXECUTE,
     ));
 
-    // Fault each page in by touching it. We're still running in ring-0
-    // and this task's PML4 — this is a demand-paging trigger, not a
-    // user-pointer-from-kernel access.
-    for i in 0..PAGES {
-        unsafe { core::ptr::write_volatile((BASE + i * 4096) as *mut u8, 0) };
-    }
-
+    // No explicit warm-up touch: with USER_ACCESSIBLE mappings a ring-0
+    // write without `stac` would itself trip SMAP. Let `copy_to_user`
+    // drive demand paging under its own STAC bracket — the fault
+    // handler's CLAC keeps the resolver running with SMAP live, and the
+    // IRET retry completes inside the bracket.
     let payload: [u8; 16] = *b"smep_smap_rtrip!";
     let mut readback = [0u8; 16];
     unsafe {

--- a/kernel/tests/smep_smap.rs
+++ b/kernel/tests/smep_smap.rs
@@ -44,7 +44,10 @@ fn panic(info: &PanicInfo) -> ! {
 fn run_tests() {
     let tests: &[(&str, &dyn Testable)] = &[
         ("cr4_smep_smap_bits_set", &(cr4_smep_smap_bits_set as fn())),
-        ("copy_rejects_kernel_half", &(copy_rejects_kernel_half as fn())),
+        (
+            "copy_rejects_kernel_half",
+            &(copy_rejects_kernel_half as fn()),
+        ),
         ("copy_rejects_wrap", &(copy_rejects_wrap as fn())),
         ("copy_roundtrip_user", &(copy_roundtrip_user as fn())),
     ];

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -505,6 +505,8 @@ fn run(opts: &BuildOpts) -> R<()> {
         .args([
             "-M",
             "q35",
+            "-cpu",
+            "max",
             "-m",
             "256M",
             "-serial",
@@ -549,6 +551,8 @@ fn test_runner(kernel: &Path) -> R<()> {
         .args([
             "-M",
             "q35",
+            "-cpu",
+            "max",
             "-m",
             "256M",
             "-serial",
@@ -631,6 +635,7 @@ fn test_all() -> R<()> {
         "addrspace",
         "addrspace_drop",
         "tlb_flusher",
+        "smep_smap",
     ] {
         cmd.arg("--test").arg(t);
     }
@@ -649,6 +654,8 @@ fn smoke(opts: &BuildOpts) -> R<()> {
         .args([
             "-M",
             "q35",
+            "-cpu",
+            "max",
             "-m",
             "256M",
             "-serial",


### PR DESCRIPTION
Closes #116

## Summary
- Enable CR4.SMEP and CR4.SMAP in `arch::init` after CPUID feature detection, ahead of the first SYSCALL.
- Introduce `arch::x86_64::uaccess` with `copy_from_user` / `copy_to_user` helpers that bounds-check against the lower canonical half (`USER_VA_END = 0x0000_8000_0000_0000`) and bracket the byte-wise copy with `STAC`/`CLAC`. A cached `SMAP_ON` flag keeps the helpers correct on CPUs without SMAP.
- Migrate the `write(1, buf, len)` syscall arm to `copy_from_user`. Without this, enabling SMAP would `#PF` the first SYSCALL from PID 1 — the old loop did a bare ring-0 `read_volatile` on the user buffer.
- QEMU's default `qemu64` CPU model hides SMEP/SMAP, so the xtask runners now pass `-cpu max`.

## Test plan
- [x] `cargo xtask build` — clean.
- [x] `cargo xtask test` — all 29 integration tests pass, including the new `smep_smap` suite (CR4 bits, kernel-half rejection, wrap rejection, real-VMA round-trip).
- [x] `cargo xtask smoke` — 27/27 markers present, boot log shows `uaccess: smep=on smap=on`.
- [x] `userspace_loader` / `userspace_module` tests continue to pass — confirms the write(1) migration didn't regress the ring-3 path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables SMEP/SMAP and changes syscall user-pointer handling and the page-fault path, which can affect all ring-3 interactions and fault behavior if the AC/SMAP bracketing is incorrect. Includes test coverage, but misconfiguration could still cause early boot/syscall regressions or unexpected #PFs on real hardware/VMs.
> 
> **Overview**
> **Enables SMEP/SMAP enforcement on x86_64** by setting CR4 bits during `arch::init()` (before the first `SYSCALL`) and adding a new `arch::x86_64::uaccess` module with `check_user_range`, `copy_from_user`, and `copy_to_user` that use `STAC`/`CLAC` (gated by a cached SMAP capability flag).
> 
> **Hardens fault and syscall behavior under SMAP**: the `#PF` handler now clears `RFLAGS.AC` on entry to ensure the handler runs with SMAP live, and the `write(1, buf, len)` syscall path switches from direct user-pointer dereferences to chunked `copy_from_user` through a small bounce buffer (returning `-EFAULT` on invalid ranges).
> 
> Adds a new `smep_smap` integration test suite and updates `xtask` QEMU invocations to use `-cpu max` so SMEP/SMAP are available in CI/dev runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bce790eb4303c75fa72955c316af40c33cd3fdcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->