### PR TITLE
fix: add missing MCP tool permissions to issue-backfill workflow

### DIFF
--- a/.github/workflows/issue-backfill.yml
+++ b/.github/workflows/issue-backfill.yml
@@ -44,6 +44,9 @@ jobs:
             "Bash(head:*)"
             "Bash(gh issue list:*)"
             "Skill(file-issue)"
+            "mcp__github__search_issues"
+            "mcp__github__add_issue_comment"
+            "mcp__github__issue_write"
           prompt: |
             You are a technical project manager for the vibix kernel — a hobby OS kernel written in Rust.
 


### PR DESCRIPTION
Closes #195

## Summary
- The `file-issue` skill requires `mcp__github__search_issues` (dedupe), `mcp__github__add_issue_comment` (duplicate-found path), and `mcp__github__issue_write` (creation) but none were listed in `--allowed-tools`
- Every scheduled run was exiting 0 while logging 57 permission denials and filing zero issues, burning ~$2.71 per run
- Added all three MCP tools to the allowed-tools list in `.github/workflows/issue-backfill.yml`

## Test plan
- [x] `cargo xtask build` — workflow-only change, no kernel code touched
- [ ] Trigger `workflow_dispatch` on the updated workflow and confirm issues are filed (requires human to pull and dispatch)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that expands the Claude Code action’s allowed tool list so scheduled runs can create/dedupe issues as intended.
> 
> **Overview**
> Fixes the `Issue Backfill` GitHub Actions workflow by adding the missing MCP GitHub tools to `--allowed-tools` (issue search, commenting, and issue writes).
> 
> This unblocks the `Skill(file-issue)` path so the scheduled backfill run can actually dedupe and file issues instead of hitting tool permission denials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7d54eb368ceaf508baa97e57642ba43e4cff1ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->