### PR TITLE
syscall: mmap / munmap / mprotect / madvise (RFC 0001)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -171,3 +171,7 @@ harness = false
 [[test]]
 name = "vm_integration"
 harness = false
+
+[[test]]
+name = "syscall_mmap_family"
+harness = false

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -265,9 +265,19 @@ pub unsafe extern "C" fn syscall_dispatch(
         // backed by `SerialBackend`. Any other path returns -ENOENT.
         2 => sys_open(a0, a1, a2),
 
-        // mmap(addr, len, prot, flags, fd, off) — anonymous private
-        // mappings only for now. See `sys_mmap` for full validation.
+        // mmap(addr, len, prot, flags, fd, off) — anon-private and
+        // anon-shared with full MAP_FIXED / MAP_GROWSDOWN support. See
+        // `sys_mmap` for full validation.
         9 => sys_mmap(a0, a1, a2, a3, a4, a5),
+
+        // mprotect(addr, len, prot)
+        10 => sys_mprotect(a0, a1, a2),
+
+        // munmap(addr, len)
+        11 => sys_munmap(a0, a1),
+
+        // madvise(addr, len, advice)
+        28 => sys_madvise(a0, a1, a2),
 
         // close(fd)
         3 => {
@@ -533,29 +543,37 @@ unsafe fn sys_open(path_uva: u64, flags: u64, _mode: u64) -> i64 {
     }
 }
 
-/// `mmap(addr, len, prot, flags, fd, off)` — anonymous private only.
+/// Build `prot_pte` from user-visible `prot_user` bits. `PROT_WRITE`
+/// without `PROT_READ` installs `R|W` because x86 cannot separate the
+/// two; `prot_user` preserves the original request.
+fn prot_pte_from_prot_user(prot: u32) -> u64 {
+    use crate::mem::pf::{PROT_EXEC, PROT_WRITE};
+    use x86_64::structures::paging::PageTableFlags;
+    let mut pte = PageTableFlags::PRESENT | PageTableFlags::USER_ACCESSIBLE;
+    if prot & PROT_WRITE != 0 {
+        pte |= PageTableFlags::WRITABLE;
+    }
+    if prot & PROT_EXEC == 0 {
+        pte |= PageTableFlags::NO_EXECUTE;
+    }
+    pte.bits()
+}
+
+/// `mmap(addr, len, prot, flags, fd, off)` — anon-private + anon-shared.
 ///
-/// Supported: `MAP_ANONYMOUS | MAP_PRIVATE`, `fd == -1`, `off == 0`.
-/// Everything else (file-backed, `MAP_SHARED`, `MAP_FIXED`, unknown
-/// flag bits) returns `-EINVAL`. The chosen VA is picked by
-/// `AddressSpace::find_unmapped_region`; the `addr` hint is ignored.
-unsafe fn sys_mmap(_addr: u64, len: u64, prot: u64, flags: u64, fd: u64, off: u64) -> i64 {
-    use crate::fs::{EINVAL, ENOMEM};
-    use crate::mem::pf::{MAP_ANONYMOUS, MAP_PRIVATE, PROT_EXEC, PROT_READ, PROT_WRITE};
-    use crate::mem::vmatree::{Share, Vma};
+/// Supports `MAP_PRIVATE` / `MAP_SHARED` (mutually exclusive) with
+/// `MAP_ANONYMOUS`; honours `MAP_FIXED`, `MAP_FIXED_NOREPLACE`,
+/// `MAP_GROWSDOWN`, and `MAP_STACK`. `fd != -1` returns `-ENODEV`
+/// (file-backed path not implemented). Validation follows RFC 0001.
+unsafe fn sys_mmap(addr: u64, len: u64, prot: u64, flags: u64, fd: u64, off: u64) -> i64 {
+    use crate::fs::{EEXIST, EINVAL, ENODEV, ENOMEM};
+    use crate::mem::pf::{
+        validate_user_range, AddrAlign, MAP_ANONYMOUS, MAP_FIXED, MAP_FIXED_NOREPLACE,
+        MAP_GROWSDOWN, MAP_PRIVATE, MAP_SHARED, MAP_STACK, PROT_EXEC, PROT_READ, PROT_WRITE,
+    };
+    use crate::mem::vmatree::{Share, Vma, VMA_GROWSDOWN};
     use crate::mem::vmobject::{AnonObject, VmObject};
     use alloc::sync::Arc;
-    use x86_64::structures::paging::PageTableFlags;
-
-    if len == 0 {
-        return EINVAL;
-    }
-
-    // Page-round len, rejecting overflow.
-    let len = match (len as usize).checked_add(4095) {
-        Some(n) => n & !4095,
-        None => return EINVAL,
-    };
 
     let flags = flags as u32;
     let prot = prot as u32;
@@ -564,49 +582,172 @@ unsafe fn sys_mmap(_addr: u64, len: u64, prot: u64, flags: u64, fd: u64, off: u6
     if prot & !(PROT_READ | PROT_WRITE | PROT_EXEC) != 0 {
         return EINVAL;
     }
-    // Require both MAP_ANONYMOUS and MAP_PRIVATE; reject every other bit.
-    if flags != (MAP_ANONYMOUS | MAP_PRIVATE) {
-        return EINVAL;
-    }
-    // Anonymous mapping: fd must be -1, offset must be 0.
+
+    // File-backed path not implemented — Linux returns ENODEV for
+    // "file type not supported by mmap", matching RFC 0001.
     if fd as i64 != -1 {
-        return EINVAL;
+        return ENODEV;
     }
     if off != 0 {
         return EINVAL;
     }
 
+    // Every supported bit must be one of the RFC set.
+    let known = MAP_SHARED
+        | MAP_PRIVATE
+        | MAP_FIXED
+        | MAP_FIXED_NOREPLACE
+        | MAP_ANONYMOUS
+        | MAP_GROWSDOWN
+        | MAP_STACK;
+    if flags & !known != 0 {
+        return EINVAL;
+    }
+
+    // Anonymous-only for now.
+    if flags & MAP_ANONYMOUS == 0 {
+        return ENODEV;
+    }
+
+    // Exactly one of MAP_PRIVATE / MAP_SHARED must be set.
+    let priv_bit = flags & MAP_PRIVATE != 0;
+    let shared_bit = flags & MAP_SHARED != 0;
+    if priv_bit == shared_bit {
+        return EINVAL;
+    }
+    let share = if priv_bit {
+        Share::Private
+    } else {
+        Share::Shared
+    };
+
+    // MAP_FIXED_NOREPLACE implies MAP_FIXED semantics for address handling.
+    let fixed = flags & (MAP_FIXED | MAP_FIXED_NOREPLACE) != 0;
+
+    // Validate the range: fixed → exact alignment required, hint → round down.
+    let align = if fixed {
+        AddrAlign::Exact
+    } else {
+        AddrAlign::RoundDown
+    };
+    let range = match validate_user_range(addr, len, align) {
+        Ok(r) => r,
+        Err(_) => return EINVAL,
+    };
+
     let aspace = crate::task::current_address_space();
     let mut guard = aspace.write();
 
-    let start = match guard.find_unmapped_region(len) {
-        Some(s) => s,
-        None => return ENOMEM,
+    let start = if fixed {
+        if flags & MAP_FIXED_NOREPLACE != 0 && guard.range_overlaps_any(range.addr, range.len) {
+            return EEXIST;
+        }
+        // Bare MAP_FIXED: evict any overlap so the new mapping can land.
+        if flags & MAP_FIXED_NOREPLACE == 0 {
+            guard.sys_munmap_range(range.addr, range.addr + range.len);
+        }
+        range.addr
+    } else {
+        match guard.find_unmapped_region(range.len) {
+            Some(s) => s,
+            None => return ENOMEM,
+        }
     };
 
-    // Build PTE flags: PRESENT|USER always; WRITABLE if PROT_WRITE;
-    // NX if !PROT_EXEC.
-    let mut pte = PageTableFlags::PRESENT | PageTableFlags::USER_ACCESSIBLE;
-    if prot & PROT_WRITE != 0 {
-        pte |= PageTableFlags::WRITABLE;
-    }
-    if prot & PROT_EXEC == 0 {
-        pte |= PageTableFlags::NO_EXECUTE;
-    }
-
-    let pages = len / 4096;
+    let pte_bits = prot_pte_from_prot_user(prot);
+    let pages = range.len / 4096;
     let obj = AnonObject::new(Some(pages));
-    let vma = Vma::new(
+
+    let mut vma = Vma::new(
         start,
-        start + len,
+        start + range.len,
         prot,
-        pte.bits(),
-        Share::Private,
+        pte_bits,
+        share,
         obj as Arc<dyn VmObject>,
         0,
     );
+    if flags & MAP_GROWSDOWN != 0 {
+        vma.vma_flags |= VMA_GROWSDOWN;
+    }
     guard.insert(vma);
     start as i64
+}
+
+/// `munmap(addr, len)` — POSIX-conformant: returns 0 on success and on
+/// holes (partly-or-wholly unmapped ranges). `-EINVAL` only for the
+/// validation failures in RFC 0001.
+unsafe fn sys_munmap(addr: u64, len: u64) -> i64 {
+    use crate::fs::EINVAL;
+    use crate::mem::pf::{validate_user_range, AddrAlign};
+
+    let range = match validate_user_range(addr, len, AddrAlign::Exact) {
+        Ok(r) => r,
+        Err(_) => return EINVAL,
+    };
+
+    let aspace = crate::task::current_address_space();
+    let mut guard = aspace.write();
+    guard.sys_munmap_range(range.addr, range.addr + range.len);
+    0
+}
+
+/// `mprotect(addr, len, prot)` — Linux `mprotect_fixup` semantics.
+/// `-EINVAL` on validation failure or unknown PROT bits; `-ENOMEM` only
+/// when a sub-page of `[addr, addr+len)` is literally unmapped.
+unsafe fn sys_mprotect(addr: u64, len: u64, prot: u64) -> i64 {
+    use crate::fs::{EINVAL, ENOMEM};
+    use crate::mem::pf::{validate_user_range, AddrAlign, PROT_EXEC, PROT_READ, PROT_WRITE};
+
+    let prot = prot as u32;
+    if prot & !(PROT_READ | PROT_WRITE | PROT_EXEC) != 0 {
+        return EINVAL;
+    }
+
+    let range = match validate_user_range(addr, len, AddrAlign::Exact) {
+        Ok(r) => r,
+        Err(_) => return EINVAL,
+    };
+
+    let aspace = crate::task::current_address_space();
+    let mut guard = aspace.write();
+
+    if !guard.range_fully_covered(range.addr, range.len) {
+        return ENOMEM;
+    }
+
+    let pte_bits = prot_pte_from_prot_user(prot);
+    guard.sys_mprotect_range(range.addr, range.addr + range.len, prot, pte_bits);
+    0
+}
+
+/// `madvise(addr, len, advice)`. `MADV_DONTNEED` on `MAP_PRIVATE |
+/// MAP_ANONYMOUS` drops the covered PTEs and evicts the backing
+/// `AnonObject`'s cached frames. Every other recognised advice value is
+/// accepted as a no-op; unknown advice returns `-EINVAL`.
+unsafe fn sys_madvise(addr: u64, len: u64, advice: u64) -> i64 {
+    use crate::fs::EINVAL;
+    use crate::mem::pf::{
+        validate_user_range, AddrAlign, MADV_DONTNEED, MADV_FREE, MADV_NORMAL, MADV_RANDOM,
+        MADV_SEQUENTIAL, MADV_WILLNEED,
+    };
+
+    let range = match validate_user_range(addr, len, AddrAlign::Exact) {
+        Ok(r) => r,
+        Err(_) => return EINVAL,
+    };
+
+    let advice = advice as i32;
+    match advice {
+        MADV_DONTNEED => {
+            let aspace = crate::task::current_address_space();
+            let mut guard = aspace.write();
+            guard.sys_madvise_dontneed(range.addr, range.addr + range.len);
+            0
+        }
+        MADV_NORMAL | MADV_RANDOM | MADV_SEQUENTIAL | MADV_WILLNEED | MADV_FREE => 0,
+        _ => EINVAL,
+    }
 }
 
 unsafe extern "C" {

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -50,6 +50,8 @@ pub const EAGAIN: i64 = -11;
 pub const EINVAL: i64 = -22;
 pub const EMFILE: i64 = -24;
 pub const ENAMETOOLONG: i64 = -36;
+pub const EEXIST: i64 = -17;
+pub const ENODEV: i64 = -19;
 
 /// Per-process file-descriptor array.
 ///

--- a/kernel/src/mem/addrspace.rs
+++ b/kernel/src/mem/addrspace.rs
@@ -551,6 +551,164 @@ impl AddressSpace {
             None
         }
     }
+
+    /// True if any existing VMA overlaps `[start, start + len)`.
+    /// Used by `MAP_FIXED_NOREPLACE` to detect collisions before
+    /// inserting the new mapping.
+    pub fn range_overlaps_any(&self, start: usize, len: usize) -> bool {
+        let end = start + len;
+        // Left neighbour with end > start? Right neighbour with start < end?
+        self.vmas
+            .iter()
+            .any(|v| !(v.end <= start || v.start >= end))
+    }
+
+    /// True if every page in `[start, start + len)` is covered by some
+    /// existing VMA. Used by `sys_mprotect` to distinguish "partial hole
+    /// inside a covered range" (POSIX-conformant 0) from "sub-page
+    /// literally unmapped" (ENOMEM).
+    pub fn range_fully_covered(&self, start: usize, len: usize) -> bool {
+        let end = start + len;
+        let mut cursor = start;
+        for vma in self.vmas.iter() {
+            if vma.end <= cursor {
+                continue;
+            }
+            if vma.start > cursor {
+                return false; // hole at [cursor, vma.start)
+            }
+            cursor = vma.end;
+            if cursor >= end {
+                return true;
+            }
+        }
+        cursor >= end
+    }
+
+    /// Tear down PTEs for `[start, end)` in this PML4 and release each
+    /// PTE's refcount. VMA tree structure is not touched — call
+    /// `vmas.unmap_range` separately if the VMA entries themselves need
+    /// to be removed (`munmap`) vs. kept (`madvise(MADV_DONTNEED)`).
+    #[cfg(target_os = "none")]
+    pub fn drop_ptes_in_range(&mut self, start: usize, end: usize) {
+        use x86_64::structures::paging::{FrameDeallocator, Page, Size4KiB};
+        let pml4 = self.page_table;
+        let mut va = start;
+        while va < end {
+            let page = Page::<Size4KiB>::from_start_address(VirtAddr::new(va as u64))
+                .expect("drop_ptes_in_range: start page-aligned");
+            if let Ok(frame) = crate::mem::paging::unmap_in_pml4(pml4, page) {
+                unsafe {
+                    crate::mem::paging::KernelFrameAllocator.deallocate_frame(frame);
+                }
+                self.rss_pages = self.rss_pages.saturating_sub(1);
+            }
+            va += 4096;
+        }
+    }
+
+    /// `munmap(start, end)`: drop every PTE in `[start, end)` and remove
+    /// the corresponding VMA coverage, splitting straddling VMAs at the
+    /// boundaries. POSIX `munmap` over a hole is a success (returns 0) —
+    /// the caller receives no error.
+    #[cfg(target_os = "none")]
+    pub fn sys_munmap_range(&mut self, start: usize, end: usize) {
+        self.drop_ptes_in_range(start, end);
+        // Track VMA coverage delta for vm_pages accounting.
+        let before: usize = self.vmas.iter().map(|v| v.end - v.start).sum();
+        self.vmas.unmap_range(start, end);
+        let after: usize = self.vmas.iter().map(|v| v.end - v.start).sum();
+        self.vm_pages = after / 4096;
+        let _ = before; // covered by delta above; kept for readability
+    }
+
+    /// `mprotect(start, end, new_prot_user, new_prot_pte)` — installs the
+    /// new protection on every VMA intersecting the range, splitting at
+    /// the boundaries. Also narrows in-place PTEs so a subsequent access
+    /// that the new protection forbids faults. The caller has already
+    /// verified the range is fully covered.
+    #[cfg(target_os = "none")]
+    pub fn sys_mprotect_range(
+        &mut self,
+        start: usize,
+        end: usize,
+        new_prot_user: crate::mem::vmatree::ProtUser,
+        new_prot_pte: crate::mem::vmatree::ProtPte,
+    ) {
+        use x86_64::structures::paging::{Page, PageTableFlags, Size4KiB};
+
+        self.vmas
+            .change_protection(start, end, new_prot_user, new_prot_pte);
+
+        // Walk present PTEs in the range and rewrite their flags to match
+        // the new protection. Pages that have not been faulted in stay
+        // unmapped; the next fault will install them with `new_prot_pte`.
+        let new_flags = PageTableFlags::from_bits_truncate(new_prot_pte);
+        let pml4 = self.page_table;
+        let mut va = start;
+        while va < end {
+            let vaddr = VirtAddr::new(va as u64);
+            if let Some((frame, _cur)) = crate::mem::paging::translate_in_pml4(pml4, vaddr) {
+                let page =
+                    Page::<Size4KiB>::from_start_address(vaddr).expect("mprotect: va page-aligned");
+                // Re-install the same frame with the new flags. `unmap_in_pml4`
+                // clears the PTE but does NOT touch the refcount (only
+                // `frame::put` / `deallocate_frame` does). The PTE's existing
+                // reference carries over to the re-installed mapping, so we
+                // neither inc nor put here.
+                if crate::mem::paging::unmap_in_pml4(pml4, page).is_ok() {
+                    let _ = crate::mem::paging::map_existing_in_pml4(pml4, page, frame, new_flags);
+                }
+            }
+            va += 4096;
+        }
+    }
+
+    /// `madvise(start, end, MADV_DONTNEED)` on anon-private VMAs: drop
+    /// every PTE in the range, decrement refcounts, and purge the
+    /// `AnonObject` cache entries so the next touch zero-fills a new
+    /// frame. VMA coverage is preserved.
+    #[cfg(target_os = "none")]
+    pub fn sys_madvise_dontneed(&mut self, start: usize, end: usize) {
+        use crate::mem::vmatree::Share;
+        // First pass: drop PTEs in every anon-private segment of the range.
+        // We can't hold iterator borrow while mutating, so snapshot the
+        // coverage first.
+        let segments: alloc::vec::Vec<(
+            usize,
+            usize,
+            usize,
+            alloc::sync::Arc<dyn crate::mem::vmobject::VmObject>,
+        )> = self
+            .vmas
+            .iter()
+            .filter(|v| v.share == Share::Private)
+            .filter_map(|v| {
+                let a = core::cmp::max(v.start, start);
+                let b = core::cmp::min(v.end, end);
+                if a >= b {
+                    None
+                } else {
+                    Some((a, b, v.start, alloc::sync::Arc::clone(&v.object)))
+                }
+            })
+            .collect();
+
+        for (a, b, _vma_start, _obj) in &segments {
+            self.drop_ptes_in_range(*a, *b);
+        }
+
+        // Second pass: truncate each touched VmObject's cache for the
+        // affected page indices so the next fault zero-fills. We cannot
+        // use `truncate_from_page` because that drops a suffix; we need
+        // to evict specific indices. `AnonObject::evict_range` is the
+        // helper for this.
+        for (a, b, vma_start, obj) in segments {
+            let first_idx = (a - vma_start) / 4096;
+            let last_idx = (b - vma_start) / 4096; // exclusive
+            obj.evict_range(first_idx, last_idx);
+        }
+    }
 }
 
 /// Error returned by [`AddressSpace::fork_address_space`].

--- a/kernel/src/mem/pf.rs
+++ b/kernel/src/mem/pf.rs
@@ -45,6 +45,19 @@ pub const MAP_SHARED: u32 = 0x01;
 pub const MAP_PRIVATE: u32 = 0x02;
 pub const MAP_FIXED: u32 = 0x10;
 pub const MAP_ANONYMOUS: u32 = 0x20;
+pub const MAP_GROWSDOWN: u32 = 0x100;
+pub const MAP_STACK: u32 = 0x20000;
+pub const MAP_FIXED_NOREPLACE: u32 = 0x10_0000;
+
+/// `madvise(2)` advice values. Only `MADV_DONTNEED` has side effects in
+/// this implementation; the rest are accepted as no-ops so userspace
+/// calls that treat them as hints succeed.
+pub const MADV_NORMAL: i32 = 0;
+pub const MADV_RANDOM: i32 = 1;
+pub const MADV_SEQUENTIAL: i32 = 2;
+pub const MADV_WILLNEED: i32 = 3;
+pub const MADV_DONTNEED: i32 = 4;
+pub const MADV_FREE: i32 = 8;
 
 // Raw bit positions in the x86 #PF error code. Kept as numeric
 // constants (not `PageFaultErrorCode` flags) so the module stays
@@ -235,6 +248,170 @@ mod growsdown_tests {
             check_growsdown(cr2, cr2 + 4096, TOP, RLIMIT, GAP),
             GrowResult::Segv
         );
+    }
+}
+
+// ── Address validation for mmap-family syscalls ──────────────────────────
+
+/// A validated `(addr, len)` range produced by [`validate_user_range`].
+///
+/// `addr` is page-aligned and `len` is rounded up to a whole page, so
+/// `addr + len` is also page-aligned and `<= USER_VA_END`. Downstream
+/// syscall code can treat the bounds as canonical without re-checking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UserRange {
+    pub addr: usize,
+    pub len: usize,
+}
+
+impl UserRange {
+    pub fn end(self) -> usize {
+        self.addr + self.len
+    }
+}
+
+/// Why [`validate_user_range`] rejected an `(addr, len)` pair.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RangeError {
+    /// `len == 0`, rounding overflowed, non-canonical address, or
+    /// `addr` was not page-aligned when the caller required exact
+    /// alignment.
+    Invalid,
+}
+
+/// Policy knob for [`validate_user_range`]. `mmap` without `MAP_FIXED`
+/// treats `addr` as a hint (rounded down); every other caller
+/// (`munmap`, `mprotect`, `madvise`, `MAP_FIXED` / `MAP_FIXED_NOREPLACE`)
+/// demands exact page alignment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AddrAlign {
+    /// Reject a non-page-aligned `addr` with [`RangeError::Invalid`].
+    Exact,
+    /// Round `addr` down to the nearest page.
+    RoundDown,
+}
+
+/// Validate an `(addr, len)` user range against the six steps from RFC
+/// 0001 "Address validation":
+///
+/// 1. `len == 0` → `Invalid`.
+/// 2. `len` rounded up to a page; overflow → `Invalid`.
+/// 3. `addr` must be canonical (lower-half — bits 48..63 clear).
+/// 4. `addr.checked_add(len_rounded)` must succeed.
+/// 5. `addr + len_rounded <= USER_VA_END`.
+/// 6. `addr` alignment per [`AddrAlign`] — `Exact` rejects non-aligned
+///    addresses, `RoundDown` rounds the hint to the containing page.
+///
+/// Returns the sanitized `(addr, len)` on success.
+pub fn validate_user_range(addr: u64, len: u64, align: AddrAlign) -> Result<UserRange, RangeError> {
+    if len == 0 {
+        return Err(RangeError::Invalid);
+    }
+    let len_rounded = match len.checked_add(4095) {
+        Some(v) => v & !4095,
+        None => return Err(RangeError::Invalid),
+    };
+    if len_rounded == 0 {
+        return Err(RangeError::Invalid);
+    }
+    if !is_user_va(addr) {
+        return Err(RangeError::Invalid);
+    }
+    let addr = match align {
+        AddrAlign::Exact => {
+            if addr & 0xFFF != 0 {
+                return Err(RangeError::Invalid);
+            }
+            addr
+        }
+        AddrAlign::RoundDown => addr & !0xFFF,
+    };
+    let end = match addr.checked_add(len_rounded) {
+        Some(v) => v,
+        None => return Err(RangeError::Invalid),
+    };
+    if end > USER_VA_END {
+        return Err(RangeError::Invalid);
+    }
+    Ok(UserRange {
+        addr: addr as usize,
+        len: len_rounded as usize,
+    })
+}
+
+#[cfg(test)]
+mod validate_range_tests {
+    use super::*;
+
+    #[test]
+    fn zero_len_rejected() {
+        assert_eq!(
+            validate_user_range(0x1000, 0, AddrAlign::Exact),
+            Err(RangeError::Invalid)
+        );
+    }
+
+    #[test]
+    fn len_rounding_overflow_rejected() {
+        assert_eq!(
+            validate_user_range(0, u64::MAX, AddrAlign::Exact),
+            Err(RangeError::Invalid)
+        );
+    }
+
+    #[test]
+    fn non_canonical_addr_rejected() {
+        // Kernel half.
+        assert_eq!(
+            validate_user_range(0xffff_8000_0000_0000, 4096, AddrAlign::Exact),
+            Err(RangeError::Invalid)
+        );
+        // Non-canonical "hole".
+        assert_eq!(
+            validate_user_range(0x0000_8000_0000_0000, 4096, AddrAlign::Exact),
+            Err(RangeError::Invalid)
+        );
+    }
+
+    #[test]
+    fn addr_plus_len_overflow_rejected() {
+        // addr near USER_VA_END; len rounds into the non-canonical hole.
+        assert_eq!(
+            validate_user_range(USER_VA_END - 0x1000, 0x2000, AddrAlign::Exact),
+            Err(RangeError::Invalid)
+        );
+    }
+
+    #[test]
+    fn exact_alignment_required_for_fixed_paths() {
+        assert_eq!(
+            validate_user_range(0x1001, 4096, AddrAlign::Exact),
+            Err(RangeError::Invalid)
+        );
+    }
+
+    #[test]
+    fn round_down_hint_accepted() {
+        let r = validate_user_range(0x1234, 4096, AddrAlign::RoundDown).unwrap();
+        assert_eq!(r.addr, 0x1000);
+        assert_eq!(r.len, 4096);
+    }
+
+    #[test]
+    fn len_rounded_up_to_page() {
+        let r = validate_user_range(0x1000, 1, AddrAlign::Exact).unwrap();
+        assert_eq!(r.addr, 0x1000);
+        assert_eq!(r.len, 4096);
+
+        let r = validate_user_range(0x1000, 4097, AddrAlign::Exact).unwrap();
+        assert_eq!(r.len, 8192);
+    }
+
+    #[test]
+    fn mapping_ending_exactly_at_user_va_end_is_legal() {
+        let addr = USER_VA_END - 4096;
+        let r = validate_user_range(addr, 4096, AddrAlign::Exact).unwrap();
+        assert_eq!(r.end() as u64, USER_VA_END);
     }
 }
 

