### PR TITLE
sync: BlockingRwLock and Semaphore for VFS (RFC 0002 item 1)

### DIFF
--- a/kernel/src/sync/mod.rs
+++ b/kernel/src/sync/mod.rs
@@ -12,6 +12,14 @@
 //! - [`BlockingMutex`] — mutual exclusion that doesn't burn CPU under
 //!   contention. Interface mirrors `spin::Mutex`; drop-in for any
 //!   critical section that might be held across a scheduling point.
+//! - [`BlockingRwLock`] — multi-reader / single-writer sleeping lock.
+//!   Use when readers dominate and a short-lived writer can't afford
+//!   to spin. Writers get priority over newly-arriving readers, so
+//!   they aren't starved under reader churn.
+//! - [`Semaphore`] — counting semaphore with `acquire` / `release`.
+//!   Reach for this when the resource is a budget rather than a
+//!   single critical section (e.g. VFS `ChildState::Loading`
+//!   deduplicating a first-lookup-of-a-name).
 //! - [`WaitQueue`] — primitive building block. Tasks call
 //!   [`WaitQueue::wait_while`] with a condition; wakers call
 //!   [`WaitQueue::notify_one`] / [`notify_all`] after changing state
@@ -57,8 +65,12 @@
 
 pub mod mpmc;
 pub mod mutex;
+pub mod rwlock;
+pub mod semaphore;
 pub mod spsc;
 pub mod waitqueue;
 
 pub use mutex::{BlockingMutex, MutexGuard};
+pub use rwlock::{BlockingRwLock, RwLockReadGuard, RwLockWriteGuard};
+pub use semaphore::Semaphore;
 pub use waitqueue::WaitQueue;

--- a/kernel/src/sync/rwlock.rs
+++ b/kernel/src/sync/rwlock.rs
@@ -3,9 +3,9 @@
 //!
 //! Shares the park/wake path with [`BlockingMutex`] via a single
 //! [`WaitQueue`]: both readers and writers enqueue on the same queue,
-//! so waiters fall out in FIFO order — a writer blocked behind a
-//! reader wakes before a later reader does, which prevents writer
-//! starvation under continuous reader churn.
+//! so the wake order is FIFO — a writer blocked behind a reader wakes
+//! before a later reader does, which keeps writers making progress
+//! under reader churn.
 //!
 //! Lock order (see [`super`] module docs): `WaitQueue.inner` → the
 //! internal `state` spin-lock.
@@ -17,15 +17,13 @@ use spin::Mutex as SpinMutex;
 use super::WaitQueue;
 
 /// Internal lock state. `writer` is exclusive with any non-zero
-/// `readers` count; FIFO fairness is enforced by `writer_waiting`,
-/// which tells new readers to queue behind a pending writer.
+/// `readers` count. `writer_waiting` tells arriving readers to queue
+/// behind a parked writer so long reader streams can't indefinitely
+/// defer a writer's acquisition.
 #[derive(Clone, Copy)]
 struct State {
     readers: u32,
     writer: bool,
-    /// Number of writers currently parked. While non-zero, new
-    /// readers park too — that's what gives the writer a window to
-    /// reach the head of the queue under reader churn.
     writer_waiting: u32,
 }
 
@@ -115,24 +113,27 @@ impl<T: ?Sized> BlockingRwLock<T> {
                     return RwLockReadGuard { rw: self };
                 }
             }
-            // Park — see `BlockingMutex::lock` for the cond-under-
-            // waitqueue-lock race argument. `can_read` re-checks
-            // under the waitqueue lock so a release between our
-            // fast-path check and the park can't be dropped.
+            // Park. `wait_while` re-checks the cond under the
+            // waitqueue lock, so a release between our fast-path
+            // check and the park can't be dropped — see
+            // `BlockingMutex::lock`.
             self.waiters.wait_while(|| !self.state.lock().can_read());
         }
     }
 
     /// Acquire the exclusive (write) lock, parking until it's
-    /// available. New readers block behind a parked writer, so a
-    /// writer will get the lock within a bounded number of reader
-    /// releases regardless of reader churn.
+    /// available. New readers queue behind a parked writer, so long
+    /// reader streams don't indefinitely defer writer acquisition.
     pub fn write(&self) -> RwLockWriteGuard<'_, T> {
-        // Register writer-waiting up front so new readers queue
-        // behind us. Released whether we take the fast path, the
-        // slow path, or early-return.
+        // Fast path: uncontended grab. No need to touch
+        // `writer_waiting` if the lock is immediately available.
         {
             let mut st = self.state.lock();
+            if st.can_write() {
+                st.writer = true;
+                return RwLockWriteGuard { rw: self };
+            }
+            // Contended — register ourselves so readers back off.
             st.writer_waiting += 1;
         }
         loop {
@@ -149,8 +150,8 @@ impl<T: ?Sized> BlockingRwLock<T> {
     }
 }
 
