### PR TITLE
syscall: implement brk(12) and set heap base from ELF image_end

### DIFF
--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -286,6 +286,13 @@ pub unsafe extern "C" fn syscall_dispatch(nr: u64, a0: u64, a1: u64, a2: u64) ->
             }
         }
 
+        // brk(addr) — set the program break; returns the new break on success
+        // or the current (unchanged) break on failure.
+        12 => {
+            let addr = a0;
+            crate::task::current_address_space().write().sys_brk(addr) as i64
+        }
+
         // fork() — clone the calling process; parent returns child PID, child returns 0.
         57 => {
             let user_rip = FORK_USER_RIP.load(Ordering::Relaxed);
@@ -339,6 +346,12 @@ pub unsafe extern "C" fn syscall_dispatch(nr: u64, a0: u64, a1: u64, a2: u64) ->
                 Ok(img) => img,
                 Err(_) => return -8, // ENOEXEC
             };
+
+            // Position the heap start immediately after the ELF image so
+            // sys_brk allocates from the right base address.
+            aspace
+                .write()
+                .set_brk_start(x86_64::VirtAddr::new(image.image_end));
 
             // Map a fresh user stack page and register it as a VMA so the
             // exec'd process's stack frame is also reclaimed on exit.

--- a/kernel/src/init_process.rs
+++ b/kernel/src/init_process.rs
@@ -63,6 +63,10 @@ pub fn launch(bytes: &[u8]) -> usize {
         image.segments
     );
 
+    // Set the heap base to immediately after the ELF image so sys_brk
+    // starts the heap at the right address.
+    aspace.set_brk_start(VirtAddr::new(image.image_end));
+
     // 3. Allocate and map the user stack, then add it as a VMA so fork
     //    copies it too.
     let stack_page = Page::<Size4KiB>::containing_address(VirtAddr::new(USER_STACK_PAGE_VA));

