### PR TITLE
feat: process table + fork/exec/wait lifecycle (#123)

### DIFF
--- a/kernel/limine.conf
+++ b/kernel/limine.conf
@@ -5,3 +5,4 @@ serial: yes
     protocol: limine
     kernel_path: boot():/boot/vibix
     module_path: boot():/boot/userspace_init.elf
+    module_path: boot():/boot/userspace_hello.elf

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -318,7 +318,9 @@ pub unsafe extern "C" fn syscall_dispatch(nr: u64, a0: u64, a1: u64, a2: u64) ->
 
             // Clear all user VMAs and reset the address space.
             {
-                crate::task::current_address_space().write().clear_for_exec();
+                crate::task::current_address_space()
+                    .write()
+                    .clear_for_exec();
             }
 
             // Close O_CLOEXEC fds as POSIX requires on exec.
@@ -401,9 +403,8 @@ pub unsafe extern "C" fn syscall_dispatch(nr: u64, a0: u64, a1: u64, a2: u64) ->
                 }
                 // Park until any child exits (EXIT_EVENT advances).
                 let snap = crate::process::exit_event_count();
-                crate::process::CHILD_WAIT.wait_while(|| {
-                    crate::process::exit_event_count() == snap
-                });
+                crate::process::CHILD_WAIT
+                    .wait_while(|| crate::process::exit_event_count() == snap);
             }
         }
 

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -80,6 +80,20 @@ static mut INIT_KERNEL_STACK: AlignedStack = AlignedStack([0u8; 16 * 1024]);
 #[no_mangle]
 pub static SYSCALL_KERNEL_RSP: AtomicU64 = AtomicU64::new(0);
 
+/// Ring-3 RIP saved by the SYSCALL entry trampoline for use by fork().
+/// Stashed before argument registers are remapped, so it reflects the
+/// exact instruction the parent will resume at after fork() returns.
+#[no_mangle]
+pub static FORK_USER_RIP: AtomicU64 = AtomicU64::new(0);
+
+/// Ring-3 RFLAGS (saved from r11 by the CPU) for use by fork().
+#[no_mangle]
+pub static FORK_USER_RFLAGS: AtomicU64 = AtomicU64::new(0);
+
+/// Ring-3 RSP (saved before switching to kernel stack) for use by fork().
+#[no_mangle]
+pub static FORK_USER_RSP: AtomicU64 = AtomicU64::new(0);
+
 /// Enable SYSCALL/SYSRET and point LSTAR at the entry trampoline.
 /// Must be called after GDT is live.
 pub fn init() {
@@ -272,10 +286,125 @@ pub unsafe extern "C" fn syscall_dispatch(nr: u64, a0: u64, a1: u64, a2: u64) ->
             }
         }
 
-        // exit(status) — PID 1 calling exit panics the kernel.
+        // fork() — clone the calling process; parent returns child PID, child returns 0.
+        57 => {
+            let user_rip = FORK_USER_RIP.load(Ordering::Relaxed);
+            let user_rflags = FORK_USER_RFLAGS.load(Ordering::Relaxed);
+            let user_rsp = FORK_USER_RSP.load(Ordering::Relaxed);
+
+            let parent_pid = crate::process::current_pid();
+            if parent_pid == 0 {
+                return -1; // not a registered process
+            }
+
+            let child_task_id =
+                match crate::task::fork_current_task(user_rip, user_rflags, user_rsp) {
+                    Ok(id) => id,
+                    Err(_) => return -12, // ENOMEM
+                };
+            let child_pid = crate::process::register(child_task_id, parent_pid);
+            child_pid as i64
+        }
+
+        // execve(path, argv, envp) — path and argv/envp are ignored; the
+        // kernel loads the `userspace_hello.elf` ramdisk module into the
+        // current address space and jumps to ring-3. Never returns on
+        // success.
+        59 => {
+            let elf_bytes = match crate::mem::userspace_hello_elf_bytes() {
+                Some(b) => b,
+                None => return -8, // ENOEXEC — hello module not present
+            };
+
+            // Clear all user VMAs and reset the address space.
+            {
+                crate::task::current_address_space().write().clear_for_exec();
+            }
+
+            // Close O_CLOEXEC fds as POSIX requires on exec.
+            crate::task::current_fd_table().lock().close_cloexec();
+
+            // Load the new ELF into the current (now empty) PML4.
+            let pml4 = crate::task::current_cr3();
+            let image = match crate::mem::loader::load_user_elf(elf_bytes, pml4) {
+                Ok(img) => img,
+                Err(_) => return -8, // ENOEXEC
+            };
+
+            // Map a fresh user stack page at the canonical init stack VA.
+            use x86_64::structures::paging::{Page, PageTableFlags, Size4KiB};
+            use x86_64::VirtAddr;
+            let stack_page = Page::<Size4KiB>::containing_address(VirtAddr::new(
+                crate::init_process::USER_STACK_PAGE_VA,
+            ));
+            crate::mem::paging::map_in_pml4(
+                pml4,
+                stack_page,
+                PageTableFlags::PRESENT
+                    | PageTableFlags::WRITABLE
+                    | PageTableFlags::USER_ACCESSIBLE
+                    | PageTableFlags::NO_EXECUTE,
+            )
+            .expect("exec: user stack mapping failed");
+
+            // Switch to the new image — never returns.
+            unsafe { jump_to_ring3(image.entry.as_u64(), crate::init_process::USER_STACK_TOP) }
+        }
+
+        // exit(status) — tear down the process and switch to the next task.
         60 => {
             let status = a0 as i32;
-            panic!("kernel panic: init exited with status {}", status);
+            let pid = crate::process::current_pid();
+            if pid != 0 {
+                crate::process::reparent_children(pid);
+                crate::process::mark_zombie(pid, status);
+            }
+            crate::task::exit();
+        }
+
+        // wait4(pid, *wstatus, options, *rusage) — wait for a child.
+        // options and rusage are ignored. `pid < 0` means any child.
+        61 => {
+            let target_pid = a0 as i32;
+            let wstatus_ptr = a1 as usize;
+            let parent_pid = crate::process::current_pid();
+
+            if parent_pid == 0 {
+                return -10; // ECHILD — not a registered process
+            }
+            if !crate::process::has_children(parent_pid) {
+                return -10; // ECHILD
+            }
+            // Validate status pointer early (zero means "don't write").
+            if wstatus_ptr != 0 {
+                if let Err(e) = uaccess::check_user_range(wstatus_ptr, 4) {
+                    return e.as_errno();
+                }
+            }
+
+            // Wait until a zombie child exists or no children remain.
+            // The condition only reads EXIT_EVENT (an atomic), so it is
+            // safe inside wait_while without taking the TABLE lock.
+            loop {
+                if let Some((child_pid, exit_status)) =
+                    crate::process::reap_child(parent_pid, target_pid)
+                {
+                    if wstatus_ptr != 0 {
+                        // Linux wait4: wstatus = (exit_code & 0xFF) << 8
+                        let encoded = ((exit_status & 0xFF) << 8) as u32;
+                        let _ = uaccess::copy_to_user(wstatus_ptr, &encoded.to_ne_bytes());
+                    }
+                    return child_pid as i64;
+                }
+                if !crate::process::has_children(parent_pid) {
+                    return -10; // ECHILD — last child was reaped by another path
+                }
+                // Park until any child exits (EXIT_EVENT advances).
+                let snap = crate::process::exit_event_count();
+                crate::process::CHILD_WAIT.wait_while(|| {
+                    crate::process::exit_event_count() == snap
+                });
+            }
         }
 
         _ => -38i64, // ENOSYS
@@ -311,6 +440,13 @@ syscall_entry:
     push r11          // user RFLAGS  (SYSRETQ restores RFLAGS from r11)
     push rcx          // user RIP     (SYSRETQ jumps to rcx)
 
+    // 3b. Stash user context in FORK_USER_* statics so fork() can prime
+    //     the child's kernel stack. Must happen before rcx is clobbered
+    //     in step 4.  r10 is user RSP, r11 is user RFLAGS, rcx is user RIP.
+    mov [rip + {fork_rip}], rcx
+    mov [rip + {fork_rflags}], r11
+    mov [rip + {fork_rsp}], r10
+
     // 4. Build syscall_dispatch(nr, a0, a1, a2) in SysV AMD64 registers.
     //    rcx is now free (user RIP is on the stack).
     mov rcx, rdx      // a2
@@ -334,4 +470,7 @@ syscall_entry:
     sysretq
     "#,
     kernel_rsp = sym SYSCALL_KERNEL_RSP,
+    fork_rip = sym FORK_USER_RIP,
+    fork_rflags = sym FORK_USER_RFLAGS,
+    fork_rsp = sym FORK_USER_RSP,
 );

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -326,28 +326,49 @@ pub unsafe extern "C" fn syscall_dispatch(nr: u64, a0: u64, a1: u64, a2: u64) ->
             // Close O_CLOEXEC fds as POSIX requires on exec.
             crate::task::current_fd_table().lock().close_cloexec();
 
-            // Load the new ELF into the current (now empty) PML4.
+            // Load the new ELF with VMA tracking so AddressSpace::drop can
+            // reclaim the data frames when the exec'd process exits. Without
+            // VMA entries the leaf frames are orphaned permanently.
             let pml4 = crate::task::current_cr3();
-            let image = match crate::mem::loader::load_user_elf(elf_bytes, pml4) {
+            let aspace = crate::task::current_address_space();
+            let image = match crate::mem::loader::load_user_elf_with_vmas(
+                elf_bytes,
+                pml4,
+                &mut aspace.write(),
+            ) {
                 Ok(img) => img,
                 Err(_) => return -8, // ENOEXEC
             };
 
-            // Map a fresh user stack page at the canonical init stack VA.
+            // Map a fresh user stack page and register it as a VMA so the
+            // exec'd process's stack frame is also reclaimed on exit.
+            use crate::mem::vmatree::{Share, Vma};
+            use crate::mem::vmobject::{AnonObject, VmObject};
             use x86_64::structures::paging::{Page, PageTableFlags, Size4KiB};
             use x86_64::VirtAddr;
+            let stack_flags = PageTableFlags::PRESENT
+                | PageTableFlags::WRITABLE
+                | PageTableFlags::USER_ACCESSIBLE
+                | PageTableFlags::NO_EXECUTE;
             let stack_page = Page::<Size4KiB>::containing_address(VirtAddr::new(
                 crate::init_process::USER_STACK_PAGE_VA,
             ));
-            crate::mem::paging::map_in_pml4(
-                pml4,
-                stack_page,
-                PageTableFlags::PRESENT
-                    | PageTableFlags::WRITABLE
-                    | PageTableFlags::USER_ACCESSIBLE
-                    | PageTableFlags::NO_EXECUTE,
-            )
-            .expect("exec: user stack mapping failed");
+            let stack_frame = crate::mem::paging::map_in_pml4(pml4, stack_page, stack_flags)
+                .expect("exec: user stack mapping failed");
+
+            let stack_obj = AnonObject::new(Some(1));
+            stack_obj.insert_existing_frame(0, stack_frame.start_address().as_u64());
+            let stack_start = crate::init_process::USER_STACK_PAGE_VA as usize;
+            let stack_vma = Vma::new(
+                stack_start,
+                stack_start + 4096,
+                0x3,
+                stack_flags.bits(),
+                Share::Private,
+                stack_obj as alloc::sync::Arc<dyn VmObject>,
+                0,
+            );
+            aspace.write().insert(stack_vma);
 
             // Switch to the new image — never returns.
             unsafe { jump_to_ring3(image.entry.as_u64(), crate::init_process::USER_STACK_TOP) }
@@ -385,9 +406,13 @@ pub unsafe extern "C" fn syscall_dispatch(nr: u64, a0: u64, a1: u64, a2: u64) ->
             }
 
             // Wait until a zombie child exists or no children remain.
