### PR TITLE
feat: per-process file-descriptor table (#124)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -159,3 +159,7 @@ harness = false
 [[test]]
 name = "smep_smap"
 harness = false
+
+[[test]]
+name = "fd_table"
+harness = false

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -282,7 +282,6 @@ pub unsafe extern "C" fn syscall_dispatch(nr: u64, a0: u64, a1: u64, a2: u64) ->
     }
 }
 
-
 unsafe extern "C" {
     fn syscall_entry();
 }

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -157,81 +157,131 @@ use super::uaccess;
 /// # Safety
 /// Called only from `syscall_entry` with the kernel stack active and
 /// interrupts disabled. User pointer arguments are validated and
-/// marshalled via `uaccess::copy_from_user` before any dereference.
+/// marshalled via `uaccess::copy_from_user` / `copy_to_user` before
+/// any dereference.
 #[no_mangle]
 pub unsafe extern "C" fn syscall_dispatch(nr: u64, a0: u64, a1: u64, a2: u64) -> i64 {
     match nr {
-        // write(fd, buf, len) — fd=1 (stdout/stderr) → serial
-        1 => {
-            let fd = a0;
+        // read(fd, buf, len) — non-blocking; returns -EAGAIN if no data.
+        0 => {
+            let fd = a0 as u32;
             let buf_va = a1 as usize;
             let len = a2 as usize;
-            // Validate the whole `[buf_va, buf_va + len)` range up
-            // front regardless of fd, so a kernel-half or wrapping
-            // pointer returns -EFAULT even for unsupported fds.
-            // Zero-length writes skip the check (no pointer access).
+            if len == 0 {
+                return 0;
+            }
+            if let Err(e) = uaccess::check_user_range(buf_va, len) {
+                return e.as_errno();
+            }
+            // Get the backend without holding the fd-table lock during I/O.
+            let backend = {
+                let tbl = crate::task::current_fd_table();
+                let x = match tbl.lock().get(fd) {
+                    Ok(b) => b,
+                    Err(e) => return e,
+                };
+                x
+            };
+            // Read into a kernel bounce buffer, then copy to user.
+            let mut chunk = [0u8; 256];
+            let n = core::cmp::min(chunk.len(), len);
+            match backend.read(&mut chunk[..n]) {
+                Ok(nread) => match uaccess::copy_to_user(buf_va, &chunk[..nread]) {
+                    Ok(()) => nread as i64,
+                    Err(e) => e.as_errno(),
+                },
+                Err(e) => e,
+            }
+        }
+
+        // write(fd, buf, len) — routes through the per-process fd table.
+        1 => {
+            let fd = a0 as u32;
+            let buf_va = a1 as usize;
+            let len = a2 as usize;
+            // Validate user range up front so a bad pointer returns
+            // -EFAULT before any observable side-effect.
             if len > 0 {
                 if let Err(e) = uaccess::check_user_range(buf_va, len) {
                     return e.as_errno();
                 }
             }
-            if fd == 1 && len > 0 {
-                // Chunk through a small kernel-stack bounce buffer so the
-                // ring-0 access window stays short and bounded — a single
-                // STAC/CLAC bracket per chunk, not per byte.
-                let mut chunk = [0u8; 256];
-                let mut off = 0;
-                while off < len {
-                    let n = core::cmp::min(chunk.len(), len - off);
-                    match uaccess::copy_from_user(&mut chunk[..n], buf_va + off) {
-                        Ok(()) => {}
-                        Err(e) => return e.as_errno(),
-                    }
-                    for &b in &chunk[..n] {
-                        uart_putc(b);
-                    }
-                    off += n;
+            // Get the backend without holding the fd-table lock during I/O.
+            let backend = {
+                let tbl = crate::task::current_fd_table();
+                let x = match tbl.lock().get(fd) {
+                    Ok(b) => b,
+                    Err(e) => return e,
+                };
+                x
+            };
+            if len == 0 {
+                return 0;
+            }
+            // Chunk through a small kernel-stack bounce buffer.
+            let mut chunk = [0u8; 256];
+            let mut written = 0usize;
+            while written < len {
+                let n = core::cmp::min(chunk.len(), len - written);
+                match uaccess::copy_from_user(&mut chunk[..n], buf_va + written) {
+                    Ok(()) => {}
+                    Err(e) => return e.as_errno(),
+                }
+                match backend.write(&chunk[..n]) {
+                    Ok(nw) => written += nw,
+                    Err(e) => return e,
                 }
             }
-            len as i64
+            written as i64
         }
+
+        // open(path, flags, mode) — VFS not yet available; stub.
+        2 => -38i64, // ENOSYS
+
+        // close(fd)
+        3 => {
+            let fd = a0 as u32;
+            let tbl = crate::task::current_fd_table();
+            let result = tbl.lock().close_fd(fd);
+            match result {
+                Ok(()) => 0,
+                Err(e) => e,
+            }
+        }
+
+        // dup(oldfd)
+        32 => {
+            let oldfd = a0 as u32;
+            let tbl = crate::task::current_fd_table();
+            let result = tbl.lock().dup(oldfd);
+            match result {
+                Ok(newfd) => newfd as i64,
+                Err(e) => e,
+            }
+        }
+
+        // dup2(oldfd, newfd)
+        33 => {
+            let oldfd = a0 as u32;
+            let newfd = a1 as u32;
+            let tbl = crate::task::current_fd_table();
+            let result = tbl.lock().dup2(oldfd, newfd);
+            match result {
+                Ok(fd) => fd as i64,
+                Err(e) => e,
+            }
+        }
+
         // exit(status) — PID 1 calling exit panics the kernel.
         60 => {
             let status = a0 as i32;
             panic!("kernel panic: init exited with status {}", status);
         }
+
         _ => -38i64, // ENOSYS
     }
 }
 
-/// Write one byte to COM1 via port I/O, spinning until the transmitter
-/// holding register is empty.
-#[inline]
-fn uart_putc(b: u8) {
-    const COM1_DATA: u16 = 0x3F8;
-    const COM1_LSR: u16 = 0x3F8 + 5;
-    unsafe {
-        // Spin on THRE (bit 5 of LSR).
-        loop {
-            let lsr: u8;
-            core::arch::asm!(
-                "in al, dx",
-                out("al") lsr,
-                in("dx") COM1_LSR,
-                options(nomem, nostack, preserves_flags),
-            );
-            if lsr & 0x20 != 0 {
-                break;
-            }
-        }
-        core::arch::asm!(
-            "out dx, al",
-            in("dx") COM1_DATA,
-            in("al") b,
-            options(nomem, nostack, preserves_flags),
-        );
-    }
-}
 
 unsafe extern "C" {
     fn syscall_entry();

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -1,0 +1,427 @@
+//! Per-process file-descriptor table and file-backend abstraction.
+//!
+//! The module is split into:
+//! - Core types (`FileBackend`, `FileDescription`, `FileDescTable`) — compiled
+//!   for both `target_os = "none"` and host unit tests.
+//! - `SerialBackend` + `FileDescTable::new_with_stdio()` — compiled for
+//!   `target_os = "none"` only (require port I/O and the serial subsystem).
+
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+
+/// I/O dispatch interface for a single open file description.
+///
+/// Implementations must be `Send + Sync` so that `Arc<dyn FileBackend>` can
+/// be shared across the process fd table.
+pub trait FileBackend: Send + Sync {
+    fn read(&self, buf: &mut [u8]) -> Result<usize, i64>;
+    fn write(&self, buf: &[u8]) -> Result<usize, i64>;
+}
+
+/// Open-file flags (subset of Linux oflags).
+pub mod flags {
+    /// Open for reading only.
+    pub const O_RDONLY: u32 = 0;
+    /// Open for writing only.
+    pub const O_WRONLY: u32 = 1;
+    /// Open for reading and writing.
+    pub const O_RDWR: u32 = 2;
+    /// Close this fd on the next `exec()`.
+    pub const O_CLOEXEC: u32 = 1 << 19;
+}
+
+/// Kernel-side open-file description.
+///
+/// Shared across duplicate fds (via `Arc` refcounting) — `dup()` bumps the
+/// count; the last `close()` drops it.
+pub struct FileDescription {
+    pub backend: Arc<dyn FileBackend>,
+    pub flags: u32,
+}
+
+/// Maximum number of simultaneously open fds per process.
+const MAX_FD: usize = 1024;
+
+/// Linux errno constants (negated so they match syscall return values).
+pub const EBADF: i64 = -9;
+pub const EAGAIN: i64 = -11;
+pub const EINVAL: i64 = -22;
+pub const EMFILE: i64 = -24;
+
+/// Per-process file-descriptor array.
+///
+/// `slots[fd]` is `Some(Arc<FileDescription>)` when `fd` is open, `None`
+/// otherwise. The array grows lazily; unallocated entries past the current
+/// length are implicitly closed.
+pub struct FileDescTable {
+    slots: Vec<Option<Arc<FileDescription>>>,
+}
+
+impl FileDescTable {
+    /// Create an empty table with no open fds.
+    pub fn new() -> Self {
+        FileDescTable { slots: Vec::new() }
+    }
+
+    /// Create a table with fds 0 (stdin), 1 (stdout), 2 (stderr) pre-wired
+    /// to the supplied backends.
+    pub fn new_with_backends(
+        stdin: Arc<dyn FileBackend>,
+        stdout: Arc<dyn FileBackend>,
+        stderr: Arc<dyn FileBackend>,
+    ) -> Self {
+        let mut t = Self::new();
+        t.slots.push(Some(Arc::new(FileDescription {
+            backend: stdin,
+            flags: flags::O_RDONLY,
+        })));
+        t.slots.push(Some(Arc::new(FileDescription {
+            backend: stdout,
+            flags: flags::O_WRONLY,
+        })));
+        t.slots.push(Some(Arc::new(FileDescription {
+            backend: stderr,
+            flags: flags::O_WRONLY,
+        })));
+        t
+    }
+
+    /// Shallow-clone the fd table for `fork()`.
+    ///
+    /// The child's slots hold `Arc` clones of the parent's open-file
+    /// descriptions, so they share the same backend. Closing an fd in one
+    /// process does not affect the other.
+    pub fn clone_for_fork(&self) -> Self {
+        FileDescTable {
+            slots: self.slots.clone(),
+        }
+    }
+
+    /// Close every fd marked `O_CLOEXEC`. Called by the `exec()` path.
+    pub fn close_cloexec(&mut self) {
+        for slot in self.slots.iter_mut() {
+            if let Some(d) = slot {
+                if d.flags & flags::O_CLOEXEC != 0 {
+                    *slot = None;
+                }
+            }
+        }
+    }
+
+    /// Allocate the lowest free fd slot and return its number.
+    ///
+    /// Returns `EMFILE` if all `MAX_FD` slots are occupied.
+    pub fn alloc_fd(&mut self, desc: Arc<FileDescription>) -> Result<u32, i64> {
+        for (i, slot) in self.slots.iter_mut().enumerate() {
+            if slot.is_none() {
+                *slot = Some(desc);
+                return Ok(i as u32);
+            }
+        }
+        if self.slots.len() >= MAX_FD {
+            return Err(EMFILE);
+        }
+        let fd = self.slots.len() as u32;
+        self.slots.push(Some(desc));
+        Ok(fd)
+    }
+
+    /// Release fd `fd`. Returns `EBADF` if the fd was not open.
+    pub fn close_fd(&mut self, fd: u32) -> Result<(), i64> {
+        match self.slots.get_mut(fd as usize) {
+            Some(slot @ Some(_)) => {
+                *slot = None;
+                Ok(())
+            }
+            _ => Err(EBADF),
+        }
+    }
+
+    /// Return a clone of the backend for `fd`, or `EBADF` if not open.
+    pub fn get(&self, fd: u32) -> Result<Arc<dyn FileBackend>, i64> {
+        self.slots
+            .get(fd as usize)
+            .and_then(Option::as_ref)
+            .map(|d| d.backend.clone())
+            .ok_or(EBADF)
+    }
+
+    /// Return `true` if `fd` is currently open.
+    pub fn is_open(&self, fd: u32) -> bool {
+        self.slots
+            .get(fd as usize)
+            .map(Option::is_some)
+            .unwrap_or(false)
+    }
+
+    fn get_desc(&self, fd: u32) -> Result<Arc<FileDescription>, i64> {
+        self.slots
+            .get(fd as usize)
+            .and_then(Option::as_ref)
+            .cloned()
+            .ok_or(EBADF)
+    }
+
+    /// Duplicate `oldfd` to the lowest free fd. Returns the new fd number.
+    pub fn dup(&mut self, oldfd: u32) -> Result<u32, i64> {
+        let desc = self.get_desc(oldfd)?;
+        self.alloc_fd(desc)
+    }
+
+    /// Make `newfd` an alias for `oldfd`'s description. Returns `newfd`.
+    ///
+    /// - If `newfd == oldfd` and it is open, returns `newfd` without any
+    ///   change.
+    /// - If `newfd` was already open, it is closed silently before
+    ///   reassignment (POSIX `dup2` semantics).
+    /// - Returns `EBADF` if `oldfd` is not open.
+    /// - Returns `EINVAL` if `newfd >= MAX_FD`.
+    pub fn dup2(&mut self, oldfd: u32, newfd: u32) -> Result<u32, i64> {
+        if newfd as usize >= MAX_FD {
+            return Err(EINVAL);
+        }
+        if oldfd == newfd {
+            // Verify oldfd is open (return EBADF if not).
+            self.get_desc(oldfd)?;
+            return Ok(newfd);
+        }
+        let desc = self.get_desc(oldfd)?;
+        // Extend the slot vector if `newfd` is beyond the current length.
+        while self.slots.len() <= newfd as usize {
+            self.slots.push(None);
+        }
+        self.slots[newfd as usize] = Some(desc);
+        Ok(newfd)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SerialBackend — only compiled for the kernel target (requires port I/O).
+// ---------------------------------------------------------------------------
+
+/// Serial (COM1) backend.
+///
+/// Used as the backend for fds 0/1/2 in early userspace before a real VFS
+/// is available.
+#[cfg(target_os = "none")]
+pub struct SerialBackend;
+
+#[cfg(target_os = "none")]
+impl FileBackend for SerialBackend {
+    /// Non-blocking read: drains whatever bytes are currently in the RX ring.
+    ///
+    /// Returns `EAGAIN` (`-11`) if no bytes are available. Callers that need
+    /// blocking semantics must re-try in a loop (the blocking wait-queue path
+    /// lives in a future `read` syscall extension).
+    fn read(&self, buf: &mut [u8]) -> Result<usize, i64> {
+        for (i, byte) in buf.iter_mut().enumerate() {
+            match crate::serial::try_read_byte() {
+                Some(b) => *byte = b,
+                None => {
+                    return if i == 0 { Err(EAGAIN) } else { Ok(i) };
+                }
+            }
+        }
+        Ok(buf.len())
+    }
+
+    fn write(&self, buf: &[u8]) -> Result<usize, i64> {
+        serial_write_bytes(buf);
+        Ok(buf.len())
+    }
+}
+
+/// Write `buf` to COM1, spinning on THRE for each byte.
+///
+/// Duplicates the inner loop from `arch::x86_64::syscall` so that the serial
+/// backend can be used from any context without going through the `Mutex`-
+/// protected `serial::_print` path (which would deadlock if a print is already
+/// in progress on the same CPU).
+#[cfg(target_os = "none")]
+fn serial_write_bytes(buf: &[u8]) {
+    const COM1_DATA: u16 = 0x3F8;
+    const COM1_LSR: u16 = 0x3F8 + 5;
+    for &b in buf {
+        unsafe {
+            loop {
+                let lsr: u8;
+                core::arch::asm!(
+                    "in al, dx",
+                    out("al") lsr,
+                    in("dx") COM1_LSR,
+                    options(nomem, nostack, preserves_flags),
+                );
+                if lsr & 0x20 != 0 {
+                    break;
+                }
+            }
+            core::arch::asm!(
+                "out dx, al",
+                in("dx") COM1_DATA,
+                in("al") b,
+                options(nomem, nostack, preserves_flags),
+            );
+        }
+    }
+}
+
+#[cfg(target_os = "none")]
+impl FileDescTable {
+    /// Create a table with fds 0/1/2 wired to the COM1 serial port.
+    ///
+    /// This is the standard starting point for every new task: stdin, stdout,
+    /// and stderr all map to the same `SerialBackend` until the VFS is
+    /// available.
+    pub fn new_with_stdio() -> Self {
+        let serial = Arc::new(SerialBackend) as Arc<dyn FileBackend>;
+        Self::new_with_backends(serial.clone(), serial.clone(), serial.clone())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Host unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::sync::Arc;
+
+    struct NullBackend;
+    impl FileBackend for NullBackend {
+        fn read(&self, _: &mut [u8]) -> Result<usize, i64> {
+            Ok(0)
+        }
+        fn write(&self, buf: &[u8]) -> Result<usize, i64> {
+            Ok(buf.len())
+        }
+    }
+
+    fn null() -> Arc<dyn FileBackend> {
+        Arc::new(NullBackend)
+    }
+
+    fn null_desc() -> Arc<FileDescription> {
+        Arc::new(FileDescription {
+            backend: null(),
+            flags: 0,
+        })
+    }
+
+    fn make_table() -> FileDescTable {
+        FileDescTable::new_with_backends(null(), null(), null())
+    }
+
+    #[test]
+    fn alloc_fd_lowest_free() {
+        let mut t = make_table();
+        // fds 0, 1, 2 occupied — next should be 3
+        assert_eq!(t.alloc_fd(null_desc()).unwrap(), 3);
+        // Close fd 1; re-alloc should return 1 (lowest free)
+        t.close_fd(1).unwrap();
+        assert_eq!(t.alloc_fd(null_desc()).unwrap(), 1);
+    }
+
+    #[test]
+    fn close_fd_ebadf_on_already_closed() {
+        let mut t = make_table();
+        t.close_fd(1).unwrap();
+        assert_eq!(t.close_fd(1), Err(EBADF));
+    }
+
+    #[test]
+    fn close_fd_ebadf_on_out_of_range() {
+        let mut t = make_table();
+        assert_eq!(t.close_fd(100), Err(EBADF));
+    }
+
+    #[test]
+    fn get_ebadf_on_closed() {
+        let t = make_table();
+        assert_eq!(t.get(99).err(), Some(EBADF));
+    }
+
+    #[test]
+    fn dup_creates_alias() {
+        let mut t = make_table();
+        let new_fd = t.dup(1).unwrap();
+        assert_eq!(new_fd, 3); // lowest free after 0,1,2
+        assert!(t.get(1).is_ok());
+        assert!(t.get(3).is_ok());
+    }
+
+    #[test]
+    fn dup_ebadf_on_closed_fd() {
+        let mut t = make_table();
+        t.close_fd(2).unwrap();
+        assert_eq!(t.dup(2), Err(EBADF));
+    }
+
+    #[test]
+    fn dup2_replaces_target() {
+        let mut t = make_table();
+        let r = t.dup2(1, 5).unwrap();
+        assert_eq!(r, 5);
+        assert!(t.get(5).is_ok());
+        // Holes 3 and 4 should still be closed
+        assert_eq!(t.get(3).err(), Some(EBADF));
+        assert_eq!(t.get(4).err(), Some(EBADF));
+    }
+
+    #[test]
+    fn dup2_same_fd_noop() {
+        let mut t = make_table();
+        assert_eq!(t.dup2(1, 1).unwrap(), 1);
+        assert!(t.get(1).is_ok());
+    }
+
+    #[test]
+    fn dup2_same_fd_ebadf_if_not_open() {
+        let mut t = make_table();
+        t.close_fd(2).unwrap();
+        assert_eq!(t.dup2(2, 2), Err(EBADF));
+    }
+
+    #[test]
+    fn dup2_ebadf_on_closed_oldfd() {
+        let mut t = make_table();
+        t.close_fd(2).unwrap();
+        assert_eq!(t.dup2(2, 5), Err(EBADF));
+    }
+
+    #[test]
+    fn dup2_einval_newfd_too_large() {
+        let mut t = make_table();
+        assert_eq!(t.dup2(1, MAX_FD as u32), Err(EINVAL));
+    }
+
+    #[test]
+    fn clone_for_fork_independent_slots() {
+        let mut t = make_table();
+        let mut child = t.clone_for_fork();
+        // Close fd 1 in parent; child should still have it
+        t.close_fd(1).unwrap();
+        assert_eq!(t.get(1).err(), Some(EBADF));
+        assert!(child.get(1).is_ok());
+        // Close fd 2 in child; parent should still have it
+        child.close_fd(2).unwrap();
+        assert!(t.get(2).is_ok());
+    }
+
+    #[test]
+    fn close_cloexec_only_closes_flagged() {
+        let mut t = make_table();
+        let cloexec_desc = Arc::new(FileDescription {
+            backend: null(),
+            flags: flags::O_CLOEXEC,
+        });
+        t.alloc_fd(cloexec_desc).unwrap(); // fd 3, flagged
+        t.close_cloexec();
+        // fd 3 (O_CLOEXEC) should be gone
+        assert_eq!(t.get(3).err(), Some(EBADF));
+        // fd 0/1/2 (not O_CLOEXEC) should survive
+        assert!(t.get(0).is_ok());
+        assert!(t.get(1).is_ok());
+        assert!(t.get(2).is_ok());
+    }
+}

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -14,6 +14,8 @@ extern crate alloc;
 #[cfg(any(test, target_os = "none"))]
 pub mod block;
 pub mod cpu;
+#[cfg(any(test, target_os = "none"))]
+pub mod fs;
 pub mod input;
 pub mod klog;
 pub mod mem;

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -203,6 +203,25 @@ pub fn set_affinity(id: usize, mask: u64) -> bool {
     found
 }
 
+/// Return the fd table of the currently-running task.
+///
+/// Briefly locks the scheduler to clone the `Arc`, then releases it.
+/// Callers that need to mutate the table should lock the returned
+/// `Arc<Mutex<FileDescTable>>` separately, *not* while holding any
+/// other lock whose ordering places it before `SCHED`.
+///
+/// # Panics
+/// Panics if called before [`init`].
+pub fn current_fd_table() -> alloc::sync::Arc<spin::Mutex<crate::fs::FileDescTable>> {
+    SCHED
+        .lock()
+        .current
+        .as_ref()
+        .expect("current_fd_table: no running task")
+        .fd_table
+        .clone()
+}
+
 /// Return the current scheduling priority of the currently-running
 /// task. Useful for callers that want to spawn a helper at the same
 /// or adjusted priority.

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -22,12 +22,13 @@ use alloc::boxed::Box;
 use alloc::sync::Arc;
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
-use spin::RwLock;
+use spin::{Mutex, RwLock};
 use x86_64::registers::control::Cr3;
 use x86_64::structures::paging::{Page, PageTableFlags, PhysFrame, Size4KiB};
 use x86_64::VirtAddr;
 
 use crate::arch::x86_64::fpu::FpuArea;
+use crate::fs::FileDescTable;
 use crate::mem::addrspace::AddressSpace;
 use crate::mem::paging;
 
@@ -129,6 +130,10 @@ pub(super) struct Task {
     /// post-`fninit` canonical FPU state so a spawned task sees the
     /// same FPU starting conditions as the bootstrap thread.
     pub fpu: Box<FpuArea>,
+    /// Per-process file-descriptor table. Wrapped in `Arc<Mutex>` so it
+    /// can be shared across threads in the same process (clone(2)-style)
+    /// and cloned cheaply for fork() and exec() paths.
+    pub fd_table: Arc<Mutex<FileDescTable>>,
 }
 
 impl Task {
@@ -157,6 +162,7 @@ impl Task {
             // overwrite this buffer with whatever live FPU state exists
             // at that moment.
             fpu: FpuArea::new_initialized(),
+            fd_table: Arc::new(Mutex::new(FileDescTable::new_with_stdio())),
         }
     }
 
@@ -244,6 +250,7 @@ impl Task {
             cr3,
             address_space: Arc::new(RwLock::new(address_space)),
             fpu: FpuArea::new_initialized(),
+            fd_table: Arc::new(Mutex::new(FileDescTable::new_with_stdio())),
         }
     }
 

--- a/kernel/tests/fd_table.rs
+++ b/kernel/tests/fd_table.rs
@@ -18,7 +18,7 @@ use core::panic::PanicInfo;
 
 use alloc::sync::Arc;
 
-use vibix::fs::{FileBackend, FileDescription, FileDescTable, flags, EBADF};
+use vibix::fs::{flags, FileBackend, FileDescTable, FileDescription, EBADF};
 use vibix::{
     exit_qemu, serial_println, task,
     test_harness::{test_panic_handler, Testable},
@@ -45,7 +45,10 @@ fn run_tests() {
         ("alloc_close_roundtrip", &(alloc_close_roundtrip as fn())),
         ("dup_creates_alias", &(dup_creates_alias as fn())),
         ("dup2_replaces_slot", &(dup2_replaces_slot as fn())),
-        ("clone_for_fork_independent", &(clone_for_fork_independent as fn())),
+        (
+            "clone_for_fork_independent",
+            &(clone_for_fork_independent as fn()),
+        ),
         ("close_cloexec", &(close_cloexec as fn())),
         ("write_via_backend", &(write_via_backend as fn())),
     ];
@@ -62,14 +65,23 @@ fn run_tests() {
 
 struct NullBackend;
 impl FileBackend for NullBackend {
-    fn read(&self, _: &mut [u8]) -> Result<usize, i64> { Ok(0) }
-    fn write(&self, buf: &[u8]) -> Result<usize, i64> { Ok(buf.len()) }
+    fn read(&self, _: &mut [u8]) -> Result<usize, i64> {
+        Ok(0)
+    }
+    fn write(&self, buf: &[u8]) -> Result<usize, i64> {
+        Ok(buf.len())
+    }
 }
 
-fn null() -> Arc<dyn FileBackend> { Arc::new(NullBackend) }
+fn null() -> Arc<dyn FileBackend> {
+    Arc::new(NullBackend)
+}
 
 fn null_desc() -> Arc<FileDescription> {
-    Arc::new(FileDescription { backend: null(), flags: 0 })
+    Arc::new(FileDescription {
+        backend: null(),
+        flags: 0,
+    })
 }
 
 fn make_table() -> FileDescTable {
@@ -138,7 +150,10 @@ fn clone_for_fork_independent() {
     // Close fd 1 in parent; child must still have it.
     t.close_fd(1).unwrap();
     assert_eq!(t.get(1).err(), Some(EBADF));
-    assert!(child.get(1).is_ok(), "child's fd 1 must survive parent close");
+    assert!(
+        child.get(1).is_ok(),
+        "child's fd 1 must survive parent close"
+    );
     // Close fd 2 in child; parent must still have it.
     child.close_fd(2).unwrap();
     assert!(t.get(2).is_ok(), "parent's fd 2 must survive child close");
@@ -154,7 +169,11 @@ fn close_cloexec() {
     let fd = t.alloc_fd(flagged).unwrap();
     assert_eq!(fd, 3);
     t.close_cloexec();
-    assert_eq!(t.get(3).err(), Some(EBADF), "O_CLOEXEC fd must be closed after exec");
+    assert_eq!(
+        t.get(3).err(),
+        Some(EBADF),
+        "O_CLOEXEC fd must be closed after exec"
+    );
     assert!(t.get(0).is_ok(), "fd 0 must survive close_cloexec");
     assert!(t.get(1).is_ok(), "fd 1 must survive close_cloexec");
     assert!(t.get(2).is_ok(), "fd 2 must survive close_cloexec");

--- a/kernel/tests/fd_table.rs
+++ b/kernel/tests/fd_table.rs
@@ -1,0 +1,170 @@
+//! Integration test for issue #124: per-process file-descriptor table.
+//!
+//! Boots the kernel, initialises the task scheduler (so every task gets a
+//! `FileDescTable`), then:
+//! 1. Verifies that the current task's fd table has fds 0/1/2 pre-wired.
+//! 2. Exercises `alloc_fd` / `close_fd` / `dup` / `dup2` / `clone_for_fork`
+//!    through the public `FileDescTable` API.
+//! 3. Confirms that `current_fd_table()` returns a live, usable table and
+//!    that writing through fd=1's backend reaches the serial port (echoed
+//!    back as test output).
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+
+use alloc::sync::Arc;
+
+use vibix::fs::{FileBackend, FileDescription, FileDescTable, flags, EBADF};
+use vibix::{
+    exit_qemu, serial_println, task,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("stdio_fds_present", &(stdio_fds_present as fn())),
+        ("alloc_close_roundtrip", &(alloc_close_roundtrip as fn())),
+        ("dup_creates_alias", &(dup_creates_alias as fn())),
+        ("dup2_replaces_slot", &(dup2_replaces_slot as fn())),
+        ("clone_for_fork_independent", &(clone_for_fork_independent as fn())),
+        ("close_cloexec", &(close_cloexec as fn())),
+        ("write_via_backend", &(write_via_backend as fn())),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+struct NullBackend;
+impl FileBackend for NullBackend {
+    fn read(&self, _: &mut [u8]) -> Result<usize, i64> { Ok(0) }
+    fn write(&self, buf: &[u8]) -> Result<usize, i64> { Ok(buf.len()) }
+}
+
+fn null() -> Arc<dyn FileBackend> { Arc::new(NullBackend) }
+
+fn null_desc() -> Arc<FileDescription> {
+    Arc::new(FileDescription { backend: null(), flags: 0 })
+}
+
+fn make_table() -> FileDescTable {
+    FileDescTable::new_with_backends(null(), null(), null())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// The current task's fd table has fds 0, 1, 2 open after task::init().
+fn stdio_fds_present() {
+    let tbl = task::current_fd_table();
+    let locked = tbl.lock();
+    assert!(locked.get(0).is_ok(), "fd 0 (stdin) must be open");
+    assert!(locked.get(1).is_ok(), "fd 1 (stdout) must be open");
+    assert!(locked.get(2).is_ok(), "fd 2 (stderr) must be open");
+    assert_eq!(locked.get(99).err(), Some(EBADF), "fd 99 must be closed");
+}
+
+/// Allocate fds beyond stdio, close one, re-allocate lands on the freed slot.
+fn alloc_close_roundtrip() {
+    let mut t = make_table();
+    let fd3 = t.alloc_fd(null_desc()).unwrap();
+    assert_eq!(fd3, 3);
+    let fd4 = t.alloc_fd(null_desc()).unwrap();
+    assert_eq!(fd4, 4);
+    t.close_fd(3).unwrap();
+    let reused = t.alloc_fd(null_desc()).unwrap();
+    assert_eq!(reused, 3, "alloc_fd must return the lowest free fd");
+    assert_eq!(t.close_fd(99), Err(EBADF));
+}
+
+/// dup() creates a new fd pointing to the same backend.
+fn dup_creates_alias() {
+    let mut t = make_table();
+    let new_fd = t.dup(1).unwrap();
+    assert_eq!(new_fd, 3);
+    assert!(t.get(1).is_ok());
+    assert!(t.get(3).is_ok());
+    // Close the original; the alias is unaffected.
+    t.close_fd(1).unwrap();
+    assert_eq!(t.get(1).err(), Some(EBADF));
+    assert!(t.get(3).is_ok());
+}
+
+/// dup2() wires newfd to oldfd's description; newfd==oldfd is a no-op.
+fn dup2_replaces_slot() {
+    let mut t = make_table();
+    // dup2(1, 5): extend and wire fd 5 to fd 1's description.
+    let r = t.dup2(1, 5).unwrap();
+    assert_eq!(r, 5);
+    assert!(t.get(5).is_ok());
+    // Holes at 3 and 4 must remain closed.
+    assert_eq!(t.get(3).err(), Some(EBADF));
+    assert_eq!(t.get(4).err(), Some(EBADF));
+    // dup2(2, 2) — same fd: no-op, fd 2 stays open.
+    assert_eq!(t.dup2(2, 2).unwrap(), 2);
+    assert!(t.get(2).is_ok());
+}
+
+/// clone_for_fork() gives the child independent slots over shared descriptions.
+fn clone_for_fork_independent() {
+    let mut t = make_table();
+    let mut child = t.clone_for_fork();
+    // Close fd 1 in parent; child must still have it.
+    t.close_fd(1).unwrap();
+    assert_eq!(t.get(1).err(), Some(EBADF));
+    assert!(child.get(1).is_ok(), "child's fd 1 must survive parent close");
+    // Close fd 2 in child; parent must still have it.
+    child.close_fd(2).unwrap();
+    assert!(t.get(2).is_ok(), "parent's fd 2 must survive child close");
+}
+
+/// close_cloexec() closes O_CLOEXEC fds and leaves others intact.
+fn close_cloexec() {
+    let mut t = make_table();
+    let flagged = Arc::new(FileDescription {
+        backend: null(),
+        flags: flags::O_CLOEXEC,
+    });
+    let fd = t.alloc_fd(flagged).unwrap();
+    assert_eq!(fd, 3);
+    t.close_cloexec();
+    assert_eq!(t.get(3).err(), Some(EBADF), "O_CLOEXEC fd must be closed after exec");
+    assert!(t.get(0).is_ok(), "fd 0 must survive close_cloexec");
+    assert!(t.get(1).is_ok(), "fd 1 must survive close_cloexec");
+    assert!(t.get(2).is_ok(), "fd 2 must survive close_cloexec");
+}
+
+/// Writing through fd=1's SerialBackend reaches the serial port.
+fn write_via_backend() {
+    let tbl = task::current_fd_table();
+    let backend = tbl.lock().get(1).expect("fd 1 must be open");
+    let msg = b"fd_table: write_via_backend ok\n";
+    let n = backend.write(msg).expect("write must succeed");
+    assert_eq!(n, msg.len(), "write must return number of bytes written");
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -637,6 +637,7 @@ fn test_all() -> R<()> {
         "fork_cow",
         "tlb_flusher",
         "smep_smap",
+        "fd_table",
     ] {
         cmd.arg("--test").arg(t);
     }


### PR DESCRIPTION
Closes #124

## Summary

- Introduces `kernel/src/fs/mod.rs` with `FileBackend` trait, `FileDescription`, and `FileDescTable` (alloc_fd / close_fd / dup / dup2 / clone_for_fork / close_cloexec), plus `SerialBackend` that wires fds 0/1/2 to COM1.
- Every `Task` gains an `Arc<Mutex<FileDescTable>>` pre-seeded with stdio (both bootstrap and spawned tasks).
- `task::current_fd_table()` exposes the running task's fd table to syscall handlers without holding the scheduler lock during I/O.
- `syscall_dispatch` extended: `read(0)` non-blocking via fd table, `write(1)` routes through fd table (replaces the hardcoded `fd==1` check), `close(3)`, `dup(32)`, `dup2(33)`. `open(2)` returns ENOSYS pending VFS (#85).

## Test plan

- [x] `cargo xtask build` — clean, one `dead_code` warning for pre-existing `is_guard_hit`
- [x] `cargo xtask test` — 120 host unit tests pass (12 new `fs::tests::*`); 7 new QEMU integration tests in `kernel/tests/fd_table.rs` all pass
- [x] `cargo xtask smoke` — all 27 serial markers present

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core task state and syscall dispatch (`read`/`write`/`close`/`dup*`), so bugs could break basic userspace I/O or descriptor lifetime semantics. Changes are contained to a new fd-table module with dedicated unit/integration coverage.
> 
> **Overview**
> Adds a new `fs` module implementing a per-process `FileDescTable` with `FileBackend`-based I/O, dup/close semantics, `O_CLOEXEC` handling, and a `SerialBackend` used to pre-wire stdio to COM1.
> 
> Updates task creation to include an `Arc<Mutex<FileDescTable>>` for each task and exposes `task::current_fd_table()` for syscall paths. `syscall_dispatch` now implements non-blocking `read(2)` and routes `write(2)` through the fd table, plus adds `close(2)`, `dup(2)`, and `dup2(2)` (with `open(2)` still stubbed as `ENOSYS`).
> 
> Registers a new QEMU integration test `fd_table` and adds host unit tests for fd-table behavior; `xtask test` and `Cargo.toml` are updated to include the new test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a013c26e3766a7a5d6fcd898a4300f4cd722413. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->