### PR TITLE
skill: wrap mid-loop Skill() calls in Agent() to preserve loop context

### DIFF
--- a/.claude/skills/auto-engineer/SKILL.md
+++ b/.claude/skills/auto-engineer/SKILL.md
@@ -203,7 +203,7 @@ ScheduleWakeup(
 - **Actionable bugs** → apply follow-up commits (never amend), `git push`, then reschedule
   another poll tick with `--fix-round R+1`.
 - **Out-of-scope nits** → reply on the PR via `mcp__github__add_issue_comment` ("deferred to
-  future work"), open a follow-up issue via the `file-issue` skill, then proceed to merge.
+  future work"), open a follow-up issue via an `Agent()` call (see "Calling file-issue from a loop" below), then proceed to merge.
 
 ### 7. Merge
 
@@ -234,10 +234,9 @@ Before reloading the next issue, scan for work that surfaced during this cycle b
 - Build/test warnings observed during step 4 that weren't blocking but deserve follow-up.
 - Anything the sub-agent's plan (step 2) explicitly listed as "out of scope" or "risks."
 
-For each distinct follow-up, **invoke the `file-issue` skill** — do not call
-`mcp__github__issue_write` directly. The `file-issue` skill handles dedupe against existing
-issues, enforces the label taxonomy from `docs/agent-playbooks/prioritization.md`, and
-produces a body in the canonical template. Feed it:
+For each distinct follow-up, open an issue via an `Agent()` call (see "Calling file-issue
+from a loop" below). Do **not** call `Skill("file-issue")` — that replaces this skill's
+context and terminates the loop. Feed each Agent():
 
 - A specific title.
 - A 1–3 sentence motivation, including `discovered while merging #<PR>` so the origin is
@@ -249,11 +248,20 @@ If nothing worth filing, skip silently. **Do not file speculative or "nice-to-ha
 
 ### 9. Check session quota
 
-Before compacting and kicking off the next cycle, run `/usage` (the `usage` skill). It emits two machine-readable lines — `remaining_pct: <float>` and `reset_ts: <ISO>` — plus a human summary. Parse `remaining_pct`.
+Before compacting and kicking off the next cycle, check quota by running the probe script
+**directly** — do **not** call `Skill("usage")`, which would terminate the loop:
+
+```sh
+bash .claude/skills/usage/probe.sh
+```
+
+Parse the single-line JSON output (see `docs/agent-playbooks/skill-composition.md` for why
+direct invocation is required here). Derive `remaining_pct` as
+`max(0, 100 - 5h.utilization*100)` and `reset_ts` as an ISO-8601 string of `5h.resets_at`.
 
 - **≥ 10% remaining** → proceed to step 10.
 - **< 10% remaining** → don't start a new cycle; the next one could tip over mid-PR and leave an orphaned branch. Instead:
-  1. Read `reset_ts` from `/usage` output.
+  1. Read `reset_ts` from the probe JSON output.
   2. Compute `secondsUntilReset = reset_ts - now`. Add a 60 s buffer so the wake-up lands *after* the reset, not on its edge.
   3. **Compaction decision:**
      - If `secondsUntilReset ≤ 90 min`: skip `/compact`. The wait is short enough that one or two un-compacted hops won't burn meaningful quota, and compaction itself costs tokens we want to save.
@@ -298,12 +306,40 @@ Stop conditions:
 - Iteration budget of 8 reached.
 - The issue was reassigned away from `dburkart` while auto-engineer held it.
 
+## Calling file-issue from a loop
+
+`Skill("file-issue")` replaces the current skill's execution context — calling it would
+terminate this loop. Instead, spawn a subagent via `Agent()`:
+
+```
+Agent(
+  description="File follow-up issue: <title>",
+  subagent_type="general-purpose",
+  prompt="""
+Read .claude/skills/file-issue/SKILL.md and docs/agent-playbooks/prioritization.md.
+Then file one GitHub issue against dburkart/vibix with:
+  title: <title>
+  motivation: <1-3 sentences, include "discovered while merging #<PR>">
+  work items: <concrete sub-tasks>
+  context: <file paths, SHAs, related issues>
+Return the new issue number and URL.
+"""
+)
+```
+
+Key points:
+- The Agent() call returns to this skill when done — the loop continues.
+- Pass all context explicitly in the prompt; the subagent starts cold with no conversation
+  history.
+- One Agent() call per issue; do not batch multiple issues into one subagent call.
+
 ## Never
 
 - Force-push, rebase pushed branches, or rewrite reviewed commits.
 - Edit `main` directly.
 - Merge without green CI.
 - Delegate the PR-wait loop to the `wait-for-pr` skill — it would steal the `ScheduleWakeup` thread. Use the embedded poll loop in step 6 instead.
+- Call `Skill("file-issue")` or `Skill("usage")` inline — use `Agent()` for file-issue and the probe script for usage. `Skill()` replaces the current context and terminates the loop.
 - Continue past 8 iterations without a fresh user invocation.
 - Auto-fix test or build logic in step 6c (fmt and clippy only; real fixes are follow-up commits).
 - Close an issue manually — let the squash-merge do it via the PR body's `Closes #N`.

--- a/docs/agent-playbooks/skill-composition.md
+++ b/docs/agent-playbooks/skill-composition.md
@@ -1,0 +1,79 @@
+# Skill composition: calling skills from inside skills
+
+## The core problem
+
+The `Skill()` tool **replaces** the current skill's execution context. When a running skill
+calls `Skill("foo")`, `foo` takes over and the original skill is gone — there is no return
+path. This is correct for top-level user invocations, but it terminates any loop that tries
+to call a skill as a helper mid-cycle.
+
+**Broken pattern — terminates the loop:**
+```
+# In auto-engineer step 8:
+Skill("file-issue", "file an issue for ...")   # ← loop dies here
+# Nothing after this line ever runs
+```
+
+**Working pattern — loop continues:**
+```
+# Spawn a subagent; it runs, returns a result, and the loop picks up where it left off.
+Agent(
+  description="File follow-up issue: <title>",
+  subagent_type="general-purpose",
+  prompt="Read .claude/skills/file-issue/SKILL.md ... <full context>"
+)
+```
+
+## Decision table
+
+| Invocation site | Correct approach |
+|---|---|
+| Top-level user request (no loop) | `Skill("foo")` |
+| Mid-loop, skill wraps shell commands only | Run the shell commands directly via `Bash` |
+| Mid-loop, skill requires MCP calls or multi-step reasoning | `Agent()` with the skill's SKILL.md embedded in the prompt |
+
+## How to wrap a skill in Agent()
+
+The subagent starts cold — it has no conversation history and no ambient context.
+Everything it needs must be in the prompt:
+
+```
+Agent(
+  description="<short label for the work log>",
+  subagent_type="general-purpose",    # or "Plan" for pure planning
+  prompt="""
+Read <path/to/SKILL.md> and any playbooks it references.
+Then perform the following task:
+  <exactly what you need done>
+  <all relevant context: issue numbers, file paths, PR numbers, commit SHAs>
+Return <what you need back — e.g. the new issue number and URL>.
+"""
+)
+```
+
+Keep these rules in mind:
+- One Agent() per discrete unit of work — do not batch unrelated items.
+- Include explicit file/resource references; do not assume the subagent can infer context.
+- The result comes back as conversation text; parse it before proceeding.
+
+## Skills that must never be called via Skill() from a loop
+
+| Skill | Correct mid-loop approach |
+|---|---|
+| `file-issue` | `Agent()` with SKILL.md embedded (see auto-engineer § "Calling file-issue from a loop") |
+| `usage` | Run `bash .claude/skills/usage/probe.sh` directly and parse the JSON |
+| `wait-for-pr` | Never delegated from auto-engineer — use the embedded poll loop in step 6 |
+| `build` / `test` | Run `cargo xtask build` / `cargo xtask test` directly |
+
+## Guidance for new skill authors
+
+If your skill is designed to be called from inside a loop (e.g. from auto-engineer), write
+it so the *loop* can call it safely:
+
+1. **Prefer shell-scriptable output** when the skill is a probe or report — emit
+   machine-readable lines a parent can parse directly without spawning a subagent.
+2. **Document how to call you from a loop** in your SKILL.md if the correct invocation
+   differs from the top-level `Skill()` form.
+3. **If your skill itself contains a loop** (poll, retry, reschedule), document that calling
+   `Skill("your-skill")` from inside another loop would steal the `ScheduleWakeup` thread,
+   and provide the Agent()-based alternative.


### PR DESCRIPTION
## Summary
- `Skill()` replaces the current execution context, so any mid-loop call to `Skill("file-issue")` or `Skill("usage")` silently terminates the auto-engineer loop
- Fix auto-engineer to use `Agent()` for `file-issue` invocations (steps 6c and 8) and run `bash .claude/skills/usage/probe.sh` directly for quota checks (step 9)
- Add a "Calling file-issue from a loop" section with a concrete `Agent()` template
- Extend the Never block to explicitly ban inline `Skill()` calls mid-loop
- Add `docs/agent-playbooks/skill-composition.md` — decision table, `Agent()` template, table of known skills and their correct mid-loop invocation, and guidance for future skill authors

## Test plan
- [x] Docs/skill-only change — no kernel code touched; `cargo xtask build` not required
- [x] Reviewed auto-engineer SKILL.md for stale `/usage` references — cleaned up one remaining instance in step 9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the `auto-engineer` runbook to change how it files follow-up issues and checks quota; if these instructions are wrong, the autonomous loop could still terminate or mis-handle quota pauses. No product/runtime code is touched.
> 
> **Overview**
> Prevents the `auto-engineer` loop from being terminated by mid-loop `Skill()` calls by updating steps 6/8 to file follow-up issues via an `Agent()` subagent template and updating step 9 to check quota by running `bash .claude/skills/usage/probe.sh` and parsing its JSON output.
> 
> Adds a new playbook, `docs/agent-playbooks/skill-composition.md`, documenting when to use `Skill()` vs direct shell vs `Agent()`, with a decision table and a short list of skills that must not be called via `Skill()` from inside loops, and updates the `Never` section to explicitly ban inline `Skill("file-issue")`/`Skill("usage")`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f848627f3f2d756bf2ccb752c66a4bce385a8f45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->