### PR TITLE
Attempt to fix the file-bug workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,9 @@ jobs:
             "Bash(gh run view:*)"
             "Bash(gh issue list:*)"
             "Skill(file-issue)"
+            "mcp__github__search_issues"
+            "mcp__github__add_issue_comment"
+            "mcp__github__issue_write"
           prompt: |
             The CI build on the main branch of the vibix kernel repo just failed.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,8 @@ jobs:
             --allowed-tools
             "Bash(gh run view:*)"
             "Bash(gh issue list:*)"
+            "Bash(cat:*)"
+            "Read"
             "Skill(file-issue)"
             "mcp__github__search_issues"
             "mcp__github__add_issue_comment"
@@ -114,6 +116,5 @@ jobs:
             - The workflow run URL above so it is easy to navigate to the logs
             - The commit SHA and message that introduced the failure
 
-            Before filing, run:
-              gh issue list --state open --search "${{ github.sha }}"
-            and skip filing if an open issue for this exact commit SHA already exists.
+            The `file-issue` skill handles duplicate detection automatically (it searches
+            by issue title keywords). Do not add any extra deduplication step.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the GitHub Actions `file-bug` job behavior (tool permissions/allowed tools and issue deduplication instructions) with no production code impact.
> 
> **Overview**
> Updates the `file-bug` step in `.github/workflows/ci.yml` to expand Claude’s allowed tooling (adds `cat`, `Read`, and GitHub MCP issue tools) to better gather failure context and create/update issues.
> 
> Removes the manual `gh issue list` deduplication instructions from the prompt and relies on the `file-issue` skill’s built-in duplicate detection instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9380bf0d7d03f10ca7b3811bd93599b0300f0285. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->