### PR TITLE
ci: file a bug via Claude when main branch build fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,58 @@ jobs:
 
       - name: cargo xtask build --release
         run: cargo xtask build --release
+
+  file-bug:
+    needs: test
+    if: failure() && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 1
+
+      - name: File bug via Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+          claude_args: >-
+            --allowed-tools
+            "Bash(gh run view:*)"
+            "Bash(gh issue list:*)"
+            "Skill(file-issue)"
+          prompt: |
+            The CI build on the main branch of the vibix kernel repo just failed.
+
+            Workflow run URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            Repository: ${{ github.repository }}
+            Branch: ${{ github.ref_name }}
+            Commit SHA: ${{ github.sha }}
+            Commit message: ${{ github.event.head_commit.message }}
+            Actor: ${{ github.actor }}
+
+            Fetch the full failure details with:
+              gh run view ${{ github.run_id }} --log-failed
+
+            Then file exactly one bug issue via the `file-issue` skill (`/file-issue`).
+            Do NOT call `gh issue create` directly — use the skill so labels are applied
+            correctly per the prioritization playbook.
+
+            The issue must include:
+            - Title: "CI: main branch build failed — <short description of failing step>"
+            - Which job/step failed and the first error message from the log
+            - The workflow run URL above so it is easy to navigate to the logs
+            - The commit SHA and message that introduced the failure
+
+            Before filing, run:
+              gh issue list --state open --limit 20
+            and skip filing if an identical open CI-failure issue already exists for
+            this commit SHA.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,5 @@ jobs:
             - The commit SHA and message that introduced the failure
 
             Before filing, run:
-              gh issue list --state open --limit 20
-            and skip filing if an identical open CI-failure issue already exists for
-            this commit SHA.
+              gh issue list --state open --search "${{ github.sha }}"
+            and skip filing if an open issue for this exact commit SHA already exists.


### PR DESCRIPTION
Closes #191

## Summary
- Adds a `file-bug` job to `ci.yml` that depends on the `test` job
- The job only runs when `test` fails **and** the ref is `refs/heads/main` — PR runs are unaffected
- On failure, invokes `claude-code-action` with `Skill(file-issue)` to file a well-labeled bug: fetches the failed-step log via `gh run view --log-failed`, deduplicates against open issues by commit SHA, then files one issue with the correct priority/area labels

## Test plan
- [x] `cargo xtask build` passes (workflow-only change, no Rust code modified)
- [x] `cargo fmt --all -- --check` passes
- The `if: failure() && github.ref == 'refs/heads/main'` condition ensures the job is silently skipped on pull_request triggers — CI on this PR itself will not fire the bug-filing job even if it were to fail

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an automated issue-creation path in CI with elevated `issues: write` permissions and a new third-party action; misconfiguration could spam issues or broaden token exposure, but it only runs on `main` failures.
> 
> **Overview**
> Adds a new `file-bug` job to the CI workflow that runs **only when the `test` job fails on `refs/heads/main`**.
> 
> On failure, it invokes `anthropics/claude-code-action@v1` (scoped to `gh run view --log-failed` and `gh issue list`) to dedupe by commit SHA and file a single labeled bug issue via the `file-issue` skill, including the failing step/error and the workflow run URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b49c7b28a8140d4790a0bce57f8b551751ff27cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->