### PR TITLE
mem: isolate AnonObject per fork child; propagate PML4 OOM to ForkError

### DIFF
--- a/kernel/src/mem/addrspace.rs
+++ b/kernel/src/mem/addrspace.rs
@@ -135,8 +135,7 @@ impl AddressSpace {
     /// fork is handled gracefully.
     #[cfg(target_os = "none")]
     pub fn try_new_empty() -> Result<Self, ForkError> {
-        let page_table = crate::mem::paging::try_new_task_pml4()
-            .ok_or(ForkError::OutOfMemory)?;
+        let page_table = crate::mem::paging::try_new_task_pml4().ok_or(ForkError::OutOfMemory)?;
         let mmap_base = VirtAddr::new(0x0000_0000_4000_0000);
         let brk_start = mmap_base;
         Ok(Self {

--- a/kernel/src/mem/addrspace.rs
+++ b/kernel/src/mem/addrspace.rs
@@ -109,7 +109,8 @@ impl AddressSpace {
     ///
     /// # Panics
     ///
-    /// Panics if called before `mem::paging::init`.
+    /// Panics if called before `mem::paging::init` or if the frame
+    /// allocator is exhausted.
     #[cfg(target_os = "none")]
     pub fn new_empty() -> Self {
         let page_table = crate::mem::paging::new_task_pml4();
@@ -126,6 +127,29 @@ impl AddressSpace {
             vm_pages: 0,
             bootstrap: false,
         }
+    }
+
+    /// Fallible variant of [`new_empty`]: returns `Err(ForkError::OutOfMemory)`
+    /// when the frame allocator cannot satisfy the PML4 allocation, instead
+    /// of panicking. Used by `fork_address_space` so frame exhaustion during
+    /// fork is handled gracefully.
+    #[cfg(target_os = "none")]
+    pub fn try_new_empty() -> Result<Self, ForkError> {
+        let page_table = crate::mem::paging::try_new_task_pml4()
+            .ok_or(ForkError::OutOfMemory)?;
+        let mmap_base = VirtAddr::new(0x0000_0000_4000_0000);
+        let brk_start = mmap_base;
+        Ok(Self {
+            page_table,
+            vmas: VmaTree::new(),
+            mmap_base,
+            brk_start,
+            brk_cur: brk_start,
+            brk_max: VirtAddr::new(mmap_base.as_u64() - DEFAULT_BRK_GUARD),
+            rss_pages: 0,
+            vm_pages: 0,
+            bootstrap: false,
+        })
     }
 
     /// Test-only constructor: build an `AddressSpace` without touching
@@ -230,7 +254,7 @@ impl AddressSpace {
         use x86_64::structures::paging::{Page, PageTableFlags, Size4KiB};
 
         // Allocate child PML4 + copy kernel upper half.
-        let mut child = AddressSpace::new_empty();
+        let mut child = AddressSpace::try_new_empty()?;
         // Inherit brk/mmap layout from parent.
         child.mmap_base = self.mmap_base;
         child.brk_start = self.brk_start;
@@ -272,14 +296,23 @@ impl AddressSpace {
             let end = *end;
             let object_offset = *object_offset;
 
-            // Insert VMA into child.
+            // Insert VMA into child with an appropriate backing object.
+            // For Private VMAs, clone_private() returns a fresh empty
+            // AnonObject so post-fork demand faults on unfaulted pages
+            // allocate independent frames in parent and child. For Shared
+            // VMAs, Arc::clone is correct — both sides intentionally share
+            // the same backing frames.
+            let child_object = match share {
+                Share::Private => object.clone_private(),
+                Share::Shared => Arc::clone(object),
+            };
             let child_vma = VmaEntry::new(
                 start,
                 end,
                 prot_user,
                 prot_pte,
                 share,
-                Arc::clone(object),
+                child_object,
                 object_offset,
             );
             child.vmas.insert(child_vma);

--- a/kernel/src/mem/paging.rs
+++ b/kernel/src/mem/paging.rs
@@ -287,6 +287,26 @@ pub fn new_task_pml4() -> PhysFrame<Size4KiB> {
     new_frame
 }
 
+/// Fallible variant of [`new_task_pml4`]: returns `None` when the frame
+/// allocator is exhausted. Used by `fork_address_space` so that PML4
+/// allocation failure surfaces as `ForkError::OutOfMemory` rather than
+/// a kernel panic.
+pub fn try_new_task_pml4() -> Option<PhysFrame<Size4KiB>> {
+    let hhdm = HHDM_OFFSET
+        .lock()
+        .expect("paging::init must run before try_new_task_pml4");
+    // SAFETY: freshly allocated, exclusively owned, zeroed through HHDM.
+    let new_frame = unsafe { try_alloc_zeroed_frame(hhdm) }?;
+    let active = Cr3::read().0;
+    // SAFETY: same rationale as `new_task_pml4`.
+    unsafe {
+        let src = pml4_as_mut(active, hhdm) as *const PageTable as *const u64;
+        let dst = pml4_as_mut(new_frame, hhdm) as *mut PageTable as *mut u64;
+        core::ptr::copy_nonoverlapping(src.add(256), dst.add(256), 256);
+    }
+    Some(new_frame)
+}
+
 /// Map `page` to a freshly-allocated zeroed frame in the PML4 rooted
 /// at `pml4_frame`, with `flags`. Intended for the `#PF` demand-paging
 /// resolver: the handler runs in the faulting task's address space, so
@@ -632,6 +652,22 @@ unsafe fn alloc_zeroed_frame(hhdm: VirtAddr) -> PhysFrame<Size4KiB> {
     let virt = hhdm + frame.start_address().as_u64();
     core::ptr::write_bytes(virt.as_mut_ptr::<u8>(), 0, 4096);
     frame
+}
+
+/// Fallible variant of [`alloc_zeroed_frame`]: returns `None` when the
+/// frame allocator is exhausted. Used by [`try_new_task_pml4`] so that
+/// OOM during fork can be surfaced as `ForkError::OutOfMemory` instead
+/// of a kernel panic.
+///
+/// # Safety
+/// Same as [`alloc_zeroed_frame`]: the returned frame is exclusively
+/// owned by the caller.
+unsafe fn try_alloc_zeroed_frame(hhdm: VirtAddr) -> Option<PhysFrame<Size4KiB>> {
+    let mut alloc = KernelFrameAllocator;
+    let frame = alloc.allocate_frame()?;
+    let virt = hhdm + frame.start_address().as_u64();
+    core::ptr::write_bytes(virt.as_mut_ptr::<u8>(), 0, 4096);
+    Some(frame)
 }
 
 /// Turn a PML4-bearing physical frame into a `&'static mut PageTable`

--- a/kernel/src/mem/vmatree.rs
+++ b/kernel/src/mem/vmatree.rs
@@ -426,6 +426,10 @@ mod tests {
         fn len_pages(&self) -> Option<usize> {
             self.len
         }
+
+        fn clone_private(&self) -> Arc<dyn VmObject> {
+            Arc::new(StubObject { len: self.len })
+        }
     }
 
     fn stub() -> Arc<dyn VmObject> {

--- a/kernel/src/mem/vmobject.rs
+++ b/kernel/src/mem/vmobject.rs
@@ -76,6 +76,15 @@ pub trait VmObject: Send + Sync {
         let _ = offset;
         None
     }
+
+    /// Return a fresh backing object for a `Share::Private` fork child.
+    ///
+    /// Called by `fork_address_space` for every Private VMA so post-fork
+    /// demand faults on unfaulted pages allocate **independent** frames in
+    /// parent and child. `AnonObject` returns a new empty cache with the
+    /// same `len_pages` bound; future file-backed objects should return a
+    /// similarly independent copy.
+    fn clone_private(&self) -> Arc<dyn VmObject>;
 }
 
 /// Clone a `VmObject` trait-object for `fork`. The default behavior is
@@ -162,6 +171,20 @@ impl VmObject for AnonObject {
     fn frame_at(&self, offset: usize) -> Option<u64> {
         let idx = offset / (crate::mem::FRAME_SIZE as usize);
         self.inner.lock().frames.get(&idx).copied()
+    }
+
+    fn clone_private(&self) -> Arc<dyn VmObject> {
+        // Return a fresh empty `AnonObject` with the same size bound.
+        // Post-fork demand faults on unfaulted pages will allocate
+        // independent frames in the child; already-W-stripped frames are
+        // handled entirely at the PTE layer by `fork_address_space` and
+        // need no entry in this cache.
+        Arc::new(Self {
+            inner: Mutex::new(AnonInner {
+                frames: BTreeMap::new(),
+            }),
+            len_pages: self.len_pages,
+        })
     }
 }
 
@@ -304,14 +327,47 @@ mod tests {
     #[test]
     fn clone_for_fork_shares_cache() {
         let _g = release_test_lock();
-        // Arc-clone is the default for fork; the forked object sees the
-        // same cached frames as the parent until the CoW path diverges
-        // them at the PTE layer.
+        // `clone_for_fork` (the free function) performs an Arc::clone —
+        // used for Share::Shared VMAs. The forked Arc sees the same
+        // cached frames as the parent (sharing is intentional for Shared).
         let anon = AnonObject::new(Some(4));
         anon.insert_for_test(0, 0x4000);
         let parent: Arc<dyn VmObject> = anon;
         let forked = clone_for_fork(&parent);
         assert_eq!(forked.fault(0, Access::Read).unwrap(), 0x4000);
+    }
+
+    #[test]
+    fn clone_private_produces_empty_independent_object() {
+        let _g = release_test_lock();
+        // clone_private (used for Share::Private VMAs) must return a new
+        // object with an empty cache so post-fork demand faults in parent
+        // and child allocate independent frames.
+        let anon = AnonObject::new(Some(4));
+        anon.insert_for_test(0, 0x4000);
+        anon.insert_for_test(1, 0x5000);
+        let parent: Arc<dyn VmObject> = anon;
+        let child = parent.clone_private();
+        // Child cache is empty — frame_at returns None for every offset.
+        assert_eq!(child.frame_at(0), None);
+        assert_eq!(child.frame_at(4096), None);
+        // Child is a distinct allocation.
+        assert!(!core::ptr::addr_eq(
+            Arc::as_ptr(&parent) as *const (),
+            Arc::as_ptr(&(child as Arc<dyn VmObject>)) as *const ()
+        ));
+    }
+
+    #[test]
+    fn clone_private_preserves_len_pages() {
+        let _g = release_test_lock();
+        let parent: Arc<dyn VmObject> = AnonObject::new(Some(8));
+        let child = parent.clone_private();
+        assert_eq!(child.len_pages(), Some(8));
+
+        let unbounded: Arc<dyn VmObject> = AnonObject::new(None);
+        let child2 = unbounded.clone_private();
+        assert_eq!(child2.len_pages(), None);
     }
 
     #[test]

--- a/kernel/tests/fork_cow.rs
+++ b/kernel/tests/fork_cow.rs
@@ -54,6 +54,10 @@ fn run_tests() {
             &(fork_cow_prefaulted_pages_w_stripped as fn()),
         ),
         ("fork_cow_no_frame_leak", &(fork_cow_no_frame_leak as fn())),
+        (
+            "fork_isolation_unfaulted_page",
+            &(fork_isolation_unfaulted_page as fn()),
+        ),
     ];
     serial_println!("running {} tests", tests.len());
     for (name, t) in tests {
@@ -120,9 +124,11 @@ fn fork_cow_vma_tree_is_cloned() {
     assert_eq!(pvma.start, cvma.start);
     assert_eq!(pvma.end, cvma.end);
     assert_eq!(pvma.share, cvma.share);
+    // Private VMAs get an independent backing object after #188 fix — the
+    // child's AnonObject is a fresh empty clone, not an Arc::clone.
     assert!(
-        core::ptr::addr_eq(Arc::as_ptr(&pvma.object), Arc::as_ptr(&cvma.object),),
-        "child object should be Arc::clone of parent's"
+        !core::ptr::addr_eq(Arc::as_ptr(&pvma.object), Arc::as_ptr(&cvma.object)),
+        "Private VMA child object must be a distinct AnonObject, not an Arc::clone"
     );
     drop(parent);
     drop(child);
@@ -195,4 +201,68 @@ fn fork_cow_no_frame_leak() {
         "frame leak: baseline={baseline}, after={after}, delta={}",
         baseline as isize - after as isize,
     );
+}
+
+/// Verify that pages not faulted before fork get **distinct** physical
+/// frames in parent and child after the fork (#188).
+///
+/// Setup: prefault page 0 only. Fork. Then demand-fault page 1 in the
+/// child and again in the parent. The two physical addresses must differ —
+/// confirming that each side's `AnonObject` allocates independently.
+fn fork_isolation_unfaulted_page() {
+    let mut parent = make_parent_aspace();
+
+    // Prefault page 0 so the W-strip path in fork_address_space runs,
+    // but leave page 1 unfaulted.
+    prefault_page(&parent, 0);
+
+    let mut flusher = Flusher::new_active();
+    let child = parent
+        .fork_address_space(&mut flusher)
+        .expect("fork_address_space failed");
+    flusher.finish();
+
+    // Demand-fault page 1 in the child by calling the child VMA's object.
+    let child_phys = {
+        let vma = child.find(FORK_VA).expect("child vma missing");
+        let child_obj = Arc::clone(&vma.object);
+        let phys = child_obj
+            .fault(1 * 4096, Access::Write)
+            .expect("child fault failed");
+        let va = FORK_VA + 4096;
+        let page = Page::<Size4KiB>::from_start_address(VirtAddr::new(va as u64))
+            .expect("page-aligned VA");
+        let frame =
+            PhysFrame::from_start_address(PhysAddr::new(phys)).expect("frame-aligned phys");
+        let flags = PageTableFlags::from_bits_truncate(prot_pte_rw());
+        paging::map_existing_in_pml4(child.page_table_frame(), page, frame, flags)
+            .expect("child map_existing failed");
+        phys
+    };
+
+    // Demand-fault page 1 in the parent.
+    let parent_phys = {
+        let vma = parent.find(FORK_VA).expect("parent vma missing");
+        let parent_obj = Arc::clone(&vma.object);
+        let phys = parent_obj
+            .fault(1 * 4096, Access::Write)
+            .expect("parent fault failed");
+        let va = FORK_VA + 4096;
+        let page = Page::<Size4KiB>::from_start_address(VirtAddr::new(va as u64))
+            .expect("page-aligned VA");
+        let frame =
+            PhysFrame::from_start_address(PhysAddr::new(phys)).expect("frame-aligned phys");
+        let flags = PageTableFlags::from_bits_truncate(prot_pte_rw());
+        paging::map_existing_in_pml4(parent.page_table_frame(), page, frame, flags)
+            .expect("parent map_existing failed");
+        phys
+    };
+
+    assert_ne!(
+        child_phys, parent_phys,
+        "parent and child must get distinct frames for unfaulted page (issue #188)"
+    );
+
+    drop(parent);
+    drop(child);
 }

--- a/kernel/tests/fork_cow.rs
+++ b/kernel/tests/fork_cow.rs
@@ -232,8 +232,7 @@ fn fork_isolation_unfaulted_page() {
         let va = FORK_VA + 4096;
         let page = Page::<Size4KiB>::from_start_address(VirtAddr::new(va as u64))
             .expect("page-aligned VA");
-        let frame =
-            PhysFrame::from_start_address(PhysAddr::new(phys)).expect("frame-aligned phys");
+        let frame = PhysFrame::from_start_address(PhysAddr::new(phys)).expect("frame-aligned phys");
         let flags = PageTableFlags::from_bits_truncate(prot_pte_rw());
         paging::map_existing_in_pml4(child.page_table_frame(), page, frame, flags)
             .expect("child map_existing failed");
@@ -250,8 +249,7 @@ fn fork_isolation_unfaulted_page() {
         let va = FORK_VA + 4096;
         let page = Page::<Size4KiB>::from_start_address(VirtAddr::new(va as u64))
             .expect("page-aligned VA");
-        let frame =
-            PhysFrame::from_start_address(PhysAddr::new(phys)).expect("frame-aligned phys");
+        let frame = PhysFrame::from_start_address(PhysAddr::new(phys)).expect("frame-aligned phys");
         let flags = PageTableFlags::from_bits_truncate(prot_pte_rw());
         paging::map_existing_in_pml4(parent.page_table_frame(), page, frame, flags)
             .expect("parent map_existing failed");


### PR DESCRIPTION
Closes #188

## Summary
- Adds `VmObject::clone_private` trait method; `AnonObject` returns a fresh empty-cache object so post-fork demand faults on unfaulted pages allocate independent frames in parent and child instead of hitting the same shared cache entry
- Updates `fork_address_space` to call `object.clone_private()` for `Share::Private` VMAs instead of `Arc::clone`, while `Share::Shared` VMAs continue to use `Arc::clone`
- Adds `paging::try_new_task_pml4` (fallible PML4 allocator) and `AddressSpace::try_new_empty` so frame exhaustion during fork surfaces as `ForkError::OutOfMemory` instead of panicking
- Fixes stale assertion in `fork_cow_vma_tree_is_cloned` that incorrectly expected `Arc::ptr_eq` on Private VMA objects

## Test plan
- [x] `cargo xtask build` — clean build, 1 pre-existing unused-method warning
- [x] `cargo xtask test` — all 122 host unit tests pass; all QEMU integration tests pass including 4 fork_cow tests (3 existing + new `fork_isolation_unfaulted_page`)
- [x] `cargo xtask smoke` — all 27 markers present
- [x] New `fork_isolation_unfaulted_page` test: prefaults page 0, forks, then demand-faults page 1 in both parent and child and asserts the physical addresses differ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core virtual-memory and fork CoW behavior plus low-level page-table allocation paths; incorrect logic could cause memory aliasing, leaks, or fork failures under memory pressure.
> 
> **Overview**
> Fixes fork CoW semantics for *unfaulted* private pages by introducing `VmObject::clone_private` and using it in `fork_address_space` for `Share::Private` VMAs, so the child gets a fresh backing object (while `Share::Shared` continues to `Arc::clone`).
> 
> Makes fork PML4 creation fallible by adding `paging::try_new_task_pml4`/`AddressSpace::try_new_empty` and returning `ForkError::OutOfMemory` instead of panicking on frame exhaustion, and updates/extends tests to assert private-object non-aliasing plus a new integration test that parent/child allocate distinct frames for post-fork demand faults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 419eb07e0fc3a09e17eb30cc8c5f4824413dda33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->