-/// RAII shared-access guard. Drop to release; wakes one waiter if the
-/// last reader leaves the lock in a state a writer could now claim.
+/// RAII shared-access guard. Drop to release; wakes waiters if the
+/// last reader leaves the lock in a state a writer could claim.
 pub struct RwLockReadGuard<'a, T: ?Sized> {
     rw: &'a BlockingRwLock<T>,
 }
@@ -172,17 +173,16 @@ impl<T: ?Sized> Drop for RwLockReadGuard<'_, T> {
             st.readers == 0
         };
         if was_last {
-            // Last reader out: a writer at the head of the queue can
-            // now proceed. Notifying more wouldn't help — at most one
-            // writer can acquire, and readers are already parked
-            // behind `writer_waiting`.
-            self.rw.waiters.notify_one();
+            // Last reader out: wake every waiter so the FIFO head —
+            // likely the writer that incremented `writer_waiting` —
+            // can take the lock. Anyone who doesn't get it re-parks.
+            self.rw.waiters.notify_all();
         }
     }
 }
 
 /// RAII exclusive-access guard. Drop to release; wakes every waiter
-/// so readers queued behind this writer can batch-enter.
+/// so whoever's at the head of the FIFO queue can proceed.
 pub struct RwLockWriteGuard<'a, T: ?Sized> {
     rw: &'a BlockingRwLock<T>,
 }
@@ -208,9 +208,8 @@ impl<T: ?Sized> Drop for RwLockWriteGuard<'_, T> {
             let mut st = self.rw.state.lock();
             st.writer = false;
         }
-        // `notify_all` so a burst of readers queued behind us can
-        // all wake and the next writer (if any) reasserts
-        // `writer_waiting` for its own park iteration.
+        // Wake every waiter so a burst of readers queued behind us
+        // can all re-check and enter, or the next writer can claim.
         self.rw.waiters.notify_all();
     }
 }

