### PR TITLE
fix: update smep_smap test to use vmatree::Vma API

### DIFF
--- a/kernel/tests/smep_smap.rs
+++ b/kernel/tests/smep_smap.rs
@@ -18,8 +18,8 @@ extern crate alloc;
 use core::panic::PanicInfo;
 
 use vibix::arch::x86_64::uaccess::{self, USER_VA_END};
-use vibix::mem::vmobject::AnonObject;
 use vibix::mem::vmatree::{Share, Vma};
+use vibix::mem::vmobject::AnonObject;
 use vibix::{
     exit_qemu, serial_println, task,
     test_harness::{test_panic_handler, Testable},

--- a/kernel/tests/smep_smap.rs
+++ b/kernel/tests/smep_smap.rs
@@ -18,7 +18,8 @@ extern crate alloc;
 use core::panic::PanicInfo;
 
 use vibix::arch::x86_64::uaccess::{self, USER_VA_END};
-use vibix::mem::vma::{Vma, VmaKind};
+use vibix::mem::vmobject::AnonObject;
+use vibix::mem::vmatree::{Share, Vma};
 use vibix::{
     exit_qemu, serial_println, task,
     test_harness::{test_panic_handler, Testable},
@@ -101,14 +102,19 @@ fn copy_roundtrip_user() {
     // and the copy_*_user helpers would appear to work even if their
     // STAC/CLAC bracket were broken. With U/S=1 the round-trip only
     // succeeds when SMAP is actually toggled inside the helpers.
+    let pte_flags = (PageTableFlags::PRESENT
+        | PageTableFlags::WRITABLE
+        | PageTableFlags::USER_ACCESSIBLE
+        | PageTableFlags::NO_EXECUTE)
+        .bits();
     task::install_vma_on_current(Vma::new(
         BASE,
         BASE + PAGES * 4096,
-        VmaKind::AnonZero,
-        PageTableFlags::PRESENT
-            | PageTableFlags::WRITABLE
-            | PageTableFlags::USER_ACCESSIBLE
-            | PageTableFlags::NO_EXECUTE,
+        0x3, // PROT_READ | PROT_WRITE
+        pte_flags,
+        Share::Private,
+        AnonObject::new(Some(PAGES)),
+        0,
     ));
 
     // No explicit warm-up touch: with USER_ACCESSIBLE mappings a ring-0


### PR DESCRIPTION
Closes #190

## Summary
- The VMA backing was migrated from `VmaKind` to `Arc<dyn VmObject>` in #180, but `kernel/tests/smep_smap.rs` still imported the removed `vibix::mem::vma` module.
- Update the import and `Vma::new` call site to use `vibix::mem::vmatree::{Vma, Share}` and `vibix::mem::vmobject::AnonObject`.

## Test plan
- [x] `cargo xtask build` — clean build, no errors
- [x] `cargo xtask test` — all 69 integration/unit test cases pass, including `smep_smap` (4 tests: `cr4_smep_smap_bits_set`, `copy_rejects_kernel_half`, `copy_rejects_wrap`, `copy_roundtrip_user`)
- [x] `cargo xtask smoke` — all 27 markers present

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates a kernel integration test to match the new VMA/VmObject APIs without changing production logic.
> 
> **Overview**
> Updates the `kernel/tests/smep_smap.rs` SMEP/SMAP integration test to use the newer `vmatree::Vma` + `VmObject` model instead of the removed `vma::VmaKind` API.
> 
> The user-mapping setup in `copy_roundtrip_user` now passes explicit user protection (`PROT_READ|PROT_WRITE`), raw PTE flags, sharing mode (`Share::Private`), and an `AnonObject` backing to `Vma::new`, keeping the test’s SMAP/STAC/CLAC round-trip behavior intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f5d6a0c2d67dc8a854779d1ee65879bf2c48ac5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->