### PR TITLE
docker: pin base image to linux/amd64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM --platform=linux/amd64 ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive \
     LANG=C.UTF-8 \


### PR DESCRIPTION
## Summary

- Pin the Dockerfile's base image to \`--platform=linux/amd64\`.
- On Apple Silicon Macs, \`FROM ubuntu:24.04\` inherits the host platform (arm64), so the pre-installed Rust toolchain resolves to \`aarch64-unknown-linux-gnu\`. That breaks \`cargo xtask test\`'s host-lib pre-pass: the kernel crate pulls in x86_64-only deps (\`pic8259\`, \`uart_16550\`, \`x86_64\`) that cannot compile for aarch64.
- Docker Desktop on Mac transparently emulates amd64 via QEMU, so this works everywhere. CI runs on \`ubuntu-latest\` (already amd64) and is unaffected.

## Test plan

- [x] Dockerfile diff is a one-line platform pin; no semantic change to installed packages.
- [ ] Next container rebuild on Apple Silicon: \`rustc -vV\` reports \`host: x86_64-unknown-linux-gnu\` and \`cargo xtask test\` host-lib step compiles.