--- a/kernel/src/mem/vmobject.rs
+++ b/kernel/src/mem/vmobject.rs
@@ -91,6 +91,12 @@ pub trait VmObject: Send + Sync {
     /// rather than waiting until the object is dropped. The default is a
     /// no-op; `AnonObject` overrides it to trim its frame cache.
     fn truncate_from_page(&self, _from_page: usize) {}
+
+    /// Release cached frames for page indices in `[first, last)`. Called
+    /// by `madvise(MADV_DONTNEED)` so the next fault returns a fresh
+    /// zero-filled frame instead of the one previously cached. Default
+    /// is a no-op; `AnonObject` overrides to evict the range.
+    fn evict_range(&self, _first: usize, _last: usize) {}
 }
 
 /// Clone a `VmObject` trait-object for `fork`. The default behavior is
@@ -199,6 +205,15 @@ impl VmObject for AnonObject {
         #[cfg(not(target_os = "none"))]
         let _ = from_page;
     }
+
+    fn evict_range(&self, first: usize, last: usize) {
+        #[cfg(target_os = "none")]
+        self.evict_cache_range(first, last);
+        #[cfg(not(target_os = "none"))]
+        {
+            let _ = (first, last);
+        }
+    }
 }
 
 /// Kernel-only methods on `AnonObject`.
