### PR TITLE
syscall: mmap/munmap/mprotect/madvise (anon-private + anon-shared)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -159,3 +159,7 @@ harness = false
 [[test]]
 name = "smep_smap"
 harness = false
+
+[[test]]
+name = "mmap_syscall"
+harness = false

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -80,6 +80,17 @@ static mut INIT_KERNEL_STACK: AlignedStack = AlignedStack([0u8; 16 * 1024]);
 #[no_mangle]
 pub static SYSCALL_KERNEL_RSP: AtomicU64 = AtomicU64::new(0);
 
+/// Single-CPU scratch cell for the user's `r10` register on SYSCALL entry.
+///
+/// The Linux x86_64 ABI uses `r10` as the 4th syscall argument (flags for
+/// `mmap`, etc.) because SYSCALL overwrites `rcx` with the user RIP.  Our
+/// entry trampoline must clobber `r10` to temporarily hold the user RSP
+/// while switching stacks; it saves the original `r10` here first so the
+/// dispatcher can read it back as `a3`.  Safe on single-CPU because no
+/// concurrent syscall can be in flight; SMP will need a per-CPU slot.
+#[no_mangle]
+pub static SYSCALL_A3_SCRATCH: AtomicU64 = AtomicU64::new(0);
+
 /// Enable SYSCALL/SYSRET and point LSTAR at the entry trampoline.
 /// Must be called after GDT is live.
 pub fn init() {
@@ -154,13 +165,34 @@ use super::uaccess;
 
 /// Syscall handler called from the `syscall_entry` trampoline.
 ///
+/// `a3` and `a4` are the 4th and 5th syscall arguments, supplied by the
+/// trampoline from the user's `r10` (saved before it is clobbered) and the
+/// user's `r8` respectively.  The 6th argument (`r9` / file offset) is not
+/// yet forwarded — it is only meaningful for file-backed `mmap`, which is
+/// not implemented in this issue.
+///
 /// # Safety
 /// Called only from `syscall_entry` with the kernel stack active and
 /// interrupts disabled. User pointer arguments are validated and
 /// marshalled via `uaccess::copy_from_user` before any dereference.
 #[no_mangle]
-pub unsafe extern "C" fn syscall_dispatch(nr: u64, a0: u64, a1: u64, a2: u64) -> i64 {
+pub unsafe extern "C" fn syscall_dispatch(
+    nr: u64,
+    a0: u64,
+    a1: u64,
+    a2: u64,
+    a3: u64,
+    a4: u64,
+) -> i64 {
     match nr {
+        // mmap(addr, len, prot, flags, fd, offset) — anon-private/shared only
+        9 => crate::mem::mmap::sys_mmap(a0, a1, a2, a3, a4, 0),
+        // mprotect(addr, len, prot)
+        10 => crate::mem::mmap::sys_mprotect(a0, a1, a2),
+        // munmap(addr, len)
+        11 => crate::mem::mmap::sys_munmap(a0, a1),
+        // madvise(addr, len, advice)
+        28 => crate::mem::mmap::sys_madvise(a0, a1, a2),
         // write(fd, buf, len) — fd=1 (stdout/stderr) → serial
         1 => {
             let fd = a0;
@@ -244,16 +276,17 @@ global_asm!(
     .align 16
 
 syscall_entry:
-    // On SYSCALL entry (x86_64):
-    //   rax=nr  rdi=a0  rsi=a1  rdx=a2
+    // On SYSCALL entry (x86_64 Linux ABI):
+    //   rax=nr  rdi=a0  rsi=a1  rdx=a2  r10=a3  r8=a4  r9=a5(unused)
     //   rcx=user_RIP  r11=user_RFLAGS  rsp=user_RSP
-    // IF is cleared by SFMASK; r10 is caller-saved and unused here.
+    // IF is cleared by SFMASK.
 
-    // 1. Save user RSP in r10 (caller-saved, not a syscall argument).
+    // 1. Preserve user r10 (a3 — flags for mmap etc.) before clobbering
+    //    it with user RSP.  Single-CPU scratch; SMP will need per-CPU slot.
+    mov [{a3_scratch}], r10
+
+    // 2. Save user RSP in r10, then switch to kernel stack.
     mov r10, rsp
-
-    // 2. Load kernel RSP: lea gives us the address of the static;
-    //    the second mov dereferences it to get the stack-top value.
     lea rsp, [rip + {kernel_rsp}]
     mov rsp, [rsp]
 
@@ -262,12 +295,16 @@ syscall_entry:
     push r11          // user RFLAGS  (SYSRETQ restores RFLAGS from r11)
     push rcx          // user RIP     (SYSRETQ jumps to rcx)
 
-    // 4. Build syscall_dispatch(nr, a0, a1, a2) in SysV AMD64 registers.
-    //    rcx is now free (user RIP is on the stack).
-    mov rcx, rdx      // a2
-    mov rdx, rsi      // a1
-    mov rsi, rdi      // a0
-    mov rdi, rax      // nr
+    // 4. Build syscall_dispatch(nr, a0, a1, a2, a3, a4) in SysV AMD64 registers.
+    //    Target ABI: rdi=nr, rsi=a0, rdx=a1, rcx=a2, r8=a3, r9=a4.
+    //    r8 currently holds user a4 (fd); move it to r9 first so we can
+    //    load a3 (flags) into r8 without clobbering a4.
+    mov r9, r8                    // r9 = a4 (user fd, was r8)
+    mov r8, [{a3_scratch}]        // r8 = a3 (user flags, saved above)
+    mov rcx, rdx                  // a2 (prot)
+    mov rdx, rsi                  // a1 (len)
+    mov rsi, rdi                  // a0 (addr)
+    mov rdi, rax                  // nr
 
     // 5. Call the Rust dispatcher. Align stack to 16 bytes first.
     sub rsp, 8
@@ -285,4 +322,5 @@ syscall_entry:
     sysretq
     "#,
     kernel_rsp = sym SYSCALL_KERNEL_RSP,
+    a3_scratch  = sym SYSCALL_A3_SCRATCH,
 );

--- a/kernel/src/mem/mmap.rs
+++ b/kernel/src/mem/mmap.rs
@@ -410,10 +410,12 @@ pub fn sys_mprotect(addr: u64, len: u64, prot: u64) -> i64 {
 /// Only `MADV_DONTNEED` on `MAP_PRIVATE | MAP_ANONYMOUS` regions is
 /// implemented.  All other advice values are silently accepted (no-op).
 ///
-/// `MADV_DONTNEED` drops the PTE for each faulted page in the range,
-/// decrementing its refcount.  On next access the fault handler allocates a
-/// fresh zero-filled frame — giving "as if freshly mapped" semantics.  The
-/// VMA records are preserved so subsequent accesses do not SIGSEGV.
+/// `MADV_DONTNEED` drops the PTE for each faulted page in the range and
+/// evicts the backing-object cache entry, releasing both references to the
+/// physical frame so it is reclaimed.  On next access the fault handler
+/// allocates a fresh zero-filled frame — giving Linux-compatible
+/// zero-on-next-touch semantics.  VMA records are preserved so subsequent
+/// accesses do not SIGSEGV.
 pub fn sys_madvise(addr: u64, len: u64, advice: u64) -> i64 {
     let advice = advice as i32;
 
@@ -433,20 +435,23 @@ pub fn sys_madvise(addr: u64, len: u64, advice: u64) -> i64 {
     let pml4 = aspace.page_table_frame();
 
     // For each present PTE in the range: unmap and release the PTE's frame
-    // reference.  The VMA and AnonObject cache entry both persist — the cache
-    // entry still holds its own reference, so the frame's refcount goes from
-    // 2 (cache + PTE) down to 1 (cache only).  A subsequent fault calls
-    // AnonObject::fault, which finds the cached frame and re-increments.
-    //
-    // To get true zero-on-next-touch semantics the cache entry would also
-    // need to be evicted; that requires a `VmObject::forget_pages` extension
-    // tracked in a follow-up issue.
+    // reference, then evict the backing-object cache entry so the frame's
+    // refcount reaches zero and it is reclaimed.  A subsequent fault calls
+    // AnonObject::fault, sees no cached frame, and allocates a fresh
+    // zero-filled page — giving Linux-compatible zero-on-next-touch semantics.
     let mut va = addr;
     while va < end {
         if let Ok(page) = Page::<Size4KiB>::from_start_address(VirtAddr::new(va)) {
             if let Ok(phys_frame) = paging::unmap_in_pml4(pml4, page) {
+                // Release the PTE's reference.
                 frame::put(phys_frame.start_address().as_u64());
             }
+        }
+        // Evict the cache entry so the backing object releases its reference
+        // and a future fault sees a fresh zero-filled page.
+        if let Some(vma) = aspace.vmas.find(va as usize) {
+            let obj_offset = vma.object_offset + (va as usize - vma.start);
+            vma.object.evict_page(obj_offset);
         }
         va += FRAME_SIZE;
     }

--- a/kernel/src/mem/mmap.rs
+++ b/kernel/src/mem/mmap.rs
@@ -1,0 +1,444 @@
+//! Userspace memory-mapping syscall implementations.
+//!
+//! Implements `mmap(2)`, `munmap(2)`, `mprotect(2)`, and `madvise(2)` per
+//! RFC 0001 — Userspace Virtual Memory Subsystem.  All four syscalls share
+//! a common address-range validation helper and route through the
+//! `AddressSpace` / `VmaTree` layer for structural bookkeeping, with direct
+//! PTE manipulation via `paging::*_in_pml4` helpers for the cases that
+//! need to tear down or reprotect live mappings.
+//!
+//! None of these functions are `unsafe extern "C"` — they are called from
+//! the safe Rust dispatcher in `arch::x86_64::syscall`, which is itself
+//! declared `unsafe extern "C"`.
+
+#![cfg(target_os = "none")]
+
+use alloc::vec::Vec;
+use x86_64::{
+    structures::paging::{Page, PageTableFlags, PhysFrame, Size4KiB},
+    VirtAddr,
+};
+
+use crate::{
+    mem::{
+        addrspace::USER_VA_END,
+        frame,
+        paging,
+        vmatree::{Share, Vma},
+        vmobject::AnonObject,
+        FRAME_SIZE,
+    },
+    task,
+};
+
+// ---------------------------------------------------------------------------
+// PROT_* bits (Linux ABI, mman.h)
+// ---------------------------------------------------------------------------
+const PROT_WRITE: u32 = 0x2;
+const PROT_EXEC: u32 = 0x4;
+
+// ---------------------------------------------------------------------------
+// MAP_* flags (Linux x86_64 ABI)
+// ---------------------------------------------------------------------------
+const MAP_SHARED: u32 = 0x01;
+const MAP_PRIVATE: u32 = 0x02;
+const MAP_FIXED: u32 = 0x10;
+const MAP_ANONYMOUS: u32 = 0x20;
+const MAP_FIXED_NOREPLACE: u32 = 0x0010_0000;
+
+// ---------------------------------------------------------------------------
+// MADV_* advice (Linux ABI)
+// ---------------------------------------------------------------------------
+const MADV_DONTNEED: i32 = 4;
+
+// ---------------------------------------------------------------------------
+// errno values (Linux ABI, negated)
+// ---------------------------------------------------------------------------
+const EINVAL: i64 = -22;
+const ENOMEM: i64 = -12;
+const EEXIST: i64 = -17;
+const ENODEV: i64 = -19;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Convert user `PROT_*` flags to `x86_64::PageTableFlags` for PTE entries.
+///
+/// Rules (RFC 0001):
+/// - Any readable mapping → `PRESENT | USER_ACCESSIBLE | NO_EXECUTE` (default NX).
+/// - `PROT_WRITE` adds `WRITABLE`.
+/// - `PROT_EXEC` clears `NO_EXECUTE`.
+/// - `PROT_NONE` → empty flags (no `PRESENT`; VMA exists but fault → SIGSEGV).
+pub fn prot_user_to_pte(prot: u32) -> PageTableFlags {
+    if prot == 0 {
+        return PageTableFlags::empty();
+    }
+    let mut f = PageTableFlags::PRESENT
+        | PageTableFlags::USER_ACCESSIBLE
+        | PageTableFlags::NO_EXECUTE;
+    if prot & PROT_WRITE != 0 {
+        f |= PageTableFlags::WRITABLE;
+    }
+    if prot & PROT_EXEC != 0 {
+        f -= PageTableFlags::NO_EXECUTE;
+    }
+    f
+}
+
+/// Validate `[addr, addr + len)` as a userspace virtual range.
+///
+/// Steps (RFC 0001 §Address validation):
+/// 1. `len == 0` → `EINVAL`
+/// 2. `len` overflows when rounded up to page boundary → `EINVAL`
+/// 3. `addr` is non-canonical (≥ `USER_VA_END`) for non-zero addr → `EINVAL`
+/// 4. `addr + rounded_len` overflows → `EINVAL`
+/// 5. `addr + rounded_len > USER_VA_END` → `EINVAL`
+/// 6. If `require_aligned`: `addr` is not page-aligned → `EINVAL`
+///
+/// Returns `(addr, rounded_len)` on success.
+fn validate_range(addr: u64, len: u64, require_aligned: bool) -> Result<(u64, u64), i64> {
+    const PAGE: u64 = FRAME_SIZE;
+
+    if len == 0 {
+        return Err(EINVAL);
+    }
+
+    // Round len up to next page boundary; check for overflow.
+    let rounded_len = len
+        .checked_add(PAGE - 1)
+        .map(|v| v & !(PAGE - 1))
+        .ok_or(EINVAL)?;
+    if rounded_len == 0 {
+        return Err(EINVAL);
+    }
+
+    // Non-canonical addr: anything ≥ USER_VA_END is in kernel half.
+    if addr >= USER_VA_END {
+        return Err(EINVAL);
+    }
+
+    // addr + rounded_len must not overflow and must stay in user half.
+    let end = addr.checked_add(rounded_len).ok_or(EINVAL)?;
+    if end > USER_VA_END {
+        return Err(EINVAL);
+    }
+
+    if require_aligned && addr % PAGE != 0 {
+        return Err(EINVAL);
+    }
+
+    Ok((addr, rounded_len))
+}
+
+/// Return `true` if any VMA in `aspace` overlaps `[start, end)`.
+fn range_has_vma(
+    aspace: &crate::mem::addrspace::AddressSpace,
+    start: usize,
+    end: usize,
+) -> bool {
+    for v in aspace.iter() {
+        if v.start < end && v.end > start {
+            return true;
+        }
+    }
+    false
+}
+
+/// Tear down all PTEs in `[start, end)` within `pml4_frame`, decrement the
+/// per-frame refcount for each, and structurally remove the VMA records from
+/// `aspace`.  Returns the number of *virtual pages* removed from `vm_pages`.
+///
+/// This is the shared munmap kernel — called by both `sys_munmap` and the
+/// MAP_FIXED overlap-clear path in `sys_mmap`.
+fn unmap_range(
+    aspace: &mut crate::mem::addrspace::AddressSpace,
+    pml4_frame: PhysFrame<Size4KiB>,
+    start: usize,
+    end: usize,
+) -> usize {
+    // Walk present PTEs and release each frame's PTE reference.
+    let mut va = start;
+    while va < end {
+        if let Ok(page) = Page::<Size4KiB>::from_start_address(VirtAddr::new(va as u64)) {
+            if let Ok(phys_frame) = paging::unmap_in_pml4(pml4_frame, page) {
+                // `unmap_in_pml4` does NOT decrement the refcount.  We do it
+                // here — mirroring AddressSpace::drop's per-PTE decrement.
+                frame::put(phys_frame.start_address().as_u64());
+            }
+        }
+        va += FRAME_SIZE as usize;
+    }
+
+    // Count how many vm_pages we will remove before the structural change.
+    let pages_before: usize = aspace
+        .iter()
+        .filter(|v| v.start < end && v.end > start)
+        .map(|v| {
+            let s = v.start.max(start);
+            let e = v.end.min(end);
+            (e - s) / FRAME_SIZE as usize
+        })
+        .sum();
+
+    // Structural VMA removal (splits as needed, drops Arc<VmObject> refs).
+    aspace.vmas.unmap_range(start, end);
+    aspace.vm_pages = aspace.vm_pages.saturating_sub(pages_before);
+
+    pages_before
+}
+
+/// Find the first free virtual address range of exactly `len` bytes (already
+/// page-rounded) starting at or above `hint`.
+///
+/// Scans the ordered VMA tree for a sufficiently large gap.  O(n VMAs).
+fn find_free_range(
+    aspace: &crate::mem::addrspace::AddressSpace,
+    hint: u64,
+    len: u64,
+) -> Option<u64> {
+    // Round hint up to page boundary.
+    let mut candidate = (hint.wrapping_add(FRAME_SIZE - 1)) & !(FRAME_SIZE - 1);
+
+    // Collect (start, end) pairs; we need to scan for gaps.
+    let vmas: Vec<(usize, usize)> = aspace.iter().map(|v| (v.start, v.end)).collect();
+
+    'outer: loop {
+        let cand_end = candidate.checked_add(len)?;
+        if cand_end > USER_VA_END {
+            return None;
+        }
+
+        for &(v_start, v_end) in &vmas {
+            // Overlap: the candidate window intersects this VMA.
+            if (v_start as u64) < cand_end && (v_end as u64) > candidate {
+                // Skip past this VMA and retry.
+                candidate = v_end as u64;
+                continue 'outer;
+            }
+        }
+
+        return Some(candidate);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Syscall implementations
+// ---------------------------------------------------------------------------
+
+/// `mmap(addr, len, prot, flags, fd, offset)` — syscall 9.
+///
+/// Supported flags: `MAP_PRIVATE | MAP_ANONYMOUS` and `MAP_SHARED | MAP_ANONYMOUS`.
+/// `MAP_FIXED` and `MAP_FIXED_NOREPLACE` are honoured.
+/// File-backed mappings (`fd != -1`) return `ENODEV`.
+pub fn sys_mmap(addr: u64, len: u64, prot: u64, flags: u64, fd: u64, _offset: u64) -> i64 {
+    let prot = prot as u32;
+    let flags = flags as u32;
+    let fd_signed = fd as i64;
+
+    // Anonymous-only: MAP_ANONYMOUS must be set and fd must be -1.
+    if flags & MAP_ANONYMOUS == 0 || fd_signed != -1 {
+        return ENODEV;
+    }
+
+    // Must specify exactly one of MAP_PRIVATE or MAP_SHARED.
+    let is_private = flags & MAP_PRIVATE != 0;
+    let is_shared = flags & MAP_SHARED != 0;
+    if !is_private && !is_shared {
+        return EINVAL;
+    }
+    let share = if is_shared { Share::Shared } else { Share::Private };
+
+    let map_fixed = flags & MAP_FIXED != 0;
+    let map_fixed_noreplace = flags & MAP_FIXED_NOREPLACE != 0;
+
+    // Validate length (addr validated below per flag).
+    if len == 0 {
+        return EINVAL;
+    }
+    let rounded_len = match len.checked_add(FRAME_SIZE - 1).map(|v| v & !(FRAME_SIZE - 1)) {
+        Some(l) if l > 0 => l,
+        _ => return EINVAL,
+    };
+
+    let pte_flags = prot_user_to_pte(prot);
+
+    let aspace_arc = task::current_address_space();
+    let mut aspace = aspace_arc.write();
+    let pml4 = aspace.page_table_frame();
+
+    let map_addr: u64 = if map_fixed || map_fixed_noreplace {
+        // MAP_FIXED / MAP_FIXED_NOREPLACE require a page-aligned non-zero addr.
+        match validate_range(addr, len, true) {
+            Ok((a, _)) if a == 0 => return EINVAL,
+            Ok((a, _)) => {
+                if map_fixed_noreplace {
+                    if range_has_vma(&aspace, a as usize, (a + rounded_len) as usize) {
+                        return EEXIST;
+                    }
+                } else {
+                    // MAP_FIXED: silently unmap whatever is there.
+                    unmap_range(&mut aspace, pml4, a as usize, (a + rounded_len) as usize);
+                }
+                a
+            }
+            Err(e) => return e,
+        }
+    } else {
+        // Hint-based: start from the provided addr (if in range) or mmap_base.
+        let hint = if addr > 0 && addr < USER_VA_END {
+            addr
+        } else {
+            aspace.mmap_base.as_u64()
+        };
+        match find_free_range(&aspace, hint, rounded_len) {
+            Some(a) => a,
+            None => return ENOMEM,
+        }
+    };
+
+    // Final range check after address is resolved.
+    let map_end = match map_addr.checked_add(rounded_len) {
+        Some(e) if e <= USER_VA_END => e,
+        _ => return EINVAL,
+    };
+
+    let object = AnonObject::new(None);
+    let vma = Vma::new(
+        map_addr as usize,
+        map_end as usize,
+        prot,
+        pte_flags.bits(),
+        share,
+        object,
+        0,
+    );
+    aspace.insert(vma);
+
+    map_addr as i64
+}
+
+/// `munmap(addr, len)` — syscall 11.
+///
+/// `addr` must be page-aligned.  Unmapping a hole (or a region with no VMA)
+/// is not an error — POSIX-conformant.  Returns `0` on success, `-EINVAL` on
+/// bad arguments.
+pub fn sys_munmap(addr: u64, len: u64) -> i64 {
+    let (addr, rounded_len) = match validate_range(addr, len, true) {
+        Ok(r) => r,
+        Err(e) => return e,
+    };
+
+    let aspace_arc = task::current_address_space();
+    let mut aspace = aspace_arc.write();
+    let pml4 = aspace.page_table_frame();
+
+    unmap_range(&mut aspace, pml4, addr as usize, (addr + rounded_len) as usize);
+    0
+}
+
+/// `mprotect(addr, len, prot)` — syscall 10.
+///
+/// Applies `prot` to every VMA byte in `[addr, addr+len)`.  Returns
+/// `-ENOMEM` if any sub-page within the range is not covered by a VMA
+/// (Linux mprotect_fixup semantics).
+pub fn sys_mprotect(addr: u64, len: u64, prot: u64) -> i64 {
+    let prot = prot as u32;
+    let (addr, rounded_len) = match validate_range(addr, len, true) {
+        Ok(r) => r,
+        Err(e) => return e,
+    };
+    let end = addr + rounded_len;
+
+    let aspace_arc = task::current_address_space();
+    let mut aspace = aspace_arc.write();
+    let pml4 = aspace.page_table_frame();
+
+    // ENOMEM check: every page in [addr, end) must be covered by a VMA.
+    let mut va = addr as usize;
+    while va < end as usize {
+        if aspace.find(va).is_none() {
+            return ENOMEM;
+        }
+        va += FRAME_SIZE as usize;
+    }
+
+    let new_pte = prot_user_to_pte(prot);
+
+    // Update VMA records structurally (splits at boundaries as needed).
+    aspace.vmas.change_protection(addr as usize, end as usize, prot, new_pte.bits());
+
+    // Walk present PTEs: unmap old PTE, remap same frame with new flags.
+    // `unmap_in_pml4` does not change the refcount; re-mapping the same frame
+    // does not change it either — so the net refcount effect is zero.
+    let mut va = addr;
+    while va < end {
+        if let Ok(page) = Page::<Size4KiB>::from_start_address(VirtAddr::new(va)) {
+            if let Some((old_frame, _)) =
+                paging::translate_in_pml4(pml4, VirtAddr::new(va))
+            {
+                // Remove the old PTE (TLB flushed inside unmap_in_pml4).
+                let _ = paging::unmap_in_pml4(pml4, page);
+
+                // Only remap if the new protection is not PROT_NONE.
+                if new_pte.contains(PageTableFlags::PRESENT) {
+                    let _ = paging::map_existing_in_pml4(pml4, page, old_frame, new_pte);
+                }
+                // If PROT_NONE, the PTE stays absent; the VMA record still
+                // tracks the mapping so a future mprotect can re-enable it.
+            }
+        }
+        va += FRAME_SIZE;
+    }
+
+    0
+}
+
+/// `madvise(addr, len, advice)` — syscall 28.
+///
+/// Only `MADV_DONTNEED` on `MAP_PRIVATE | MAP_ANONYMOUS` regions is
+/// implemented.  All other advice values are silently accepted (no-op).
+///
+/// `MADV_DONTNEED` drops the PTE for each faulted page in the range,
+/// decrementing its refcount.  On next access the fault handler allocates a
+/// fresh zero-filled frame — giving "as if freshly mapped" semantics.  The
+/// VMA records are preserved so subsequent accesses do not SIGSEGV.
+pub fn sys_madvise(addr: u64, len: u64, advice: u64) -> i64 {
+    let advice = advice as i32;
+
+    // All advice other than MADV_DONTNEED is a no-op.
+    if advice != MADV_DONTNEED {
+        return 0;
+    }
+
+    let (addr, rounded_len) = match validate_range(addr, len, true) {
+        Ok(r) => r,
+        Err(e) => return e,
+    };
+    let end = addr + rounded_len;
+
+    let aspace_arc = task::current_address_space();
+    let aspace = aspace_arc.write();
+    let pml4 = aspace.page_table_frame();
+
+    // For each present PTE in the range: unmap and release the PTE's frame
+    // reference.  The VMA and AnonObject cache entry both persist — the cache
+    // entry still holds its own reference, so the frame's refcount goes from
+    // 2 (cache + PTE) down to 1 (cache only).  A subsequent fault calls
+    // AnonObject::fault, which finds the cached frame and re-increments.
+    //
+    // To get true zero-on-next-touch semantics the cache entry would also
+    // need to be evicted; that requires a `VmObject::forget_pages` extension
+    // tracked in a follow-up issue.
+    let mut va = addr;
+    while va < end {
+        if let Ok(page) = Page::<Size4KiB>::from_start_address(VirtAddr::new(va)) {
+            if let Ok(phys_frame) = paging::unmap_in_pml4(pml4, page) {
+                frame::put(phys_frame.start_address().as_u64());
+            }
+        }
+        va += FRAME_SIZE;
+    }
+
+    0
+}

--- a/kernel/src/mem/mmap.rs
+++ b/kernel/src/mem/mmap.rs
@@ -244,7 +244,8 @@ pub fn sys_mmap(addr: u64, len: u64, prot: u64, flags: u64, fd: u64, _offset: u6
     // Must specify exactly one of MAP_PRIVATE or MAP_SHARED.
     let is_private = flags & MAP_PRIVATE != 0;
     let is_shared = flags & MAP_SHARED != 0;
-    if !is_private && !is_shared {
+    if is_private == is_shared {
+        // Neither set, or both set (Linux rejects MAP_PRIVATE|MAP_SHARED).
         return EINVAL;
     }
     let share = if is_shared { Share::Shared } else { Share::Private };
@@ -383,9 +384,12 @@ pub fn sys_mprotect(addr: u64, len: u64, prot: u64) -> i64 {
                 // Only remap if the new protection is not PROT_NONE.
                 if new_pte.contains(PageTableFlags::PRESENT) {
                     let _ = paging::map_existing_in_pml4(pml4, page, old_frame, new_pte);
+                } else {
+                    // PROT_NONE: the PTE stays absent but the frame is still
+                    // owned by the VMA.  `unmap_in_pml4` does not decrement
+                    // the PTE refcount, so we must do it here to avoid a leak.
+                    frame::put(old_frame.start_address().as_u64());
                 }
-                // If PROT_NONE, the PTE stays absent; the VMA record still
-                // tracks the mapping so a future mprotect can re-enable it.
             }
         }
         va += FRAME_SIZE;

--- a/kernel/src/mem/mmap.rs
+++ b/kernel/src/mem/mmap.rs
@@ -448,10 +448,15 @@ pub fn sys_madvise(addr: u64, len: u64, advice: u64) -> i64 {
             }
         }
         // Evict the cache entry so the backing object releases its reference
-        // and a future fault sees a fresh zero-filled page.
+        // and a future fault sees a fresh zero-filled page.  Only safe for
+        // Share::Private: for Share::Shared the AnonObject is shared across
+        // fork children; evicting the entry would silently desynchronise
+        // their views of the mapping.
         if let Some(vma) = aspace.vmas.find(va as usize) {
-            let obj_offset = vma.object_offset + (va as usize - vma.start);
-            vma.object.evict_page(obj_offset);
+            if vma.share == Share::Private {
+                let obj_offset = vma.object_offset + (va as usize - vma.start);
+                vma.object.evict_page(obj_offset);
+            }
         }
         va += FRAME_SIZE;
     }

--- a/kernel/src/mem/mmap.rs
+++ b/kernel/src/mem/mmap.rs
@@ -273,13 +273,16 @@ pub fn sys_mmap(addr: u64, len: u64, prot: u64, flags: u64, fd: u64, _offset: u6
         match validate_range(addr, len, true) {
             Ok((a, _)) if a == 0 => return EINVAL,
             Ok((a, _)) => {
-                if map_fixed_noreplace {
+                if map_fixed {
+                    // MAP_FIXED takes precedence over MAP_FIXED_NOREPLACE when
+                    // both are set (Linux-documented behaviour): replace any
+                    // existing mapping in the range unconditionally.
+                    unmap_range(&mut aspace, pml4, a as usize, (a + rounded_len) as usize);
+                } else {
+                    // MAP_FIXED_NOREPLACE only: fail if any VMA overlaps.
                     if range_has_vma(&aspace, a as usize, (a + rounded_len) as usize) {
                         return EEXIST;
                     }
-                } else {
-                    // MAP_FIXED: silently unmap whatever is there.
-                    unmap_range(&mut aspace, pml4, a as usize, (a + rounded_len) as usize);
                 }
                 a
             }
@@ -383,7 +386,11 @@ pub fn sys_mprotect(addr: u64, len: u64, prot: u64) -> i64 {
 
                 // Only remap if the new protection is not PROT_NONE.
                 if new_pte.contains(PageTableFlags::PRESENT) {
-                    let _ = paging::map_existing_in_pml4(pml4, page, old_frame, new_pte);
+                    if paging::map_existing_in_pml4(pml4, page, old_frame, new_pte).is_err() {
+                        // Remap failed: PTE is gone but refcount was not
+                        // decremented by unmap_in_pml4; release it now.
+                        frame::put(old_frame.start_address().as_u64());
+                    }
                 } else {
                     // PROT_NONE: the PTE stays absent but the frame is still
                     // owned by the VMA.  `unmap_in_pml4` does not decrement

--- a/kernel/src/mem/mod.rs
+++ b/kernel/src/mem/mod.rs
@@ -36,6 +36,9 @@ pub mod pf;
 pub mod addrspace;
 
 #[cfg(target_os = "none")]
+pub mod mmap;
+
+#[cfg(target_os = "none")]
 use spin::Once;
 
 #[cfg(target_os = "none")]

--- a/kernel/src/mem/vmobject.rs
+++ b/kernel/src/mem/vmobject.rs
@@ -76,6 +76,18 @@ pub trait VmObject: Send + Sync {
         let _ = offset;
         None
     }
+
+    /// Evict the cache entry for `offset` (page-aligned bytes into this
+    /// object), releasing the cache's own frame reference so the physical
+    /// frame can be reclaimed and a subsequent [`fault`] obtains a fresh
+    /// zero-filled page.
+    ///
+    /// The default no-op is correct for objects that do not cache frames
+    /// (future file-backed objects). `AnonObject` overrides this to
+    /// implement `MADV_DONTNEED` zero-on-next-touch semantics.
+    fn evict_page(&self, offset: usize) {
+        let _ = offset;
+    }
 }
 
 /// Clone a `VmObject` trait-object for `fork`. The default behavior is
@@ -162,6 +174,13 @@ impl VmObject for AnonObject {
     fn frame_at(&self, offset: usize) -> Option<u64> {
         let idx = offset / (crate::mem::FRAME_SIZE as usize);
         self.inner.lock().frames.get(&idx).copied()
+    }
+
+    fn evict_page(&self, offset: usize) {
+        let idx = offset / (FRAME_SIZE as usize);
+        if let Some(phys) = self.inner.lock().frames.remove(&idx) {
+            release_frame(phys);
+        }
     }
 }
 

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -411,6 +411,20 @@ pub fn update_current_cr3(
     current.cr3 = frame;
 }
 
+/// Clone the `Arc<RwLock<AddressSpace>>` for the currently-running task.
+///
+/// Syscall handlers that need to mutate the address space (mmap, munmap,
+/// mprotect, madvise) call this to get a handle they can lock independently
+/// of the scheduler lock.
+pub fn current_address_space() -> alloc::sync::Arc<spin::RwLock<crate::mem::addrspace::AddressSpace>> {
+    let sched = SCHED.lock();
+    let current = sched
+        .current
+        .as_ref()
+        .expect("current_address_space: no running task");
+    current.address_space.clone()
+}
+
 /// Install a VMA on the currently-running task. The VMA is resolved
 /// lazily by the `#PF` handler on first touch of each page via
 /// [`VmObject::fault`].

--- a/kernel/tests/mmap_syscall.rs
+++ b/kernel/tests/mmap_syscall.rs
@@ -1,0 +1,249 @@
+//! Integration test: mmap / munmap / mprotect / madvise syscall implementations.
+//!
+//! Exercises the kernel-side implementations in the bootstrap task's address
+//! space.  Memory access uses `copy_to_user` / `copy_from_user` so the
+//! STAC/CLAC bracket makes demand-paging work under SMAP — direct
+//! `ptr::read_volatile` of a USER_ACCESSIBLE page from ring-0 would trip SMAP
+//! on the retry after the fault handler maps the PTE.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+
+use vibix::arch::x86_64::uaccess;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    vibix::task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("mmap_anon_private_touch", &(mmap_anon_private_touch as fn())),
+        ("mmap_hint_advances", &(mmap_hint_advances as fn())),
+        ("mmap_fixed", &(mmap_fixed as fn())),
+        ("mmap_fixed_noreplace_conflict", &(mmap_fixed_noreplace_conflict as fn())),
+        ("munmap_returns_zero", &(munmap_returns_zero as fn())),
+        ("munmap_vma_removed", &(munmap_vma_removed as fn())),
+        ("mprotect_readwrite", &(mprotect_readwrite as fn())),
+        ("madvise_dontneed_no_crash", &(madvise_dontneed_no_crash as fn())),
+        ("mmap_invalid_args", &(mmap_invalid_args as fn())),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+// Linux-ABI constants used by the tests.
+const PROT_READ: u64 = 1;
+const PROT_WRITE: u64 = 2;
+const MAP_PRIVATE: u64 = 0x02;
+const MAP_ANONYMOUS: u64 = 0x20;
+const MAP_FIXED: u64 = 0x10;
+const MAP_FIXED_NOREPLACE: u64 = 0x0010_0000;
+const MAP_ANON_PRIVATE: u64 = MAP_PRIVATE | MAP_ANONYMOUS;
+const FD_NONE: u64 = u64::MAX; // -1 as u64
+const EINVAL: i64 = -22;
+const ENOMEM: i64 = -12;
+const EEXIST: i64 = -17;
+const ENODEV: i64 = -19;
+const PAGE: u64 = 4096;
+
+// ---------------------------------------------------------------------------
+
+/// Map a page, write a sentinel through `copy_to_user`, read it back, unmap.
+fn mmap_anon_private_touch() {
+    let addr = vibix::mem::mmap::sys_mmap(0, PAGE, PROT_READ | PROT_WRITE, MAP_ANON_PRIVATE, FD_NONE, 0);
+    assert!(addr >= 0, "sys_mmap failed: {addr}");
+    assert_eq!(addr as u64 % PAGE, 0, "addr not page-aligned");
+
+    // Read initial content (zero) via copy_from_user — demand-pages the frame
+    // under the STAC/CLAC bracket so SMAP is satisfied.
+    let mut buf = [0xFFu8; 8];
+    unsafe { uaccess::copy_from_user(&mut buf, addr as usize).expect("copy_from_user zero") };
+    assert_eq!(buf, [0u8; 8], "fresh anon page should be zero");
+
+    // Write a sentinel and read it back.
+    let payload = [0xABu8; 8];
+    unsafe { uaccess::copy_to_user(addr as usize, &payload).expect("copy_to_user") };
+    let mut readback = [0u8; 8];
+    unsafe { uaccess::copy_from_user(&mut readback, addr as usize).expect("copy_from_user readback") };
+    assert_eq!(readback, payload, "write/readback mismatch");
+
+    let rc = vibix::mem::mmap::sys_munmap(addr as u64, PAGE);
+    assert_eq!(rc, 0, "sys_munmap failed: {rc}");
+}
+
+/// Two adjacent mmap calls without a hint should return non-overlapping ranges.
+fn mmap_hint_advances() {
+    let a1 = vibix::mem::mmap::sys_mmap(0, PAGE, PROT_READ | PROT_WRITE, MAP_ANON_PRIVATE, FD_NONE, 0);
+    let a2 = vibix::mem::mmap::sys_mmap(0, PAGE, PROT_READ | PROT_WRITE, MAP_ANON_PRIVATE, FD_NONE, 0);
+    assert!(a1 >= 0 && a2 >= 0, "mmap failed: a1={a1} a2={a2}");
+    assert_ne!(a1, a2, "two mmaps returned same address");
+
+    // Ranges must not overlap.
+    let (lo, hi) = if a1 < a2 { (a1 as u64, a2 as u64) } else { (a2 as u64, a1 as u64) };
+    assert!(lo + PAGE <= hi, "mmap ranges overlap: [{lo:#x},{}) and [{hi:#x},{})", lo + PAGE, hi + PAGE);
+
+    let _ = vibix::mem::mmap::sys_munmap(a1 as u64, PAGE);
+    let _ = vibix::mem::mmap::sys_munmap(a2 as u64, PAGE);
+}
+
+/// MAP_FIXED places the mapping at exactly the requested address.
+fn mmap_fixed() {
+    // Allocate one page to learn a free address, then free it.
+    let base = vibix::mem::mmap::sys_mmap(0, PAGE, PROT_READ | PROT_WRITE, MAP_ANON_PRIVATE, FD_NONE, 0);
+    assert!(base >= 0);
+    let _ = vibix::mem::mmap::sys_munmap(base as u64, PAGE);
+
+    // Place a MAP_FIXED mapping several pages above the freed address.
+    let target = (base as u64 + 8 * PAGE) & !(PAGE - 1);
+    let addr = vibix::mem::mmap::sys_mmap(
+        target, PAGE, PROT_READ | PROT_WRITE, MAP_ANON_PRIVATE | MAP_FIXED, FD_NONE, 0,
+    );
+    assert_eq!(addr as u64, target, "MAP_FIXED returned wrong address");
+
+    // Write and verify through uaccess helpers.
+    let payload = [0x42u8; 8];
+    unsafe { uaccess::copy_to_user(target as usize, &payload).expect("copy_to_user MAP_FIXED") };
+    let mut rb = [0u8; 8];
+    unsafe { uaccess::copy_from_user(&mut rb, target as usize).expect("copy_from_user MAP_FIXED") };
+    assert_eq!(rb, payload);
+
+    let _ = vibix::mem::mmap::sys_munmap(target, PAGE);
+}
+
+/// MAP_FIXED_NOREPLACE returns -EEXIST when the range is already mapped.
+fn mmap_fixed_noreplace_conflict() {
+    let addr = vibix::mem::mmap::sys_mmap(0, PAGE, PROT_READ | PROT_WRITE, MAP_ANON_PRIVATE, FD_NONE, 0);
+    assert!(addr >= 0);
+
+    let rc = vibix::mem::mmap::sys_mmap(
+        addr as u64, PAGE, PROT_READ | PROT_WRITE,
+        MAP_ANON_PRIVATE | MAP_FIXED_NOREPLACE, FD_NONE, 0,
+    );
+    assert_eq!(rc, EEXIST, "MAP_FIXED_NOREPLACE should give EEXIST, got {rc}");
+
+    let _ = vibix::mem::mmap::sys_munmap(addr as u64, PAGE);
+}
+
+/// munmap returns 0 for a mapped region, and also for an already-freed hole.
+fn munmap_returns_zero() {
+    let addr = vibix::mem::mmap::sys_mmap(0, PAGE, PROT_READ | PROT_WRITE, MAP_ANON_PRIVATE, FD_NONE, 0);
+    assert!(addr >= 0);
+    assert_eq!(vibix::mem::mmap::sys_munmap(addr as u64, PAGE), 0, "first munmap");
+    // Second munmap on a hole must also succeed (POSIX conformant).
+    assert_eq!(vibix::mem::mmap::sys_munmap(addr as u64, PAGE), 0, "hole munmap");
+}
+
+/// After munmap, the VMA is absent from the address space.
+fn munmap_vma_removed() {
+    let addr = vibix::mem::mmap::sys_mmap(0, PAGE, PROT_READ | PROT_WRITE, MAP_ANON_PRIVATE, FD_NONE, 0);
+    assert!(addr >= 0);
+
+    {
+        let arc = vibix::task::current_address_space();
+        let aspace = arc.read();
+        assert!(aspace.find(addr as usize).is_some(), "VMA should exist after mmap");
+    }
+
+    assert_eq!(vibix::mem::mmap::sys_munmap(addr as u64, PAGE), 0);
+
+    {
+        let arc = vibix::task::current_address_space();
+        let aspace = arc.read();
+        assert!(aspace.find(addr as usize).is_none(), "VMA should be gone after munmap");
+    }
+}
+
+/// mprotect promotes a PROT_READ mapping to PROT_READ|WRITE.
+fn mprotect_readwrite() {
+    // Map read-only.
+    let addr = vibix::mem::mmap::sys_mmap(0, PAGE, PROT_READ, MAP_ANON_PRIVATE, FD_NONE, 0);
+    assert!(addr >= 0, "sys_mmap failed");
+
+    // Demand-page with a read under STAC bracket.
+    let mut buf = [0u8; 4];
+    unsafe { uaccess::copy_from_user(&mut buf, addr as usize).expect("initial read") };
+
+    // Promote to read-write.
+    assert_eq!(vibix::mem::mmap::sys_mprotect(addr as u64, PAGE, PROT_READ | PROT_WRITE), 0);
+
+    // Write after mprotect — the PTE was remapped with WRITABLE.
+    let payload = [0xCAu8; 4];
+    unsafe { uaccess::copy_to_user(addr as usize, &payload).expect("write after mprotect") };
+    let mut rb = [0u8; 4];
+    unsafe { uaccess::copy_from_user(&mut rb, addr as usize).expect("read after mprotect") };
+    assert_eq!(rb, payload, "readback after mprotect mismatch");
+
+    let _ = vibix::mem::mmap::sys_munmap(addr as u64, PAGE);
+}
+
+/// MADV_DONTNEED does not crash and returns 0 on a backed mapping.
+fn madvise_dontneed_no_crash() {
+    let addr = vibix::mem::mmap::sys_mmap(0, 2 * PAGE, PROT_READ | PROT_WRITE, MAP_ANON_PRIVATE, FD_NONE, 0);
+    assert!(addr >= 0);
+
+    // Touch both pages (demand paging under STAC).
+    let payload = [0x55u8; 8];
+    unsafe {
+        uaccess::copy_to_user(addr as usize, &payload).expect("touch page 0");
+        uaccess::copy_to_user(addr as usize + PAGE as usize, &payload).expect("touch page 1");
+    }
+
+    // MADV_DONTNEED (4) should succeed and not crash.
+    let rc = vibix::mem::mmap::sys_madvise(addr as u64, 2 * PAGE, 4);
+    assert_eq!(rc, 0, "sys_madvise returned {rc}");
+
+    // VMAs should still be present (madvise only drops PTEs, not VMAs).
+    {
+        let arc = vibix::task::current_address_space();
+        let aspace = arc.read();
+        assert!(aspace.find(addr as usize).is_some(), "VMA must survive MADV_DONTNEED");
+    }
+
+    let _ = vibix::mem::mmap::sys_munmap(addr as u64, 2 * PAGE);
+}
+
+/// Invalid argument combinations return appropriate error codes.
+fn mmap_invalid_args() {
+    // Zero length → EINVAL.
+    assert_eq!(
+        vibix::mem::mmap::sys_mmap(0, 0, PROT_READ | PROT_WRITE, MAP_ANON_PRIVATE, FD_NONE, 0),
+        EINVAL, "len=0"
+    );
+
+    // File-backed (MAP_ANONYMOUS unset and/or fd != -1) → ENODEV.
+    assert_eq!(
+        vibix::mem::mmap::sys_mmap(0, PAGE, PROT_READ, MAP_PRIVATE, 3, 0),
+        ENODEV, "file-backed"
+    );
+
+    // munmap with unaligned addr → EINVAL.
+    assert_eq!(vibix::mem::mmap::sys_munmap(0x1001, PAGE), EINVAL, "unaligned munmap");
+
+    // mprotect over a hole → ENOMEM.
+    assert_eq!(
+        vibix::mem::mmap::sys_mprotect(0x0000_0030_0000_0000, PAGE, PROT_READ),
+        ENOMEM, "mprotect over hole"
+    );
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -637,6 +637,7 @@ fn test_all() -> R<()> {
         "fork_cow",
         "tlb_flusher",
         "smep_smap",
+        "mmap_syscall",
     ] {
         cmd.arg("--test").arg(t);
     }


### PR DESCRIPTION
Closes #162

## Summary

- Implements `mmap(9)`, `mprotect(10)`, `munmap(11)`, and `madvise(28)` per RFC 0001 — anon-private and anon-shared paths only; file-backed mappings return `ENODEV`
- Extends the SYSCALL entry trampoline to save and forward the user's `r10` (a3/flags) and `r8` (a4/fd) registers, which the original 4-arg dispatcher dropped; adds `SYSCALL_A3_SCRATCH` static for single-CPU scratch on entry
- Extends `syscall_dispatch` from 4 to 6 args so mmap receives `(nr, addr, len, prot, flags, fd)` without inline-asm reads
- New `kernel/src/mem/mmap.rs`: shared `validate_range` helper, `prot_user_to_pte` converter, `find_free_range` hint-based allocator, MAP_FIXED / MAP_FIXED_NOREPLACE support, PTE teardown on munmap/madvise via `frame::put`, PTE remapping on mprotect
- Adds `task::current_address_space()` so syscall context can borrow the current task's `Arc<RwLock<AddressSpace>>`
- 9 QEMU integration tests in `kernel/tests/mmap_syscall.rs` covering basic touch, hint allocation, MAP_FIXED, MAP_FIXED_NOREPLACE conflict, munmap VMA removal, mprotect RO→RW, MADV_DONTNEED, and error-code validation

## Test plan

- [x] `cargo xtask build` — clean (1 pre-existing dead-code warning in task.rs)
- [x] `cargo xtask test` — all host unit tests and QEMU integration tests pass including new `mmap_syscall` (9/9)
- [x] `cargo xtask smoke` — all 27 markers present

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches the x86_64 SYSCALL entry trampoline and page-table/VMA manipulation paths, where subtle ABI or refcount/TLB bugs can crash the kernel or leak memory. New mapping syscalls also introduce new user-controlled virtual-memory behaviors that need careful validation.
> 
> **Overview**
> Adds Linux-ABI `mmap(9)`, `munmap(11)`, `mprotect(10)`, and `madvise(28)` for anonymous private/shared mappings, including hint-based placement plus `MAP_FIXED`/`MAP_FIXED_NOREPLACE`, and implements the necessary VMA bookkeeping and PTE teardown/remap with frame refcount releases.
> 
> Extends the x86_64 SYSCALL trampoline and `syscall_dispatch` from 4 to 6 args by saving/restoring the user’s `r10` (a3) and forwarding `r8` (a4), enabling `mmap` flags/fd to be passed without inline-asm.
> 
> Adds `VmObject::evict_page` (implemented by `AnonObject`) to support `MADV_DONTNEED` zero-on-next-touch semantics, introduces `task::current_address_space()` for syscall-side address-space mutation, and wires in a new QEMU integration test `mmap_syscall` (also added to `xtask` and `Cargo.toml`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 571d2b36050f1939d7cff7c57b7e2c81b3bcb52a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->