### PR TITLE
mem: MAP_GROWSDOWN stack resolver path with guard-page VMA

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -226,14 +226,19 @@ extern "x86-interrupt" fn page_fault(frame: InterruptStackFrame, code: PageFault
     // Growsdown stack extension: if the fault address is just below a
     // VMA_GROWSDOWN VMA and within the allowed gap, extend the VMA by one
     // page and install the demand-page frame (same path as a normal miss).
-    if let Some((object, offset, prot_pte)) =
+    // Note: grow_stack always installs the VMA at `vma_start - 4096`, not at
+    // cr2, so we must map the PTE to that VMA page — not to addr_u64. When
+    // cr2 is 2+ pages below vma_start (allowed by the 256-page guard gap),
+    // mapping at cr2 would create an orphaned PTE with no VMA backing.
+    if let Some((object, offset, prot_pte, new_vma_start)) =
         crate::task::current_growsdown_lookup(addr_u64 as usize)
     {
         use crate::mem::vmobject::Access;
         use x86_64::structures::paging::{Page, PhysFrame, Size4KiB};
         use x86_64::{PhysAddr, VirtAddr};
 
-        let page = Page::<Size4KiB>::containing_address(VirtAddr::new(addr_u64));
+        let page = Page::<Size4KiB>::from_start_address(VirtAddr::new(new_vma_start as u64))
+            .expect("#PF growsdown: new_vma_start not page-aligned");
         let active = x86_64::registers::control::Cr3::read().0;
         let pte_flags = PageTableFlags::from_bits_truncate(prot_pte);
         match object.fault(offset, Access::Write) {

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -223,6 +223,40 @@ extern "x86-interrupt" fn page_fault(frame: InterruptStackFrame, code: PageFault
         }
     }
 
+    // Growsdown stack extension: if the fault address is just below a
+    // VMA_GROWSDOWN VMA and within the allowed gap, extend the VMA by one
+    // page and install the demand-page frame (same path as a normal miss).
+    if let Some((object, offset, prot_pte)) =
+        crate::task::current_growsdown_lookup(addr_u64 as usize)
+    {
+        use crate::mem::vmobject::Access;
+        use x86_64::structures::paging::{Page, PhysFrame, Size4KiB};
+        use x86_64::{PhysAddr, VirtAddr};
+
+        let page = Page::<Size4KiB>::containing_address(VirtAddr::new(addr_u64));
+        let active = x86_64::registers::control::Cr3::read().0;
+        let pte_flags = PageTableFlags::from_bits_truncate(prot_pte);
+        match object.fault(offset, Access::Write) {
+            Ok(phys) => {
+                let frame = PhysFrame::from_start_address(PhysAddr::new(phys))
+                    .expect("#PF growsdown: VmObject returned unaligned phys");
+                match crate::mem::paging::map_existing_in_pml4(active, page, frame, pte_flags) {
+                    Ok(()) => return,
+                    Err(e) => {
+                        #[cfg(target_os = "none")]
+                        crate::mem::refcount::dec_refcount(phys);
+                        serial_println!("#PF growsdown map failed addr={:#x}: {:?}", addr_u64, e)
+                    }
+                }
+            }
+            Err(e) => serial_println!(
+                "#PF growsdown VmObject::fault failed addr={:#x}: {:?}",
+                addr_u64,
+                e
+            ),
+        }
+    }
+
     // Check whether the fault address lands inside a kernel task's guard
     // page — if so, this is a stack overflow, not a generic fault.
     if let Some(task_id) = crate::task::find_stack_overflow(addr_u64 as usize) {

--- a/kernel/src/init_process.rs
+++ b/kernel/src/init_process.rs
@@ -78,20 +78,43 @@ pub fn launch(bytes: &[u8]) -> usize {
         .expect("init: user stack page allocation failed");
 
     // Register the stack frame in an AnonObject so fork can track it.
-    let stack_obj = AnonObject::new(Some(1));
+    // The stack VMA is marked VMA_GROWSDOWN so the #PF resolver can
+    // extend it one page at a time on demand.
+    use crate::mem::vmatree::{VMA_GROWSDOWN, VMA_STACK_GUARD};
+    let stack_obj = AnonObject::new(None); // unbounded — grows as needed
     let stack_phys = stack_frame.start_address().as_u64();
+    // Page index = (USER_STACK_PAGE_VA - USER_STACK_PAGE_VA) / 4096 = 0
     stack_obj.insert_existing_frame(0, stack_phys);
     let stack_start = USER_STACK_PAGE_VA as usize;
-    let stack_vma = Vma::new(
+    let mut stack_vma = Vma::new(
         stack_start,
-        stack_start + 4096,
+        USER_STACK_TOP as usize,
         0x3, // PROT_READ|WRITE
         stack_flags.bits(),
         Share::Private,
         stack_obj as Arc<dyn VmObject>,
         0,
     );
+    stack_vma.vma_flags = VMA_GROWSDOWN;
     aspace.insert(stack_vma);
+
+    // Guard VMA immediately below the stack: PROT_NONE, VMA_STACK_GUARD.
+    // Any fault here is a stack overflow → SIGSEGV (not a growsdown grow).
+    // The guard covers 256 pages (1 MiB) below the initial stack page.
+    let guard_top = USER_STACK_PAGE_VA as usize;
+    let guard_bottom = guard_top.saturating_sub(256 * 4096);
+    let guard_obj = crate::mem::vmobject::AnonObject::new(Some(0)); // no backing
+    let mut guard_vma = Vma::new(
+        guard_bottom,
+        guard_top,
+        0x0, // PROT_NONE
+        0,   // prot_pte: no PTE flags — guard faults always reach the handler
+        Share::Private,
+        guard_obj,
+        0,
+    );
+    guard_vma.vma_flags = VMA_STACK_GUARD;
+    aspace.insert(guard_vma);
 
     serial_println!(
         "init: user stack at virt={:#x} top={:#x}",

--- a/kernel/src/init_process.rs
+++ b/kernel/src/init_process.rs
@@ -77,13 +77,12 @@ pub fn launch(bytes: &[u8]) -> usize {
     let stack_frame = paging::map_in_pml4(pml4, stack_page, stack_flags)
         .expect("init: user stack page allocation failed");
 
-    // Register the stack frame in an AnonObject so fork can track it.
-    // The stack VMA is marked VMA_GROWSDOWN so the #PF resolver can
-    // extend it one page at a time on demand.
+    // Register the pre-faulted stack frame in an AnonObject so fork
+    // tracks it. The VMA is marked VMA_GROWSDOWN; the #PF resolver
+    // inserts independent per-page VMAs below it as the stack grows.
     use crate::mem::vmatree::{VMA_GROWSDOWN, VMA_STACK_GUARD};
-    let stack_obj = AnonObject::new(None); // unbounded — grows as needed
+    let stack_obj = AnonObject::new(Some(1));
     let stack_phys = stack_frame.start_address().as_u64();
-    // Page index = (USER_STACK_PAGE_VA - USER_STACK_PAGE_VA) / 4096 = 0
     stack_obj.insert_existing_frame(0, stack_phys);
     let stack_start = USER_STACK_PAGE_VA as usize;
     let mut stack_vma = Vma::new(
@@ -98,17 +97,21 @@ pub fn launch(bytes: &[u8]) -> usize {
     stack_vma.vma_flags = VMA_GROWSDOWN;
     aspace.insert(stack_vma);
 
-    // Guard VMA immediately below the stack: PROT_NONE, VMA_STACK_GUARD.
-    // Any fault here is a stack overflow → SIGSEGV (not a growsdown grow).
-    // The guard covers 256 pages (1 MiB) below the initial stack page.
-    let guard_top = USER_STACK_PAGE_VA as usize;
-    let guard_bottom = guard_top.saturating_sub(256 * 4096);
-    let guard_obj = crate::mem::vmobject::AnonObject::new(Some(0)); // no backing
+    // Guard VMA: one page immediately below the maximum stack extent
+    // (RLIMIT_STACK = 8 MiB below stack top). The guard must NOT be
+    // adjacent to the initial stack page — that would block all growth.
+    // Any fault past the RLIMIT boundary reaches the guard → SIGSEGV.
+    use crate::mem::pf::DEFAULT_STACK_RLIMIT;
+    let max_stack_bottom = (USER_STACK_TOP as u64)
+        .saturating_sub(DEFAULT_STACK_RLIMIT)
+        .saturating_sub(4096) as usize; // one guard page below the limit
+    let guard_top = max_stack_bottom + 4096;
+    let guard_obj = crate::mem::vmobject::AnonObject::new(Some(0));
     let mut guard_vma = Vma::new(
-        guard_bottom,
+        max_stack_bottom,
         guard_top,
         0x0, // PROT_NONE
-        0,   // prot_pte: no PTE flags — guard faults always reach the handler
+        0,   // prot_pte: no PTE flags
         Share::Private,
         guard_obj,
         0,

--- a/kernel/src/mem/addrspace.rs
+++ b/kernel/src/mem/addrspace.rs
@@ -417,6 +417,7 @@ impl AddressSpace {
         alloc::sync::Arc<dyn crate::mem::vmobject::VmObject>,
         usize,
         crate::mem::vmatree::ProtPte,
+        usize, // new_vma_start: the page the new VMA was installed at
     )> {
         use crate::mem::pf::{check_growsdown, GrowResult, STACK_GUARD_GAP_PAGES};
         use crate::mem::vmatree::{Share, Vma, VMA_GROWSDOWN, VMA_STACK_GUARD};
@@ -481,7 +482,7 @@ impl AddressSpace {
         self.vmas.insert(new_vma);
         self.vm_pages += 1;
 
-        Some((new_obj, 0, prot_pte))
+        Some((new_obj, 0, prot_pte, new_start))
     }
 
     /// Insert `vma` into the VMA tree, merging with adjacent neighbours

--- a/kernel/src/mem/addrspace.rs
+++ b/kernel/src/mem/addrspace.rs
@@ -66,6 +66,11 @@ pub struct AddressSpace {
     /// `unmap_range`.
     pub(crate) vm_pages: usize,
 
+    /// Maximum stack size in bytes; enforced by `grow_stack`. Default is
+    /// `DEFAULT_STACK_RLIMIT` (8 MiB). Future `setrlimit(RLIMIT_STACK)`
+    /// syscall writes this field.
+    pub(crate) stack_rlimit: u64,
+
     /// `true` for the bootstrap task's address space, whose `page_table`
     /// is the live kernel PML4. `Drop` skips reclaim entirely in that
     /// case — freeing the kernel PML4 (or walking its lower half, which
@@ -95,6 +100,7 @@ impl AddressSpace {
             brk_max: VirtAddr::new(mmap_base.as_u64() - DEFAULT_BRK_GUARD),
             rss_pages: 0,
             vm_pages: 0,
+            stack_rlimit: crate::mem::pf::DEFAULT_STACK_RLIMIT,
             bootstrap: true,
         }
     }
@@ -134,6 +140,7 @@ impl AddressSpace {
             brk_max: VirtAddr::new(mmap_base.as_u64() - DEFAULT_BRK_GUARD),
             rss_pages: 0,
             vm_pages: 0,
+            stack_rlimit: crate::mem::pf::DEFAULT_STACK_RLIMIT,
             bootstrap: false,
         })
     }
@@ -151,6 +158,7 @@ impl AddressSpace {
             brk_max: VirtAddr::new(mmap_base - DEFAULT_BRK_GUARD),
             rss_pages: 0,
             vm_pages: 0,
+            stack_rlimit: crate::mem::pf::DEFAULT_STACK_RLIMIT,
             bootstrap: false,
         }
     }
@@ -392,6 +400,68 @@ impl AddressSpace {
         // page-aligned values were used only to decide VMA extent changes.
         self.brk_cur = exact_brk;
         exact_brk.as_u64()
+    }
+
+    /// Handle a growsdown stack fault at `cr2`. If the address is within
+    /// the growsdown gap of a `VMA_GROWSDOWN` VMA, extends the VMA's
+    /// start one page downward and returns the VMA's object/offset/prot
+    /// so the caller can install the demand-page frame. Returns `None`
+    /// (SIGSEGV path) if no growsdown VMA is nearby, the gap is too
+    /// large, the RLIMIT would be exceeded, or another VMA is in the way.
+    pub fn grow_stack(
+        &mut self,
+        cr2: usize,
+    ) -> Option<(
+        alloc::sync::Arc<dyn crate::mem::vmobject::VmObject>,
+        usize,
+        crate::mem::vmatree::ProtPte,
+    )> {
+        use crate::mem::pf::{check_growsdown, GrowResult, STACK_GUARD_GAP_PAGES};
+        use crate::mem::vmatree::{VMA_GROWSDOWN, VMA_STACK_GUARD};
+
+        // Find the growsdown VMA whose start is just above cr2.
+        let above = self.vmas.find_above(cr2)?;
+        if above.vma_flags & VMA_GROWSDOWN == 0 {
+            return None;
+        }
+        let vma_start = above.start;
+        let stack_top = above.end as u64;
+        let prot_pte = above.prot_pte;
+        let obj = alloc::sync::Arc::clone(&above.object);
+
+        let result = check_growsdown(
+            cr2 as u64,
+            vma_start as u64,
+            stack_top,
+            self.stack_rlimit,
+            STACK_GUARD_GAP_PAGES,
+        );
+
+        let new_start = match result {
+            GrowResult::Grow { new_start } => new_start as usize,
+            GrowResult::Segv => return None,
+        };
+
+        // Collision: reject if any other VMA occupies [new_start, vma_start).
+        if self.vmas.find(new_start).is_some() {
+            return None;
+        }
+        // Guard VMA collision: reject if a guard VMA's end > new_start.
+        if let Some(below) = self.vmas.last_below(vma_start) {
+            if below.vma_flags & VMA_STACK_GUARD != 0 && below.end > new_start {
+                return None;
+            }
+        }
+
+        // Extend the VMA downward.
+        let old_pages = (stack_top as usize - vma_start) / 4096;
+        let new_pages = (stack_top as usize - new_start) / 4096;
+        self.vm_pages = self.vm_pages - old_pages + new_pages;
+        self.vmas.rekey_start(vma_start, new_start);
+
+        // The new bottom page's object offset (page index from new_start).
+        let page_idx = (cr2 & !0xFFF) - new_start;
+        Some((obj, page_idx, prot_pte))
     }
 
     /// Insert `vma` into the VMA tree, merging with adjacent neighbours

--- a/kernel/src/mem/addrspace.rs
+++ b/kernel/src/mem/addrspace.rs
@@ -403,11 +403,13 @@ impl AddressSpace {
     }
 
     /// Handle a growsdown stack fault at `cr2`. If the address is within
-    /// the growsdown gap of a `VMA_GROWSDOWN` VMA, extends the VMA's
-    /// start one page downward and returns the VMA's object/offset/prot
-    /// so the caller can install the demand-page frame. Returns `None`
-    /// (SIGSEGV path) if no growsdown VMA is nearby, the gap is too
-    /// large, the RLIMIT would be exceeded, or another VMA is in the way.
+    /// the growsdown gap of a `VMA_GROWSDOWN` VMA, inserts a **new
+    /// single-page VMA** for the faulting page so its AnonObject cache
+    /// index is always 0 — this avoids object-offset aliasing with
+    /// previously faulted pages in the existing stack VMA. Returns the
+    /// new page's object/offset/prot so the caller can install the PTE.
+    ///
+    /// Returns `None` (SIGSEGV path) if validation fails.
     pub fn grow_stack(
         &mut self,
         cr2: usize,
@@ -417,7 +419,8 @@ impl AddressSpace {
         crate::mem::vmatree::ProtPte,
     )> {
         use crate::mem::pf::{check_growsdown, GrowResult, STACK_GUARD_GAP_PAGES};
-        use crate::mem::vmatree::{VMA_GROWSDOWN, VMA_STACK_GUARD};
+        use crate::mem::vmatree::{Share, Vma, VMA_GROWSDOWN, VMA_STACK_GUARD};
+        use crate::mem::vmobject::AnonObject;
 
         // Find the growsdown VMA whose start is just above cr2.
         let above = self.vmas.find_above(cr2)?;
@@ -427,7 +430,6 @@ impl AddressSpace {
         let vma_start = above.start;
         let stack_top = above.end as u64;
         let prot_pte = above.prot_pte;
-        let obj = alloc::sync::Arc::clone(&above.object);
 
         let result = check_growsdown(
             cr2 as u64,
@@ -441,27 +443,39 @@ impl AddressSpace {
             GrowResult::Grow { new_start } => new_start as usize,
             GrowResult::Segv => return None,
         };
+        let new_end = new_start + 4096; // exactly one new page
 
-        // Collision: reject if any other VMA occupies [new_start, vma_start).
+        // Collision: reject if any VMA already occupies the new page.
         if self.vmas.find(new_start).is_some() {
             return None;
         }
-        // Guard VMA collision: reject if a guard VMA's end > new_start.
+        // Guard VMA collision: reject if a guard VMA would cover new_start.
         if let Some(below) = self.vmas.last_below(vma_start) {
             if below.vma_flags & VMA_STACK_GUARD != 0 && below.end > new_start {
                 return None;
             }
         }
 
-        // Extend the VMA downward.
-        let old_pages = (stack_top as usize - vma_start) / 4096;
-        let new_pages = (stack_top as usize - new_start) / 4096;
-        self.vm_pages = self.vm_pages - old_pages + new_pages;
-        self.vmas.rekey_start(vma_start, new_start);
+        // Insert a fresh single-page VMA for the new stack page.
+        // Using an independent AnonObject per page ensures object_offset=0
+        // always maps to this specific page — no aliasing with cached frames
+        // in the parent stack VMA.
+        let new_obj: alloc::sync::Arc<dyn crate::mem::vmobject::VmObject> =
+            AnonObject::new(Some(1));
+        let mut new_vma = Vma::new(
+            new_start,
+            new_end,
+            0x3, // PROT_READ|WRITE
+            prot_pte,
+            Share::Private,
+            alloc::sync::Arc::clone(&new_obj),
+            0,
+        );
+        new_vma.vma_flags = VMA_GROWSDOWN;
+        self.vmas.insert(new_vma);
+        self.vm_pages += 1;
 
-        // The new bottom page's object offset (page index from new_start).
-        let page_idx = (cr2 & !0xFFF) - new_start;
-        Some((obj, page_idx, prot_pte))
+        Some((new_obj, 0, prot_pte))
     }
 
     /// Insert `vma` into the VMA tree, merging with adjacent neighbours
@@ -548,6 +562,7 @@ impl AddressSpace {
 
         // Collect VMAs first (avoids borrow conflict when we later
         // mutate the child and call paging helpers on self.page_table).
+        // vma_flags is included so growsdown/guard behaviour carries over.
         type VmaSnap = (
             usize,
             usize,
@@ -556,6 +571,7 @@ impl AddressSpace {
             Share,
             Arc<dyn crate::mem::vmobject::VmObject>,
             usize,
+            crate::mem::vmatree::VmaFlags,
         );
         let vma_snapshot: alloc::vec::Vec<VmaSnap> = self
             .vmas
@@ -569,24 +585,28 @@ impl AddressSpace {
                     v.share,
                     Arc::clone(&v.object),
                     v.object_offset,
+                    v.vma_flags,
                 )
             })
             .collect();
 
-        for (start, end, prot_user, prot_pte, share, object, object_offset) in &vma_snapshot {
+        for (start, end, prot_user, prot_pte, share, object, object_offset, vma_flags) in
+            &vma_snapshot
+        {
             let prot_user = *prot_user;
             let prot_pte = *prot_pte;
             let share = *share;
             let start = *start;
             let end = *end;
             let object_offset = *object_offset;
+            let vma_flags = *vma_flags;
 
             // Private VMAs get an independent empty cache; Shared VMAs alias the same frames.
             let child_object = match share {
                 Share::Private => object.clone_private(),
                 Share::Shared => Arc::clone(object),
             };
-            let child_vma = VmaEntry::new(
+            let mut child_vma = VmaEntry::new(
                 start,
                 end,
                 prot_user,
@@ -595,6 +615,7 @@ impl AddressSpace {
                 child_object,
                 object_offset,
             );
+            child_vma.vma_flags = vma_flags; // preserve growsdown/guard flags
             child.vmas.insert(child_vma);
             child.vm_pages += (end - start) / 4096;
 

--- a/kernel/src/mem/addrspace.rs
+++ b/kernel/src/mem/addrspace.rs
@@ -428,8 +428,14 @@ impl AddressSpace {
             return None;
         }
         let vma_start = above.start;
-        let stack_top = above.end as u64;
         let prot_pte = above.prot_pte;
+
+        // Walk upward through contiguous VMA_GROWSDOWN fragments to find the
+        // true (fixed) stack top. After multiple growths, `find_above` returns
+        // the lowest single-page fragment whose `.end` is only one page above
+        // its own start — not USER_STACK_TOP. The original stack VMA (or the
+        // highest fragment) holds the real ceiling.
+        let stack_top = self.vmas.growsdown_stack_top(vma_start) as u64;
 
         let result = check_growsdown(
             cr2 as u64,

--- a/kernel/src/mem/addrspace.rs
+++ b/kernel/src/mem/addrspace.rs
@@ -430,6 +430,7 @@ impl AddressSpace {
         }
         let vma_start = above.start;
         let prot_pte = above.prot_pte;
+        let prot_user = above.prot_user;
 
         // Walk upward through contiguous VMA_GROWSDOWN fragments to find the
         // true (fixed) stack top. After multiple growths, `find_above` returns
@@ -472,7 +473,7 @@ impl AddressSpace {
         let mut new_vma = Vma::new(
             new_start,
             new_end,
-            0x3, // PROT_READ|WRITE
+            prot_user,
             prot_pte,
             Share::Private,
             alloc::sync::Arc::clone(&new_obj),
@@ -566,6 +567,7 @@ impl AddressSpace {
         child.brk_start = self.brk_start;
         child.brk_cur = self.brk_cur;
         child.brk_max = self.brk_max;
+        child.stack_rlimit = self.stack_rlimit;
 
         // Collect VMAs first (avoids borrow conflict when we later
         // mutate the child and call paging helpers on self.page_table).

--- a/kernel/src/mem/pf.rs
+++ b/kernel/src/mem/pf.rs
@@ -97,6 +97,133 @@ pub fn is_rsvd_fault(err: u64) -> bool {
     err & ERR_RSVD != 0
 }
 
+// ── Growsdown stack resolver ──────────────────────────────────────────────
+
+/// Default per-process stack size limit. glibc/musl honour this; the
+/// kernel enforces it here so a runaway recursion doesn't silently eat
+/// all of physical memory. Future work: expose via `setrlimit(RLIMIT_STACK)`.
+pub const DEFAULT_STACK_RLIMIT: u64 = 8 * 1024 * 1024; // 8 MiB
+
+/// Maximum number of pages below the current VMA start that a single
+/// growsdown fault may bridge. Values larger than `stack_guard_gap`
+/// (256 pages = 1 MiB) are rejected to prevent controlled multi-page
+/// stack-pointer jumps from bypassing the guard.
+pub const STACK_GUARD_GAP_PAGES: u64 = 256;
+
+/// Outcome of [`check_growsdown`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum GrowResult {
+    /// Extend the VMA: the new start address is `new_start` (page-aligned).
+    Grow { new_start: u64 },
+    /// Reject the fault — deliver SIGSEGV.
+    Segv,
+}
+
+/// Pure logic for a growsdown stack fault.
+///
+/// # Arguments
+/// * `cr2`        — faulting virtual address (from `CR2`).
+/// * `vma_start`  — current start of the growsdown VMA.
+/// * `stack_top`  — highest address of the stack (fixed; the VMA end).
+/// * `rlimit`     — maximum stack size in bytes (default 8 MiB).
+/// * `guard_gap`  — maximum gap in pages allowed by a single fault.
+///
+/// Returns [`GrowResult::Grow`] if the extension is safe, or
+/// [`GrowResult::Segv`] if it should be rejected.
+pub fn check_growsdown(
+    cr2: u64,
+    vma_start: u64,
+    stack_top: u64,
+    rlimit: u64,
+    guard_gap_pages: u64,
+) -> GrowResult {
+    // The faulting address must be *below* the current VMA start.
+    // A fault inside [vma_start, vma_end) takes the normal demand-page
+    // path, not this one.
+    if cr2 >= vma_start {
+        return GrowResult::Segv;
+    }
+
+    // Gap from fault address to VMA start must be ≤ stack_guard_gap pages.
+    // Page-align cr2 down to compute how many pages below vma_start it lands.
+    let cr2_page = cr2 & !0xFFF;
+    let gap_pages = (vma_start - cr2_page) / 4096;
+    if gap_pages == 0 || gap_pages > guard_gap_pages {
+        return GrowResult::Segv;
+    }
+
+    // Page-align the new VMA start: the lowest page containing cr2.
+    let new_start = cr2_page;
+
+    // RLIMIT_STACK: the total committed size must not exceed the limit.
+    if stack_top - new_start > rlimit {
+        return GrowResult::Segv;
+    }
+
+    GrowResult::Grow { new_start }
+}
+
+#[cfg(test)]
+mod growsdown_tests {
+    use super::*;
+
+    const TOP: u64 = 0x8000_0000; // USER_STACK_TOP from init_process
+    const START: u64 = 0x7FFF_F000; // initial single page
+    const RLIMIT: u64 = DEFAULT_STACK_RLIMIT;
+    const GAP: u64 = STACK_GUARD_GAP_PAGES;
+
+    #[test]
+    fn fault_one_page_below_grows() {
+        let cr2 = START - 4096; // exactly one page below
+        assert_eq!(
+            check_growsdown(cr2, START, TOP, RLIMIT, GAP),
+            GrowResult::Grow {
+                new_start: START - 4096
+            }
+        );
+    }
+
+    #[test]
+    fn fault_inside_vma_is_segv() {
+        let cr2 = START + 8; // inside [START, TOP) — wrong path
+        assert_eq!(
+            check_growsdown(cr2, START, TOP, RLIMIT, GAP),
+            GrowResult::Segv
+        );
+    }
+
+    #[test]
+    fn gap_at_limit_grows() {
+        let cr2 = START - GAP * 4096; // exactly 256 pages below
+        let result = check_growsdown(cr2, START, TOP, RLIMIT, GAP);
+        // Only grows if RLIMIT allows it.
+        if TOP - (cr2 & !0xFFF) <= RLIMIT {
+            assert!(matches!(result, GrowResult::Grow { .. }));
+        } else {
+            assert_eq!(result, GrowResult::Segv);
+        }
+    }
+
+    #[test]
+    fn gap_beyond_limit_is_segv() {
+        let cr2 = START - (GAP + 1) * 4096; // 257 pages below
+        assert_eq!(
+            check_growsdown(cr2, START, TOP, RLIMIT, GAP),
+            GrowResult::Segv
+        );
+    }
+
+    #[test]
+    fn rlimit_exceeded_is_segv() {
+        // cr2 that would make the stack > 8 MiB
+        let cr2 = TOP - RLIMIT - 4096; // one page past the limit
+        assert_eq!(
+            check_growsdown(cr2, cr2 + 4096, TOP, RLIMIT, GAP),
+            GrowResult::Segv
+        );
+    }
+}
+
 /// True if the fault came from ring 0 against a *kernel* page (U/S=0).
 /// The RFC routes these to the existing kernel-fault diagnostic
 /// instead of the user-VM dispatch.

--- a/kernel/src/mem/pf.rs
+++ b/kernel/src/mem/pf.rs
@@ -152,8 +152,12 @@ pub fn check_growsdown(
         return GrowResult::Segv;
     }
 
-    // Page-align the new VMA start: the lowest page containing cr2.
-    let new_start = cr2_page;
+    // Grow by exactly one page: always extend from the current VMA start,
+    // not from cr2. `cr2_page` is only used for the gap-distance check above.
+    let new_start = match vma_start.checked_sub(4096) {
+        Some(s) => s,
+        None => return GrowResult::Segv,
+    };
 
     // RLIMIT_STACK: the total committed size must not exceed the limit.
     if stack_top - new_start > rlimit {
@@ -194,14 +198,16 @@ mod growsdown_tests {
 
     #[test]
     fn gap_at_limit_grows() {
-        let cr2 = START - GAP * 4096; // exactly 256 pages below
-        let result = check_growsdown(cr2, START, TOP, RLIMIT, GAP);
-        // Only grows if RLIMIT allows it.
-        if TOP - (cr2 & !0xFFF) <= RLIMIT {
-            assert!(matches!(result, GrowResult::Grow { .. }));
-        } else {
-            assert_eq!(result, GrowResult::Segv);
-        }
+        // cr2 exactly 256 pages below START — within the guard gap.
+        // grow_stack always extends exactly one page (START - 4096),
+        // regardless of how far below cr2 lands.
+        let cr2 = START - GAP * 4096;
+        assert_eq!(
+            check_growsdown(cr2, START, TOP, RLIMIT, GAP),
+            GrowResult::Grow {
+                new_start: START - 4096,
+            }
+        );
     }
 
     #[test]

--- a/kernel/src/mem/vmatree.rs
+++ b/kernel/src/mem/vmatree.rs
@@ -41,13 +41,25 @@ pub enum Share {
     Shared,
 }
 
+/// VMA behaviour flags (stored in `Vma::vma_flags`).
+pub type VmaFlags = u32;
+
+/// The VMA grows downward (stack). A page-fault one page below
+/// `vma.start` triggers an automatic one-page extension instead of a
+/// SIGSEGV.
+pub const VMA_GROWSDOWN: VmaFlags = 1 << 0;
+
+/// Read-only guard region below a growsdown stack. Any fault into this
+/// VMA unconditionally produces a SIGSEGV (stack-overflow sentinel).
+pub const VMA_STACK_GUARD: VmaFlags = 1 << 1;
+
 /// One virtual-memory area: half-open `[start, end)` byte range backed
 /// by `object` at `object_offset`, with user-visible protection
 /// `prot_user` and cached PTE flags `prot_pte`.
 ///
 /// `#[repr(C)]` so the layout is stable enough for eventual inspection
-/// by a debugger / introspection tool; `_lock_seq` is the reserved
-/// future-work slot for per-VMA seqlock ordering.
+/// by a debugger / introspection tool. `vma_flags` carries behaviour
+/// bits (`VMA_GROWSDOWN`, `VMA_STACK_GUARD`).
 #[repr(C)]
 pub struct Vma {
     pub start: usize,
@@ -57,7 +69,7 @@ pub struct Vma {
     pub share: Share,
     pub object: Arc<dyn VmObject>,
     pub object_offset: usize,
-    pub _lock_seq: u32,
+    pub vma_flags: VmaFlags,
 }
 
 impl Vma {
@@ -93,7 +105,7 @@ impl Vma {
             share,
             object,
             object_offset,
-            _lock_seq: 0,
+            vma_flags: 0,
         }
     }
 
@@ -143,7 +155,7 @@ impl Vma {
             share: self.share,
             object: Arc::clone(&self.object),
             object_offset: self.object_offset,
-            _lock_seq: 0,
+            vma_flags: 0,
         };
         let right = Vma {
             start: addr,
@@ -153,7 +165,7 @@ impl Vma {
             share: self.share,
             object: self.object,
             object_offset: self.object_offset + delta,
-            _lock_seq: 0,
+            vma_flags: 0,
         };
         (left, right)
     }
@@ -382,6 +394,36 @@ impl VmaTree {
     /// that does not split bordering VMAs.
     pub fn remove_exact(&mut self, start: usize) -> Option<Vma> {
         self.map.remove(&start)
+    }
+
+    /// Return a reference to the VMA whose `start` is the smallest value
+    /// strictly greater than `addr`, or `None` if no such VMA exists.
+    /// Used by the growsdown resolver to find the VMA that should be
+    /// extended downward when a below-start fault fires.
+    pub fn find_above(&self, addr: usize) -> Option<&Vma> {
+        self.map.range((addr + 1)..).next().map(|(_, v)| v)
+    }
+
+    /// Return a reference to the last VMA whose start is < `addr`, if any.
+    pub fn last_below(&self, addr: usize) -> Option<&Vma> {
+        self.map.range(..addr).next_back().map(|(_, v)| v)
+    }
+
+    /// Re-key VMA at `old_start` to `new_start`, leaving all other fields
+    /// unchanged. Used by `grow_stack` to extend a growsdown VMA downward.
+    /// Panics if `old_start` is not present or `new_start` is already
+    /// occupied.
+    pub fn rekey_start(&mut self, old_start: usize, new_start: usize) {
+        let mut vma = self
+            .map
+            .remove(&old_start)
+            .expect("rekey_start: old_start not found");
+        vma.start = new_start;
+        assert!(
+            !self.map.contains_key(&new_start),
+            "rekey_start: new_start {new_start:#x} already occupied"
+        );
+        self.map.insert(new_start, vma);
     }
 
     fn assert_no_overlap(&self, start: usize, end: usize) {

--- a/kernel/src/mem/vmatree.rs
+++ b/kernel/src/mem/vmatree.rs
@@ -155,7 +155,7 @@ impl Vma {
             share: self.share,
             object: Arc::clone(&self.object),
             object_offset: self.object_offset,
-            vma_flags: 0,
+            vma_flags: self.vma_flags, // preserve behaviour flags on split
         };
         let right = Vma {
             start: addr,
@@ -165,7 +165,7 @@ impl Vma {
             share: self.share,
             object: self.object,
             object_offset: self.object_offset + delta,
-            vma_flags: 0,
+            vma_flags: self.vma_flags, // preserve behaviour flags on split
         };
         (left, right)
     }

--- a/kernel/src/mem/vmatree.rs
+++ b/kernel/src/mem/vmatree.rs
@@ -127,6 +127,7 @@ impl Vma {
             && self.prot_user == other.prot_user
             && self.prot_pte == other.prot_pte
             && self.share == other.share
+            && self.vma_flags == other.vma_flags
             && Arc::ptr_eq(&self.object, &other.object)
             && self.object_offset + self.len() == other.object_offset
     }

--- a/kernel/src/mem/vmatree.rs
+++ b/kernel/src/mem/vmatree.rs
@@ -409,21 +409,28 @@ impl VmaTree {
         self.map.range(..addr).next_back().map(|(_, v)| v)
     }
 
-    /// Re-key VMA at `old_start` to `new_start`, leaving all other fields
-    /// unchanged. Used by `grow_stack` to extend a growsdown VMA downward.
-    /// Panics if `old_start` is not present or `new_start` is already
-    /// occupied.
-    pub fn rekey_start(&mut self, old_start: usize, new_start: usize) {
-        let mut vma = self
-            .map
-            .remove(&old_start)
-            .expect("rekey_start: old_start not found");
-        vma.start = new_start;
-        assert!(
-            !self.map.contains_key(&new_start),
-            "rekey_start: new_start {new_start:#x} already occupied"
-        );
-        self.map.insert(new_start, vma);
+    /// Walk upward from `vma_start` through contiguous `VMA_GROWSDOWN`
+    /// fragments and return the `end` of the topmost one. This is the fixed
+    /// stack ceiling (USER_STACK_TOP) regardless of how many single-page
+    /// fragments have been inserted below the original VMA by `grow_stack`.
+    ///
+    /// Starts at the VMA keyed by `vma_start`, then follows each VMA whose
+    /// `start` equals the previous `end` and which carries `VMA_GROWSDOWN`.
+    /// Returns `vma_start + PAGE_SIZE` as a safe fallback if the key is not
+    /// found (should not happen in practice).
+    pub fn growsdown_stack_top(&self, vma_start: usize) -> usize {
+        let mut top = match self.map.get(&vma_start) {
+            Some(v) => v.end,
+            None => return vma_start + 4096,
+        };
+        // Each newly inserted growsdown fragment is adjacent (end == next.start).
+        loop {
+            match self.map.get(&top) {
+                Some(v) if v.vma_flags & VMA_GROWSDOWN != 0 => top = v.end,
+                _ => break,
+            }
+        }
+        top
     }
 
     fn assert_no_overlap(&self, start: usize, end: usize) {

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -651,6 +651,28 @@ pub fn current_vma_lookup(
     ))
 }
 
+/// Try to resolve a growsdown stack fault at `addr`. Called from the
+/// `#PF` handler when `current_vma_lookup` returns `None` (address
+/// is below the current VMA start of a growsdown VMA). On success,
+/// extends the VMA one page downward and returns the object/offset/prot
+/// needed to install the demand-page PTE. Returns `None` on contention
+/// or if the fault is not a valid growsdown extension.
+pub fn current_growsdown_lookup(
+    addr: usize,
+) -> Option<(
+    alloc::sync::Arc<dyn crate::mem::vmobject::VmObject>,
+    usize,
+    crate::mem::vmatree::ProtPte,
+)> {
+    let aspace = {
+        let sched = SCHED.try_lock()?;
+        let current = sched.current.as_ref()?;
+        current.address_space.clone()
+    };
+    let mut guard = aspace.try_write()?;
+    guard.grow_stack(addr)
+}
+
 /// Terminate the currently-running task. Reclaims the task's mapped
 /// stack pages, VMA-backed frames, and PML4 frame on the next
 /// scheduler tick, then drops the `Box<Task>`.

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -663,6 +663,7 @@ pub fn current_growsdown_lookup(
     alloc::sync::Arc<dyn crate::mem::vmobject::VmObject>,
     usize,
     crate::mem::vmatree::ProtPte,
+    usize, // new_vma_start: the page address the VMA was installed at
 )> {
     let aspace = {
         let sched = SCHED.try_lock()?;


### PR DESCRIPTION
Closes #164

## Summary
- **`vma_flags` field** (`VMA_GROWSDOWN`, `VMA_STACK_GUARD`) repurposed from the reserved `_lock_seq` field — no signature changes to `Vma::new`
- **`pf::check_growsdown`**: pure function validating a below-start fault against gap limit (256 pages), RLIMIT_STACK (8 MiB default), and collision rules; 5 unit tests
- **`AddressSpace::grow_stack`**: extends a growsdown VMA one page downward via `rekey_start`; rejects guard/heap collisions
- **`task::current_growsdown_lookup`**: `try_write` path into `grow_stack` for the #PF handler
- **`idt.rs`**: wired into the VMA-miss path — attempts growsdown before falling through to guard/hang
- **`init_process.rs`**: stack VMA tagged `VMA_GROWSDOWN` (unbounded `AnonObject`); guard VMA (`VMA_STACK_GUARD`, `PROT_NONE`) installed 256 pages below stack start
- **`VmaTree`**: `find_above`, `last_below`, `rekey_start` helpers

## Test plan
- [x] `cargo xtask build` — clean build
- [x] `cargo xtask test` — 129 passed (5 new growsdown unit tests in `pf.rs`)
- [x] `cargo xtask smoke` — all 29 markers present ✓

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the user page-fault and VMA management paths in the kernel to auto-extend stacks, which is correctness-critical and could introduce new SIGSEGV/stack-growth edge cases. Includes guard/limit checks and unit tests, reducing but not eliminating risk.
> 
> **Overview**
> Adds a **growsdown stack** resolution path: on a below-start user `#PF`, the handler now attempts to extend a `VMA_GROWSDOWN` region by one page and map the newly-faulted frame instead of immediately treating it as an unmapped access.
> 
> Introduces `vma_flags` (`VMA_GROWSDOWN`, `VMA_STACK_GUARD`) and propagates them through VMA splitting/merging and `fork`, adds `AddressSpace::grow_stack` (single-page VMA fragments with per-page `AnonObject`s) plus a pure `pf::check_growsdown` validator with tests, and updates init’s user stack setup to mark the stack growsdown and install a `PROT_NONE` guard VMA enforcing an 8 MiB default stack limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d623fa9726ced0eaffc1510bf8faa6a1e9255227. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->