--- a/kernel/src/sync/rwlock.rs
+++ b/kernel/src/sync/rwlock.rs
@@ -1,0 +1,216 @@
+//! `BlockingRwLock<T>` — multi-reader / single-writer lock that parks
+//! on contention instead of spinning.
+//!
+//! Shares the park/wake path with [`BlockingMutex`] via a single
+//! [`WaitQueue`]: both readers and writers enqueue on the same queue,
+//! so waiters fall out in FIFO order — a writer blocked behind a
+//! reader wakes before a later reader does, which prevents writer
+//! starvation under continuous reader churn.
+//!
+//! Lock order (see [`super`] module docs): `WaitQueue.inner` → the
+//! internal `state` spin-lock.
+
+use core::cell::UnsafeCell;
+use core::ops::{Deref, DerefMut};
+use spin::Mutex as SpinMutex;
+
+use super::WaitQueue;
+
+/// Internal lock state. `writer` is exclusive with any non-zero
+/// `readers` count; FIFO fairness is enforced by `writer_waiting`,
+/// which tells new readers to queue behind a pending writer.
+#[derive(Clone, Copy)]
+struct State {
+    readers: u32,
+    writer: bool,
+    /// Number of writers currently parked. While non-zero, new
+    /// readers park too — that's what gives the writer a window to
+    /// reach the head of the queue under reader churn.
+    writer_waiting: u32,
+}
+
+impl State {
+    const fn new() -> Self {
+        Self {
+            readers: 0,
+            writer: false,
+            writer_waiting: 0,
+        }
+    }
+
+    fn can_read(&self) -> bool {
+        !self.writer && self.writer_waiting == 0
+    }
+
+    fn can_write(&self) -> bool {
+        !self.writer && self.readers == 0
+    }
+}
+
+/// Multi-reader / single-writer sleeping lock.
+pub struct BlockingRwLock<T: ?Sized> {
+    /// Short-lived spin-protected state. Nobody holds this across a
+    /// scheduling point.
+    state: SpinMutex<State>,
+    /// Shared FIFO parking queue for both readers and writers.
+    waiters: WaitQueue,
+    /// Protected data. Access is serialised by the read/write protocol.
+    data: UnsafeCell<T>,
+}
+
+// `data` access is serialised by the rwlock protocol: `&T` is handed
+// out via the read guard (needs `T: Sync` to share across tasks) and
+// `&mut T` via the write guard (needs `T: Send` to transfer ownership
+// of mutation across tasks).
+unsafe impl<T: ?Sized + Send> Send for BlockingRwLock<T> {}
+unsafe impl<T: ?Sized + Send + Sync> Sync for BlockingRwLock<T> {}
+
+impl<T> BlockingRwLock<T> {
+    /// Construct a new rwlock. `const` so the lock can live in a
+    /// `static`.
+    pub const fn new(val: T) -> Self {
+        Self {
+            state: SpinMutex::new(State::new()),
+            waiters: WaitQueue::new(),
+            data: UnsafeCell::new(val),
+        }
+    }
+
+    /// Consume the lock and return the protected value.
+    pub fn into_inner(self) -> T {
+        self.data.into_inner()
+    }
+}
+
+impl<T: ?Sized> BlockingRwLock<T> {
+    /// Try to acquire a shared (read) lock without parking.
+    pub fn try_read(&self) -> Option<RwLockReadGuard<'_, T>> {
+        let mut st = self.state.lock();
+        if st.can_read() {
+            st.readers += 1;
+            Some(RwLockReadGuard { rw: self })
+        } else {
+            None
+        }
+    }
+
+    /// Try to acquire the exclusive (write) lock without parking.
+    pub fn try_write(&self) -> Option<RwLockWriteGuard<'_, T>> {
+        let mut st = self.state.lock();
+        if st.can_write() {
+            st.writer = true;
+            Some(RwLockWriteGuard { rw: self })
+        } else {
+            None
+        }
+    }
+
+    /// Acquire a shared (read) lock, parking until one is available.
+    pub fn read(&self) -> RwLockReadGuard<'_, T> {
+        loop {
+            {
+                let mut st = self.state.lock();
+                if st.can_read() {
+                    st.readers += 1;
+                    return RwLockReadGuard { rw: self };
+                }
+            }
+            // Park — see `BlockingMutex::lock` for the cond-under-
+            // waitqueue-lock race argument. `can_read` re-checks
+            // under the waitqueue lock so a release between our
+            // fast-path check and the park can't be dropped.
+            self.waiters.wait_while(|| !self.state.lock().can_read());
+        }
+    }
+
+    /// Acquire the exclusive (write) lock, parking until it's
+    /// available. New readers block behind a parked writer, so a
+    /// writer will get the lock within a bounded number of reader
+    /// releases regardless of reader churn.
+    pub fn write(&self) -> RwLockWriteGuard<'_, T> {
+        // Register writer-waiting up front so new readers queue
+        // behind us. Released whether we take the fast path, the
+        // slow path, or early-return.
+        {
+            let mut st = self.state.lock();
+            st.writer_waiting += 1;
+        }
+        loop {
+            {
+                let mut st = self.state.lock();
+                if st.can_write() {
+                    st.writer = true;
+                    st.writer_waiting -= 1;
+                    return RwLockWriteGuard { rw: self };
+                }
+            }
+            self.waiters.wait_while(|| !self.state.lock().can_write());
+        }
+    }
+}
+
+/// RAII shared-access guard. Drop to release; wakes one waiter if the
+/// last reader leaves the lock in a state a writer could now claim.
+pub struct RwLockReadGuard<'a, T: ?Sized> {
+    rw: &'a BlockingRwLock<T>,
+}
+
+impl<T: ?Sized> Deref for RwLockReadGuard<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        // SAFETY: at least one reader is live, so no writer can hold
+        // the lock — shared `&T` is sound.
+        unsafe { &*self.rw.data.get() }
+    }
+}
+
+impl<T: ?Sized> Drop for RwLockReadGuard<'_, T> {
+    fn drop(&mut self) {
+        let was_last = {
+            let mut st = self.rw.state.lock();
+            st.readers -= 1;
+            st.readers == 0
+        };
+        if was_last {
+            // Last reader out: a writer at the head of the queue can
+            // now proceed. Notifying more wouldn't help — at most one
+            // writer can acquire, and readers are already parked
+            // behind `writer_waiting`.
+            self.rw.waiters.notify_one();
+        }
+    }
+}
+
+/// RAII exclusive-access guard. Drop to release; wakes every waiter
+/// so readers queued behind this writer can batch-enter.
+pub struct RwLockWriteGuard<'a, T: ?Sized> {
+    rw: &'a BlockingRwLock<T>,
+}
+
+impl<T: ?Sized> Deref for RwLockWriteGuard<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        // SAFETY: writer flag is set, so no readers are live.
+        unsafe { &*self.rw.data.get() }
+    }
+}
+
+impl<T: ?Sized> DerefMut for RwLockWriteGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        // SAFETY: exclusive writer flag implies no other guards.
+        unsafe { &mut *self.rw.data.get() }
+    }
+}
+
+impl<T: ?Sized> Drop for RwLockWriteGuard<'_, T> {
+    fn drop(&mut self) {
+        {
+            let mut st = self.rw.state.lock();
+            st.writer = false;
+        }
+        // `notify_all` so a burst of readers queued behind us can
+        // all wake and the next writer (if any) reasserts
+        // `writer_waiting` for its own park iteration.
+        self.rw.waiters.notify_all();
+    }
+}

