### PR TITLE
skill: fix auto-engineer review-bot detection (inline PR comments + cursor bot)

### DIFF
--- a/.claude/skills/auto-engineer/SKILL.md
+++ b/.claude/skills/auto-engineer/SKILL.md
@@ -140,12 +140,22 @@ Record the PR open time. Run one poll tick (step 6b below), then either proceed 
    ```sh
    gh pr checks <M> --json name,state,bucket,link
    ```
-2. Count review-bot activity:
+2. Count review-bot activity. Bots post in **two** different places — check both:
    ```sh
+   # Issue-level comments (CodeRabbit summaries, top-level bot posts)
    gh api "repos/{owner}/{repo}/issues/<M>/comments" \
-     --jq '[.[] | select(.user.login | test("coderabbitai|greptile|github-advanced-security"))] | length'
+     --jq '[.[] | select(.user.login | test("coderabbitai|greptile|github-advanced-security|cursor"))] | length'
+
+   # Inline diff comments (Cursor Bugbot findings, some CodeRabbit inline notes)
+   gh api "repos/{owner}/{repo}/pulls/<M>/comments" \
+     --jq '[.[] | select(.user.login | test("coderabbitai|greptile|github-advanced-security|cursor"))] | length'
    ```
-   Also fetch formal reviews via `mcp__github__get_pull_request_reviews`.
+   Sum both counts. Also fetch formal reviews via `mcp__github__get_pull_request_reviews`.
+
+   > **Why two endpoints?** `issues/<M>/comments` returns issue-level (top-of-page) comments.
+   > `pulls/<M>/comments` returns inline review comments attached to specific diff lines.
+   > Cursor Bugbot posts exclusively inline; missing the second endpoint means all Cursor
+   > findings are invisible. The bot login is `cursor[bot]`, matched by the `cursor` pattern.
 
 3. Evaluate "done" criteria (from `docs/agent-playbooks/pr-review.md`):
    - Every check is in a terminal state (`success`, `failure`, `skipped`, `cancelled`,
@@ -196,6 +206,15 @@ ScheduleWakeup(
   ...
 )
 ```
+
+**Read all review findings before classifying.** There are three sources — collect all before
+deciding:
+
+1. `mcp__github__get_pull_request_reviews` — formal approve/request-changes reviews.
+2. `mcp__github__get_pull_request_comments` — **inline diff comments** (where Cursor Bugbot
+   and other bots post line-level findings). Do not skip this even if the issue-level comment
+   count was ≥1 — bots may have posted summaries at issue level AND findings inline.
+3. `gh api "repos/{owner}/{repo}/issues/<M>/comments"` — top-level issue comments.
 
 **Classify review findings** using `docs/agent-playbooks/pr-review.md`:
 


### PR DESCRIPTION
## Summary

Fixes two bugs that caused auto-engineer to silently miss all Cursor Bugbot findings on PR #197, merging with unaddressed medium-severity review comments.

**Bug 1 — Wrong API endpoint**: The poll step only queried `issues/<M>/comments` (issue-level, top-of-page comments). Cursor Bugbot posts inline diff comments via `pulls/<M>/comments` — a completely separate GitHub endpoint. All three Cursor findings on PR #197 were invisible to the review-bot count.

**Bug 2 — Missing bot pattern**: The filter `test("coderabbitai|greptile|github-advanced-security")` doesn't match `cursor[bot]`, Cursor Bugbot's actual GitHub login. Even querying the right endpoint wouldn't have counted the findings.

**Step 6b** now:
- Checks *both* `issues/<M>/comments` and `pulls/<M>/comments`
- Adds `cursor` to the bot-login pattern
- Includes an explanatory note so future readers understand why two endpoints are needed

**Step 6c** now explicitly lists `mcp__github__get_pull_request_comments` as a required read before classifying findings, so inline findings from any bot are not overlooked.

## Test plan
- [x] Reviewed the three Cursor Bugbot findings from PR #197 that were missed; confirmed this change would have surfaced all three
- [x] Skill is a markdown doc — no build/test required; change is mechanically correct against the GitHub API documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that change the skill’s operational guidance, reducing the chance of merging with unaddressed bot findings; no runtime code or production logic is modified.
> 
> **Overview**
> Prevents `auto-engineer` from missing automated review feedback by updating the PR polling step to count bot activity from **both** `issues/<M>/comments` (top-level) and `pulls/<M>/comments` (inline diff), and by expanding the bot-login matcher to include `cursor`.
> 
> Tightens the review-response checklist to explicitly require reading inline PR comments via `mcp__github__get_pull_request_comments` (in addition to formal reviews and issue comments) before classifying findings, with added documentation explaining the two GitHub comment endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4214053993f998154bf7057b314e3a5535e280f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->