### PR TITLE
refactor: eliminate new_empty/try_new_empty duplication; extract test helper

### DIFF
--- a/kernel/src/mem/addrspace.rs
+++ b/kernel/src/mem/addrspace.rs
@@ -113,20 +113,7 @@ impl AddressSpace {
     /// allocator is exhausted.
     #[cfg(target_os = "none")]
     pub fn new_empty() -> Self {
-        let page_table = crate::mem::paging::new_task_pml4();
-        let mmap_base = VirtAddr::new(0x0000_0000_4000_0000);
-        let brk_start = mmap_base;
-        Self {
-            page_table,
-            vmas: VmaTree::new(),
-            mmap_base,
-            brk_start,
-            brk_cur: brk_start,
-            brk_max: VirtAddr::new(mmap_base.as_u64() - DEFAULT_BRK_GUARD),
-            rss_pages: 0,
-            vm_pages: 0,
-            bootstrap: false,
-        }
+        Self::try_new_empty().expect("frame allocator exhausted during AddressSpace::new_empty")
     }
 
     /// Fallible variant of [`new_empty`]: returns `Err(ForkError::OutOfMemory)`
@@ -295,12 +282,7 @@ impl AddressSpace {
             let end = *end;
             let object_offset = *object_offset;
 
-            // Insert VMA into child with an appropriate backing object.
-            // For Private VMAs, clone_private() returns a fresh empty
-            // AnonObject so post-fork demand faults on unfaulted pages
-            // allocate independent frames in parent and child. For Shared
-            // VMAs, Arc::clone is correct — both sides intentionally share
-            // the same backing frames.
+            // Private VMAs get an independent empty cache; Shared VMAs alias the same frames.
             let child_object = match share {
                 Share::Private => object.clone_private(),
                 Share::Shared => Arc::clone(object),

--- a/kernel/tests/fork_cow.rs
+++ b/kernel/tests/fork_cow.rs
@@ -203,12 +203,27 @@ fn fork_cow_no_frame_leak() {
     );
 }
 
+/// Demand-fault `page_index` into `aspace`, install the resulting PTE, and
+/// return the physical address. Used by `fork_isolation_unfaulted_page` to
+/// trigger demand faults in parent and child independently after a fork.
+fn demand_fault_and_map(aspace: &AddressSpace, page_index: usize) -> u64 {
+    let vma = aspace.find(FORK_VA).expect("vma missing");
+    let obj = Arc::clone(&vma.object);
+    let phys = obj
+        .fault(page_index * 4096, Access::Write)
+        .expect("VmObject::fault failed");
+    let va = FORK_VA + page_index * 4096;
+    let page =
+        Page::<Size4KiB>::from_start_address(VirtAddr::new(va as u64)).expect("page-aligned VA");
+    let frame = PhysFrame::from_start_address(PhysAddr::new(phys)).expect("frame-aligned phys");
+    let flags = PageTableFlags::from_bits_truncate(prot_pte_rw());
+    paging::map_existing_in_pml4(aspace.page_table_frame(), page, frame, flags)
+        .expect("map_existing_in_pml4 failed");
+    phys
+}
+
 /// Verify that pages not faulted before fork get **distinct** physical
 /// frames in parent and child after the fork (#188).
-///
-/// Setup: prefault page 0 only. Fork. Then demand-fault page 1 in the
-/// child and again in the parent. The two physical addresses must differ —
-/// confirming that each side's `AnonObject` allocates independently.
 fn fork_isolation_unfaulted_page() {
     let mut parent = make_parent_aspace();
 
@@ -222,39 +237,8 @@ fn fork_isolation_unfaulted_page() {
         .expect("fork_address_space failed");
     flusher.finish();
 
-    // Demand-fault page 1 in the child by calling the child VMA's object.
-    let child_phys = {
-        let vma = child.find(FORK_VA).expect("child vma missing");
-        let child_obj = Arc::clone(&vma.object);
-        let phys = child_obj
-            .fault(1 * 4096, Access::Write)
-            .expect("child fault failed");
-        let va = FORK_VA + 4096;
-        let page = Page::<Size4KiB>::from_start_address(VirtAddr::new(va as u64))
-            .expect("page-aligned VA");
-        let frame = PhysFrame::from_start_address(PhysAddr::new(phys)).expect("frame-aligned phys");
-        let flags = PageTableFlags::from_bits_truncate(prot_pte_rw());
-        paging::map_existing_in_pml4(child.page_table_frame(), page, frame, flags)
-            .expect("child map_existing failed");
-        phys
-    };
-
-    // Demand-fault page 1 in the parent.
-    let parent_phys = {
-        let vma = parent.find(FORK_VA).expect("parent vma missing");
-        let parent_obj = Arc::clone(&vma.object);
-        let phys = parent_obj
-            .fault(1 * 4096, Access::Write)
-            .expect("parent fault failed");
-        let va = FORK_VA + 4096;
-        let page = Page::<Size4KiB>::from_start_address(VirtAddr::new(va as u64))
-            .expect("page-aligned VA");
-        let frame = PhysFrame::from_start_address(PhysAddr::new(phys)).expect("frame-aligned phys");
-        let flags = PageTableFlags::from_bits_truncate(prot_pte_rw());
-        paging::map_existing_in_pml4(parent.page_table_frame(), page, frame, flags)
-            .expect("parent map_existing failed");
-        phys
-    };
+    let child_phys = demand_fault_and_map(&child, 1);
+    let parent_phys = demand_fault_and_map(&parent, 1);
 
     assert_ne!(
         child_phys, parent_phys,


### PR DESCRIPTION
## Summary
- `AddressSpace::new_empty` now delegates to `try_new_empty().expect(...)`, eliminating the duplicated 9-field struct literal — both paths now stay in sync automatically as `AddressSpace` fields evolve
- Adds `demand_fault_and_map` helper in `fork_cow.rs` to unify the two identical fault+map blocks in `fork_isolation_unfaulted_page`
- Trims an over-long comment in `fork_address_space` to one line (WHAT was obvious from the code, kept the WHY)

## Test plan
- [x] `cargo xtask test` — all 122 host unit tests + all QEMU integration tests pass (fork_cow suite: 4/4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only changes: constructor now delegates to the fallible path and a test helper consolidates duplicated fault+map logic; behavior should be unchanged aside from improved consistency, with low risk limited to constructor error-message/panic-path changes.
> 
> **Overview**
> `AddressSpace::new_empty` now delegates to `try_new_empty().expect(...)`, removing duplicated struct initialization so both constructors stay in sync.
> 
> In `fork_address_space`, the private/shared backing-object selection comment is shortened without changing logic.
> 
> The `fork_cow` integration test extracts duplicated demand-fault+PTE-install code into `demand_fault_and_map`, and reuses it to assert parent/child get distinct frames for an unfaulted page post-fork.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df737d37319c54856f9120702ef257f720315eab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->