--- a/kernel/src/mem/addrspace.rs
+++ b/kernel/src/mem/addrspace.rs
@@ -272,13 +272,22 @@ impl AddressSpace {
         if new_brk_raw >= USER_VA_END {
             return self.brk_cur.as_u64(); // rounded up into non-canonical range
         }
-        // Construct the page-aligned address used for VMA extent decisions.
-        let new_brk = VirtAddr::new(new_brk_raw);
         // Linux stores the EXACT requested address in mm->brk (not the
         // page-aligned value), so glibc/musl sbrk tracking is correct.
         let exact_brk = VirtAddr::new(addr);
 
-        if new_brk > self.brk_max || new_brk < self.brk_start {
+        // Validate exact address against brk_start BEFORE page-rounding.
+        // A value in (brk_start - PAGE, brk_start) rounds UP to brk_start and
+        // would otherwise pass the page-aligned lower-bound check, then write
+        // an exact brk_cur below the heap base.
+        if exact_brk < self.brk_start {
+            return self.brk_cur.as_u64();
+        }
+
+        // Construct the page-aligned address used for VMA extent decisions.
+        let new_brk = VirtAddr::new(new_brk_raw);
+
+        if new_brk > self.brk_max {
             return self.brk_cur.as_u64();
         }
         // No page-mapping change needed if we stay inside the same page.
@@ -346,6 +355,7 @@ impl AddressSpace {
                     unsafe {
                         crate::mem::paging::KernelFrameAllocator.deallocate_frame(frame);
                     }
+                    self.rss_pages = self.rss_pages.saturating_sub(1);
                 }
                 va += 4096;
             }

--- a/kernel/src/mem/addrspace.rs
+++ b/kernel/src/mem/addrspace.rs
@@ -212,6 +212,143 @@ impl AddressSpace {
         self.brk_max = VirtAddr::new(mmap_base.as_u64() - DEFAULT_BRK_GUARD);
     }
 
+    /// Set the heap base to `image_end` (the page-aligned address one byte
+    /// past the last `PT_LOAD` segment). Called after `load_user_elf_with_vmas`
+    /// so that `sys_brk` starts the heap immediately after the ELF image
+    /// rather than at the arbitrary `mmap_base` placeholder.
+    pub fn set_brk_start(&mut self, image_end: VirtAddr) {
+        self.brk_start = image_end;
+        self.brk_cur = image_end;
+        // brk_max stays at mmap_base − DEFAULT_BRK_GUARD.
+    }
+
+    /// Implement the `brk(2)` contract (Linux-compatible):
+    ///
+    /// - `addr == 0`: return the current break without moving it.
+    /// - `addr > brk_max`: heap limit exceeded — return current break unchanged.
+    /// - `addr < brk_start`: cannot shrink below heap base — return unchanged.
+    /// - Otherwise: grow or shrink the heap and return the new break.
+    ///
+    /// The heap is maintained as a **single** anonymous-private VMA
+    /// `[brk_start, brk_cur)` with an unbounded `AnonObject` backing.
+    /// On grow the existing VMA is replaced with a larger one (same
+    /// `AnonObject` Arc so already-faulted frames are preserved). On shrink,
+    /// the old PTEs in the freed range are unmapped and the VMA is replaced
+    /// with a smaller one.
+    ///
+    /// Returns the new (or unchanged) break address. No errno is set on
+    /// failure — returning the old break is the POSIX failure signal.
+    #[cfg(target_os = "none")]
+    pub fn sys_brk(&mut self, addr: u64) -> u64 {
+        use crate::mem::vmatree::{Share, Vma};
+        use crate::mem::vmobject::{AnonObject, VmObject};
+        use alloc::sync::Arc;
+        use x86_64::structures::paging::{PageTableFlags, Size4KiB};
+        use x86_64::VirtAddr;
+
+        if addr == 0 {
+            return self.brk_cur.as_u64();
+        }
+
+        // Page-align upward to match Linux semantics.
+        let new_brk_raw = (addr + 4095) & !4095;
+        let new_brk = VirtAddr::new(new_brk_raw);
+
+        if new_brk > self.brk_max || new_brk < self.brk_start {
+            return self.brk_cur.as_u64();
+        }
+        if new_brk == self.brk_cur {
+            return self.brk_cur.as_u64();
+        }
+
+        let old_brk = self.brk_cur;
+        let brk_start = self.brk_start;
+        let brk_start_usize = brk_start.as_u64() as usize;
+
+        let heap_flags = PageTableFlags::PRESENT
+            | PageTableFlags::WRITABLE
+            | PageTableFlags::USER_ACCESSIBLE
+            | PageTableFlags::NO_EXECUTE;
+
+        if new_brk > old_brk {
+            // Grow: remove existing heap VMA (if any), keep its AnonObject,
+            // then reinsert with a larger end. New pages are demand-faulted.
+            let obj: Arc<dyn VmObject> = if old_brk > brk_start {
+                // There is already a heap VMA — clone its AnonObject so the
+                // already-faulted frames are not freed when we remove the VMA.
+                let old = self
+                    .vmas
+                    .remove_exact(brk_start_usize)
+                    .expect("heap VMA missing despite brk_cur > brk_start");
+                self.vm_pages -= (old_brk - brk_start) as usize / 4096;
+                let arc = Arc::clone(&old.object);
+                drop(old);
+                arc
+            } else {
+                // First brk call — create a fresh unbounded AnonObject.
+                AnonObject::new(None)
+            };
+
+            let vma = Vma::new(
+                brk_start_usize,
+                new_brk.as_u64() as usize,
+                0x3, // PROT_READ|WRITE
+                heap_flags.bits(),
+                Share::Private,
+                obj,
+                0,
+            );
+            self.vmas.insert(vma);
+            self.vm_pages += (new_brk - brk_start) as usize / 4096;
+        } else {
+            // Shrink: free PTEs for [new_brk, old_brk), then reinsert a
+            // smaller VMA with the same AnonObject so its Drop path can
+            // release the cache frames when the process exits.
+            let pml4 = self.page_table;
+            let mut va = new_brk.as_u64() as usize;
+            while va < old_brk.as_u64() as usize {
+                use x86_64::structures::paging::{FrameDeallocator, Page};
+                let page = Page::<Size4KiB>::from_start_address(VirtAddr::new(va as u64))
+                    .expect("page aligned");
+                if let Ok(frame) = crate::mem::paging::unmap_in_pml4(pml4, page) {
+                    // Release the PTE's reference. AnonObject still holds
+                    // the cache reference so the frame's refcount drops to
+                    // 1, not 0 — it will be freed by AnonObject::drop.
+                    unsafe {
+                        crate::mem::paging::KernelFrameAllocator.deallocate_frame(frame);
+                    }
+                }
+                va += 4096;
+            }
+
+            if old_brk > brk_start {
+                let old = self
+                    .vmas
+                    .remove_exact(brk_start_usize)
+                    .expect("heap VMA missing despite brk_cur > brk_start");
+                self.vm_pages -= (old_brk - brk_start) as usize / 4096;
+                if new_brk > brk_start {
+                    let obj = Arc::clone(&old.object);
+                    drop(old);
+                    let vma = Vma::new(
+                        brk_start_usize,
+                        new_brk.as_u64() as usize,
+                        0x3,
+                        heap_flags.bits(),
+                        Share::Private,
+                        obj,
+                        0,
+                    );
+                    self.vmas.insert(vma);
+                    self.vm_pages += (new_brk - brk_start) as usize / 4096;
+                }
+            }
+        }
+
+        self.brk_cur = new_brk;
+        new_brk.as_u64()
+    }
+
     /// Insert `vma` into the VMA tree, merging with adjacent neighbours
     /// where possible. Panics if `vma` overlaps any existing entry —
     /// overlapping VMAs are a programmer error.
@@ -646,5 +783,26 @@ mod tests {
         let aspace = AddressSpace::new_for_test(0x4000_0000);
         assert_eq!(aspace.brk_start, aspace.brk_cur);
         assert!(aspace.brk_max.as_u64() + DEFAULT_BRK_GUARD == aspace.mmap_base.as_u64());
+    }
+
+    #[test]
+    fn brk_zero_returns_current_break() {
+        let aspace = AddressSpace::new_for_test(0x4000_0000);
+        // Before any brk, brk_cur == brk_start == mmap_base.
+        let r = aspace.brk_cur.as_u64();
+        // sys_brk is #[cfg(target_os = "none")] — just test set_brk_start.
+        assert_eq!(aspace.brk_start, aspace.brk_cur);
+        let _ = r;
+    }
+
+    #[test]
+    fn set_brk_start_advances_heap_base() {
+        let mut aspace = AddressSpace::new_for_test(0x4000_0000);
+        let img_end = x86_64::VirtAddr::new(0x0060_0000);
+        aspace.set_brk_start(img_end);
+        assert_eq!(aspace.brk_start, img_end);
+        assert_eq!(aspace.brk_cur, img_end);
+        // brk_max unchanged
+        assert!(aspace.brk_max.as_u64() < aspace.mmap_base.as_u64());
     }
 }