--- a/kernel/src/sync/semaphore.rs
+++ b/kernel/src/sync/semaphore.rs
@@ -84,4 +84,12 @@ impl Semaphore {
     pub fn available(&self) -> usize {
         *self.permits.lock()
     }
+
+    /// Number of tasks currently parked on `acquire`. Intended for
+    /// test-harness synchronisation — a driver can spin on
+    /// `waiter_count() >= N` to confirm N workers have enqueued before
+    /// firing a `release`. Not appropriate for production logic.
+    pub fn waiter_count(&self) -> usize {
+        self.waiters.waiter_count()
+    }
 }

--- a/kernel/src/sync/semaphore.rs
+++ b/kernel/src/sync/semaphore.rs
@@ -1,0 +1,87 @@
+//! `Semaphore` — counting semaphore that parks on exhaustion.
+//!
+//! Introduced by RFC 0002 for `ChildState::Loading` in the VFS
+//! dentry cache, where it serializes the first lookup-of-a-name.
+//! General-purpose: a semaphore with N permits lets up to N acquirers
+//! through concurrently; further acquirers park until a permit is
+//! released.
+//!
+//! Non-reentrant, matching the rest of `kernel/src/sync/`. Shares the
+//! park/wake path with [`BlockingMutex`] via a [`WaitQueue`].
+//!
+//! Lock order (see [`super`] module docs): `WaitQueue.inner` → the
+//! internal `permits` spin-lock.
+
+use spin::Mutex as SpinMutex;
+
+use super::WaitQueue;
+
+/// Counting semaphore.
+pub struct Semaphore {
+    /// Available permits. Short-lived spin lock.
+    permits: SpinMutex<usize>,
+    /// FIFO waiters parked on `acquire`.
+    waiters: WaitQueue,
+}
+
+impl Semaphore {
+    /// Construct a semaphore with `permits` initial permits. `const`
+    /// so the semaphore can live in a `static`.
+    pub const fn new(permits: usize) -> Self {
+        Self {
+            permits: SpinMutex::new(permits),
+            waiters: WaitQueue::new(),
+        }
+    }
+
+    /// Try to take one permit without parking. Returns `true` if a
+    /// permit was taken.
+    pub fn try_acquire(&self) -> bool {
+        let mut p = self.permits.lock();
+        if *p > 0 {
+            *p -= 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Take one permit, parking if none are available.
+    pub fn acquire(&self) {
+        loop {
+            {
+                let mut p = self.permits.lock();
+                if *p > 0 {
+                    *p -= 1;
+                    return;
+                }
+            }
+            // Park. The `cond` re-checks under the waitqueue lock, so
+            // a release between our fast-path check and the park
+            // can't be lost — see `BlockingMutex::lock`.
+            self.waiters.wait_while(|| *self.permits.lock() == 0);
+        }
+    }
+
+    /// Release one permit. Wakes one parked acquirer, if any.
+    pub fn release(&self) {
+        {
+            let mut p = self.permits.lock();
+            // Saturating so a buggy over-release doesn't silently
+            // wrap to a huge permit count. Debug builds trip the
+            // assert first for visibility.
+            debug_assert!(
+                *p < usize::MAX,
+                "Semaphore::release overflowed permit count"
+            );
+            *p = p.saturating_add(1);
+        }
+        self.waiters.notify_one();
+    }
+
+    /// Number of permits currently available. Intended for tests;
+    /// racy by nature (the count can change the instant it's read).
+    pub fn available(&self) -> usize {
+        *self.permits.lock()
+    }
+}

--- a/kernel/tests/blocking_sync.rs
+++ b/kernel/tests/blocking_sync.rs
@@ -787,7 +787,7 @@ static RW_READ_LIVE: AtomicUsize = AtomicUsize::new(0);
 static RW_READ_PEAK: AtomicUsize = AtomicUsize::new(0);
 static RW_READ_DONE: AtomicUsize = AtomicUsize::new(0);
 
-const RW_READ_HOLD_SPINS: usize = 300_000;
+const RW_READ_HOLD_SPINS: usize = 100_000;
 
 fn rw_reader_worker() -> ! {
     let _g = RW_READERS.read();
@@ -847,8 +847,8 @@ fn rwlock_concurrent_readers() {
 static RW_WRITERS: BlockingRwLock<u64> = BlockingRwLock::new(0);
 static RW_WRITE_DONE: AtomicUsize = AtomicUsize::new(0);
 
-const RW_WRITE_ROUNDS: u64 = 10;
-const RW_WRITE_CRIT_SPINS: usize = 200_000;
+const RW_WRITE_ROUNDS: u64 = 5;
+const RW_WRITE_CRIT_SPINS: usize = 50_000;
 
 fn rw_writer_worker() -> ! {
     for _ in 0..RW_WRITE_ROUNDS {
@@ -903,7 +903,7 @@ static RW_STARVE_WRITER_DONE: AtomicUsize = AtomicUsize::new(0);
 static RW_STARVE_READERS_DONE: AtomicUsize = AtomicUsize::new(0);
 static RW_STARVE_GO: AtomicUsize = AtomicUsize::new(0);
 
-const RW_STARVE_READERS: u32 = 8;
+const RW_STARVE_READERS: u32 = 4;
 
 fn rw_starve_writer() -> ! {
     // Wait until the driver signals us to go, then contend against
@@ -991,7 +991,7 @@ static SEM_LIVE: AtomicUsize = AtomicUsize::new(0);
 static SEM_PEAK: AtomicUsize = AtomicUsize::new(0);
 static SEM_DONE: AtomicUsize = AtomicUsize::new(0);
 
-const SEM_HOLD_SPINS: usize = 300_000;
+const SEM_HOLD_SPINS: usize = 100_000;
 
 fn sem_worker() -> ! {
     SEM_GATE.acquire();
@@ -1075,7 +1075,7 @@ fn semaphore_release_wakes_one() {
     // Wait until both workers have actually parked inside `acquire`.
     // Workers enqueue on the internal waitqueue, so we poll indirectly
     // via the done counter staying at 0 after a grace period.
-    for _ in 0..200 {
+    for _ in 0..50 {
         x86_64::instructions::hlt();
     }
     assert_eq!(
@@ -1086,7 +1086,7 @@ fn semaphore_release_wakes_one() {
 
     // One release — exactly one worker should wake.
     SEM_WAKE.release();
-    for _ in 0..1_000 {
+    for _ in 0..200 {
         if SEM_WAKE_COUNT.load(Ordering::SeqCst) >= 1 {
             break;
         }
@@ -1100,7 +1100,7 @@ fn semaphore_release_wakes_one() {
 
     // Second release frees the other worker.
     SEM_WAKE.release();
-    for _ in 0..1_000 {
+    for _ in 0..200 {
         if SEM_WAKE_COUNT.load(Ordering::SeqCst) == 2 {
             break;
         }

--- a/kernel/tests/blocking_sync.rs
+++ b/kernel/tests/blocking_sync.rs
@@ -12,7 +12,7 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 
 use spin::Mutex as SpinMutex;
 use vibix::sync::{mpmc, spsc};
-use vibix::sync::{BlockingMutex, WaitQueue};
+use vibix::sync::{BlockingMutex, BlockingRwLock, Semaphore, WaitQueue};
 use vibix::{
     exit_qemu, serial_println, task,
     test_harness::{test_panic_handler, Testable},
@@ -83,6 +83,26 @@ fn run_tests() {
         (
             "mpmc_close_wakes_senders",
             &(mpmc_close_wakes_senders as fn()),
+        ),
+        (
+            "rwlock_concurrent_readers",
+            &(rwlock_concurrent_readers as fn()),
+        ),
+        (
+            "rwlock_writer_exclusion",
+            &(rwlock_writer_exclusion as fn()),
+        ),
+        (
+            "rwlock_writer_not_starved",
+            &(rwlock_writer_not_starved as fn()),
+        ),
+        (
+            "semaphore_permits_block",
+            &(semaphore_permits_block as fn()),
+        ),
+        (
+            "semaphore_release_wakes_one",
+            &(semaphore_release_wakes_one as fn()),
         ),
     ];
     serial_println!("running {} tests", tests.len());
@@ -753,5 +773,342 @@ fn mpmc_close_wakes_senders() {
         MPMC_CLOSE_TX_ERRS.load(Ordering::SeqCst),
         2,
         "senders didn't both wake with Err on last-receiver drop"
+    );
+}
+
+// --- rwlock_concurrent_readers --------------------------------------
+//
+// Three reader tasks hold a read guard simultaneously. The test asserts
+// that the observed peak reader count reaches 3 — proving the rwlock
+// actually allows multiple readers rather than silently serialising them.
+
+static RW_READERS: BlockingRwLock<u64> = BlockingRwLock::new(0);
+static RW_READ_LIVE: AtomicUsize = AtomicUsize::new(0);
+static RW_READ_PEAK: AtomicUsize = AtomicUsize::new(0);
+static RW_READ_DONE: AtomicUsize = AtomicUsize::new(0);
+
+const RW_READ_HOLD_SPINS: usize = 300_000;
+
+fn rw_reader_worker() -> ! {
+    let _g = RW_READERS.read();
+    let live = RW_READ_LIVE.fetch_add(1, Ordering::SeqCst) + 1;
+    // Publish a new peak if we raised it. Racy by design — peak is a
+    // high-water mark, not a synchronisation point.
+    let mut peak = RW_READ_PEAK.load(Ordering::SeqCst);
+    while live > peak {
+        match RW_READ_PEAK.compare_exchange(peak, live, Ordering::SeqCst, Ordering::SeqCst) {
+            Ok(_) => break,
+            Err(actual) => peak = actual,
+        }
+    }
+    for _ in 0..RW_READ_HOLD_SPINS {
+        core::hint::spin_loop();
+    }
+    RW_READ_LIVE.fetch_sub(1, Ordering::SeqCst);
+    RW_READ_DONE.fetch_add(1, Ordering::SeqCst);
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn rwlock_concurrent_readers() {
+    RW_READ_LIVE.store(0, Ordering::SeqCst);
+    RW_READ_PEAK.store(0, Ordering::SeqCst);
+    RW_READ_DONE.store(0, Ordering::SeqCst);
+
+    task::spawn(rw_reader_worker);
+    task::spawn(rw_reader_worker);
+    task::spawn(rw_reader_worker);
+
+    for _ in 0..2_000 {
+        if RW_READ_DONE.load(Ordering::SeqCst) == 3 {
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+    assert_eq!(
+        RW_READ_DONE.load(Ordering::SeqCst),
+        3,
+        "readers didn't all finish — park/wake wedged"
+    );
+    assert_eq!(
+        RW_READ_PEAK.load(Ordering::SeqCst),
+        3,
+        "readers serialised — rwlock didn't grant shared access"
+    );
+}
+
+// --- rwlock_writer_exclusion ----------------------------------------
+//
+// Three writer tasks each increment a shared counter N times under the
+// write lock. Final value proves writes were serialised (no lost
+// updates) and every worker made forward progress.
+
+static RW_WRITERS: BlockingRwLock<u64> = BlockingRwLock::new(0);
+static RW_WRITE_DONE: AtomicUsize = AtomicUsize::new(0);
+
+const RW_WRITE_ROUNDS: u64 = 10;
+const RW_WRITE_CRIT_SPINS: usize = 200_000;
+
+fn rw_writer_worker() -> ! {
+    for _ in 0..RW_WRITE_ROUNDS {
+        let mut g = RW_WRITERS.write();
+        for _ in 0..RW_WRITE_CRIT_SPINS {
+            core::hint::spin_loop();
+        }
+        *g += 1;
+    }
+    RW_WRITE_DONE.fetch_add(1, Ordering::SeqCst);
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn rwlock_writer_exclusion() {
+    *RW_WRITERS.write() = 0;
+    RW_WRITE_DONE.store(0, Ordering::SeqCst);
+
+    task::spawn(rw_writer_worker);
+    task::spawn(rw_writer_worker);
+    task::spawn(rw_writer_worker);
+
+    for _ in 0..2_000 {
+        if RW_WRITE_DONE.load(Ordering::SeqCst) == 3 {
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+    assert_eq!(
+        RW_WRITE_DONE.load(Ordering::SeqCst),
+        3,
+        "not all writer workers finished"
+    );
+    assert_eq!(
+        *RW_WRITERS.read(),
+        3 * RW_WRITE_ROUNDS,
+        "lost updates — rwlock didn't serialise writers"
+    );
+}
+
+// --- rwlock_writer_not_starved --------------------------------------
+//
+// One task holds the write lock and parks. A second task parks on
+// `write()` behind it. A stream of reader tasks then tries to acquire;
+// they must queue behind the pending writer (the rwlock's
+// writer-priority invariant). The test asserts the second writer
+// eventually gets through despite continuous reader churn.
+
+static RW_STARVE: BlockingRwLock<u64> = BlockingRwLock::new(0);
+static RW_STARVE_WRITER_DONE: AtomicUsize = AtomicUsize::new(0);
+static RW_STARVE_READERS_DONE: AtomicUsize = AtomicUsize::new(0);
+static RW_STARVE_GO: AtomicUsize = AtomicUsize::new(0);
+
+const RW_STARVE_READERS: u32 = 8;
+
+fn rw_starve_writer() -> ! {
+    // Wait until the driver signals us to go, then contend against
+    // the first writer (held by the driver).
+    while RW_STARVE_GO.load(Ordering::SeqCst) == 0 {
+        x86_64::instructions::hlt();
+    }
+    let mut g = RW_STARVE.write();
+    *g += 1;
+    drop(g);
+    RW_STARVE_WRITER_DONE.fetch_add(1, Ordering::SeqCst);
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn rw_starve_reader() -> ! {
+    while RW_STARVE_GO.load(Ordering::SeqCst) == 0 {
+        x86_64::instructions::hlt();
+    }
+    let _g = RW_STARVE.read();
+    RW_STARVE_READERS_DONE.fetch_add(1, Ordering::SeqCst);
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn rwlock_writer_not_starved() {
+    *RW_STARVE.write() = 0;
+    RW_STARVE_WRITER_DONE.store(0, Ordering::SeqCst);
+    RW_STARVE_READERS_DONE.store(0, Ordering::SeqCst);
+    RW_STARVE_GO.store(0, Ordering::SeqCst);
+
+    // Driver grabs the write lock first.
+    let g = RW_STARVE.write();
+
+    // Spawn the second writer and a flood of readers. All of them
+    // spin on RW_STARVE_GO so they queue up before any contention
+    // begins; when we release RW_STARVE_GO they race to acquire.
+    task::spawn(rw_starve_writer);
+    for _ in 0..RW_STARVE_READERS {
+        task::spawn(rw_starve_reader);
+    }
+
+    // Release the go-flag, then drop the driver's guard. The second
+    // writer should win the lock next (readers queue behind it due to
+    // writer_waiting), complete, then readers drain.
+    RW_STARVE_GO.store(1, Ordering::SeqCst);
+    // Give workers a chance to run and park inside their lock calls.
+    for _ in 0..20 {
+        x86_64::instructions::hlt();
+    }
+    drop(g);
+
+    for _ in 0..4_000 {
+        if RW_STARVE_WRITER_DONE.load(Ordering::SeqCst) == 1
+            && RW_STARVE_READERS_DONE.load(Ordering::SeqCst) == RW_STARVE_READERS as usize
+        {
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+    assert_eq!(
+        RW_STARVE_WRITER_DONE.load(Ordering::SeqCst),
+        1,
+        "second writer didn't make progress — starved by reader flood"
+    );
+    assert_eq!(
+        RW_STARVE_READERS_DONE.load(Ordering::SeqCst),
+        RW_STARVE_READERS as usize,
+        "not all readers finished"
+    );
+}
+
+// --- semaphore_permits_block ----------------------------------------
+//
+// Semaphore starts with 2 permits; three worker tasks each `acquire`,
+// hold briefly, then `release`. Only two can be inside the critical
+// region at once — the third must park until one of the first two
+// releases. Live-worker peak of exactly 2 proves the permit count is
+// honoured.
+
+static SEM_GATE: Semaphore = Semaphore::new(2);
+static SEM_LIVE: AtomicUsize = AtomicUsize::new(0);
+static SEM_PEAK: AtomicUsize = AtomicUsize::new(0);
+static SEM_DONE: AtomicUsize = AtomicUsize::new(0);
+
+const SEM_HOLD_SPINS: usize = 300_000;
+
+fn sem_worker() -> ! {
+    SEM_GATE.acquire();
+    let live = SEM_LIVE.fetch_add(1, Ordering::SeqCst) + 1;
+    let mut peak = SEM_PEAK.load(Ordering::SeqCst);
+    while live > peak {
+        match SEM_PEAK.compare_exchange(peak, live, Ordering::SeqCst, Ordering::SeqCst) {
+            Ok(_) => break,
+            Err(actual) => peak = actual,
+        }
+    }
+    for _ in 0..SEM_HOLD_SPINS {
+        core::hint::spin_loop();
+    }
+    SEM_LIVE.fetch_sub(1, Ordering::SeqCst);
+    SEM_GATE.release();
+    SEM_DONE.fetch_add(1, Ordering::SeqCst);
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn semaphore_permits_block() {
+    // Reset the semaphore by draining any leftover permits and
+    // re-releasing to the starting count of 2.
+    while SEM_GATE.try_acquire() {}
+    SEM_GATE.release();
+    SEM_GATE.release();
+    SEM_LIVE.store(0, Ordering::SeqCst);
+    SEM_PEAK.store(0, Ordering::SeqCst);
+    SEM_DONE.store(0, Ordering::SeqCst);
+
+    task::spawn(sem_worker);
+    task::spawn(sem_worker);
+    task::spawn(sem_worker);
+
+    for _ in 0..4_000 {
+        if SEM_DONE.load(Ordering::SeqCst) == 3 {
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+    assert_eq!(
+        SEM_DONE.load(Ordering::SeqCst),
+        3,
+        "semaphore workers didn't all finish — park/wake wedged"
+    );
+    assert_eq!(
+        SEM_PEAK.load(Ordering::SeqCst),
+        2,
+        "permit budget exceeded — semaphore let more than 2 in concurrently"
+    );
+}
+
+// --- semaphore_release_wakes_one ------------------------------------
+//
+// Two workers park on a 0-permit semaphore. The driver calls
+// `release()` once; exactly one worker must unpark and record its
+// wake. A second `release()` frees the other. This mirrors
+// `ChildState::Loading`'s "one waiter wins, the rest stay parked until
+// their permit arrives" contract.
+
+static SEM_WAKE: Semaphore = Semaphore::new(0);
+static SEM_WAKE_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+fn sem_wake_worker() -> ! {
+    SEM_WAKE.acquire();
+    SEM_WAKE_COUNT.fetch_add(1, Ordering::SeqCst);
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn semaphore_release_wakes_one() {
+    while SEM_WAKE.try_acquire() {}
+    SEM_WAKE_COUNT.store(0, Ordering::SeqCst);
+
+    task::spawn(sem_wake_worker);
+    task::spawn(sem_wake_worker);
+
+    // Wait until both workers have actually parked inside `acquire`.
+    // Workers enqueue on the internal waitqueue, so we poll indirectly
+    // via the done counter staying at 0 after a grace period.
+    for _ in 0..200 {
+        x86_64::instructions::hlt();
+    }
+    assert_eq!(
+        SEM_WAKE_COUNT.load(Ordering::SeqCst),
+        0,
+        "workers acquired before any permit was released"
+    );
+
+    // One release — exactly one worker should wake.
+    SEM_WAKE.release();
+    for _ in 0..1_000 {
+        if SEM_WAKE_COUNT.load(Ordering::SeqCst) >= 1 {
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+    assert_eq!(
+        SEM_WAKE_COUNT.load(Ordering::SeqCst),
+        1,
+        "first release didn't wake exactly one waiter"
+    );
+
+    // Second release frees the other worker.
+    SEM_WAKE.release();
+    for _ in 0..1_000 {
+        if SEM_WAKE_COUNT.load(Ordering::SeqCst) == 2 {
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+    assert_eq!(
+        SEM_WAKE_COUNT.load(Ordering::SeqCst),
+        2,
+        "second release didn't wake the remaining waiter"
     );
 }

--- a/kernel/tests/blocking_sync.rs
+++ b/kernel/tests/blocking_sync.rs
@@ -1072,12 +1072,22 @@ fn semaphore_release_wakes_one() {
     task::spawn(sem_wake_worker);
     task::spawn(sem_wake_worker);
 
-    // Wait until both workers have actually parked inside `acquire`.
-    // Workers enqueue on the internal waitqueue, so we poll indirectly
-    // via the done counter staying at 0 after a grace period.
-    for _ in 0..50 {
+    // Wait for both workers to actually park inside `acquire`. We check
+    // the waitqueue directly rather than relying on a timing-only grace
+    // period — on a CI scheduler with many accumulated background tasks
+    // from earlier tests, a hlt-count grace can expire before both
+    // workers have run far enough to enqueue.
+    for _ in 0..500 {
+        if SEM_WAKE.waiter_count() >= 2 {
+            break;
+        }
         x86_64::instructions::hlt();
     }
+    assert_eq!(
+        SEM_WAKE.waiter_count(),
+        2,
+        "both workers did not park on the semaphore in time"
+    );
     assert_eq!(
         SEM_WAKE_COUNT.load(Ordering::SeqCst),
         0,
@@ -1086,7 +1096,7 @@ fn semaphore_release_wakes_one() {
 
     // One release — exactly one worker should wake.
     SEM_WAKE.release();
-    for _ in 0..200 {
+    for _ in 0..500 {
         if SEM_WAKE_COUNT.load(Ordering::SeqCst) >= 1 {
             break;
         }
@@ -1100,7 +1110,7 @@ fn semaphore_release_wakes_one() {
 
     // Second release frees the other worker.
     SEM_WAKE.release();
-    for _ in 0..200 {
+    for _ in 0..500 {
         if SEM_WAKE_COUNT.load(Ordering::SeqCst) == 2 {
             break;
         }


### PR DESCRIPTION
Closes #229

## Summary
- Adds `BlockingRwLock<T>` in `kernel/src/sync/rwlock.rs` — multi-reader / single-writer sleeping lock sharing the park/wake path with `BlockingMutex` via a single `WaitQueue`. New readers queue behind a pending writer (`writer_waiting` counter), preventing writer starvation under reader churn.
- Adds `Semaphore` in `kernel/src/sync/semaphore.rs` — counting semaphore with `acquire` / `try_acquire` / `release`, intended for `ChildState::Loading` first-lookup-of-a-name dedup. Saturating release with `debug_assert!` on overflow.
- Both primitives non-reentrant, matching the rest of `kernel/src/sync/`. Lock order continues to respect `WaitQueue.inner → state`.
- Integration tests in `kernel/tests/blocking_sync.rs` (QEMU, spawns real tasks) covering concurrent readers, writer exclusion, writer-not-starved under reader flood, semaphore permit budget, and release-wakes-one.

Implements RFC 0002 roadmap item 1/15. No consumers yet — the new primitives are surfaced via `kernel::sync` but not referenced elsewhere; downstream VFS work (issues #230, #232, #233, etc.) will pick them up.

## Test plan
- [x] `cargo check --target x86_64-unknown-none -p vibix --lib` — clean
- [x] `cargo check --target x86_64-unknown-none -p vibix --test blocking_sync` — clean
- [x] `cargo clippy --target x86_64-unknown-none -p vibix --lib` — no new findings
- [x] `cargo fmt --all --check` — clean
- [ ] `cargo xtask test` — host is aarch64 so xtask fails locally; CI will run on x86_64