### PR TITLE
fix: add macOS compatibility to auto-engineer container script

### DIFF
--- a/scripts/auto-engineer.sh
+++ b/scripts/auto-engineer.sh
@@ -49,10 +49,33 @@ if command -v getenforce >/dev/null 2>&1 && [ "$(getenforce 2>/dev/null)" != "Di
     docker_sec_opts+=(--security-opt label=disable)
 fi
 
+# On macOS, Docker Desktop runs containers in a Linux VM so host UIDs don't
+# map into the container. The OAuth token also lives in the macOS Keychain,
+# not in .claude.json, so we extract it and pass it via env var.
+claude_vol_opts=()
+if [ "$(uname -s)" = "Darwin" ]; then
+    _keychain_json="$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null || true)"
+    CLAUDE_CODE_OAUTH_TOKEN="$(echo "$_keychain_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['claudeAiOauth']['accessToken'])" 2>/dev/null || true)"
+    if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+        echo "error: could not read Claude OAuth token from Keychain — log in to Claude Code on the host first" >&2
+        exit 1
+    fi
+    claude_vol_opts+=(
+        -v "$HOME/.claude:/home/agent/.claude-host:ro"
+        -v "$HOME/.claude.json:/home/agent/.claude-host.json:ro"
+        -e CLAUDE_AUTH_STAGE=1
+        -e "CLAUDE_CODE_OAUTH_TOKEN=$CLAUDE_CODE_OAUTH_TOKEN"
+    )
+else
+    claude_vol_opts+=(
+        -v "$HOME/.claude:/home/agent/.claude"
+        -v "$HOME/.claude.json:/home/agent/.claude.json"
+    )
+fi
+
 docker run --rm -it \
     ${docker_sec_opts[@]+"${docker_sec_opts[@]}"} \
-    -v "$HOME/.claude:/home/agent/.claude" \
-    -v "$HOME/.claude.json:/home/agent/.claude.json" \
+    "${claude_vol_opts[@]}" \
     -e GITHUB_TOKEN \
     -e ANTHROPIC_API_KEY \
     -e GIT_AUTHOR_NAME \

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -3,6 +3,18 @@ set -euo pipefail
 
 : "${GITHUB_TOKEN:?GITHUB_TOKEN is required for autonomous operation}"
 
+# On macOS, auth files are mounted read-only to staging paths (to work around
+# Docker Desktop's UID mismatch). Copy them into the agent home so Claude Code
+# can read and write them with the correct ownership.
+if [ "${CLAUDE_AUTH_STAGE:-0}" = "1" ]; then
+    if [ -d /home/agent/.claude-host ]; then
+        cp -a /home/agent/.claude-host/. /home/agent/.claude/
+    fi
+    if [ -f /home/agent/.claude-host.json ]; then
+        cp /home/agent/.claude-host.json /home/agent/.claude.json
+    fi
+fi
+
 GIT_AUTHOR_NAME="${GIT_AUTHOR_NAME:-vibix auto-engineer}"
 GIT_AUTHOR_EMAIL="${GIT_AUTHOR_EMAIL:-noreply@anthropic.com}"
 REPO_SLUG="${VIBIX_REPO:-dburkart/vibix}"


### PR DESCRIPTION
## Summary

- Docker Desktop on macOS runs a Linux VM, so volume-mounted `~/.claude` files keep their host UID (501) and are unwritable by the container's `agent` user (UID 1000)
- Claude Code on macOS stores its OAuth token in the system Keychain, not in `.claude.json`, so a plain file mount leaves the container unauthenticated with "Not logged in"

**On macOS**, `auto-engineer.sh` now:
1. Reads the OAuth token from the Keychain via `security find-generic-password` and passes it as `CLAUDE_CODE_OAUTH_TOKEN`
2. Mounts `.claude/` and `.claude.json` read-only to staging paths; `docker-entrypoint.sh` copies them into the agent home on startup so the `agent` user owns them

Linux behaviour is unchanged.

## Test plan

- [x] Ran `scripts/auto-engineer.sh` on macOS — container reaches `claude auth status` → `loggedIn: true, authMethod: oauth_token`
- [x] Verified Linux path unchanged (no `uname -s = Darwin` branch taken)
- [x] Confirmed bad/missing Keychain entry prints a clear error and exits before `docker run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches container auth bootstrapping and credential handling; while scoped to scripts, mistakes could break local runs or expose tokens via environment/command-line inspection.
> 
> **Overview**
> Adds macOS-specific handling to the auto-engineer Docker runner so Claude Code auth works under Docker Desktop.
> 
> On Darwin, `auto-engineer.sh` now reads the Claude OAuth access token from the macOS Keychain and passes it into the container, and mounts `~/.claude`/`~/.claude.json` to read-only staging paths. `docker-entrypoint.sh` conditionally copies these staged auth files into the agent home on startup (guarded by `CLAUDE_AUTH_STAGE`) to avoid UID/permissions issues; non-macOS behavior keeps the original direct mounts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 778d17e404c7b46a38fde40ad0392457f32cc11f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->