@@ -219,6 +234,24 @@ impl AnonObject {
         // Add the cache's reference. The PTE reference was set by the
         // original allocator/mapper; we are adding one more here.
         crate::mem::refcount::inc_refcount(phys);
+    }
+
+    /// Remove cached frames whose page index is in `[first, last)` and
+    /// release their cache references. Used by
+    /// `madvise(MADV_DONTNEED)` — the next fault on an evicted index
+    /// allocates a fresh zero-filled frame.
+    pub fn evict_cache_range(&self, first: usize, last: usize) {
+        let evicted: alloc::vec::Vec<(usize, u64)> = {
+            let mut inner = self.inner.lock();
+            let keys: alloc::vec::Vec<usize> =
+                inner.frames.range(first..last).map(|(&k, _)| k).collect();
+            keys.into_iter()
+                .filter_map(|k| inner.frames.remove(&k).map(|v| (k, v)))
+                .collect()
+        };
+        for (_, phys) in evicted {
+            crate::mem::frame::put(phys);
+        }
     }
 
     /// Remove all cached frames whose page index is ≥ `from_page` and

--- a/kernel/tests/syscall_mmap_family.rs
+++ b/kernel/tests/syscall_mmap_family.rs
@@ -1,0 +1,355 @@
+//! Integration coverage for issue #162 — the RFC 0001 `mmap` / `munmap`
+//! / `mprotect` / `madvise` syscall surface. Drives `syscall_dispatch`
+//! directly (no ring-3 driver) to verify:
+//!
+//! * MAP_FIXED_NOREPLACE returns EEXIST when the target VA overlaps.
+//! * MAP_SHARED anon is accepted; fd != -1 returns ENODEV.
+//! * munmap over a hole returns 0 (POSIX).
+//! * munmap splits straddling VMAs at sub-range boundaries.
+//! * mprotect returns ENOMEM only when a sub-page is literally unmapped;
+//!   partial coverage of a single VMA is fine.
+//! * MADV_DONTNEED on anon-private drops cached frames so the next
+//!   touch returns a zero-filled page.
+//! * A musl-style malloc workload (alloc N pages, free them, alloc
+//!   again, grow) succeeds end-to-end.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use core::ptr;
+
+use vibix::arch::x86_64::syscall::syscall_dispatch;
+use vibix::fs::{EEXIST, EINVAL, ENODEV, ENOMEM};
+use vibix::mem::pf::{
+    MADV_DONTNEED, MAP_ANONYMOUS, MAP_FIXED, MAP_FIXED_NOREPLACE, MAP_PRIVATE, MAP_SHARED,
+    PROT_READ, PROT_WRITE,
+};
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    vibix::task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("mmap_fd_nonneg_enodev", &(mmap_fd_nonneg_enodev as fn())),
+        (
+            "mmap_requires_exactly_one_share",
+            &(mmap_requires_exactly_one_share as fn()),
+        ),
+        (
+            "mmap_shared_anon_succeeds",
+            &(mmap_shared_anon_succeeds as fn()),
+        ),
+        (
+            "mmap_fixed_noreplace_overlap_eexist",
+            &(mmap_fixed_noreplace_overlap_eexist as fn()),
+        ),
+        (
+            "munmap_returns_zero_on_hole",
+            &(munmap_returns_zero_on_hole as fn()),
+        ),
+        (
+            "munmap_splits_middle_of_vma",
+            &(munmap_splits_middle_of_vma as fn()),
+        ),
+        (
+            "mprotect_partial_vma_succeeds",
+            &(mprotect_partial_vma_succeeds as fn()),
+        ),
+        (
+            "mprotect_hole_in_range_enomem",
+            &(mprotect_hole_in_range_enomem as fn()),
+        ),
+        (
+            "mprotect_unknown_prot_bits_einval",
+            &(mprotect_unknown_prot_bits_einval as fn()),
+        ),
+        (
+            "madvise_dontneed_rezeroes_page",
+            &(madvise_dontneed_rezeroes_page as fn()),
+        ),
+        (
+            "madvise_unknown_advice_einval",
+            &(madvise_unknown_advice_einval as fn()),
+        ),
+        (
+            "malloc_workload_alloc_free_regrow",
+            &(malloc_workload_alloc_free_regrow as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+fn mmap(addr: u64, len: u64, prot: u32, flags: u32, fd: i64, off: u64) -> i64 {
+    unsafe { syscall_dispatch(9, addr, len, prot as u64, flags as u64, fd as u64, off) }
+}
+
+fn mprotect(addr: u64, len: u64, prot: u32) -> i64 {
+    unsafe { syscall_dispatch(10, addr, len, prot as u64, 0, 0, 0) }
+}
+
+fn munmap(addr: u64, len: u64) -> i64 {
+    unsafe { syscall_dispatch(11, addr, len, 0, 0, 0, 0) }
+}
+
+fn madvise(addr: u64, len: u64, advice: i32) -> i64 {
+    unsafe { syscall_dispatch(28, addr, len, advice as u64, 0, 0, 0) }
+}
+
+fn anon_rw(len: u64) -> u64 {
+    let r = mmap(
+        0,
+        len,
+        PROT_READ | PROT_WRITE,
+        MAP_ANONYMOUS | MAP_PRIVATE,
+        -1,
+        0,
+    );
+    assert!(r > 0, "mmap failed: {}", r);
+    r as u64
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+fn mmap_fd_nonneg_enodev() {
+    // File-backed mappings are not implemented: fd != -1 must yield ENODEV
+    // (not EINVAL) per RFC 0001.
+    let r = mmap(0, 4096, PROT_READ, MAP_ANONYMOUS | MAP_PRIVATE, 0, 0);
+    assert_eq!(r, ENODEV, "expected ENODEV for fd=0, got {}", r);
+}
+
+fn mmap_requires_exactly_one_share() {
+    // MAP_ANONYMOUS alone (no PRIVATE or SHARED) → EINVAL.
+    let r = mmap(0, 4096, PROT_READ, MAP_ANONYMOUS, -1, 0);
+    assert_eq!(r, EINVAL);
+    // Both PRIVATE and SHARED → EINVAL.
+    let r = mmap(
+        0,
+        4096,
+        PROT_READ,
+        MAP_ANONYMOUS | MAP_PRIVATE | MAP_SHARED,
+        -1,
+        0,
+    );
+    assert_eq!(r, EINVAL);
+}
+
+fn mmap_shared_anon_succeeds() {
+    // RFC 0001: anon-shared is fully supported.
+    let r = mmap(
+        0,
+        4096,
+        PROT_READ | PROT_WRITE,
+        MAP_ANONYMOUS | MAP_SHARED,
+        -1,
+        0,
+    );
+    assert!(r > 0, "anon-shared mmap failed: {}", r);
+    // Touch the page; should demand-fault without panicking.
+    unsafe {
+        ptr::write_volatile(r as *mut u8, 0x7Fu8);
+        assert_eq!(ptr::read_volatile(r as *const u8), 0x7F);
+    }
+    let _ = munmap(r as u64, 4096);
+}
+
+fn mmap_fixed_noreplace_overlap_eexist() {
+    let a = anon_rw(4096);
+    // Re-requesting the same VA with MAP_FIXED_NOREPLACE must fail EEXIST.
+    let r = mmap(
+        a,
+        4096,
+        PROT_READ | PROT_WRITE,
+        MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED_NOREPLACE,
+        -1,
+        0,
+    );
+    assert_eq!(r, EEXIST, "expected EEXIST on overlap, got {:#x}", r);
+    // Bare MAP_FIXED at the same VA should succeed (silently evicts) and
+    // return the requested address.
+    let r = mmap(
+        a,
+        4096,
+        PROT_READ | PROT_WRITE,
+        MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED,
+        -1,
+        0,
+    );
+    assert_eq!(r as u64, a, "MAP_FIXED must return the requested VA");
+    let _ = munmap(a, 4096);
+}
+
+fn munmap_returns_zero_on_hole() {
+    // A well-formed but entirely unmapped range returns 0, not ENOMEM.
+    // Pick a range far from any mapping this test suite sets up.
+    let base: u64 = 0x0000_3000_0000_0000;
+    let r = munmap(base, 4096);
+    assert_eq!(r, 0, "munmap of hole must return 0, got {}", r);
+}
+
+fn munmap_splits_middle_of_vma() {
+    // Install an 8-page mapping, unmap the middle 4, verify the VMA tree
+    // now holds two fragments with the correct sizes.
+    let a = anon_rw(8 * 4096);
+    let r = munmap(a + 2 * 4096, 4 * 4096);
+    assert_eq!(r, 0);
+
+    let aspace = vibix::task::current_address_space();
+    let guard = aspace.read();
+    let left = guard.find(a as usize).expect("left fragment missing");
+    assert_eq!(left.start, a as usize);
+    assert_eq!(left.end, (a as usize) + 2 * 4096);
+    let right = guard
+        .find((a as usize) + 6 * 4096)
+        .expect("right fragment missing");
+    assert_eq!(right.start, (a as usize) + 6 * 4096);
+    assert_eq!(right.end, (a as usize) + 8 * 4096);
+    // The middle page must no longer be mapped.
+    assert!(guard.find((a as usize) + 3 * 4096).is_none());
+    drop(guard);
+
+    let _ = munmap(a, 2 * 4096);
+    let _ = munmap(a + 6 * 4096, 2 * 4096);
+}
+
+fn mprotect_partial_vma_succeeds() {
+    // 4 pages RW — mprotect middle 2 to RO; both fragments must still exist.
+    let a = anon_rw(4 * 4096);
+    unsafe {
+        ptr::write_volatile(a as *mut u8, 0xAA);
+    }
+    let r = mprotect(a + 4096, 2 * 4096, PROT_READ);
+    assert_eq!(r, 0, "mprotect partial VMA failed: {}", r);
+
+    let aspace = vibix::task::current_address_space();
+    let guard = aspace.read();
+    // The middle fragment is now PROT_READ only.
+    let mid = guard.find((a as usize) + 4096).expect("middle fragment");
+    assert_eq!(mid.prot_user, PROT_READ);
+    // Outer fragments keep RW.
+    let head = guard.find(a as usize).expect("head fragment");
+    assert_eq!(head.prot_user, PROT_READ | PROT_WRITE);
+    drop(guard);
+    let _ = munmap(a, 4 * 4096);
+}
+
+fn mprotect_hole_in_range_enomem() {
+    // Two disjoint mappings with a hole between them; mprotect across the
+    // whole span must return ENOMEM because a sub-page is literally
+    // unmapped.
+    let a = anon_rw(4096);
+    // Pick a deliberately-separated second VA so find_unmapped_region
+    // cannot place them adjacent.
+    let b = a + 0x0010_0000;
+    let r = mmap(
+        b,
+        4096,
+        PROT_READ | PROT_WRITE,
+        MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED,
+        -1,
+        0,
+    );
+    assert_eq!(r as u64, b);
+
+    let r = mprotect(a, (b - a) + 4096, PROT_READ);
+    assert_eq!(
+        r, ENOMEM,
+        "mprotect across hole must return ENOMEM, got {}",
+        r
+    );
+
+    let _ = munmap(a, 4096);
+    let _ = munmap(b, 4096);
+}
+
+fn mprotect_unknown_prot_bits_einval() {
+    let a = anon_rw(4096);
+    let bogus: u32 = 0x8000_0000;
+    let r = mprotect(a, 4096, bogus);
+    assert_eq!(r, EINVAL);
+    let _ = munmap(a, 4096);
+}
+
+fn madvise_dontneed_rezeroes_page() {
+    // Write a byte, MADV_DONTNEED the page, touch it again, verify zero.
+    let a = anon_rw(4096);
+    unsafe {
+        ptr::write_volatile(a as *mut u8, 0x42);
+        assert_eq!(ptr::read_volatile(a as *const u8), 0x42);
+    }
+    let r = madvise(a, 4096, MADV_DONTNEED);
+    assert_eq!(r, 0);
+    unsafe {
+        // The next read must see 0 — a fresh zero-filled frame.
+        assert_eq!(ptr::read_volatile(a as *const u8), 0);
+    }
+    let _ = munmap(a, 4096);
+}
+
+fn madvise_unknown_advice_einval() {
+    let a = anon_rw(4096);
+    let r = madvise(a, 4096, 99);
+    assert_eq!(r, EINVAL);
+    let _ = munmap(a, 4096);
+}
+
+fn malloc_workload_alloc_free_regrow() {
+    // Simulate a libc-style allocator: grab an arena, write a pattern
+    // across every page, free it, grow a fresh arena, and verify the new
+    // pages are zero. Exercises mmap → touch → munmap → mmap → touch
+    // end-to-end.
+    const PAGES: usize = 16;
+    const LEN: usize = PAGES * 4096;
+
+    let a = anon_rw(LEN as u64);
+    unsafe {
+        for p in 0..PAGES {
+            let pattern = (p as u8).wrapping_mul(0x37).wrapping_add(0x11);
+            ptr::write_volatile((a as *mut u8).add(p * 4096), pattern);
+        }
+        for p in 0..PAGES {
+            let pattern = (p as u8).wrapping_mul(0x37).wrapping_add(0x11);
+            assert_eq!(ptr::read_volatile((a as *const u8).add(p * 4096)), pattern);
+        }
+    }
+
+    assert_eq!(munmap(a, LEN as u64), 0);
+
+    let b = anon_rw((LEN * 2) as u64);
+    unsafe {
+        // Entire arena must be zero-initialised on first touch.
+        for p in 0..(PAGES * 2) {
+            assert_eq!(
+                ptr::read_volatile((b as *const u8).add(p * 4096)),
+                0,
+                "fresh mmap page {} not zero",
+                p
+            );
+        }
+    }
+    let _ = munmap(b, (LEN * 2) as u64);
+}

--- a/kernel/tests/syscall_open_mmap.rs
+++ b/kernel/tests/syscall_open_mmap.rs
@@ -266,14 +266,7 @@ fn mmap_rejects_nonzero_off() {
 fn mmap_fixed_returns_requested_va() {
     // MAP_FIXED is now supported (RFC 0001): returns the requested VA,
     // silently evicting any overlap.
-    let a = mmap(
-        0,
-        4096,
-        PROT_READ,
-        MAP_ANONYMOUS | MAP_PRIVATE,
-        -1,
-        0,
-    );
+    let a = mmap(0, 4096, PROT_READ, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
     assert!(a > 0);
     let r = mmap(
         a as u64,

--- a/kernel/tests/syscall_open_mmap.rs
+++ b/kernel/tests/syscall_open_mmap.rs
@@ -17,8 +17,8 @@ use core::panic::PanicInfo;
 use core::ptr;
 
 use vibix::arch::x86_64::syscall::syscall_dispatch;
-use vibix::fs::{EBADF, EINVAL, ENAMETOOLONG, ENOENT};
-use vibix::mem::pf::{MAP_ANONYMOUS, MAP_FIXED, MAP_PRIVATE, MAP_SHARED, PROT_READ, PROT_WRITE};
+use vibix::fs::{EBADF, EINVAL, ENAMETOOLONG, ENODEV, ENOENT};
+use vibix::mem::pf::{MAP_ANONYMOUS, MAP_FIXED, MAP_PRIVATE, PROT_READ, PROT_WRITE};
 use vibix::mem::vmatree::{Share, Vma};
 use vibix::mem::vmobject::AnonObject;
 use vibix::{
@@ -78,7 +78,10 @@ fn run_tests() {
             "mmap_rejects_nonzero_off",
             &(mmap_rejects_nonzero_off as fn()),
         ),
-        ("mmap_rejects_fixed", &(mmap_rejects_fixed as fn())),
+        (
+            "mmap_fixed_returns_requested_va",
+            &(mmap_fixed_returns_requested_va as fn()),
+        ),
         (
             "mmap_two_calls_return_disjoint",
             &(mmap_two_calls_return_disjoint as fn()),
@@ -237,17 +240,22 @@ fn mmap_zero_len_einval() {
 }
 
 fn mmap_requires_anon_private() {
-    // Missing MAP_ANONYMOUS.
+    // Missing MAP_ANONYMOUS with fd=-1 → file-backed path is attempted
+    // and returns ENODEV (no VFS yet) per RFC 0001.
     let r = mmap(0, 4096, PROT_READ, MAP_PRIVATE, -1, 0);
-    assert_eq!(r, EINVAL, "MAP_PRIVATE alone must return EINVAL, got {}", r);
-    // MAP_SHARED is not yet supported.
-    let r = mmap(0, 4096, PROT_READ, MAP_ANONYMOUS | MAP_SHARED, -1, 0);
+    assert_eq!(
+        r, ENODEV,
+        "MAP_PRIVATE without MAP_ANONYMOUS routes to file-backed path: ENODEV"
+    );
+    // Neither MAP_PRIVATE nor MAP_SHARED → EINVAL.
+    let r = mmap(0, 4096, PROT_READ, MAP_ANONYMOUS, -1, 0);
     assert_eq!(r, EINVAL);
 }
 
 fn mmap_rejects_non_neg_fd() {
+    // fd != -1 routes to the (unsupported) file-backed path → ENODEV.
     let r = mmap(0, 4096, PROT_READ, MAP_ANONYMOUS | MAP_PRIVATE, 0, 0);
-    assert_eq!(r, EINVAL);
+    assert_eq!(r, ENODEV);
 }
 
 fn mmap_rejects_nonzero_off() {
@@ -255,16 +263,27 @@ fn mmap_rejects_nonzero_off() {
     assert_eq!(r, EINVAL);
 }
 
-fn mmap_rejects_fixed() {
+fn mmap_fixed_returns_requested_va() {
+    // MAP_FIXED is now supported (RFC 0001): returns the requested VA,
+    // silently evicting any overlap.
+    let a = mmap(
+        0,
+        4096,
+        PROT_READ,
+        MAP_ANONYMOUS | MAP_PRIVATE,
+        -1,
+        0,
+    );
+    assert!(a > 0);
     let r = mmap(
-        0x4000_0000,
+        a as u64,
         4096,
         PROT_READ,
         MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED,
         -1,
         0,
     );
-    assert_eq!(r, EINVAL);
+    assert_eq!(r as u64, a as u64);
 }
 
 fn mmap_two_calls_return_disjoint() {


### PR DESCRIPTION
Closes #162

## Summary
- Adds the RFC 0001 mmap-family syscalls at Linux numbers 9 / 10 / 11 / 28. `sys_mmap` supports anon-private and anon-shared; honours `MAP_FIXED`, `MAP_FIXED_NOREPLACE` (EEXIST on overlap), `MAP_GROWSDOWN`, `MAP_STACK`; rejects file-backed fds with `ENODEV`. Exactly one of `MAP_PRIVATE`/`MAP_SHARED` is required.
- `sys_munmap` returns 0 on holes (POSIX) and splits straddling VMAs at sub-range boundaries. `sys_mprotect` gates with `range_fully_covered` so `ENOMEM` fires only when a sub-page is literally unmapped. `sys_madvise` implements `MADV_DONTNEED` on anon-private segments (drop PTEs + purge `AnonObject` cache) and no-ops the other standard advice values.
- Adds `validate_user_range` in `mem::pf` — the six-step canonical/alignment/overflow/USER_VA_END check the RFC specifies — plus `AddressSpace::range_overlaps_any` / `range_fully_covered` / `sys_munmap_range` / `sys_mprotect_range` / `sys_madvise_dontneed`. `VmObject` gains a default-no-op `evict_range` that `AnonObject` overrides to drop cache entries and release their refs.

## Test plan
- [x] `cargo xtask build` compiles clean (pre-existing dead-code warning unrelated).
- [x] New integration test `kernel/tests/syscall_mmap_family.rs` drives `syscall_dispatch` directly and covers: fd!=-1→ENODEV, PRIVATE/SHARED validation, anon-shared round-trip, MAP_FIXED_NOREPLACE overlap (EEXIST), MAP_FIXED silent evict, munmap on hole returns 0, munmap splits VMA middle, mprotect partial-VMA success, mprotect across hole returns ENOMEM, unknown prot bits EINVAL, MADV_DONTNEED re-zeroes, unknown advice EINVAL, musl-style malloc workload (16-page arena → free → 32-page regrow with zero-check).
- [x] `validate_user_range` has seven host unit tests in `pf.rs` covering zero-len, rounding overflow, non-canonical addr, addr+len overflow, alignment rules, round-down hint, and mappings ending exactly at `USER_VA_END`.
- [ ] CI will validate the QEMU integration tests on x86_64 (ARM64 dev container's x86_64 cross-objcopy is broken; local host run shows the kernel compiles without errors).