-            // The condition only reads EXIT_EVENT (an atomic), so it is
-            // safe inside wait_while without taking the TABLE lock.
+            // Snapshot EXIT_EVENT BEFORE the reap attempt so a child that
+            // exits in the gap between reap_child returning None and the
+            // wait_while park is not missed: if the event fires before snap
+            // is read, the condition (count == snap) is immediately false and
+            // wait_while returns at once, letting us loop back to reap.
             loop {
+                let snap = crate::process::exit_event_count();
                 if let Some((child_pid, exit_status)) =
                     crate::process::reap_child(parent_pid, target_pid)
                 {
@@ -401,8 +426,7 @@ pub unsafe extern "C" fn syscall_dispatch(nr: u64, a0: u64, a1: u64, a2: u64) ->
                 if !crate::process::has_children(parent_pid) {
                     return -10; // ECHILD — last child was reaped by another path
                 }
-                // Park until any child exits (EXIT_EVENT advances).
-                let snap = crate::process::exit_event_count();
+                // Park while no new exit event has occurred.
                 crate::process::CHILD_WAIT
                     .wait_while(|| crate::process::exit_event_count() == snap);
             }

--- a/kernel/src/init_process.rs
+++ b/kernel/src/init_process.rs
@@ -127,7 +127,10 @@ fn init_ring3_entry() -> ! {
 
     let pml4_frame = init_aspace.read().page_table_frame();
 
-    crate::task::replace_current_address_space(init_aspace, pml4_frame);
+    // Replace the task's address space, keeping the old Arc alive until after
+    // the CR3 switch so the old PML4 frame stays valid for any IRQs that fire
+    // in the gap between the assignment and the write to CR3.
+    let _old_aspace = crate::task::replace_current_address_space(init_aspace, pml4_frame);
 
     // Switch to the init process's address space.
     unsafe {
@@ -136,6 +139,8 @@ fn init_ring3_entry() -> ! {
             x86_64::registers::control::Cr3Flags::empty(),
         );
     }
+    // _old_aspace is dropped here — after CR3 switch, safe to free the old PML4.
+    drop(_old_aspace);
     serial_println!("init: switched to process PML4");
 
     // Configure TSS.rsp[0] and SYSCALL_KERNEL_RSP to use this task's OWN

--- a/kernel/src/init_process.rs
+++ b/kernel/src/init_process.rs
@@ -1,65 +1,59 @@
 //! PID 1 / init process bootstrap.
 //!
-//! `launch(bytes)` loads a lower-half ELF from `bytes` into a fresh
-//! per-process PML4, allocates a user stack, then spawns a kernel task
-//! (`init_ring3_entry`) that switches to the process's address space and
-//! drops to ring-3 via `iretq`.
+//! `launch(bytes)` builds a complete `AddressSpace` for the init process —
+//! fresh PML4 + ELF segments loaded with VMA tracking — then spawns a
+//! kernel task (`init_ring3_entry`) that installs the address space and
+//! drops to ring-3 via `sysretq`.
 //!
-//! ## Relationship to the rest of the kernel
-//!
-//! After `launch` returns, the init process is queued in the scheduler
-//! as a normal task. Its kernel task function (`init_ring3_entry`) is
-//! the *only* ring-0 code running on behalf of the process; once it
-//! executes `iretq` it never returns. Subsequent entries into the kernel
-//! (syscalls, IRQs, exceptions from ring-3) use the dedicated
-//! `INIT_KERNEL_STACK` in `arch::x86_64::syscall`.
-//!
-//! ## PID
-//!
-//! PID assignment is intentionally minimal for this issue. Task IDs
-//! start at 1 for the first spawned task. The bootstrap task (task 0)
-//! and the shell / cursor-blink tasks occupy IDs 1…N. This module
-//! assigns the first spawned task ID as the init PID and stores it in
-//! `INIT_TASK_ID` so that `exit()` in the syscall dispatcher can
-//! identify init. A proper PID table is tracked in issue #123.
+//! Building the AddressSpace in `launch()` (not in `init_ring3_entry`) is
+//! necessary so `fork_address_space` can walk the VMA tree when the init
+//! process calls fork(). The ELF segments are registered as private VMAs
+//! with pre-populated `AnonObject` caches so CoW fork semantics apply.
 
+use alloc::sync::Arc;
 use core::sync::atomic::{AtomicU64, Ordering};
 
-use x86_64::structures::paging::{Page, PageTableFlags, PhysFrame, Size4KiB};
-use x86_64::{PhysAddr, VirtAddr};
+use spin::{Once, RwLock};
+use x86_64::structures::paging::{Page, PageTableFlags, Size4KiB};
+use x86_64::VirtAddr;
 
 use crate::arch::x86_64::syscall;
+use crate::mem::addrspace::AddressSpace;
+use crate::mem::vmobject::{AnonObject, VmObject};
+use crate::mem::vmatree::{Share, Vma};
 use crate::mem::{loader, paging};
 use crate::serial_println;
 
 /// User-space entry point — set by `launch` before the task runs.
 static INIT_ENTRY: AtomicU64 = AtomicU64::new(0);
 
-/// Physical address of the init process's PML4 — set by `launch`.
-static INIT_PML4_PHYS: AtomicU64 = AtomicU64::new(0);
+/// Pre-built init AddressSpace (with ELF VMAs and stack VMA).
+/// Consumed by `init_ring3_entry` on first and only use.
+static INIT_ADDRESS_SPACE: Once<Arc<RwLock<AddressSpace>>> = Once::new();
 
-/// Top of the single-page user stack allocated for init.
+/// Top of the single-page user stack allocated for init and exec children.
 /// VA layout: one page at `USER_STACK_PAGE_VA`; top = page_base + 4096.
-const USER_STACK_PAGE_VA: u64 = 0x7FFF_F000;
+pub const USER_STACK_PAGE_VA: u64 = 0x7FFF_F000;
 pub const USER_STACK_TOP: u64 = USER_STACK_PAGE_VA + 0x1000;
 
-/// Load `bytes` as the init ELF, allocate a user PML4 + stack, and
-/// spawn the ring-3 entry task. Returns the task ID of the init task.
+/// Load `bytes` as the init ELF, build a complete per-process
+/// `AddressSpace` (PML4 + ELF VMAs + stack), and spawn the ring-3 entry
+/// task. Returns the task ID of the init task.
 ///
 /// # Panics
 /// - If `bytes` is empty or fails ELF parsing.
 /// - If frame allocation or PTE installation fails.
 pub fn launch(bytes: &[u8]) -> usize {
-    // 1. Allocate a fresh per-process PML4 with the kernel upper-half
-    //    pre-populated so kernel code remains reachable after CR3 switch.
-    let pml4: PhysFrame<Size4KiB> = paging::new_task_pml4();
+    // 1. Build a fresh AddressSpace with a new PML4.
+    let mut aspace = AddressSpace::new_empty();
+    let pml4 = aspace.page_table_frame();
     serial_println!(
         "init: new PML4 at phys={:#x}",
         pml4.start_address().as_u64()
     );
 
-    // 2. Load the ELF into the lower-half of this PML4.
-    let image = match loader::load_user_elf(bytes, pml4) {
+    // 2. Load the ELF and populate VMA entries so fork can walk them.
+    let image = match loader::load_user_elf_with_vmas(bytes, pml4, &mut aspace) {
         Ok(img) => img,
         Err(e) => panic!("kernel panic: /init ELF load failed: {:?}", e),
     };
@@ -69,68 +63,73 @@ pub fn launch(bytes: &[u8]) -> usize {
         image.segments
     );
 
-    // 3. Allocate and map the user stack — one page at USER_STACK_PAGE_VA.
+    // 3. Allocate and map the user stack, then add it as a VMA so fork
+    //    copies it too.
     let stack_page = Page::<Size4KiB>::containing_address(VirtAddr::new(USER_STACK_PAGE_VA));
-    paging::map_in_pml4(
-        pml4,
-        stack_page,
-        PageTableFlags::PRESENT
-            | PageTableFlags::WRITABLE
-            | PageTableFlags::USER_ACCESSIBLE
-            | PageTableFlags::NO_EXECUTE,
-    )
-    .expect("init: user stack page allocation failed");
+    let stack_flags = PageTableFlags::PRESENT
+        | PageTableFlags::WRITABLE
+        | PageTableFlags::USER_ACCESSIBLE
+        | PageTableFlags::NO_EXECUTE;
+    let stack_frame = paging::map_in_pml4(pml4, stack_page, stack_flags)
+        .expect("init: user stack page allocation failed");
+
+    // Register the stack frame in an AnonObject so fork can track it.
+    let stack_obj = AnonObject::new(Some(1));
+    let stack_phys = stack_frame.start_address().as_u64();
+    stack_obj.insert_existing_frame(0, stack_phys);
+    let stack_start = USER_STACK_PAGE_VA as usize;
+    let stack_vma = Vma::new(
+        stack_start,
+        stack_start + 4096,
+        0x3, // PROT_READ|WRITE
+        stack_flags.bits(),
+        Share::Private,
+        stack_obj as Arc<dyn VmObject>,
+        0,
+    );
+    aspace.insert(stack_vma);
+
     serial_println!(
         "init: user stack at virt={:#x} top={:#x}",
         USER_STACK_PAGE_VA,
         USER_STACK_TOP
     );
 
-    // 4. Publish entry + PML4 for the spawned task to read.
+    // 4. Publish entry point and stash the address space.
     INIT_ENTRY.store(image.entry.as_u64(), Ordering::Release);
-    INIT_PML4_PHYS.store(pml4.start_address().as_u64(), Ordering::Release);
+    INIT_ADDRESS_SPACE.call_once(|| Arc::new(RwLock::new(aspace)));
 
-    // 5. Spawn the kernel task that will drop to ring-3.
-    //    task::spawn returns immediately; the task is queued.
-    crate::task::spawn(init_ring3_entry);
-    serial_println!("init: ring-3 entry task spawned");
-
-    // Return an approximation of the task ID. The first spawned task
-    // after task::init() gets ID 1 if the shell and cursor-blink tasks
-    // have already been spawned. We log this for diagnostics; a proper
-    // PID table is issue #123.
-    //
-    // NOTE: we cannot easily read the ID of the just-spawned task from
-    // here without reaching into scheduler internals. For this minimal
-    // implementation the caller doesn't need the exact ID.
-    1
+    // 5. Spawn the kernel task that will drop to ring-3 and register it
+    //    as PID 1 in the process table so fork()/exit()/wait() can track it.
+    let task_id = crate::task::spawn_and_get_id(init_ring3_entry);
+    crate::process::register_init(task_id);
+    serial_println!("init: ring-3 entry task spawned (task_id={task_id}, pid=1)");
+    task_id
 }
 
 /// Kernel task function for the init process. Runs once, drops to ring-3.
 ///
 /// Execution order:
-/// 1. Read INIT_PML4_PHYS and INIT_ENTRY (set by `launch`).
-/// 2. Update this task's stored CR3 so future context switches use the
-///    init process's PML4.
-/// 3. Write CR3 to switch to the init address space.
-/// 4. Configure TSS.rsp[0] and the SYSCALL kernel stack.
-/// 5. Execute `iretq` to ring-3 — never returns.
+/// 1. Take the pre-built `INIT_ADDRESS_SPACE` and install it on this task,
+///    replacing the empty one created by `Task::new_with_priority`.
+/// 2. Write CR3 to switch to the init address space.
+/// 3. Configure TSS.rsp[0] and the SYSCALL kernel stack.
+/// 4. Execute `sysretq` to ring-3 — never returns.
 fn init_ring3_entry() -> ! {
     let entry = INIT_ENTRY.load(Ordering::Acquire);
-    let pml4_phys = INIT_PML4_PHYS.load(Ordering::Acquire);
-
     assert!(entry != 0, "init_ring3_entry: INIT_ENTRY not set");
-    assert!(pml4_phys != 0, "init_ring3_entry: INIT_PML4_PHYS not set");
 
-    let pml4_frame = PhysFrame::<Size4KiB>::containing_address(PhysAddr::new(pml4_phys));
+    // Replace this task's (empty) address space with the pre-built one.
+    let init_aspace = INIT_ADDRESS_SPACE
+        .get()
+        .expect("init_ring3_entry: INIT_ADDRESS_SPACE not set")
+        .clone();
 
-    // Update this task's saved CR3 so context switches back to init use
-    // the init process's PML4.
-    crate::task::update_current_cr3(pml4_frame);
+    let pml4_frame = init_aspace.read().page_table_frame();
 
-    // Switch to the init process's address space. The upper half (kernel
-    // mappings) is identical to the current PML4 so code execution is
-    // uninterrupted.
+    crate::task::replace_current_address_space(init_aspace, pml4_frame);
+
+    // Switch to the init process's address space.
     unsafe {
         x86_64::registers::control::Cr3::write(
             pml4_frame,
@@ -139,9 +138,11 @@ fn init_ring3_entry() -> ! {
     }
     serial_println!("init: switched to process PML4");
 
-    // Configure TSS.rsp[0] so interrupts from ring-3 land on a valid
-    // kernel stack, and SYSCALL_KERNEL_RSP for the syscall path.
-    syscall::setup_ring3_stacks();
+    // Configure TSS.rsp[0] and SYSCALL_KERNEL_RSP to use this task's OWN
+    // kernel stack, not the shared INIT_KERNEL_STACK. This is required for
+    // multi-process correctness: each user-space task needs its own SYSCALL
+    // stack so concurrent/parallel syscalls don't clobber each other.
+    crate::task::arm_ring3_syscall_stack();
 
     serial_println!(
         "init: entering ring-3 entry={:#x} stack={:#x}",

--- a/kernel/src/init_process.rs
+++ b/kernel/src/init_process.rs
@@ -19,8 +19,8 @@ use x86_64::VirtAddr;
 
 use crate::arch::x86_64::syscall;
 use crate::mem::addrspace::AddressSpace;
-use crate::mem::vmobject::{AnonObject, VmObject};
 use crate::mem::vmatree::{Share, Vma};
+use crate::mem::vmobject::{AnonObject, VmObject};
 use crate::mem::{loader, paging};
 use crate::serial_println;
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -38,9 +38,9 @@ pub mod hpet;
 #[cfg(target_os = "none")]
 pub mod init_process;
 #[cfg(target_os = "none")]
-pub mod process;
-#[cfg(target_os = "none")]
 pub mod ksymtab;
+#[cfg(target_os = "none")]
+pub mod process;
 #[cfg(target_os = "none")]
 pub mod serial;
 #[cfg(target_os = "none")]

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -38,6 +38,8 @@ pub mod hpet;
 #[cfg(target_os = "none")]
 pub mod init_process;
 #[cfg(target_os = "none")]
+pub mod process;
+#[cfg(target_os = "none")]
 pub mod ksymtab;
 #[cfg(target_os = "none")]
 pub mod serial;

--- a/kernel/src/mem/addrspace.rs
+++ b/kernel/src/mem/addrspace.rs
@@ -165,6 +165,53 @@ impl AddressSpace {
         self.page_table
     }
 
+    /// Unmap all user-half VMAs and their PTE frames, free L1/L2/L3
+    /// intermediate page-table frames, and reset the `brk`/`mmap` layout —
+    /// but keep the PML4 frame and its kernel upper-half entries intact.
+    ///
+    /// Used by `execve()` to clear the old process image before loading
+    /// a new ELF into the same address-space slot. After this call the
+    /// lower half of the PML4 is empty and ready for `load_user_elf`.
+    #[cfg(target_os = "none")]
+    pub fn clear_for_exec(&mut self) {
+        use crate::mem::paging;
+        use x86_64::structures::paging::{FrameDeallocator, Page, Size4KiB};
+
+        let pml4 = self.page_table;
+        for vma in self.vmas.iter() {
+            let mut va = vma.start;
+            while va < vma.end {
+                let page = Page::<Size4KiB>::from_start_address(VirtAddr::new(va as u64))
+                    .expect("vma page VA aligned");
+                if let Ok(pte_frame) = paging::unmap_in_pml4(pml4, page) {
+                    // SAFETY: frame belongs to this address space.
+                    unsafe {
+                        paging::KernelFrameAllocator.deallocate_frame(pte_frame);
+                    }
+                }
+                va += 4096;
+            }
+        }
+        // Drop all VMA objects (releases AnonObject caches and their frames).
+        self.vmas = crate::mem::vmatree::VmaTree::new();
+        self.vm_pages = 0;
+        self.rss_pages = 0;
+
+        // Free the now-empty L1/L2/L3 page-table frames in the user half.
+        // SAFETY: all leaf PTEs were removed above; the PML4 itself stays.
+        unsafe {
+            paging::free_user_page_tables(pml4);
+        }
+
+        // Reset brk/mmap to the constructor defaults so the new process
+        // image starts with a clean virtual-address layout.
+        let mmap_base = VirtAddr::new(0x0000_0000_4000_0000);
+        self.mmap_base = mmap_base;
+        self.brk_start = mmap_base;
+        self.brk_cur = mmap_base;
+        self.brk_max = VirtAddr::new(mmap_base.as_u64() - DEFAULT_BRK_GUARD);
+    }
+
     /// Insert `vma` into the VMA tree, merging with adjacent neighbours
     /// where possible. Panics if `vma` overlaps any existing entry —
     /// overlapping VMAs are a programmer error.

--- a/kernel/src/mem/elf.rs
+++ b/kernel/src/mem/elf.rs
@@ -202,6 +202,22 @@ pub(crate) fn first_loaded_module_bytes() -> Option<&'static [u8]> {
     Some(unsafe { core::slice::from_raw_parts(base, size) })
 }
 
+/// Return the raw bytes of the `userspace_hello.elf` Limine module, or
+/// `None` if the module was not loaded. Used by the `execve` syscall to
+/// replace the calling process's image with a fresh ELF payload.
+#[cfg(target_os = "none")]
+pub(crate) fn hello_module_bytes() -> Option<&'static [u8]> {
+    let resp = crate::boot::MODULE_REQUEST.get_response()?;
+    let file = resp
+        .modules()
+        .iter()
+        .find(|f| f.path().to_bytes().ends_with(b"/boot/userspace_hello.elf"))?;
+    let base = file.addr();
+    let size = file.size() as usize;
+    // SAFETY: same lifetime guarantee as first_loaded_module_bytes.
+    Some(unsafe { core::slice::from_raw_parts(base, size) })
+}
+
 #[cfg(target_os = "none")]
 pub(crate) fn first_loaded_module_elf_summary() -> Option<(VirtAddr, usize)> {
     let resp = crate::boot::MODULE_REQUEST.get_response()?;

--- a/kernel/src/mem/loader.rs
+++ b/kernel/src/mem/loader.rs
@@ -23,6 +23,8 @@ use x86_64::structures::paging::mapper::MapToError;
 use x86_64::structures::paging::{Page, PageTableFlags, PhysFrame, Size4KiB};
 use x86_64::VirtAddr;
 
+use alloc::sync::Arc;
+
 use super::elf;
 use super::paging;
 use super::tlb::Flusher;
@@ -139,6 +141,59 @@ pub fn load_user_elf(bytes: &[u8], pml4: PhysFrame<Size4KiB>) -> Result<LoadedIm
     }
 
     Ok(LoadedImage { entry, segments })
+}
+
+/// Load `bytes` as a lower-half ELF into `pml4` AND register each
+/// `PT_LOAD` segment as a `Share::Private` VMA in `address_space` with
+/// a pre-populated `AnonObject` cache. This lets `fork_address_space`
+/// walk the segments when forking a process that was bootstrapped via
+/// the ELF loader.
+///
+/// Each frame allocated by the loader is inserted into the AnonObject
+/// cache with an extra reference count so the cache and PTE both hold
+/// independent references, matching the invariant `AnonObject::fault`
+/// establishes for demand-paged frames.
+#[cfg(target_os = "none")]
+pub fn load_user_elf_with_vmas(
+    bytes: &[u8],
+    pml4: PhysFrame<Size4KiB>,
+    address_space: &mut super::addrspace::AddressSpace,
+) -> Result<LoadedImage, LoadError> {
+    use super::vmobject::{AnonObject, VmObject};
+    use super::vmatree::{Share, Vma};
+    use x86_64::VirtAddr;
+
+    let image = load_user_elf(bytes, pml4)?;
+
+    let parsed = elf::try_parse_elf64(bytes).ok_or(LoadError::NotElf64)?;
+    for seg in parsed.load_segments() {
+        if seg.vaddr.as_u64() >= UPPER_HALF_START {
+            continue;
+        }
+        let page_count = seg.memsz.div_ceil(PAGE_SIZE) as usize;
+        let start = seg.vaddr.as_u64() as usize;
+        let end = start + page_count * PAGE_SIZE as usize;
+        let obj = AnonObject::new(Some(page_count));
+
+        // Pre-populate the cache with the frames the loader just mapped.
+        for i in 0..page_count {
+            let va = VirtAddr::new(seg.vaddr.as_u64() + i as u64 * PAGE_SIZE);
+            if let Some((frame, _)) = paging::translate_in_pml4(pml4, va) {
+                let phys = frame.start_address().as_u64();
+                // insert_existing_frame increments refcount by 1 for the
+                // cache reference. The PTE reference was set by load_user_elf.
+                obj.insert_existing_frame(i, phys);
+            }
+        }
+
+        let prot_pte = (seg.flags
+            | x86_64::structures::paging::PageTableFlags::USER_ACCESSIBLE)
+            .bits();
+        let vma = Vma::new(start, end, 0x3, prot_pte, Share::Private, obj as Arc<dyn VmObject>, 0);
+        address_space.insert(vma);
+    }
+
+    Ok(image)
 }
 
 fn map_user_segment(

--- a/kernel/src/mem/loader.rs
+++ b/kernel/src/mem/loader.rs
@@ -159,8 +159,8 @@ pub fn load_user_elf_with_vmas(
     pml4: PhysFrame<Size4KiB>,
     address_space: &mut super::addrspace::AddressSpace,
 ) -> Result<LoadedImage, LoadError> {
-    use super::vmobject::{AnonObject, VmObject};
     use super::vmatree::{Share, Vma};
+    use super::vmobject::{AnonObject, VmObject};
     use x86_64::VirtAddr;
 
     let image = load_user_elf(bytes, pml4)?;
@@ -186,10 +186,17 @@ pub fn load_user_elf_with_vmas(
             }
         }
 
-        let prot_pte = (seg.flags
-            | x86_64::structures::paging::PageTableFlags::USER_ACCESSIBLE)
-            .bits();
-        let vma = Vma::new(start, end, 0x3, prot_pte, Share::Private, obj as Arc<dyn VmObject>, 0);
+        let prot_pte =
+            (seg.flags | x86_64::structures::paging::PageTableFlags::USER_ACCESSIBLE).bits();
+        let vma = Vma::new(
+            start,
+            end,
+            0x3,
+            prot_pte,
+            Share::Private,
+            obj as Arc<dyn VmObject>,
+            0,
+        );
         address_space.insert(vma);
     }
 

--- a/kernel/src/mem/mod.rs
+++ b/kernel/src/mem/mod.rs
@@ -116,3 +116,11 @@ pub fn userspace_module_elf_summary() -> Option<(x86_64::VirtAddr, usize)> {
 pub fn userspace_module_elf_bytes() -> Option<&'static [u8]> {
     USERSPACE_MODULE_ELF_BYTES.get().copied().flatten()
 }
+
+/// Raw bytes of the `userspace_hello.elf` Limine module. Fetched on
+/// demand (not cached in a Once because it's only needed at exec time).
+/// Returns `None` if the module was not included in the ISO.
+#[cfg(target_os = "none")]
+pub fn userspace_hello_elf_bytes() -> Option<&'static [u8]> {
+    elf::hello_module_bytes()
+}

--- a/kernel/src/mem/mod.rs
+++ b/kernel/src/mem/mod.rs
@@ -44,6 +44,12 @@ static USERSPACE_MODULE_ELF_SUMMARY: Once<Option<(x86_64::VirtAddr, usize)>> = O
 #[cfg(target_os = "none")]
 static USERSPACE_MODULE_ELF_BYTES: Once<Option<&'static [u8]>> = Once::new();
 
+/// Cached bytes of the `userspace_hello.elf` Limine module, snapshotted during
+/// `init()` before BOOTLOADER_RECLAIMABLE is freed (same reason as
+/// `USERSPACE_MODULE_ELF_BYTES`).
+#[cfg(target_os = "none")]
+static USERSPACE_HELLO_ELF_BYTES: Once<Option<&'static [u8]>> = Once::new();
+
 /// 4 KiB. The only page size we care about right now.
 pub const FRAME_SIZE: u64 = 4096;
 
@@ -88,6 +94,7 @@ pub fn init() {
     // valid after reclaim; only Limine's response structs go away.
     USERSPACE_MODULE_ELF_BYTES.call_once(elf::first_loaded_module_bytes);
     USERSPACE_MODULE_ELF_SUMMARY.call_once(elf::first_loaded_module_elf_summary);
+    USERSPACE_HELLO_ELF_BYTES.call_once(elf::hello_module_bytes);
 
     heap::init();
     crate::arch::x86_64::ist_guard::install();
@@ -117,10 +124,10 @@ pub fn userspace_module_elf_bytes() -> Option<&'static [u8]> {
     USERSPACE_MODULE_ELF_BYTES.get().copied().flatten()
 }
 
-/// Raw bytes of the `userspace_hello.elf` Limine module. Fetched on
-/// demand (not cached in a Once because it's only needed at exec time).
-/// Returns `None` if the module was not included in the ISO.
+/// Raw bytes of the `userspace_hello.elf` Limine module, snapshotted during
+/// `init()` before `BOOTLOADER_RECLAIMABLE` is freed. Returns `None` if the
+/// module was not included in the ISO.
 #[cfg(target_os = "none")]
 pub fn userspace_hello_elf_bytes() -> Option<&'static [u8]> {
-    elf::hello_module_bytes()
+    USERSPACE_HELLO_ELF_BYTES.get().copied().flatten()
 }

--- a/kernel/src/mem/vmobject.rs
+++ b/kernel/src/mem/vmobject.rs
@@ -236,6 +236,27 @@ fn release_frame(_phys: u64) {
     tests::HOST_RELEASE_COUNT.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
 }
 
+/// Kernel-only methods on `AnonObject`.
+#[cfg(target_os = "none")]
+impl AnonObject {
+    /// Insert `phys` into the frame cache at page index `idx` and
+    /// increment its refcount by one for the cache's ownership.
+    ///
+    /// Use this when frames are pre-mapped into a PML4 by an external
+    /// loader (e.g. `load_user_elf`) and you want to retroactively
+    /// register them in an `AnonObject` so the VMA machinery can track
+    /// and fork them correctly.
+    ///
+    /// The caller must ensure that `phys` already has a PTE reference
+    /// (refcount ≥ 1). This method adds the cache reference on top.
+    pub fn insert_existing_frame(&self, idx: usize, phys: u64) {
+        self.inner.lock().frames.insert(idx, phys);
+        // Add the cache's reference. The PTE reference was set by the
+        // original allocator/mapper; we are adding one more here.
+        crate::mem::refcount::inc_refcount(phys);
+    }
+}
+
 #[cfg(test)]
 impl AnonObject {
     /// Test-only: inject a synthetic frame address for page `idx` so

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -1,0 +1,205 @@
+//! Kernel process table — PID allocation, parent/child tracking, and the
+//! wait/exit rendezvous. One `ProcessEntry` exists per live or zombie user
+//! process; the table maps `pid → entry` and `task_id → pid`.
+//!
+//! ## Lock ordering
+//!
+//! `TABLE` → `SCHED` (task module) is forbidden. `TABLE` is always released
+//! before calling any function that may take `SCHED`. In practice the only
+//! cross-lock path is `mark_zombie` → `CHILD_WAIT.notify_all()` →
+//! `task::wake(id)` → `SCHED`, which is safe because `TABLE` is dropped
+//! before the notify call.
+
+use alloc::collections::BTreeMap;
+use core::sync::atomic::{AtomicU32, AtomicU32 as ExitEvent, Ordering};
+
+use spin::{Lazy, Mutex};
+
+use crate::sync::WaitQueue;
+
+/// Scheduling / lifecycle state of a process entry.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ProcessState {
+    Alive,
+    /// Exit status recorded; waiting to be reaped by the parent.
+    Zombie,
+}
+
+/// One entry in the process table.
+pub struct ProcessEntry {
+    /// This process's PID.
+    pub pid: u32,
+    /// Scheduler task ID for the thread of execution.
+    pub task_id: usize,
+    /// PID of the parent that spawned this process. `0` = kernel.
+    pub parent_pid: u32,
+    /// Recorded exit status (meaningful only when `state == Zombie`).
+    pub exit_status: Option<i32>,
+    /// Whether the process is still alive or waiting to be reaped.
+    pub state: ProcessState,
+}
+
+struct Table {
+    by_pid: BTreeMap<u32, ProcessEntry>,
+    /// Reverse map: scheduler task id → pid.
+    pid_of: BTreeMap<usize, u32>,
+}
+
+impl Table {
+    const fn new() -> Self {
+        Self {
+            by_pid: BTreeMap::new(),
+            pid_of: BTreeMap::new(),
+        }
+    }
+}
+
+/// Monotonic PID allocator. PID 1 is assigned explicitly by
+/// `register_init`; subsequent processes start at 2.
+static NEXT_PID: AtomicU32 = AtomicU32::new(2);
+
+/// Incremented each time any process transitions to Zombie. Used by
+/// `waitpid` to wait without holding TABLE lock inside WaitQueue.
+static EXIT_EVENT: ExitEvent = AtomicU32::new(0);
+
+/// All wait()-ing parents sleep on this queue until a child exits.
+pub static CHILD_WAIT: Lazy<WaitQueue> = Lazy::new(WaitQueue::new);
+
+static TABLE: Lazy<Mutex<Table>> = Lazy::new(|| Mutex::new(Table::new()));
+
+// --- public API ---
+
+/// Register PID 1 (the init process) with a specific task id.
+/// Must be called exactly once, before any `fork()`.
+pub fn register_init(task_id: usize) {
+    let mut t = TABLE.lock();
+    t.by_pid.insert(
+        1,
+        ProcessEntry {
+            pid: 1,
+            task_id,
+            parent_pid: 0,
+            exit_status: None,
+            state: ProcessState::Alive,
+        },
+    );
+    t.pid_of.insert(task_id, 1);
+}
+
+/// Allocate a new PID and insert a live entry for `task_id` with
+/// `parent_pid` as parent. Returns the new PID.
+pub fn register(task_id: usize, parent_pid: u32) -> u32 {
+    let pid = NEXT_PID.fetch_add(1, Ordering::Relaxed);
+    let mut t = TABLE.lock();
+    t.by_pid.insert(
+        pid,
+        ProcessEntry {
+            pid,
+            task_id,
+            parent_pid,
+            exit_status: None,
+            state: ProcessState::Alive,
+        },
+    );
+    t.pid_of.insert(task_id, pid);
+    pid
+}
+
+/// Return the PID of the currently-running task, or `0` if the running
+/// task has no process table entry (e.g. the bootstrap kernel task).
+pub fn current_pid() -> u32 {
+    let task_id = crate::task::current_id();
+    TABLE
+        .lock()
+        .pid_of
+        .get(&task_id)
+        .copied()
+        .unwrap_or(0)
+}
+
+/// Mark `pid` as a zombie with `exit_status`, then wake any parents
+/// sleeping in `waitpid`. TABLE is released before notify to satisfy
+/// the lock-ordering rule described in the module docs.
+pub fn mark_zombie(pid: u32, status: i32) {
+    {
+        let mut t = TABLE.lock();
+        if let Some(entry) = t.by_pid.get_mut(&pid) {
+            entry.state = ProcessState::Zombie;
+            entry.exit_status = Some(status);
+        }
+    }
+    // Bump the event counter so wait_while predicates can check it
+    // atomically without taking TABLE.
+    EXIT_EVENT.fetch_add(1, Ordering::Release);
+    CHILD_WAIT.notify_all();
+}
+
+/// Return the current value of the exit-event counter. `waitpid` uses
+/// this to detect new zombie children without taking TABLE inside the
+/// WaitQueue predicate (which would invert the TABLE → WaitQueue order).
+pub fn exit_event_count() -> u32 {
+    EXIT_EVENT.load(Ordering::Acquire)
+}
+
+/// Try to reap one zombie child of `parent_pid`. If `target_pid >= 0`,
+/// only that specific child is considered; pass `-1` to reap any child.
+///
+/// Returns `Some((child_pid, exit_status))` on success, `None` if no
+/// matching zombie child exists.
+pub fn reap_child(parent_pid: u32, target_pid: i32) -> Option<(u32, i32)> {
+    let mut t = TABLE.lock();
+    let zombie_pid = t
+        .by_pid
+        .values()
+        .find(|e| {
+            e.parent_pid == parent_pid
+                && e.state == ProcessState::Zombie
+                && (target_pid < 0 || e.pid == target_pid as u32)
+        })
+        .map(|e| e.pid);
+
+    zombie_pid.map(|pid| {
+        let entry = t.by_pid.remove(&pid).unwrap();
+        // Remove the reverse task_id → pid mapping for the zombie.
+        t.pid_of.retain(|_, &mut p| p != pid);
+        (pid, entry.exit_status.unwrap_or(0))
+    })
+}
+
+/// Returns `true` if `parent_pid` has at least one child (alive or
+/// zombie) in the process table.
+pub fn has_children(parent_pid: u32) -> bool {
+    TABLE
+        .lock()
+        .by_pid
+        .values()
+        .any(|e| e.parent_pid == parent_pid)
+}
+
+/// Reparent all children of `dead_pid` to PID 1 so they are not left
+/// orphaned. Called by the `exit()` syscall before marking the process
+/// as a zombie.
+pub fn reparent_children(dead_pid: u32) {
+    let mut t = TABLE.lock();
+    for entry in t.by_pid.values_mut() {
+        if entry.parent_pid == dead_pid {
+            entry.parent_pid = 1;
+        }
+    }
+}
+
+/// Update the task_id stored for `pid` (needed after exec() replaces
+/// the task identity under the same PID).
+#[allow(dead_code)]
+pub fn update_task_id(pid: u32, new_task_id: usize) {
+    let mut t = TABLE.lock();
+    // Remove stale reverse entry.
+    if let Some(entry) = t.by_pid.get(&pid) {
+        let old = entry.task_id;
+        t.pid_of.remove(&old);
+    }
+    if let Some(entry) = t.by_pid.get_mut(&pid) {
+        entry.task_id = new_task_id;
+    }
+    t.pid_of.insert(new_task_id, pid);
+}

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -109,12 +109,7 @@ pub fn register(task_id: usize, parent_pid: u32) -> u32 {
 /// task has no process table entry (e.g. the bootstrap kernel task).
 pub fn current_pid() -> u32 {
     let task_id = crate::task::current_id();
-    TABLE
-        .lock()
-        .pid_of
-        .get(&task_id)
-        .copied()
-        .unwrap_or(0)
+    TABLE.lock().pid_of.get(&task_id).copied().unwrap_or(0)
 }
 
 /// Mark `pid` as a zombie with `exit_status`, then wake any parents

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -137,9 +137,7 @@ pub fn fork_current_task(
     // CoW-clone the address space (requires AddressSpace write lock).
     let child_aspace = {
         let mut tlb = crate::mem::tlb::Flusher::new_active();
-        let child = parent_address_space
-            .write()
-            .fork_address_space(&mut tlb)?;
+        let child = parent_address_space.write().fork_address_space(&mut tlb)?;
         tlb.finish();
         child
     };
@@ -706,7 +704,13 @@ pub fn exit() -> ! {
         // reap it until a later tick, so the heap location remains
         // valid for this context_switch's single write.
         let prev_rsp_ptr: *mut usize = &mut prev_ref.rsp as *mut usize;
-        (prev_rsp_ptr, next_rsp, next_cr3, next_fpu_ptr, next_syscall_top)
+        (
+            prev_rsp_ptr,
+            next_rsp,
+            next_cr3,
+            next_fpu_ptr,
+            next_syscall_top,
+        )
     };
     // SAFETY: IRQs are masked, SCHED is dropped, prev_rsp_ptr targets
     // a stable heap location, next_cr3 is a valid per-task PML4,

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -542,8 +542,10 @@ pub fn update_current_cr3(
 }
 
 /// Replace the current task's address space and CR3 with a pre-built
-/// `AddressSpace`. The old (empty) address space that `Task::new_with_priority`
-/// allocated is dropped, freeing its PML4 frame.
+/// `AddressSpace`. Returns the *old* `Arc` so the caller can drop it **after**
+/// the CPU's CR3 has been switched away — dropping it here would free the
+/// old PML4 frame while it is still the active page table root, creating a
+/// use-after-free if an interrupt fires in the gap.
 ///
 /// Called from `init_ring3_entry` to install the address space that was
 /// prepared in `init_process::launch` (which includes ELF VMA entries and
@@ -551,15 +553,15 @@ pub fn update_current_cr3(
 pub fn replace_current_address_space(
     aspace: alloc::sync::Arc<spin::RwLock<crate::mem::addrspace::AddressSpace>>,
     cr3: x86_64::structures::paging::PhysFrame<x86_64::structures::paging::Size4KiB>,
-) {
+) -> alloc::sync::Arc<spin::RwLock<crate::mem::addrspace::AddressSpace>> {
     let mut sched = SCHED.lock();
     let current = sched
         .current
         .as_mut()
         .expect("replace_current_address_space: no running task");
-    // The old address_space Arc is dropped here, which frees the empty PML4.
-    current.address_space = aspace;
+    let old = core::mem::replace(&mut current.address_space, aspace);
     current.cr3 = cr3;
+    old // caller must drop this AFTER switching CR3
 }
 
 /// Prepare the current task to run in ring-3: configure TSS.rsp[0] and

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -88,6 +88,119 @@ pub fn spawn_with_priority(entry: fn() -> !, priority: u8) {
     maybe_preempt_current_for_priority(&mut sched, new_prio);
 }
 
+/// Like [`spawn`] but returns the newly-assigned task ID.
+/// Used by `init_process::launch` to register PID 1 with the correct ID.
+pub fn spawn_and_get_id(entry: fn() -> !) -> usize {
+    let task = Box::new(Task::new_with_priority(entry, DEFAULT_PRIORITY));
+    let id = task.id;
+    let new_prio = task.priority;
+    let mut sched = SCHED.lock();
+    sched.push_ready(task);
+    maybe_preempt_current_for_priority(&mut sched, new_prio);
+    id
+}
+
+/// Clone the current task's address space and fd table for a fork child,
+/// allocate a new kernel stack, push the child onto the ready queue, and
+/// return the child's task ID.
+///
+/// `user_rip`, `user_rflags`, `user_rsp` are the ring-3 register state
+/// saved by the SYSCALL entry before invoking `syscall_dispatch`.
+pub fn fork_current_task(
+    user_rip: u64,
+    user_rflags: u64,
+    user_rsp: u64,
+) -> Result<usize, crate::mem::addrspace::ForkError> {
+    use alloc::sync::Arc;
+    use spin::{Mutex, RwLock};
+
+    // Snapshot everything needed from the current task while holding
+    // SCHED, then release it before calling fork_address_space.
+    let (parent_address_space, parent_fd_table, parent_priority, parent_affinity, parent_fpu_ptr) = {
+        let sched = SCHED.lock();
+        let cur = sched
+            .current
+            .as_ref()
+            .expect("fork_current_task: no running task");
+        (
+            Arc::clone(&cur.address_space),
+            Arc::clone(&cur.fd_table),
+            cur.priority,
+            cur.affinity,
+            // SAFETY: the parent Task is the currently-running task and stays
+            // alive in SCHED for the duration of this syscall. We only read
+            // the FPU area during the new_forked call below.
+            &*cur.fpu as *const crate::arch::x86_64::fpu::FpuArea,
+        )
+    };
+
+    // CoW-clone the address space (requires AddressSpace write lock).
+    let child_aspace = {
+        let mut tlb = crate::mem::tlb::Flusher::new_active();
+        let child = parent_address_space
+            .write()
+            .fork_address_space(&mut tlb)?;
+        tlb.finish();
+        child
+    };
+    let child_cr3 = child_aspace.page_table_frame();
+    let child_aspace = Arc::new(RwLock::new(child_aspace));
+
+    // Clone the fd table (slot-independent, description-shared).
+    let child_fd = Arc::new(Mutex::new(parent_fd_table.lock().clone_for_fork()));
+
+    // SAFETY: parent_fpu_ptr was snapshotted while SCHED was held; the
+    // parent task is the currently-running task and cannot be removed while
+    // we are executing in its syscall context (single-CPU kernel).
+    let child = unsafe {
+        Task::new_forked(
+            user_rip,
+            user_rflags,
+            user_rsp,
+            parent_priority,
+            parent_affinity,
+            parent_fpu_ptr,
+            child_aspace,
+            child_cr3,
+            child_fd,
+        )
+    };
+    let child_id = child.id;
+    let child_box = Box::new(child);
+    let new_prio = child_box.priority;
+    let mut sched = SCHED.lock();
+    sched.push_ready(child_box);
+    maybe_preempt_current_for_priority(&mut sched, new_prio);
+    Ok(child_id)
+}
+
+/// Return the `Arc<RwLock<AddressSpace>>` of the currently-running task.
+/// Used by the exec() syscall to clear and reload the address space.
+///
+/// # Panics
+/// Panics if called before `task::init`.
+pub fn current_address_space() -> alloc::sync::Arc<spin::RwLock<crate::mem::addrspace::AddressSpace>>
+{
+    SCHED
+        .lock()
+        .current
+        .as_ref()
+        .expect("current_address_space: no running task")
+        .address_space
+        .clone()
+}
+
+/// Return the CR3 frame of the currently-running task.
+pub fn current_cr3() -> x86_64::structures::paging::PhysFrame<x86_64::structures::paging::Size4KiB>
+{
+    SCHED
+        .lock()
+        .current
+        .as_ref()
+        .expect("current_cr3: no running task")
+        .cr3
+}
+
 /// Like [`spawn_with_priority`] but accepts a UNIX-style nice value
 /// (`-20..=19`). Wrapper for API ergonomics — mapping lives in
 /// [`priority_from_nice`].
@@ -430,6 +543,59 @@ pub fn update_current_cr3(
     current.cr3 = frame;
 }
 
+/// Replace the current task's address space and CR3 with a pre-built
+/// `AddressSpace`. The old (empty) address space that `Task::new_with_priority`
+/// allocated is dropped, freeing its PML4 frame.
+///
+/// Called from `init_ring3_entry` to install the address space that was
+/// prepared in `init_process::launch` (which includes ELF VMA entries and
+/// a stack VMA so fork works correctly).
+pub fn replace_current_address_space(
+    aspace: alloc::sync::Arc<spin::RwLock<crate::mem::addrspace::AddressSpace>>,
+    cr3: x86_64::structures::paging::PhysFrame<x86_64::structures::paging::Size4KiB>,
+) {
+    let mut sched = SCHED.lock();
+    let current = sched
+        .current
+        .as_mut()
+        .expect("replace_current_address_space: no running task");
+    // The old address_space Arc is dropped here, which frees the empty PML4.
+    current.address_space = aspace;
+    current.cr3 = cr3;
+}
+
+/// Prepare the current task to run in ring-3: configure TSS.rsp[0] and
+/// `SYSCALL_KERNEL_RSP` to point at the TOP of this task's own kernel stack
+/// so ring-3 syscalls and exceptions land on a per-task stack (not the shared
+/// `INIT_KERNEL_STACK`). Also records `syscall_stack_top` in the task so
+/// the preempt/block paths can restore it when context-switching back here.
+///
+/// Must be called from the task's kernel entry function (e.g.
+/// `init_ring3_entry`) *before* jumping to ring-3 with `jump_to_ring3`.
+pub fn arm_ring3_syscall_stack() {
+    use crate::arch::x86_64::gdt::set_tss_rsp0;
+    use crate::arch::x86_64::syscall::SYSCALL_KERNEL_RSP;
+    use core::sync::atomic::Ordering;
+    // GUARD_SIZE=4096 and STACK_SIZE=16*1024 from task.rs (private constants;
+    // replicated here to avoid visibility issues — must stay in sync with task.rs).
+    const GUARD_SIZE: usize = 4096;
+    const STACK_SIZE: usize = 16 * 1024;
+
+    let stack_top = {
+        let mut sched = SCHED.lock();
+        let current = sched
+            .current
+            .as_mut()
+            .expect("arm_ring3_syscall_stack: no running task");
+        let top = (current.guard_base + GUARD_SIZE + STACK_SIZE) as u64;
+        current.syscall_stack_top = top;
+        top
+    };
+    // Point the SYSCALL entry and IRQ entry stacks at the task's own stack.
+    SYSCALL_KERNEL_RSP.store(stack_top, Ordering::Relaxed);
+    set_tss_rsp0(stack_top);
+}
+
 /// Install a VMA on the currently-running task. The VMA is resolved
 /// lazily by the `#PF` handler on first touch of each page via
 /// [`VmObject::fault`].
@@ -505,7 +671,7 @@ pub fn current_vma_lookup(
 ///   inherited boot stack, neither of which the reaper may reclaim.
 pub fn exit() -> ! {
     interrupts::disable();
-    let (prev_rsp_ptr, next_rsp, next_cr3, next_fpu_ptr) = {
+    let (prev_rsp_ptr, next_rsp, next_cr3, next_fpu_ptr, next_syscall_top) = {
         let mut sched = SCHED.lock();
         // Exiting the bootstrap task would reap the kernel PML4 and
         // the inherited boot stack — neither of which we own. Reject
@@ -530,6 +696,7 @@ pub fn exit() -> ! {
         sched.current = Some(next);
         sched.current.as_mut().unwrap().slice_remaining_ms = DEFAULT_SLICE_MS;
         let next_fpu_ptr: *const fpu::FpuArea = &*sched.current.as_ref().unwrap().fpu;
+        let next_syscall_top = sched.current.as_ref().unwrap().syscall_stack_top;
         // Enqueue the doomed task; the next `preempt_tick` drains the
         // whole queue. Back-to-back exits between ticks just append.
         sched.pending_exit.push_back(prev);
@@ -539,7 +706,7 @@ pub fn exit() -> ! {
         // reap it until a later tick, so the heap location remains
         // valid for this context_switch's single write.
         let prev_rsp_ptr: *mut usize = &mut prev_ref.rsp as *mut usize;
-        (prev_rsp_ptr, next_rsp, next_cr3, next_fpu_ptr)
+        (prev_rsp_ptr, next_rsp, next_cr3, next_fpu_ptr, next_syscall_top)
     };
     // SAFETY: IRQs are masked, SCHED is dropped, prev_rsp_ptr targets
     // a stable heap location, next_cr3 is a valid per-task PML4,
@@ -547,6 +714,12 @@ pub fn exit() -> ! {
     // We intentionally skip `fpu::save` — the exiting task is doomed.
     unsafe {
         fpu::restore(&*next_fpu_ptr);
+        if next_syscall_top != 0 {
+            use core::sync::atomic::Ordering;
+            crate::arch::x86_64::syscall::SYSCALL_KERNEL_RSP
+                .store(next_syscall_top, Ordering::Relaxed);
+            crate::arch::x86_64::gdt::set_tss_rsp0(next_syscall_top);
+        }
         context_switch(prev_rsp_ptr, next_rsp, next_cr3);
     }
     unreachable!("task::exit returned from context_switch");
@@ -685,6 +858,7 @@ pub fn preempt_tick() {
     // still hold the mutable borrow; we'll dereference it after the
     // lock is dropped.
     let next_fpu_ptr: *const fpu::FpuArea = &*sched.current.as_ref().unwrap().fpu;
+    let next_syscall_top = sched.current.as_ref().unwrap().syscall_stack_top;
     sched.push_ready(prev);
     // The push above put `prev` at the back of its priority's queue;
     // retrieve the pointer through the bank to keep the Box-stability
@@ -711,6 +885,16 @@ pub fn preempt_tick() {
     unsafe {
         fpu::save(&mut *prev_fpu_ptr);
         fpu::restore(&*next_fpu_ptr);
+        // Update the SYSCALL/TSS stack pointer to the incoming task's
+        // own per-task kernel stack, if it has one. This prevents ring-3
+        // syscalls from the incoming task clobbering the shared INIT_KERNEL_STACK
+        // state of other tasks that are blocked mid-syscall.
+        if next_syscall_top != 0 {
+            use core::sync::atomic::Ordering;
+            crate::arch::x86_64::syscall::SYSCALL_KERNEL_RSP
+                .store(next_syscall_top, Ordering::Relaxed);
+            crate::arch::x86_64::gdt::set_tss_rsp0(next_syscall_top);
+        }
         context_switch(prev_rsp_ptr, next_rsp, next_cr3);
     }
 }
@@ -751,7 +935,7 @@ pub fn block_current() {
     let was_on = interrupts::are_enabled();
     interrupts::disable();
 
-    let (prev_rsp_ptr, prev_fpu_ptr, next_fpu_ptr, next_rsp, next_cr3) = {
+    let (prev_rsp_ptr, prev_fpu_ptr, next_fpu_ptr, next_rsp, next_cr3, next_syscall_top) = {
         let mut sched = SCHED.lock();
 
         // Fast path: a prior wake() set wake_pending while we were
@@ -789,6 +973,7 @@ pub fn block_current() {
         sched.current = Some(next);
         sched.current.as_mut().unwrap().slice_remaining_ms = DEFAULT_SLICE_MS;
         let next_fpu_ptr: *const fpu::FpuArea = &*sched.current.as_ref().unwrap().fpu;
+        let next_syscall_top = sched.current.as_ref().unwrap().syscall_stack_top;
         sched.parked.insert(prev_id, prev);
 
         let prev_ref = sched
@@ -803,7 +988,14 @@ pub fn block_current() {
         let prev_rsp_ptr: *mut usize = &mut prev_ref.rsp as *mut usize;
         let prev_fpu_ptr: *mut fpu::FpuArea = &mut *prev_ref.fpu;
 
-        (prev_rsp_ptr, prev_fpu_ptr, next_fpu_ptr, next_rsp, next_cr3)
+        (
+            prev_rsp_ptr,
+            prev_fpu_ptr,
+            next_fpu_ptr,
+            next_rsp,
+            next_cr3,
+            next_syscall_top,
+        )
     };
 
     // SAFETY: IRQs are masked, the SCHED lock is dropped so the
@@ -814,6 +1006,12 @@ pub fn block_current() {
     unsafe {
         fpu::save(&mut *prev_fpu_ptr);
         fpu::restore(&*next_fpu_ptr);
+        if next_syscall_top != 0 {
+            use core::sync::atomic::Ordering;
+            crate::arch::x86_64::syscall::SYSCALL_KERNEL_RSP
+                .store(next_syscall_top, Ordering::Relaxed);
+            crate::arch::x86_64::gdt::set_tss_rsp0(next_syscall_top);
+        }
         context_switch(prev_rsp_ptr, next_rsp, next_cr3);
     }
 

--- a/kernel/src/task/switch.rs
+++ b/kernel/src/task/switch.rs
@@ -102,11 +102,14 @@ fork_child_sysret:
     //
     // SYSRETQ: rcx → RIP, r11 → RFLAGS, CS/SS switched to ring-3 selectors.
     //
-    // sti: IF was cleared by SFMASK on the parent's SYSCALL entry (which
-    // forked us). Re-enable interrupts so the child can be preempted.
-    sti
+    // Do NOT sti here: rbx already holds the parent's saved RFLAGS which
+    // includes IF=1 (user mode runs with interrupts enabled). SYSRETQ
+    // restores RFLAGS from r11, so IF is re-enabled atomically when the CPU
+    // transitions to ring-3. An explicit sti before the RSP switch would
+    // allow an IRQ to fire with a kernel-mode CS but a user-mode RSP,
+    // corrupting the user stack.
     mov rcx, r12      // user RIP
-    mov r11, rbx      // user RFLAGS
+    mov r11, rbx      // user RFLAGS (IF=1 → interrupts re-enabled by SYSRETQ)
     xor eax, eax      // return 0 — fork() child path
     mov rsp, rbp      // restore user RSP (switch stack before SYSRETQ)
     sysretq

--- a/kernel/src/task/switch.rs
+++ b/kernel/src/task/switch.rs
@@ -38,6 +38,16 @@ unsafe extern "C" {
     /// First-entry trampoline for a freshly primed task. The entry fn
     /// pointer is passed in `r12`; the trampoline just `call`s it.
     pub fn task_entry_trampoline();
+
+    /// First-entry trampoline for a fork child. Called by `context_switch`
+    /// when the child task is first scheduled. Callee-saved registers are
+    /// primed by `Task::new_forked` with the user-space context:
+    ///   r12 = user RIP  (→ rcx for SYSRETQ)
+    ///   rbp = user RSP  (→ rsp before SYSRETQ)
+    ///   rbx = user RFLAGS (→ r11 for SYSRETQ)
+    ///
+    /// Returns to ring-3 with rax=0 so the child sees 0 from fork().
+    pub fn fork_child_sysret();
 }
 
 global_asm!(
@@ -79,5 +89,26 @@ task_entry_trampoline:
     sti
     call r12
     ud2
+
+    .global fork_child_sysret
+fork_child_sysret:
+    // Called as the first instruction of a fork child after context_switch
+    // loads its primed kernel stack.
+    //
+    // Register state set by Task::new_forked priming:
+    //   r12 = user RIP   → loaded into rcx for SYSRETQ
+    //   rbp = user RSP   → loaded into rsp before SYSRETQ
+    //   rbx = user RFLAGS → loaded into r11 for SYSRETQ
+    //
+    // SYSRETQ: rcx → RIP, r11 → RFLAGS, CS/SS switched to ring-3 selectors.
+    //
+    // sti: IF was cleared by SFMASK on the parent's SYSCALL entry (which
+    // forked us). Re-enable interrupts so the child can be preempted.
+    sti
+    mov rcx, r12      // user RIP
+    mov r11, rbx      // user RFLAGS
+    xor eax, eax      // return 0 — fork() child path
+    mov rsp, rbp      // restore user RSP (switch stack before SYSRETQ)
+    sysretq
 "#
 );

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -33,7 +33,7 @@ use crate::mem::addrspace::AddressSpace;
 use crate::mem::paging;
 
 use super::priority::{AFFINITY_ALL, DEFAULT_PRIORITY};
-use super::switch::task_entry_trampoline;
+use super::switch::{fork_child_sysret, task_entry_trampoline};
 use super::DEFAULT_SLICE_MS;
 
 /// Scheduling state of a [`Task`].
@@ -134,6 +134,19 @@ pub(super) struct Task {
     /// can be shared across threads in the same process (clone(2)-style)
     /// and cloned cheaply for fork() and exec() paths.
     pub fd_table: Arc<Mutex<FileDescTable>>,
+
+    /// Top of this task's dedicated SYSCALL kernel stack (set when this
+    /// task runs in ring-3 and needs its own syscall entry point).
+    ///
+    /// `0` means "use the global `INIT_KERNEL_STACK`" — correct for
+    /// purely-kernel tasks that never execute SYSCALL from ring-3, and
+    /// for the init task before `init_ring3_entry` initialises it.
+    ///
+    /// Set to `guard_base + GUARD_SIZE + STACK_SIZE` for user-space
+    /// tasks. The preempt / block paths update `SYSCALL_KERNEL_RSP` to
+    /// this value whenever they switch into this task so that ring-3
+    /// syscalls land on the right per-task stack.
+    pub syscall_stack_top: u64,
 }
 
 impl Task {
@@ -163,6 +176,7 @@ impl Task {
             // at that moment.
             fpu: FpuArea::new_initialized(),
             fd_table: Arc::new(Mutex::new(FileDescTable::new_with_stdio())),
+            syscall_stack_top: 0,
         }
     }
 
@@ -251,6 +265,7 @@ impl Task {
             address_space: Arc::new(RwLock::new(address_space)),
             fpu: FpuArea::new_initialized(),
             fd_table: Arc::new(Mutex::new(FileDescTable::new_with_stdio())),
+            syscall_stack_top: 0, // kernel-only task — no ring-3 syscall stack needed yet
         }
     }
 
@@ -280,5 +295,95 @@ impl Task {
     /// Always returns `false` for the bootstrap task (`guard_base == 0`).
     pub fn is_guard_hit(&self, addr: usize) -> bool {
         self.guard_base != 0 && addr >= self.guard_base && addr < self.guard_base + GUARD_SIZE
+    }
+
+    /// Build a new task that is a fork child. On first scheduling the task
+    /// returns to ring-3 via `fork_child_sysret` with rax=0 (the child's
+    /// fork() return value).
+    ///
+    /// `user_rip`, `user_rflags`, and `user_rsp` are the saved ring-3
+    /// register context from the parent's SYSCALL entry.
+    /// `parent_fpu` is the parent's current FPU save area (copied verbatim
+    /// so the child inherits the same floating-point state at fork time).
+    /// `parent_priority` / `parent_affinity` are copied directly.
+    ///
+    /// # Safety
+    /// `parent_fpu` must be a valid, aligned `FpuArea` that remains live
+    /// for the duration of this call (the FPU copy happens before return).
+    pub unsafe fn new_forked(
+        user_rip: u64,
+        user_rflags: u64,
+        user_rsp: u64,
+        parent_priority: u8,
+        parent_affinity: u64,
+        parent_fpu: *const crate::arch::x86_64::fpu::FpuArea,
+        child_address_space: alloc::sync::Arc<spin::RwLock<AddressSpace>>,
+        child_cr3: PhysFrame<Size4KiB>,
+        child_fd_table: alloc::sync::Arc<Mutex<crate::fs::FileDescTable>>,
+    ) -> Self {
+        // Allocate a fresh guard+stack slot.
+        let slot_va = NEXT_STACK_VA.fetch_add(TASK_SLOT_SIZE, Ordering::Relaxed);
+        let guard_base = slot_va;
+        let stack_base = slot_va + GUARD_SIZE;
+
+        Page::<Size4KiB>::from_start_address(VirtAddr::new(stack_base as u64))
+            .expect("forked task stack base must be page aligned");
+        let stack_page_count = (STACK_SIZE / 4096) as u64;
+        let mut flusher = crate::mem::tlb::Flusher::new_active();
+        paging::map_range(
+            VirtAddr::new(stack_base as u64),
+            stack_page_count,
+            PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE,
+            &mut flusher,
+        )
+        .expect("failed to map forked task stack");
+        flusher.finish();
+
+        let top = stack_base + STACK_SIZE;
+
+        // Prime the stack so context_switch restores:
+        //   r15=0, r14=0, r13=0,
+        //   r12 = user_rip    → rcx for SYSRETQ
+        //   rbp = user_rsp    → rsp before SYSRETQ
+        //   rbx = user_rflags → r11 for SYSRETQ
+        //   ret = fork_child_sysret
+        let rsp = top - 7 * 8;
+        let slots = rsp as *mut usize;
+        unsafe {
+            slots.add(0).write(0); // r15
+            slots.add(1).write(0); // r14
+            slots.add(2).write(0); // r13
+            slots.add(3).write(user_rip as usize); // r12 → rcx
+            slots.add(4).write(user_rsp as usize); // rbp → rsp
+            slots.add(5).write(user_rflags as usize); // rbx → r11
+            slots.add(6).write(fork_child_sysret as *const () as usize); // ret
+        }
+
+        let id = NEXT_TASK_ID.fetch_add(1, Ordering::Relaxed);
+
+        // Copy the parent's FPU state into a fresh area.
+        let mut fpu = FpuArea::new_initialized();
+        unsafe {
+            core::ptr::copy_nonoverlapping(parent_fpu, &mut *fpu as *mut _, 1);
+        }
+
+        Self {
+            id,
+            guard_base,
+            rsp,
+            slice_remaining_ms: DEFAULT_SLICE_MS,
+            state: TaskState::Ready,
+            wake_pending: AtomicBool::new(false),
+            priority: parent_priority,
+            affinity: parent_affinity,
+            cr3: child_cr3,
+            address_space: child_address_space,
+            fpu,
+            fd_table: child_fd_table,
+            // The child task runs in ring-3; it needs its own SYSCALL stack
+            // so it doesn't clobber the parent's saved SYSCALL context on the
+            // shared INIT_KERNEL_STACK. Use the top of this task's kernel stack.
+            syscall_stack_top: (stack_base + STACK_SIZE) as u64,
+        }
     }
 }

--- a/userspace/hello/link.ld
+++ b/userspace/hello/link.ld
@@ -1,13 +1,8 @@
-/* Linker script for the userspace hello ELF loaded by the kernel.
+/* Linker script for the userspace hello binary (ring-3, lower half).
  *
- * Virtual base: 0xffff_ffff_c000_0000 — 1 GiB into the top 2 GiB kernel
- * region. The kernel itself lives at 0xffff_ffff_8000_0000 and is at
- * most a few megabytes, leaving the rest of the -2 GiB window free.
- * The range is canonical, falls within `code-model=kernel`'s ±2 GiB
- * reach, and sits in the upper half of the address space — upper-half
- * PML4 slots are shared by every task PML4 via paging::new_task_pml4,
- * so a mapping installed in the kernel PML4 before task::init() is
- * visible to any task that later runs this code.
+ * Loaded by the kernel's exec() syscall into a fresh user address space.
+ * Uses the same lower-half layout as userspace/init so load_user_elf
+ * accepts it.
  */
 
 OUTPUT_FORMAT(elf64-x86-64)
@@ -16,14 +11,14 @@ ENTRY(_start)
 
 PHDRS
 {
-    text   PT_LOAD;
-    rodata PT_LOAD;
-    data   PT_LOAD;
+    text   PT_LOAD FLAGS(5);   /* R+X */
+    rodata PT_LOAD FLAGS(4);   /* R   */
+    data   PT_LOAD FLAGS(6);   /* R+W */
 }
 
 SECTIONS
 {
-    . = 0xffffffffc0000000;
+    . = 0x0000000000400000;
 
     .text : {
         *(.text .text.*)
@@ -51,5 +46,6 @@ SECTIONS
         *(.note.*)
         *(.comment)
         *(.dynamic)
+        *(.got .got.plt)
     }
 }

--- a/userspace/hello/src/main.rs
+++ b/userspace/hello/src/main.rs
@@ -1,48 +1,52 @@
-//! Tiny userspace ELF payload for the ring-0 loader smoke test.
+//! Hello binary — the exec() target for the fork+exec+wait integration test.
 //!
-//! Runs with the kernel's descriptors still active (we don't yet have
-//! ring-3). The only contract is: write the "USRHELLO\n" marker to the
-//! COM1 serial port so `xtask smoke` can observe control transfer, then
-//! park via `hlt`.
+//! Loaded by the kernel's execve() syscall (nr=59) into the child process's
+//! address space. Writes a marker to stdout (serial fd 1) and exits with
+//! status 0 so the parent's waitpid() can verify the exit code.
+//!
+//! Uses the same Linux x86_64 syscall ABI as the init binary.
 
 #![no_std]
 #![no_main]
 
 use core::panic::PanicInfo;
 
-const COM1: u16 = 0x3F8;
-const MARKER: &[u8] = b"USRHELLO\n";
+const MSG: &[u8] = b"hello: hello from execed child\n";
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
-    for &b in MARKER {
-        unsafe {
-            // Spin on the THR-empty bit (LSR.5) so bytes don't get
-            // dropped if the UART isn't drained yet.
-            while (inb(COM1 + 5) & 0x20) == 0 {}
-            outb(COM1, b);
-        }
+    // write(1, MSG, MSG.len())
+    unsafe {
+        core::arch::asm!(
+            "syscall",
+            in("rax") 1u64,
+            in("rdi") 1u64,
+            in("rsi") MSG.as_ptr() as u64,
+            in("rdx") MSG.len() as u64,
+            lateout("rcx") _,
+            lateout("r11") _,
+            options(nostack, preserves_flags),
+        );
+    }
+    // exit(0)
+    unsafe {
+        core::arch::asm!(
+            "syscall",
+            in("rax") 60u64,
+            in("rdi") 0u64,
+            lateout("rcx") _,
+            lateout("r11") _,
+            options(nostack, preserves_flags),
+        );
     }
     loop {
-        unsafe { core::arch::asm!("hlt", options(nomem, nostack)) };
+        core::hint::spin_loop();
     }
-}
-
-#[inline(always)]
-unsafe fn outb(port: u16, val: u8) {
-    core::arch::asm!("out dx, al", in("dx") port, in("al") val, options(nomem, nostack, preserves_flags));
-}
-
-#[inline(always)]
-unsafe fn inb(port: u16) -> u8 {
-    let val: u8;
-    core::arch::asm!("in al, dx", out("al") val, in("dx") port, options(nomem, nostack, preserves_flags));
-    val
 }
 
 #[panic_handler]
 fn panic(_info: &PanicInfo) -> ! {
     loop {
-        unsafe { core::arch::asm!("hlt", options(nomem, nostack)) };
+        core::hint::spin_loop();
     }
 }

--- a/userspace/init/src/main.rs
+++ b/userspace/init/src/main.rs
@@ -1,14 +1,15 @@
 //! PID 1 init binary — the first userspace process on vibix.
 //!
-//! This minimal binary demonstrates ring-3 execution and the syscall path:
-//! 1. Makes one `write(1, msg, len)` syscall to print to the serial console.
-//! 2. Loops forever (busy-spins without issuing any more syscalls).
-//!
-//! The marker line `init: hello from pid 1` is asserted by `cargo xtask smoke`.
+//! Demonstrates the full fork+exec+wait lifecycle:
+//! 1. Prints the smoke-test marker "init: hello from pid 1".
+//! 2. Calls fork(). The child calls execve() to load the hello binary,
+//!    which prints "hello: hello from execed child" and exits(0).
+//! 3. The parent calls wait4() to collect the child's exit status, then
+//!    prints "init: fork+exec+wait ok" and loops forever.
 //!
 //! Syscall ABI (Linux x86_64 convention used by the vibix kernel):
 //! - rax = syscall number
-//! - rdi = arg0,  rsi = arg1,  rdx = arg2
+//! - rdi = arg0,  rsi = arg1,  rdx = arg2,  r10 = arg3
 //! - rcx and r11 are clobbered by SYSCALL/SYSRET
 //! - Return value in rax
 
@@ -17,26 +18,88 @@
 
 use core::panic::PanicInfo;
 
-const MSG: &[u8] = b"init: hello from pid 1\n";
+/// Smoke-test marker — asserted by `cargo xtask smoke`.
+const HELLO_MSG: &[u8] = b"init: hello from pid 1\n";
+
+/// Emitted after the parent collects the child's exit status.
+const DONE_MSG: &[u8] = b"init: fork+exec+wait ok\n";
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
-    // write(fd=1, buf=MSG.as_ptr(), len=MSG.len())
+    write(1, HELLO_MSG);
+
+    // fork() — child PID returned to parent; 0 returned to child.
+    let fork_ret: i64;
+    unsafe {
+        core::arch::asm!(
+            "syscall",
+            inlateout("rax") 57u64 => fork_ret,
+            lateout("rcx") _,
+            lateout("r11") _,
+            options(nostack, preserves_flags),
+        );
+    }
+
+    if fork_ret == 0 {
+        // Child: exec the hello binary (execve ignores path/argv/envp,
+        // loads userspace_hello.elf from the ramdisk module).
+        unsafe {
+            core::arch::asm!(
+                "syscall",
+                in("rax") 59u64,  // execve
+                in("rdi") 0u64,   // path (ignored)
+                in("rsi") 0u64,   // argv (ignored)
+                in("rdx") 0u64,   // envp (ignored)
+                lateout("rcx") _,
+                lateout("r11") _,
+                options(nostack, preserves_flags),
+            );
+        }
+        // execve only returns on failure — spin.
+        loop {
+            core::hint::spin_loop();
+        }
+    }
+
+    // Parent: wait for the child to exit.
+    if fork_ret > 0 {
+        let child_pid = fork_ret as u64;
+        let mut wstatus: i32 = 0;
+        let _waited: i64;
+        unsafe {
+            core::arch::asm!(
+                "syscall",
+                inlateout("rax") 61u64 => _waited,  // wait4
+                in("rdi") child_pid,                  // pid
+                in("rsi") &mut wstatus as *mut i32 as u64,
+                in("rdx") 0u64,                       // options
+                in("r10") 0u64,                       // rusage
+                lateout("rcx") _,
+                lateout("r11") _,
+                options(nostack),
+            );
+        }
+        write(1, DONE_MSG);
+    }
+
+    // Loop forever.
+    loop {
+        core::hint::spin_loop();
+    }
+}
+
+fn write(fd: u64, buf: &[u8]) {
     unsafe {
         core::arch::asm!(
             "syscall",
             in("rax") 1u64,
-            in("rdi") 1u64,
-            in("rsi") MSG.as_ptr() as u64,
-            in("rdx") MSG.len() as u64,
-            lateout("rcx") _,  // SYSCALL saves user RIP here
-            lateout("r11") _,  // SYSCALL saves user RFLAGS here
+            in("rdi") fd,
+            in("rsi") buf.as_ptr() as u64,
+            in("rdx") buf.len() as u64,
+            lateout("rcx") _,
+            lateout("r11") _,
             options(nostack, preserves_flags),
         );
-    }
-    // Park forever — no exit syscall needed for the smoke test.
-    loop {
-        core::hint::spin_loop();
     }
 }
 

--- a/userspace/init/src/main.rs
+++ b/userspace/init/src/main.rs
@@ -55,7 +55,17 @@ pub extern "C" fn _start() -> ! {
                 options(nostack, preserves_flags),
             );
         }
-        // execve only returns on failure — spin.
+        // execve only returns on failure — exit with an error code.
+        unsafe {
+            core::arch::asm!(
+                "syscall",
+                in("rax") 60u64, // exit
+                in("rdi") 1u64,  // status 1 (exec failed)
+                lateout("rcx") _,
+                lateout("r11") _,
+                options(nostack, preserves_flags),
+            );
+        }
         loop {
             core::hint::spin_loop();
         }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -723,7 +723,11 @@ fn smoke(opts: &BuildOpts) -> R<()> {
         Ok(out)
     });
 
-    std::thread::sleep(Duration::from_secs(4));
+    // Wait long enough for the fork+exec+wait round-trip to complete.
+    // 4 s was sufficient before multi-process support; CI runners are
+    // slower than local QEMU, so 8 s gives the init process time to fork,
+    // exec the hello binary, and collect the exit status before we kill.
+    std::thread::sleep(Duration::from_secs(8));
     // Kill QEMU so the reader thread can drain and return.
     let _ = Command::new("kill").arg(pid.to_string()).status();
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -724,10 +724,11 @@ fn smoke(opts: &BuildOpts) -> R<()> {
     });
 
     // Wait long enough for the fork+exec+wait round-trip to complete.
-    // 4 s was sufficient before multi-process support; CI runners are
-    // slower than local QEMU, so 8 s gives the init process time to fork,
-    // exec the hello binary, and collect the exit status before we kill.
-    std::thread::sleep(Duration::from_secs(8));
+    // CI runners are significantly slower than local QEMU: the kernel
+    // boot alone takes ~7–8 s on the runner, leaving no time for the
+    // fork+exec+wait sequence inside an 8 s window. 15 s gives a
+    // comfortable margin for the full boot + process lifecycle.
+    std::thread::sleep(Duration::from_secs(15));
     // Kill QEMU so the reader thread can drain and return.
     let _ = Command::new("kill").arg(pid.to_string()).status();
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -73,6 +73,8 @@ const SMOKE_MARKERS: &[&str] = &[
     "userspace: loader mapping image",
     "syscall: SYSCALL/SYSRET enabled",
     "init: hello from pid 1",
+    "hello: hello from execed child",
+    "init: fork+exec+wait ok",
 ];
 
 fn main() -> R<()> {
@@ -234,6 +236,39 @@ fn build_userspace_init() -> R<PathBuf> {
     let bin = userspace_init_binary();
     if !bin.exists() {
         return Err(format!("userspace init binary missing at {}", bin.display()).into());
+    }
+    strip_debug(&bin)?;
+    Ok(bin)
+}
+
+fn userspace_hello_binary() -> PathBuf {
+    workspace_root()
+        .join("target")
+        .join(KERNEL_TARGET)
+        .join("debug")
+        .join("userspace_hello")
+}
+
+/// Build the hello binary — the exec() target for the fork+exec+wait test.
+/// Links at 0x400000 (lower half) just like init so load_user_elf accepts it.
+fn build_userspace_hello() -> R<PathBuf> {
+    let rustflags = [
+        "-C link-arg=-Tuserspace/hello/link.ld",
+        "-C relocation-model=static",
+        "-C code-model=small",
+        "-C no-redzone=yes",
+        "-C force-frame-pointers=yes",
+    ]
+    .join(" ");
+    let mut cmd = Command::new("cargo");
+    cmd.current_dir(workspace_root())
+        .env("RUSTFLAGS", rustflags)
+        .args(["build", "--package", "userspace_hello"])
+        .args(KERNEL_BUILD_STD_ARGS);
+    check(cmd.status()?)?;
+    let bin = userspace_hello_binary();
+    if !bin.exists() {
+        return Err(format!("userspace hello binary missing at {}", bin.display()).into());
     }
     strip_debug(&bin)?;
     Ok(bin)
@@ -429,6 +464,7 @@ fn ensure_limine() -> R<PathBuf> {
 fn make_iso(kernel: &Path, iso_out: &Path, staging: &str) -> R<()> {
     let limine = ensure_limine()?;
     let userspace_init = build_userspace_init()?;
+    let userspace_hello = build_userspace_hello()?;
     let iso_root = workspace_root().join("build").join(staging);
     let _ = fs::remove_dir_all(&iso_root);
     fs::create_dir_all(iso_root.join("boot/limine"))?;
@@ -436,6 +472,7 @@ fn make_iso(kernel: &Path, iso_out: &Path, staging: &str) -> R<()> {
 
     fs::copy(kernel, iso_root.join("boot/vibix"))?;
     fs::copy(userspace_init, iso_root.join("boot/userspace_init.elf"))?;
+    fs::copy(userspace_hello, iso_root.join("boot/userspace_hello.elf"))?;
     fs::copy(
         workspace_root().join("kernel/limine.conf"),
         iso_root.join("boot/limine/limine.conf"),


### PR DESCRIPTION
Closes #123

## Summary
- **Process table** (`kernel/src/process/mod.rs`): PID allocator, `ProcessEntry` (pid/parent/exit_status/state), `mark_zombie`/`reap_child`/`reparent_children`/`has_children`, `EXIT_EVENT` atomic + `CHILD_WAIT` queue for race-free `waitpid`
- **Per-task SYSCALL stacks**: adds `syscall_stack_top` to `Task`; each ring-3 task gets its own SYSCALL entry stack (top of its kernel task stack) so concurrent syscalls don't clobber each other's saved register context on the old shared `INIT_KERNEL_STACK`; all `context_switch` call sites update `SYSCALL_KERNEL_RSP`/`TSS.rsp[0]` on every switch
- **fork() (nr=57)**: CoW address-space clone via `fork_address_space`; child task is primed with `fork_child_sysret` asm stub to return 0 from ring-3
- **execve() (nr=59)**: clears the current address space, loads `userspace_hello.elf` from the second ramdisk module, maps a fresh user stack, and jumps to ring-3
- **exit() (nr=60)**: reparents children, marks zombie, wakes `waitpid` waiters, calls `task::exit()`
- **wait4() (nr=61)**: loop + `block_current` until a zombie child appears, encode WEXITSTATUS, return child PID
- **ELF VMA tracking**: `load_user_elf_with_vmas` populates `AnonObject` VMAs with pre-loaded frames so `fork_address_space` can CoW-clone ELF segments; `AddressSpace::clear_for_exec` unmaps the user half without freeing the PML4
- **Smoke test**: adds hello binary as a second Limine module; init forks → child execs hello → hello prints and exits → parent waits and prints "init: fork+exec+wait ok"

## Test plan
- [x] `cargo xtask build` — clean, 1 pre-existing unused-method warning
- [x] `cargo xtask test` — 122 host unit tests pass; all QEMU integration tests pass
- [x] `cargo xtask smoke` — all 29 markers present ✓ (including 2 new: `hello: hello from execed child`, `init: fork+exec+wait ok`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because this adds/changes core kernel lifecycle primitives (new process table, `fork`/`execve`/`exit`/`wait4` syscalls) and modifies syscall entry/stack and scheduler context-switch paths, which can easily introduce memory-safety, refcount, or scheduling regressions.
> 
> **Overview**
> Adds a kernel `process` table for PID allocation and parent/child lifecycle tracking, enabling zombie/reap semantics and a wait queue used by `wait4`.
> 
> Extends the syscall layer with `fork` (nr=57), `execve` (nr=59), `exit` (nr=60), and `wait4` (nr=61); `fork` clones the current task/address space and returns via a new `fork_child_sysret` trampoline, while `execve` clears the current user address space, reloads a new ELF image, recreates a user stack VMA, and jumps back to ring-3.
> 
> Reworks init and memory plumbing to support this lifecycle: init now prebuilds an `AddressSpace` with VMA-tracked ELF segments, `AddressSpace::clear_for_exec` is added, the ELF loader gains `load_user_elf_with_vmas` plus `AnonObject::insert_existing_frame`, and task switching is updated to maintain a **per-task** `SYSCALL_KERNEL_RSP`/`TSS.rsp[0]` so ring-3 syscalls don’t share `INIT_KERNEL_STACK`.
> 
> Updates boot/test artifacts to exercise the flow end-to-end: adds `userspace_hello.elf` as a Limine module, changes userspace init to `fork → execve → wait4`, updates the hello binary/linker layout accordingly, and expands the smoke test markers and timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37eaca3b31058bc5569effe96d87f75d4d4c1b59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->