--- a/kernel/src/mem/addrspace.rs
+++ b/kernel/src/mem/addrspace.rs
@@ -216,7 +216,15 @@ impl AddressSpace {
     /// past the last `PT_LOAD` segment). Called after `load_user_elf_with_vmas`
     /// so that `sys_brk` starts the heap immediately after the ELF image
     /// rather than at the arbitrary `mmap_base` placeholder.
+    ///
+    /// If `image_end > brk_max` (e.g. an extremely large ELF), the heap window
+    /// would be zero-sized or inverted, so the call is a no-op — callers should
+    /// handle this by falling back to the existing brk_start.
     pub fn set_brk_start(&mut self, image_end: VirtAddr) {
+        if image_end > self.brk_max {
+            // Heap window would be empty; leave the existing placeholder.
+            return;
+        }
         self.brk_start = image_end;
         self.brk_cur = image_end;
         // brk_max stays at mmap_base − DEFAULT_BRK_GUARD.
@@ -250,18 +258,39 @@ impl AddressSpace {
             return self.brk_cur.as_u64();
         }
 
-        // Page-align upward to match Linux semantics.
-        let new_brk_raw = (addr + 4095) & !4095;
+        // Reject non-canonical addresses and overflow before constructing
+        // VirtAddr — VirtAddr::new panics on non-canonical values.
+        // USER_VA_END is the first non-canonical lower-half address.
+        if addr >= USER_VA_END {
+            return self.brk_cur.as_u64();
+        }
+        // Overflow-safe page-align upward.
+        let new_brk_raw = match addr.checked_add(4095) {
+            Some(v) => v & !4095,
+            None => return self.brk_cur.as_u64(), // would overflow u64
+        };
+        if new_brk_raw >= USER_VA_END {
+            return self.brk_cur.as_u64(); // rounded up into non-canonical range
+        }
+        // Construct the page-aligned address used for VMA extent decisions.
         let new_brk = VirtAddr::new(new_brk_raw);
+        // Linux stores the EXACT requested address in mm->brk (not the
+        // page-aligned value), so glibc/musl sbrk tracking is correct.
+        let exact_brk = VirtAddr::new(addr);
 
         if new_brk > self.brk_max || new_brk < self.brk_start {
             return self.brk_cur.as_u64();
         }
-        if new_brk == self.brk_cur {
-            return self.brk_cur.as_u64();
+        // No page-mapping change needed if we stay inside the same page.
+        let old_brk_page = VirtAddr::new((self.brk_cur.as_u64() + 4095) & !4095);
+        if new_brk == old_brk_page {
+            self.brk_cur = exact_brk;
+            return exact_brk.as_u64();
         }
 
-        let old_brk = self.brk_cur;
+        // Use page-aligned values for VMA extent decisions; store the exact
+        // requested address in brk_cur (Linux semantics: mm->brk is exact).
+        let old_brk = old_brk_page; // page-aligned old break
         let brk_start = self.brk_start;
         let brk_start_usize = brk_start.as_u64() as usize;
 
@@ -329,6 +358,10 @@ impl AddressSpace {
                 self.vm_pages -= (old_brk - brk_start) as usize / 4096;
                 if new_brk > brk_start {
                     let obj = Arc::clone(&old.object);
+                    // Trim the VmObject's frame cache for the freed range so
+                    // cached frames are released now rather than at exit.
+                    let from_page = (new_brk - brk_start) as usize / 4096;
+                    obj.truncate_from_page(from_page);
                     drop(old);
                     let vma = Vma::new(
                         brk_start_usize,
@@ -345,8 +378,10 @@ impl AddressSpace {
             }
         }
 
-        self.brk_cur = new_brk;
-        new_brk.as_u64()
+        // Store the exact requested address per Linux mm->brk semantics;
+        // page-aligned values were used only to decide VMA extent changes.
+        self.brk_cur = exact_brk;
+        exact_brk.as_u64()
     }
 
     /// Insert `vma` into the VMA tree, merging with adjacent neighbours
@@ -786,13 +821,12 @@ mod tests {
     }
 
     #[test]
-    fn brk_zero_returns_current_break() {
+    fn brk_constructor_sets_start_eq_cur() {
+        // new_for_test initialises brk_start == brk_cur == mmap_base.
+        // sys_brk(0) behaviour is only testable in QEMU (cfg=none); this
+        // test just verifies the constructor invariant.
         let aspace = AddressSpace::new_for_test(0x4000_0000);
-        // Before any brk, brk_cur == brk_start == mmap_base.
-        let r = aspace.brk_cur.as_u64();
-        // sys_brk is #[cfg(target_os = "none")] — just test set_brk_start.
         assert_eq!(aspace.brk_start, aspace.brk_cur);
-        let _ = r;
     }
 
     #[test]

--- a/kernel/src/mem/loader.rs
+++ b/kernel/src/mem/loader.rs
@@ -54,12 +54,17 @@ pub enum LoadError {
     MapFailed(MapToError<Size4KiB>),
 }
 
-/// Result of a successful load: the entry point and the number of
-/// `PT_LOAD` segments that were mapped.
+/// Result of a successful load: the entry point, segment count, and the
+/// page-aligned virtual address one byte past the last `PT_LOAD` segment.
+/// `image_end` is the natural place to start the heap (`brk_start`) after
+/// the process image is loaded.
 #[derive(Debug, Clone, Copy)]
 pub struct LoadedImage {
     pub entry: VirtAddr,
     pub segments: usize,
+    /// First page-aligned address after the last PT_LOAD segment.
+    /// The `sys_brk` implementation uses this as the initial heap start.
+    pub image_end: u64,
 }
 
 /// Parse `bytes` as an ELF64 image and install its `PT_LOAD` segments
@@ -76,12 +81,18 @@ pub fn load(bytes: &[u8]) -> Result<LoadedImage, LoadError> {
     }
 
     let mut segments = 0usize;
+    let mut image_end = 0u64;
     let mut flusher = Flusher::new_active();
     let mut err: Option<LoadError> = None;
     for seg in parsed.load_segments() {
         if let Err(e) = map_segment(bytes, seg, &mut flusher) {
             err = Some(e);
             break;
+        }
+        // Track the page-aligned end of the highest PT_LOAD segment.
+        let seg_end = (seg.vaddr.as_u64() + seg.memsz + PAGE_SIZE - 1) & !(PAGE_SIZE - 1);
+        if seg_end > image_end {
+            image_end = seg_end;
         }
         segments += 1;
     }
@@ -93,7 +104,11 @@ pub fn load(bytes: &[u8]) -> Result<LoadedImage, LoadError> {
         return Err(e);
     }
 
-    Ok(LoadedImage { entry, segments })
+    Ok(LoadedImage {
+        entry,
+        segments,
+        image_end,
+    })
 }
 
 /// First canonical upper-half address. Bits [63:47] must all be 1 for
@@ -124,11 +139,16 @@ pub fn load_user_elf(bytes: &[u8], pml4: PhysFrame<Size4KiB>) -> Result<LoadedIm
     }
 
     let mut segments = 0usize;
+    let mut image_end = 0u64;
     let mut err: Option<LoadError> = None;
     for seg in parsed.load_segments() {
         if let Err(e) = map_user_segment(bytes, seg, pml4) {
             err = Some(e);
             break;
+        }
+        let seg_end = (seg.vaddr.as_u64() + seg.memsz + PAGE_SIZE - 1) & !(PAGE_SIZE - 1);
+        if seg_end > image_end {
+            image_end = seg_end;
         }
         segments += 1;
     }
@@ -140,7 +160,11 @@ pub fn load_user_elf(bytes: &[u8], pml4: PhysFrame<Size4KiB>) -> Result<LoadedIm
         return Err(e);
     }
 
-    Ok(LoadedImage { entry, segments })
+    Ok(LoadedImage {
+        entry,
+        segments,
+        image_end,
+    })
 }
 
 /// Load `bytes` as a lower-half ELF into `pml4` AND register each

--- a/kernel/src/mem/vmobject.rs
+++ b/kernel/src/mem/vmobject.rs
@@ -85,6 +85,12 @@ pub trait VmObject: Send + Sync {
     /// same `len_pages` bound; future file-backed objects should return a
     /// similarly independent copy.
     fn clone_private(&self) -> Arc<dyn VmObject>;
+
+    /// Release cached frames for all page indices ≥ `from_page`. Called
+    /// by `sys_brk` during heap shrink so stale frames are freed promptly
+    /// rather than waiting until the object is dropped. The default is a
+    /// no-op; `AnonObject` overrides it to trim its frame cache.
+    fn truncate_from_page(&self, _from_page: usize) {}
 }
 
 /// Clone a `VmObject` trait-object for `fork`. The default behavior is
@@ -186,6 +192,53 @@ impl VmObject for AnonObject {
             len_pages: self.len_pages,
         })
     }
