### PR TITLE
tests: cover MAP_FIXED_NOREPLACE success case and wire mmap-family suite

### DIFF
--- a/kernel/tests/syscall_mmap_family.rs
+++ b/kernel/tests/syscall_mmap_family.rs
@@ -63,6 +63,10 @@ fn run_tests() {
             &(mmap_fixed_noreplace_overlap_eexist as fn()),
         ),
         (
+            "mmap_fixed_noreplace_unused_succeeds",
+            &(mmap_fixed_noreplace_unused_succeeds as fn()),
+        ),
+        (
             "munmap_returns_zero_on_hole",
             &(munmap_returns_zero_on_hole as fn()),
         ),
@@ -201,6 +205,54 @@ fn mmap_fixed_noreplace_overlap_eexist() {
     );
     assert_eq!(r as u64, a, "MAP_FIXED must return the requested VA");
     let _ = munmap(a, 4096);
+}
+
+fn mmap_fixed_noreplace_unused_succeeds() {
+    // MAP_FIXED_NOREPLACE at an unused, aligned VA must honour the
+    // requested address exactly and install a working VMA.
+    let base: u64 = 0x0000_3000_1000_0000;
+    let r = mmap(
+        base,
+        4096,
+        PROT_READ | PROT_WRITE,
+        MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED_NOREPLACE,
+        -1,
+        0,
+    );
+    assert_eq!(r as u64, base, "expected exact VA, got {:#x}", r);
+
+    // The page must be usable — demand-fault on first write, read-back.
+    unsafe {
+        ptr::write_volatile(base as *mut u8, 0x5A);
+        assert_eq!(ptr::read_volatile(base as *const u8), 0x5A);
+    }
+
+    assert_eq!(munmap(base, 4096), 0);
+
+    // After unmap the VA is free again: a second NOREPLACE at the same
+    // VA must succeed, proving the earlier VMA was cleanly removed.
+    let r = mmap(
+        base,
+        4096,
+        PROT_READ | PROT_WRITE,
+        MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED_NOREPLACE,
+        -1,
+        0,
+    );
+    assert_eq!(r as u64, base);
+    let _ = munmap(base, 4096);
+
+    // Unaligned addr with MAP_FIXED_NOREPLACE must reject with EINVAL
+    // (fixed mappings demand exact page alignment).
+    let r = mmap(
+        base + 1,
+        4096,
+        PROT_READ | PROT_WRITE,
+        MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED_NOREPLACE,
+        -1,
+        0,
+    );
+    assert_eq!(r, EINVAL, "unaligned NOREPLACE must be EINVAL, got {}", r);
 }
 
 fn munmap_returns_zero_on_hole() {

--- a/kernel/tests/vm_integration.rs
+++ b/kernel/tests/vm_integration.rs
@@ -6,7 +6,6 @@
 //! Out of scope for this file (tracked separately):
 //! - `mprotect` downgrade → write SIGSEGV: needs a ring-3 userspace
 //!   driver and the `#PF` test-hook dance.
-//! - `MAP_FIXED_NOREPLACE` EEXIST: no syscall plumbing yet.
 //! - Refcount saturation rollback in fork: the current fork path
 //!   silently pins at `u16::MAX` rather than erroring, so there is no
 //!   rollback to test until that lands.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -676,6 +676,7 @@ fn test_all() -> R<()> {
         "smep_smap",
         "fd_table",
         "syscall_open_mmap",
+        "syscall_mmap_family",
         "vm_integration",
     ] {
         cmd.arg("--test").arg(t);


### PR DESCRIPTION
Closes #226.

## Summary

- The `mmap` / `munmap` / `mprotect` / `madvise` syscall plumbing landed in #214 and #228, including `MAP_FIXED_NOREPLACE` and its EEXIST-on-overlap semantics. The existing `syscall_mmap_family` integration suite already exercises the overlap path, but the suite was never added to the xtask `test_all` list, so CI was not actually running it.
- Adds `syscall_mmap_family` to `xtask test_all` so all thirteen cases (including the overlap → EEXIST assertion) run under QEMU on every CI build.
- Adds a new success-case test `mmap_fixed_noreplace_unused_succeeds` covering the other half of issue #226: a `MAP_FIXED_NOREPLACE` at an unused VA must honour the requested address exactly, actually demand-fault, and tear down cleanly.
- Drops the now-stale "no syscall plumbing yet" bullet from `vm_integration.rs`.

## Test plan

- [x] `cargo build --package vibix --test syscall_mmap_family --target x86_64-unknown-none -Z build-std=core,alloc,compiler_builtins` — integration test compiles clean
- [x] `cargo build --package xtask` — xtask changes compile clean
- [ ] `cargo xtask test` — exercises the new case + existing overlap test under QEMU (runs on CI; the local dev environment is aarch64 and cannot run the x86_64 host-lib pre-pass)
- [ ] `cargo xtask smoke` — no behavior change expected (runs on CI)