### PR TITLE
fix: add macOS compatibility to usage probe script

### DIFF
--- a/.claude/skills/usage/probe.sh
+++ b/.claude/skills/usage/probe.sh
@@ -14,18 +14,29 @@ FORCE=0
 [[ "${1:-}" == "--force" ]] && FORCE=1
 
 if [[ $FORCE -eq 0 && -f "$CACHE" ]]; then
-  age=$(( $(date +%s) - $(stat -c %Y "$CACHE" 2>/dev/null || echo 0) ))
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    mtime=$(stat -f %m "$CACHE" 2>/dev/null || echo 0)
+  else
+    mtime=$(stat -c %Y "$CACHE" 2>/dev/null || echo 0)
+  fi
+  age=$(( $(date +%s) - mtime ))
   if [[ $age -lt $TTL ]]; then
     cat "$CACHE"; exit 0
   fi
 fi
 
-CREDS="${HOME}/.claude/.credentials.json"
-[[ -r "$CREDS" ]] || { echo '{"error":"no-credentials"}'; exit 2; }
-
-TOK=$(python3 -c "import json,sys;print(json.load(open('$CREDS'))['claudeAiOauth']['accessToken'])" 2>/dev/null) || {
-  echo '{"error":"credentials-parse-failed"}'; exit 2;
-}
+# On macOS, the OAuth token lives in the Keychain; on Linux it's in .credentials.json
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  _keychain_json="$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null || true)"
+  TOK=$(echo "$_keychain_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['claudeAiOauth']['accessToken'])" 2>/dev/null || true)
+  [[ -n "$TOK" ]] || { echo '{"error":"no-credentials"}'; exit 2; }
+else
+  CREDS="${HOME}/.claude/.credentials.json"
+  [[ -r "$CREDS" ]] || { echo '{"error":"no-credentials"}'; exit 2; }
+  TOK=$(python3 -c "import json,sys;print(json.load(open('$CREDS'))['claudeAiOauth']['accessToken'])" 2>/dev/null) || {
+    echo '{"error":"credentials-parse-failed"}'; exit 2;
+  }
+fi
 
 HDR=$(mktemp); BODY=$(mktemp)
 trap 'rm -f "$HDR" "$BODY"' EXIT


### PR DESCRIPTION
## Summary
- `probe.sh` failed on macOS with `{"error":"no-credentials"}` because Claude Code stores the OAuth token in the macOS Keychain, not in `~/.claude/.credentials.json`
- `stat -c %Y` (used for cache mtime) is Linux-only; macOS uses `stat -f %m`

Mirrors the same fix applied to `auto-engineer.sh` in #213.

## Test plan
- [x] Ran `bash .claude/skills/usage/probe.sh --force` on macOS — returns valid JSON with 5h/7d utilization
- [x] Linux code path unchanged (guarded by `uname -s` check)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, OS-guarded shell changes limited to cache mtime and credential lookup; Linux path remains intact.
> 
> **Overview**
> Fixes `.claude/skills/usage/probe.sh` compatibility on macOS by using `stat -f %m` for cache age calculation and reading the OAuth access token from the macOS Keychain (`security find-generic-password`) instead of `~/.claude/.credentials.json`.
> 
> Linux behavior is preserved via `uname -s` branching, keeping the existing file-based credential parsing and `stat -c %Y` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01e963c490c6421aeddf6593dc5d7f3382ed2e4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->