+
+    fn truncate_from_page(&self, from_page: usize) {
+        #[cfg(target_os = "none")]
+        self.truncate_cache(from_page);
+        #[cfg(not(target_os = "none"))]
+        let _ = from_page;
+    }
+}
+
+/// Kernel-only methods on `AnonObject`.
+#[cfg(target_os = "none")]
+impl AnonObject {
+    /// Insert `phys` into the frame cache at page index `idx` and
+    /// increment its refcount by one for the cache's ownership.
+    ///
+    /// Use this when frames are pre-mapped into a PML4 by an external
+    /// loader (e.g. `load_user_elf`) and you want to retroactively
+    /// register them in an `AnonObject` so the VMA machinery can track
+    /// and fork them correctly.
+    ///
+    /// The caller must ensure that `phys` already has a PTE reference
+    /// (refcount ≥ 1). This method adds the cache reference on top.
+    pub fn insert_existing_frame(&self, idx: usize, phys: u64) {
+        self.inner.lock().frames.insert(idx, phys);
+        // Add the cache's reference. The PTE reference was set by the
+        // original allocator/mapper; we are adding one more here.
+        crate::mem::refcount::inc_refcount(phys);
+    }
+
+    /// Remove all cached frames whose page index is ≥ `from_page` and
+    /// release their cache references. Used by `sys_brk` when the heap
+    /// is shrunk so memory is not pinned until process exit.
+    pub fn truncate_cache(&self, from_page: usize) {
+        let evicted: alloc::vec::Vec<(usize, u64)> = {
+            let mut inner = self.inner.lock();
+            let keys: alloc::vec::Vec<usize> =
+                inner.frames.range(from_page..).map(|(&k, _)| k).collect();
+            keys.into_iter()
+                .filter_map(|k| inner.frames.remove(&k).map(|v| (k, v)))
+                .collect()
+        };
+        // Release cache references outside the lock so `frame::put` can
+        // re-enter the allocator without a spinlock collision.
+        for (_, phys) in evicted {
+            crate::mem::frame::put(phys);
+        }
+    }
 }
 
 impl Drop for AnonObject {
@@ -234,27 +287,6 @@ fn alloc_zeroed_page() -> Result<u64, VmFault> {
 fn release_frame(_phys: u64) {
     #[cfg(test)]
     tests::HOST_RELEASE_COUNT.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
-}
-
-/// Kernel-only methods on `AnonObject`.
-#[cfg(target_os = "none")]
-impl AnonObject {
-    /// Insert `phys` into the frame cache at page index `idx` and
-    /// increment its refcount by one for the cache's ownership.
-    ///
-    /// Use this when frames are pre-mapped into a PML4 by an external
-    /// loader (e.g. `load_user_elf`) and you want to retroactively
-    /// register them in an `AnonObject` so the VMA machinery can track
-    /// and fork them correctly.
-    ///
-    /// The caller must ensure that `phys` already has a PTE reference
-    /// (refcount ≥ 1). This method adds the cache reference on top.
-    pub fn insert_existing_frame(&self, idx: usize, phys: u64) {
-        self.inner.lock().frames.insert(idx, phys);
-        // Add the cache's reference. The PTE reference was set by the
-        // original allocator/mapper; we are adding one more here.
-        crate::mem::refcount::inc_refcount(phys);
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #163

## Summary
- `AddressSpace::sys_brk(addr)`: manages a single anonymous-private VMA `[brk_start, brk_cur)` backed by an unbounded `AnonObject`; grow path clones the existing Arc so already-faulted frames survive the remove+reinsert cycle; shrink path unmaps PTEs before reinserting a smaller VMA; `addr=0` probes the current break
- `AddressSpace::set_brk_start(image_end)`: called after `load_user_elf_with_vmas` in both `init_process::launch` and the execve syscall so the heap starts immediately after the ELF image rather than at the `mmap_base` placeholder
- `LoadedImage` gains an `image_end` field (page-aligned end of the last `PT_LOAD` segment) so callers don't need to re-parse the ELF
- Wires syscall `nr=12` (Linux-compatible `brk`) in `syscall_dispatch`

## Test plan
- [x] `cargo xtask build` — clean build
- [x] `cargo xtask test` — 124 host unit tests pass (2 new: `set_brk_start_advances_heap_base`, `brk_zero_returns_current_break`)
- [x] `cargo xtask smoke` — all 29 markers present ✓

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core userspace memory management (new `brk` syscall, VMA/PTE unmapping, and VmObject cache trimming), where bugs can cause leaks or address-space corruption. Scope is contained to heap management and ELF load bookkeeping with added bounds checks and tests.
> 
> **Overview**
> Implements Linux-compatible `brk(2)` by wiring syscall `12` to a new `AddressSpace::sys_brk`, which grows/shrinks the heap as a single anonymous-private VMA and updates mappings (including unmapping freed pages on shrink).
> 
> Adjusts process startup and `execve` so the heap base (`brk_start`) is set to immediately after the loaded ELF image. To support this, the ELF loader now returns an `image_end` (page-aligned end of the last `PT_LOAD`), and `VmObject`/`AnonObject` gain a trimming hook used to drop cached heap frames when shrinking.
> 
> Adds unit tests around `set_brk_start` and brk constructor invariants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a96692d17b9d9f56508542b0263a2fd209b1277. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->