### PR TITLE
vfs: core types for RFC 0002 (item 2/15)

### DIFF
--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -9,6 +9,8 @@
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 
+pub mod vfs;
+
 /// I/O dispatch interface for a single open file description.
 ///
 /// Implementations must be `Send + Sync` so that `Arc<dyn FileBackend>` can

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -9,6 +9,7 @@
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 
+#[cfg(target_os = "none")]
 pub mod vfs;
 
 /// I/O dispatch interface for a single open file description.

--- a/kernel/src/fs/vfs/dentry.rs
+++ b/kernel/src/fs/vfs/dentry.rs
@@ -120,10 +120,11 @@ impl Dentry {
     }
 
     /// Construct the root dentry: self-parenting via `Arc::new_cyclic`.
-    /// The name is empty (roots don't have a component name).
+    /// Roots have no path-component name; `DString` rejects `/` so we
+    /// use `.` as the sentinel that always passes validation.
     pub fn new_root(inode: Arc<Inode>) -> Arc<Self> {
         Arc::new_cyclic(|weak_self| Self {
-            name: DString::try_from_bytes(b"/").unwrap_or_else(|_| unreachable!("'/' is valid")),
+            name: DString::try_from_bytes(b".").unwrap_or_else(|_| unreachable!("'.' is valid")),
             parent: weak_self.clone(),
             inode: BlockingRwLock::new(Some(inode)),
             mount: BlockingRwLock::new(None),

--- a/kernel/src/fs/vfs/dentry.rs
+++ b/kernel/src/fs/vfs/dentry.rs
@@ -1,0 +1,238 @@
+//! `Dentry` — name-to-Inode cache node. Also the mount-edge carrier.
+//!
+//! A dentry is the entry point for every path lookup: the `children`
+//! map caches name→dentry resolutions for its own inode's directory
+//! entries, and the `mount` field (`Some` when this dentry itself is a
+//! mount point) redirects traversal into another filesystem.
+//!
+//! Negative dentries (`inode` is `None`) let the VFS cache
+//! "definitely does not exist" results so repeated failing lookups
+//! don't hammer the underlying FS.
+//!
+//! Concurrent first-lookup-of-a-name is serialised by
+//! [`ChildState::Loading`]: the first walker inserts a `Loading`
+//! holding an `Arc<Semaphore>`; later walkers park on that semaphore
+//! and retry when released. See RFC 0002 §Path resolution.
+
+use alloc::collections::BTreeMap;
+use alloc::sync::{Arc, Weak};
+
+use crate::sync::{BlockingRwLock, Semaphore};
+
+use super::DString;
+use super::inode::Inode;
+use super::super_block::SuperBlock;
+
+/// Per-dentry flags (IS_ROOT, DISCONNECTED, ...). Empty for now;
+/// filled out by later RFC 0002 items.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct DFlags(pub u32);
+
+impl DFlags {
+    pub const IS_ROOT: DFlags = DFlags(1 << 0);
+    pub const DISCONNECTED: DFlags = DFlags(1 << 1);
+
+    pub const fn contains(self, other: DFlags) -> bool {
+        (self.0 & other.0) == other.0
+    }
+}
+
+impl core::ops::BitOr for DFlags {
+    type Output = DFlags;
+    fn bitor(self, rhs: Self) -> Self {
+        DFlags(self.0 | rhs.0)
+    }
+}
+
+/// Per-mount flags. Distinct from [`super::SbFlags`]: these decorate
+/// the mount edge, not the filesystem itself (e.g. a read-only bind
+/// mount of a read-write FS).
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct MountFlags(pub u32);
+
+impl MountFlags {
+    pub const RDONLY: MountFlags = MountFlags(1 << 0);
+    pub const NOEXEC: MountFlags = MountFlags(1 << 1);
+    pub const NOSUID: MountFlags = MountFlags(1 << 2);
+    pub const NODEV: MountFlags = MountFlags(1 << 3);
+
+    pub const fn contains(self, other: MountFlags) -> bool {
+        (self.0 & other.0) == other.0
+    }
+}
+
+impl core::ops::BitOr for MountFlags {
+    type Output = MountFlags;
+    fn bitor(self, rhs: Self) -> Self {
+        MountFlags(self.0 | rhs.0)
+    }
+}
+
+/// One edge in the mount graph. Installed on the mountpoint dentry's
+/// `mount` slot while holding the mount-table write lock.
+pub struct MountEdge {
+    pub mountpoint: Weak<Dentry>,
+    pub super_block: Arc<SuperBlock>,
+    pub root_dentry: Arc<Dentry>,
+    pub flags: MountFlags,
+}
+
+/// State of a name in a parent's children map.
+///
+/// `Loading` is a transient synchronisation marker: the first walker
+/// for a name publishes `Loading(sem)` before calling
+/// `InodeOps::lookup`, later walkers park on `sem.acquire`, and the
+/// first walker replaces the entry with `Resolved` or `Negative` and
+/// calls `sem.release` for every waiter.
+pub enum ChildState {
+    Loading(Arc<Semaphore>),
+    Negative,
+    Resolved(Arc<Dentry>),
+}
+
+/// Cached path-component node.
+///
+/// `parent` is a weak back-edge so a child cannot keep its parent
+/// alive. The root dentry is self-parenting, installed via
+/// [`Arc::new_cyclic`] at mount time.
+pub struct Dentry {
+    pub name: DString,
+    pub parent: Weak<Dentry>,
+    pub inode: BlockingRwLock<Option<Arc<Inode>>>,
+    pub mount: BlockingRwLock<Option<Arc<MountEdge>>>,
+    pub children: BlockingRwLock<BTreeMap<DString, ChildState>>,
+    pub flags: DFlags,
+}
+
+impl Dentry {
+    /// Construct a non-root dentry with an explicit parent.
+    pub fn new(name: DString, parent: Weak<Dentry>, inode: Option<Arc<Inode>>) -> Arc<Self> {
+        Arc::new(Self {
+            name,
+            parent,
+            inode: BlockingRwLock::new(inode),
+            mount: BlockingRwLock::new(None),
+            children: BlockingRwLock::new(BTreeMap::new()),
+            flags: DFlags::default(),
+        })
+    }
+
+    /// Construct the root dentry: self-parenting via `Arc::new_cyclic`.
+    /// The name is empty (roots don't have a component name).
+    pub fn new_root(inode: Arc<Inode>) -> Arc<Self> {
+        Arc::new_cyclic(|weak_self| Self {
+            name: DString::try_from_bytes(b"/").unwrap_or_else(|_| unreachable!("'/' is valid")),
+            parent: weak_self.clone(),
+            inode: BlockingRwLock::new(Some(inode)),
+            mount: BlockingRwLock::new(None),
+            children: BlockingRwLock::new(BTreeMap::new()),
+            flags: DFlags::IS_ROOT,
+        })
+    }
+
+    /// `true` if `inode` is currently populated (positive dentry).
+    pub fn is_positive(&self) -> bool {
+        self.inode.read().is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fs::vfs::inode::{Inode, InodeKind, InodeMeta};
+    use crate::fs::vfs::ops::{FileOps, InodeOps, SetAttr, Stat, StatFs, SuperOps};
+    use crate::fs::vfs::super_block::{SbFlags, SuperBlock};
+    use crate::fs::vfs::FsId;
+
+    struct StubInode;
+    impl InodeOps for StubInode {
+        fn getattr(&self, _inode: &Inode, _out: &mut Stat) -> Result<(), i64> {
+            Ok(())
+        }
+        fn setattr(&self, _inode: &Inode, _attr: &SetAttr) -> Result<(), i64> {
+            Ok(())
+        }
+    }
+    struct StubFile;
+    impl FileOps for StubFile {}
+    struct StubSuper;
+    impl SuperOps for StubSuper {
+        fn root_inode(&self) -> Arc<Inode> {
+            unreachable!()
+        }
+        fn statfs(&self) -> Result<StatFs, i64> {
+            Ok(StatFs::default())
+        }
+        fn unmount(&self) -> Result<(), i64> {
+            Ok(())
+        }
+    }
+
+    fn make_inode() -> Arc<Inode> {
+        let sb = Arc::new(SuperBlock::new(
+            FsId(1),
+            Arc::new(StubSuper),
+            "stub",
+            512,
+            SbFlags::default(),
+        ));
+        Arc::new(Inode::new(
+            1,
+            Arc::downgrade(&sb),
+            Arc::new(StubInode),
+            Arc::new(StubFile),
+            InodeKind::Dir,
+            InodeMeta {
+                mode: 0o755,
+                nlink: 2,
+                ..Default::default()
+            },
+        ))
+    }
+
+    #[test]
+    fn root_is_self_parenting() {
+        let ino = make_inode();
+        let root = Dentry::new_root(ino);
+        let parent = root.parent.upgrade().expect("weak to self must upgrade");
+        assert!(Arc::ptr_eq(&root, &parent));
+        assert!(root.flags.contains(DFlags::IS_ROOT));
+        assert!(root.is_positive());
+    }
+
+    #[test]
+    fn non_root_parent_weak() {
+        let ino = make_inode();
+        let root = Dentry::new_root(ino.clone());
+        let child = Dentry::new(
+            DString::try_from_bytes(b"child").unwrap(),
+            Arc::downgrade(&root),
+            Some(ino),
+        );
+        assert!(Arc::ptr_eq(
+            &root,
+            &child.parent.upgrade().expect("parent alive")
+        ));
+    }
+
+    #[test]
+    fn negative_dentry() {
+        let root = Dentry::new_root(make_inode());
+        let neg = Dentry::new(
+            DString::try_from_bytes(b"missing").unwrap(),
+            Arc::downgrade(&root),
+            None,
+        );
+        assert!(!neg.is_positive());
+    }
+
+    #[test]
+    fn mountflags_bitor() {
+        let f = MountFlags::RDONLY | MountFlags::NOEXEC;
+        assert!(f.contains(MountFlags::RDONLY));
+        assert!(f.contains(MountFlags::NOEXEC));
+        assert!(!f.contains(MountFlags::NOSUID));
+    }
+}

--- a/kernel/src/fs/vfs/dentry.rs
+++ b/kernel/src/fs/vfs/dentry.rs
@@ -19,9 +19,9 @@ use alloc::sync::{Arc, Weak};
 
 use crate::sync::{BlockingRwLock, Semaphore};
 
-use super::DString;
 use super::inode::Inode;
 use super::super_block::SuperBlock;
+use super::DString;
 
 /// Per-dentry flags (IS_ROOT, DISCONNECTED, ...). Empty for now;
 /// filled out by later RFC 0002 items.

--- a/kernel/src/fs/vfs/inode.rs
+++ b/kernel/src/fs/vfs/inode.rs
@@ -1,0 +1,176 @@
+//! `Inode` — one object per unique file on a mounted filesystem.
+//!
+//! Identity is `(sb.fs_id, ino)`. The `sb` back-reference is `Weak`
+//! to break the SB → Inode → SB reference cycle; every path that
+//! needs the SB upgrades the weak and fails with `ENOENT` if the SB
+//! has already been torn down.
+
+use alloc::sync::{Arc, Weak};
+
+use crate::sync::{BlockingMutex, BlockingRwLock};
+
+use super::Timespec;
+use super::ops::{FileOps, InodeOps};
+use super::super_block::SuperBlock;
+
+/// Enumerated file kind. Packs into `S_IFMT` bits of `st_mode` at
+/// `getattr` time.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InodeKind {
+    Reg,
+    Dir,
+    Link,
+    Chr,
+    Blk,
+    Fifo,
+    Sock,
+}
+
+/// Mutable metadata. Separated from the dir-mutation rwsem so that
+/// `stat(2)` doesn't serialise against directory modifications.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct InodeMeta {
+    pub mode: u16,
+    pub uid: u32,
+    pub gid: u32,
+    pub size: u64,
+    pub nlink: u32,
+    pub atime: Timespec,
+    pub mtime: Timespec,
+    pub ctime: Timespec,
+    pub rdev: u64,
+    pub blksize: u32,
+    pub blocks: u64,
+}
+
+/// Lifecycle bookkeeping for an inode. Short-lived lock; no
+/// scheduling point is held while inspecting these.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct InodeState {
+    /// `true` once the last link has been removed but the inode still
+    /// has open references — POSIX "unlinked but open".
+    pub unlinked: bool,
+    /// Set when any `setattr`/write path has dirtied the inode since
+    /// the last `sync`.
+    pub dirty: bool,
+    /// Number of `OpenFile` + `path_walk` pins outstanding.
+    pub pin_count: u32,
+}
+
+/// In-memory representation of a single FS object.
+///
+/// Constructed by `InodeOps::lookup` / `create` / `mkdir` and
+/// published via a [`super::dentry::Dentry`]. Immutable fields live on
+/// the struct; mutable state is behind `BlockingRwLock` / `BlockingMutex`.
+pub struct Inode {
+    pub ino: u64,
+    pub sb: Weak<SuperBlock>,
+    pub ops: Arc<dyn InodeOps>,
+    pub file_ops: Arc<dyn FileOps>,
+    /// `i_rwsem` analogue: write-locked by directory mutations,
+    /// read-locked by lookup + permission checks during path walk.
+    /// Non-directory inodes never acquire it.
+    pub dir_rwsem: BlockingRwLock<()>,
+    pub meta: BlockingRwLock<InodeMeta>,
+    pub state: BlockingMutex<InodeState>,
+    pub kind: InodeKind,
+}
+
+impl Inode {
+    pub fn new(
+        ino: u64,
+        sb: Weak<SuperBlock>,
+        ops: Arc<dyn InodeOps>,
+        file_ops: Arc<dyn FileOps>,
+        kind: InodeKind,
+        meta: InodeMeta,
+    ) -> Self {
+        Self {
+            ino,
+            sb,
+            ops,
+            file_ops,
+            dir_rwsem: BlockingRwLock::new(()),
+            meta: BlockingRwLock::new(meta),
+            state: BlockingMutex::new(InodeState::default()),
+            kind,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fs::vfs::ops::{SetAttr, Stat, StatFs};
+    use crate::fs::vfs::super_block::{SbFlags, SuperBlock};
+    use crate::fs::vfs::{FsId, InodeKind};
+    use alloc::sync::Arc;
+
+    struct StubInode;
+    impl InodeOps for StubInode {
+        fn getattr(&self, _inode: &Inode, _out: &mut Stat) -> Result<(), i64> {
+            Ok(())
+        }
+        fn setattr(&self, _inode: &Inode, _attr: &SetAttr) -> Result<(), i64> {
+            Ok(())
+        }
+    }
+
+    struct StubFile;
+    impl FileOps for StubFile {}
+
+    struct StubSuper;
+    impl super::super::ops::SuperOps for StubSuper {
+        fn root_inode(&self) -> Arc<Inode> {
+            unreachable!()
+        }
+        fn statfs(&self) -> Result<StatFs, i64> {
+            Ok(StatFs::default())
+        }
+        fn unmount(&self) -> Result<(), i64> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn inode_construction_roundtrip() {
+        let sb = Arc::new(SuperBlock::new(
+            FsId(7),
+            Arc::new(StubSuper),
+            "stub",
+            512,
+            SbFlags::default(),
+        ));
+        let ino = Inode::new(
+            42,
+            Arc::downgrade(&sb),
+            Arc::new(StubInode),
+            Arc::new(StubFile),
+            InodeKind::Reg,
+            InodeMeta {
+                mode: 0o644,
+                nlink: 1,
+                size: 100,
+                ..Default::default()
+            },
+        );
+        assert_eq!(ino.ino, 42);
+        assert_eq!(ino.meta.read().size, 100);
+        assert!(!ino.state.lock().unlinked);
+    }
+
+    #[test]
+    fn weak_sb_does_not_cycle() {
+        let sb = Arc::new(SuperBlock::new(
+            FsId(1),
+            Arc::new(StubSuper),
+            "stub",
+            512,
+            SbFlags::default(),
+        ));
+        let weak = Arc::downgrade(&sb);
+        // Dropping the strong sb drops inode's only SB reference path.
+        drop(sb);
+        assert!(weak.upgrade().is_none());
+    }
+}

--- a/kernel/src/fs/vfs/inode.rs
+++ b/kernel/src/fs/vfs/inode.rs
@@ -9,9 +9,9 @@ use alloc::sync::{Arc, Weak};
 
 use crate::sync::{BlockingMutex, BlockingRwLock};
 
-use super::Timespec;
 use super::ops::{FileOps, InodeOps};
 use super::super_block::SuperBlock;
+use super::Timespec;
 
 /// Enumerated file kind. Packs into `S_IFMT` bits of `st_mode` at
 /// `getattr` time.

--- a/kernel/src/fs/vfs/mod.rs
+++ b/kernel/src/fs/vfs/mod.rs
@@ -47,17 +47,17 @@ use alloc::vec::Vec;
 
 pub mod dentry;
 pub mod inode;
-pub mod ops;
 pub mod open_file;
+pub mod ops;
 pub mod super_block;
 
 pub use dentry::{ChildState, DFlags, Dentry, MountEdge, MountFlags};
 pub use inode::{Inode, InodeKind, InodeMeta, InodeState};
-pub use ops::{
-    FileOps, FileSystem, InodeOps, MountSource, SetAttr, SetAttrMask, Stat, StatFs, SuperOps,
-    Whence, default_permission,
-};
 pub use open_file::OpenFile;
+pub use ops::{
+    default_permission, FileOps, FileSystem, InodeOps, MountSource, SetAttr, SetAttrMask, Stat,
+    StatFs, SuperOps, Whence,
+};
 pub use super_block::{SbActiveGuard, SbFlags, SuperBlock};
 
 /// POSIX-imposed cap on a single path component.

--- a/kernel/src/fs/vfs/mod.rs
+++ b/kernel/src/fs/vfs/mod.rs
@@ -1,0 +1,208 @@
+//! Virtual filesystem core types.
+//!
+//! Foundation for RFC 0002 — every path-based syscall ultimately
+//! resolves through these objects. Concrete filesystems (ramfs, tarfs,
+//! devfs) plug in by implementing [`FileSystem`] and the three
+//! operation traits [`SuperOps`], [`InodeOps`], [`FileOps`].
+//!
+//! No drivers live here yet; this module establishes the type layout
+//! and the invariants, so later roadmap items can build on it without
+//! retrofitting.
+//!
+//! ## Object relationships
+//!
+//! ```text
+//!   SuperBlock (per mounted FS instance)
+//!     ├── Arc<dyn SuperOps>
+//!     └── root: Arc<Inode>
+//!
+//!   Inode  ── Weak<SuperBlock>   // breaks the SB→Inode→SB cycle
+//!     ├── Arc<dyn InodeOps>
+//!     └── Arc<dyn FileOps>       // for regular files
+//!
+//!   Dentry (cache-name-to-Inode)
+//!     ├── Weak<Dentry> parent    // root self-parent via Arc::new_cyclic
+//!     ├── Option<Arc<Inode>>     // None == negative dentry
+//!     ├── Option<Arc<MountEdge>> // Some when this dentry is a mountpoint
+//!     └── BTreeMap<DString, ChildState>
+//!
+//!   OpenFile (per sys_open success)
+//!     ├── Arc<Dentry>
+//!     ├── Arc<Inode>
+//!     └── Arc<SuperBlock>        // strong — anchors SB lifetime
+//! ```
+//!
+//! ## Threading
+//!
+//! Every type here is `Send + Sync`. Concurrent access is protected by
+//! the primitives in [`crate::sync`]: [`crate::sync::BlockingRwLock`]
+//! on `Inode.dir_rwsem` / `Inode.meta` / `Dentry.children` /
+//! `Dentry.inode` / `Dentry.mount`; [`crate::sync::BlockingMutex`] on
+//! `SuperBlock.rename_mutex` and `Inode.state`;
+//! [`crate::sync::Semaphore`] on `ChildState::Loading`.
+
+#![allow(dead_code)]
+
+use alloc::vec::Vec;
+
+/// POSIX-imposed cap on a single path component.
+pub const NAME_MAX: usize = 255;
+
+/// POSIX-imposed cap on symlink-follow depth during `path_walk`.
+pub const SYMLOOP_MAX: u32 = 40;
+
+/// Unique identifier for a mounted FS instance. Assigned by
+/// `MountTable::mount`; stable for the lifetime of the [`SuperBlock`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct FsId(pub u64);
+
+/// Wall-clock timestamp, POSIX `struct timespec` layout.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct Timespec {
+    pub sec: i64,
+    pub nsec: u32,
+}
+
+/// Caller credentials consulted by [`InodeOps::permission`].
+///
+/// Ownership fields default to `0` (root) so kernel-internal callers
+/// that don't have a userspace task context can skip supplying one.
+#[derive(Clone, Debug, Default)]
+pub struct Credential {
+    pub uid: u32,
+    pub gid: u32,
+    pub groups: Vec<u32>,
+}
+
+/// Access modes checked against `InodeMeta.mode` by
+/// [`default_permission`]. Mirrors the low three bits of POSIX
+/// `access(2)`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct Access(pub u32);
+
+impl Access {
+    pub const READ: Access = Access(1 << 2); // R_OK
+    pub const WRITE: Access = Access(1 << 1); // W_OK
+    pub const EXECUTE: Access = Access(1 << 0); // X_OK
+    pub const NONE: Access = Access(0);
+
+    pub const fn bits(self) -> u32 {
+        self.0
+    }
+    pub const fn contains(self, other: Access) -> bool {
+        (self.0 & other.0) == other.0
+    }
+}
+
+impl core::ops::BitOr for Access {
+    type Output = Access;
+    fn bitor(self, rhs: Self) -> Self {
+        Access(self.0 | rhs.0)
+    }
+}
+
+impl core::ops::BitAnd for Access {
+    type Output = Access;
+    fn bitand(self, rhs: Self) -> Self {
+        Access(self.0 & rhs.0)
+    }
+}
+
+/// Bounded directory-entry name. Allocates on the heap (we're always
+/// in task context for VFS work) but caps the length at [`NAME_MAX`]
+/// bytes — longer names are rejected at construction time with
+/// `ENAMETOOLONG`.
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct DString {
+    bytes: Vec<u8>,
+}
+
+impl DString {
+    /// Construct from a byte slice. Rejects empty names, names longer
+    /// than [`NAME_MAX`], and names containing `/` or NUL (both
+    /// illegal per POSIX §4.5).
+    pub fn try_from_bytes(s: &[u8]) -> Result<Self, i64> {
+        if s.is_empty() || s.len() > NAME_MAX {
+            return Err(super::ENAMETOOLONG);
+        }
+        if s.iter().any(|&b| b == b'/' || b == 0) {
+            return Err(super::EINVAL);
+        }
+        Ok(Self { bytes: s.to_vec() })
+    }
+
+    /// Raw bytes. No trailing NUL.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    pub fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
+}
+
+// Every type that appears in this module (or its submodules) must be
+// Send + Sync so it can live behind `Arc` and be shared across tasks.
+// If any of these loses `Send + Sync` during a refactor, the kernel
+// fails to build.
+const _: () = {
+    const fn assert_send_sync<T: ?Sized + Send + Sync>() {}
+    assert_send_sync::<FsId>();
+    assert_send_sync::<Timespec>();
+    assert_send_sync::<Credential>();
+    assert_send_sync::<Access>();
+    assert_send_sync::<DString>();
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dstring_rejects_empty() {
+        assert!(DString::try_from_bytes(b"").is_err());
+    }
+
+    #[test]
+    fn dstring_rejects_too_long() {
+        let long = [b'a'; NAME_MAX + 1];
+        assert!(DString::try_from_bytes(&long).is_err());
+    }
+
+    #[test]
+    fn dstring_accepts_max_length() {
+        let at_limit = [b'a'; NAME_MAX];
+        assert!(DString::try_from_bytes(&at_limit).is_ok());
+    }
+
+    #[test]
+    fn dstring_rejects_slash() {
+        assert!(DString::try_from_bytes(b"foo/bar").is_err());
+    }
+
+    #[test]
+    fn dstring_rejects_nul() {
+        assert!(DString::try_from_bytes(b"foo\0bar").is_err());
+    }
+
+    #[test]
+    fn dstring_roundtrip() {
+        let d = DString::try_from_bytes(b"hello").unwrap();
+        assert_eq!(d.as_bytes(), b"hello");
+        assert_eq!(d.len(), 5);
+        assert!(!d.is_empty());
+    }
+
+    #[test]
+    fn access_bitflags() {
+        let a = Access::READ | Access::EXECUTE;
+        assert!(a.contains(Access::READ));
+        assert!(!a.contains(Access::WRITE));
+        assert!(a.contains(Access::EXECUTE));
+    }
+}

--- a/kernel/src/fs/vfs/mod.rs
+++ b/kernel/src/fs/vfs/mod.rs
@@ -45,6 +45,21 @@
 
 use alloc::vec::Vec;
 
+pub mod dentry;
+pub mod inode;
+pub mod ops;
+pub mod open_file;
+pub mod super_block;
+
+pub use dentry::{ChildState, DFlags, Dentry, MountEdge, MountFlags};
+pub use inode::{Inode, InodeKind, InodeMeta, InodeState};
+pub use ops::{
+    FileOps, FileSystem, InodeOps, MountSource, SetAttr, SetAttrMask, Stat, StatFs, SuperOps,
+    Whence, default_permission,
+};
+pub use open_file::OpenFile;
+pub use super_block::{SbActiveGuard, SbFlags, SuperBlock};
+
 /// POSIX-imposed cap on a single path component.
 pub const NAME_MAX: usize = 255;
 
@@ -157,6 +172,13 @@ const _: () = {
     assert_send_sync::<Credential>();
     assert_send_sync::<Access>();
     assert_send_sync::<DString>();
+    assert_send_sync::<SuperBlock>();
+    assert_send_sync::<Inode>();
+    assert_send_sync::<InodeMeta>();
+    assert_send_sync::<InodeState>();
+    assert_send_sync::<Dentry>();
+    assert_send_sync::<MountEdge>();
+    assert_send_sync::<OpenFile>();
 };
 
 #[cfg(test)]

--- a/kernel/src/fs/vfs/mod.rs
+++ b/kernel/src/fs/vfs/mod.rs
@@ -80,13 +80,28 @@ pub struct Timespec {
 
 /// Caller credentials consulted by [`InodeOps::permission`].
 ///
-/// Ownership fields default to `0` (root) so kernel-internal callers
-/// that don't have a userspace task context can skip supplying one.
-#[derive(Clone, Debug, Default)]
+/// `Default` is deliberately not implemented: a default-constructed
+/// `Credential` would be uid 0, which `default_permission` treats as
+/// the root bypass — that would let any caller who reaches for
+/// `Credential::default()` accidentally elevate. Construct via
+/// [`Credential::kernel`] (root) or by setting fields explicitly.
+#[derive(Clone, Debug)]
 pub struct Credential {
     pub uid: u32,
     pub gid: u32,
     pub groups: Vec<u32>,
+}
+
+impl Credential {
+    /// Kernel-internal credential: root. Use only from kernel code
+    /// paths that are not acting on behalf of a userspace task.
+    pub fn kernel() -> Self {
+        Self {
+            uid: 0,
+            gid: 0,
+            groups: Vec::new(),
+        }
+    }
 }
 
 /// Access modes checked against `InodeMeta.mode` by

--- a/kernel/src/fs/vfs/open_file.rs
+++ b/kernel/src/fs/vfs/open_file.rs
@@ -1,0 +1,112 @@
+//! `OpenFile` — one per successful `sys_open`.
+//!
+//! Holds strong references to its dentry, inode, and super-block; the
+//! `sb` strong ref is the anchor that closes OS-B6 — an `Inode`
+//! cannot outlive its `SuperBlock` while any `OpenFile` on that SB is
+//! still live.
+//!
+//! Separate from the existing `kernel::fs::FileDescription` for now;
+//! the bridge between the two lands with RFC 0002 item 14 (fd-table
+//! integration).
+
+use alloc::sync::Arc;
+
+use crate::sync::BlockingMutex;
+
+use super::dentry::Dentry;
+use super::inode::Inode;
+use super::ops::FileOps;
+use super::super_block::SuperBlock;
+
+/// Per-open-file state.
+pub struct OpenFile {
+    pub dentry: Arc<Dentry>,
+    pub inode: Arc<Inode>,
+    /// Serialises `read`/`write`/`lseek` offset mutation — matches
+    /// POSIX "one offset per open file description" semantics.
+    pub offset: BlockingMutex<u64>,
+    pub flags: u32,
+    pub ops: Arc<dyn FileOps>,
+    pub sb: Arc<SuperBlock>,
+}
+
+impl OpenFile {
+    pub fn new(
+        dentry: Arc<Dentry>,
+        inode: Arc<Inode>,
+        ops: Arc<dyn FileOps>,
+        sb: Arc<SuperBlock>,
+        flags: u32,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            dentry,
+            inode,
+            offset: BlockingMutex::new(0),
+            flags,
+            ops,
+            sb,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fs::vfs::dentry::Dentry;
+    use crate::fs::vfs::inode::{Inode, InodeKind, InodeMeta};
+    use crate::fs::vfs::ops::{FileOps, InodeOps, SetAttr, Stat, StatFs, SuperOps};
+    use crate::fs::vfs::super_block::{SbFlags, SuperBlock};
+    use crate::fs::vfs::FsId;
+
+    struct StubInode;
+    impl InodeOps for StubInode {
+        fn getattr(&self, _inode: &Inode, _out: &mut Stat) -> Result<(), i64> {
+            Ok(())
+        }
+        fn setattr(&self, _inode: &Inode, _attr: &SetAttr) -> Result<(), i64> {
+            Ok(())
+        }
+    }
+    struct StubFile;
+    impl FileOps for StubFile {}
+    struct StubSuper;
+    impl SuperOps for StubSuper {
+        fn root_inode(&self) -> Arc<Inode> {
+            unreachable!()
+        }
+        fn statfs(&self) -> Result<StatFs, i64> {
+            Ok(StatFs::default())
+        }
+        fn unmount(&self) -> Result<(), i64> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn open_file_pins_super_block() {
+        let sb = Arc::new(SuperBlock::new(
+            FsId(1),
+            Arc::new(StubSuper),
+            "stub",
+            512,
+            SbFlags::default(),
+        ));
+        let inode = Arc::new(Inode::new(
+            1,
+            Arc::downgrade(&sb),
+            Arc::new(StubInode),
+            Arc::new(StubFile),
+            InodeKind::Reg,
+            InodeMeta::default(),
+        ));
+        let dentry = Dentry::new_root(inode.clone());
+        let file_ops: Arc<dyn FileOps> = Arc::new(StubFile);
+        let of = OpenFile::new(dentry, inode, file_ops, sb.clone(), 0);
+
+        // Drop the local strong ref; the OpenFile still pins the SB.
+        let weak = Arc::downgrade(&sb);
+        drop(sb);
+        assert!(weak.upgrade().is_some(), "OpenFile must pin SuperBlock");
+        assert_eq!(*of.offset.lock(), 0);
+    }
+}

--- a/kernel/src/fs/vfs/ops.rs
+++ b/kernel/src/fs/vfs/ops.rs
@@ -11,10 +11,10 @@
 
 use alloc::sync::Arc;
 
-use super::{Access, Credential, InodeKind, Timespec};
 use super::inode::{Inode, InodeMeta};
 use super::open_file::OpenFile;
 use super::super_block::SuperBlock;
+use super::{Access, Credential, InodeKind, Timespec};
 
 /// Source of a mount operation. Separated from the target path so
 /// future sources (block device, ramdisk module, network URL) can be
@@ -278,7 +278,13 @@ pub fn default_permission(inode: &Inode, cred: &Credential, access: Access) -> R
 /// private helper so callers inside this crate can reach for it
 /// without pulling in the whole stat-construction scaffolding.
 #[allow(dead_code)]
-pub(crate) fn meta_into_stat(meta: &InodeMeta, kind: InodeKind, fs_id: u64, ino: u64, out: &mut Stat) {
+pub(crate) fn meta_into_stat(
+    meta: &InodeMeta,
+    kind: InodeKind,
+    fs_id: u64,
+    ino: u64,
+    out: &mut Stat,
+) {
     let kind_bits: u32 = match kind {
         InodeKind::Reg => 0o100_000,
         InodeKind::Dir => 0o040_000,

--- a/kernel/src/fs/vfs/ops.rs
+++ b/kernel/src/fs/vfs/ops.rs
@@ -1,0 +1,307 @@
+//! The four VFS operation traits (`FileSystem`, `SuperOps`,
+//! `InodeOps`, `FileOps`) and their associated value types.
+//!
+//! These are the plug-in surface every concrete filesystem implements.
+//! Concrete drivers (ramfs, tarfs, devfs) live in sibling modules and
+//! provide `Arc<dyn *Ops>` on object construction.
+//!
+//! Most methods have sensible defaults so a read-only FS doesn't have
+//! to stub a dozen write paths; overriding lookup/getattr is the
+//! minimum viable FS.
+
+use alloc::sync::Arc;
+
+use super::{Access, Credential, InodeKind, Timespec};
+use super::inode::{Inode, InodeMeta};
+use super::open_file::OpenFile;
+use super::super_block::SuperBlock;
+
+/// Source of a mount operation. Separated from the target path so
+/// future sources (block device, ramdisk module, network URL) can be
+/// added without breaking the trait signature.
+#[derive(Debug)]
+pub enum MountSource<'a> {
+    /// No backing — the FS synthesises its own storage (ramfs, devfs).
+    None,
+    /// A path in the current namespace (future: loop-mount support).
+    Path(&'a [u8]),
+    /// Static byte slice with 'static lifetime (initrd tarball).
+    Static(&'static [u8]),
+}
+
+/// Linux `struct stat` layout (x86_64). Emitted by
+/// [`InodeOps::getattr`]; copied verbatim to userspace. Always
+/// zero-initialised before dispatch to close Sec-B4 (uninitialised
+/// padding infoleak).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Stat {
+    pub st_dev: u64,
+    pub st_ino: u64,
+    pub st_nlink: u64,
+    pub st_mode: u32,
+    pub st_uid: u32,
+    pub st_gid: u32,
+    pub __pad0: u32,
+    pub st_rdev: u64,
+    pub st_size: i64,
+    pub st_blksize: i64,
+    pub st_blocks: i64,
+    pub st_atime: i64,
+    pub st_atime_nsec: i64,
+    pub st_mtime: i64,
+    pub st_mtime_nsec: i64,
+    pub st_ctime: i64,
+    pub st_ctime_nsec: i64,
+    pub __unused: [i64; 3],
+}
+
+const _: () = {
+    assert!(core::mem::size_of::<Stat>() == 0x90);
+    assert!(core::mem::align_of::<Stat>() == 8);
+};
+
+/// Bitmask describing which fields of [`SetAttr`] the caller wants
+/// applied. Matches Linux `ATTR_*`.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct SetAttrMask(pub u32);
+
+impl SetAttrMask {
+    pub const MODE: SetAttrMask = SetAttrMask(1 << 0);
+    pub const UID: SetAttrMask = SetAttrMask(1 << 1);
+    pub const GID: SetAttrMask = SetAttrMask(1 << 2);
+    pub const SIZE: SetAttrMask = SetAttrMask(1 << 3);
+    pub const ATIME: SetAttrMask = SetAttrMask(1 << 4);
+    pub const MTIME: SetAttrMask = SetAttrMask(1 << 5);
+    pub const CTIME: SetAttrMask = SetAttrMask(1 << 6);
+
+    pub const fn contains(self, other: SetAttrMask) -> bool {
+        (self.0 & other.0) == other.0
+    }
+}
+
+impl core::ops::BitOr for SetAttrMask {
+    type Output = SetAttrMask;
+    fn bitor(self, rhs: Self) -> Self {
+        SetAttrMask(self.0 | rhs.0)
+    }
+}
+
+/// Metadata update request. `mask` tells the driver which of the other
+/// fields are authoritative; unmasked fields must be ignored.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SetAttr {
+    pub mask: SetAttrMask,
+    pub mode: u16,
+    pub uid: u32,
+    pub gid: u32,
+    pub size: u64,
+    pub atime: Timespec,
+    pub mtime: Timespec,
+    pub ctime: Timespec,
+}
+
+/// Filesystem-wide statistics returned by [`SuperOps::statfs`].
+/// Mirrors Linux `struct statfs` field-by-field semantically (not
+/// byte-compatibly — the syscall layer lays out the wire format).
+#[derive(Clone, Copy, Debug, Default)]
+pub struct StatFs {
+    pub f_type: u64,
+    pub f_bsize: u64,
+    pub f_blocks: u64,
+    pub f_bfree: u64,
+    pub f_bavail: u64,
+    pub f_files: u64,
+    pub f_ffree: u64,
+    pub f_namelen: u64,
+}
+
+/// `lseek(2)` reference point.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Whence {
+    Set,
+    Cur,
+    End,
+}
+
+/// Filesystem-type factory. One `Arc<dyn FileSystem>` is registered
+/// per FS implementation; `mount` is invoked once per mount instance
+/// to produce a fresh [`SuperBlock`].
+pub trait FileSystem: Send + Sync {
+    fn name(&self) -> &'static str;
+    fn mount(
+        &self,
+        source: MountSource<'_>,
+        flags: super::MountFlags,
+    ) -> Result<Arc<SuperBlock>, i64>;
+}
+
+/// Per-mount-instance operations.
+pub trait SuperOps: Send + Sync {
+    fn root_inode(&self) -> Arc<Inode>;
+    fn sync(&self) -> Result<(), i64> {
+        Ok(())
+    }
+    fn evict_inode(&self, _ino: u64) -> Result<(), i64> {
+        Ok(())
+    }
+    fn statfs(&self) -> Result<StatFs, i64>;
+    fn unmount(&self) -> Result<(), i64>;
+}
+
+/// Per-inode operations: namespace mutation, metadata, permission.
+/// Non-directory inodes only need `getattr` / `setattr` / `permission`
+/// / `readlink`; directory methods default to `EPERM` so a read-only
+/// FS doesn't have to stub them.
+pub trait InodeOps: Send + Sync {
+    fn lookup(&self, _dir: &Inode, _name: &[u8]) -> Result<Arc<Inode>, i64> {
+        Err(super::super::ENOENT)
+    }
+    fn create(&self, _dir: &Inode, _name: &[u8], _mode: u16) -> Result<Arc<Inode>, i64> {
+        Err(EPERM)
+    }
+    fn mkdir(&self, _dir: &Inode, _name: &[u8], _mode: u16) -> Result<Arc<Inode>, i64> {
+        Err(EPERM)
+    }
+    fn unlink(&self, _dir: &Inode, _name: &[u8]) -> Result<(), i64> {
+        Err(EPERM)
+    }
+    fn rmdir(&self, _dir: &Inode, _name: &[u8]) -> Result<(), i64> {
+        Err(EPERM)
+    }
+    fn rename(
+        &self,
+        _old_dir: &Inode,
+        _old_name: &[u8],
+        _new_dir: &Inode,
+        _new_name: &[u8],
+    ) -> Result<(), i64> {
+        Err(EPERM)
+    }
+    fn link(&self, _dir: &Inode, _name: &[u8], _target: &Inode) -> Result<(), i64> {
+        Err(EPERM)
+    }
+    fn symlink(&self, _dir: &Inode, _name: &[u8], _target: &[u8]) -> Result<Arc<Inode>, i64> {
+        Err(EPERM)
+    }
+
+    fn readlink(&self, _inode: &Inode, _buf: &mut [u8]) -> Result<usize, i64> {
+        Err(EINVAL_OP)
+    }
+
+    fn getattr(&self, inode: &Inode, out: &mut Stat) -> Result<(), i64>;
+    fn setattr(&self, _inode: &Inode, _attr: &SetAttr) -> Result<(), i64> {
+        Err(EPERM)
+    }
+
+    fn permission(&self, inode: &Inode, cred: &Credential, access: Access) -> Result<(), i64> {
+        default_permission(inode, cred, access)
+    }
+}
+
+/// Per-open-file operations. Regular-file I/O, directory reading,
+/// control channel.
+pub trait FileOps: Send + Sync {
+    fn read(&self, _f: &OpenFile, _buf: &mut [u8], _off: u64) -> Result<usize, i64> {
+        Err(EINVAL_OP)
+    }
+    fn write(&self, _f: &OpenFile, _buf: &[u8], _off: u64) -> Result<usize, i64> {
+        Err(EINVAL_OP)
+    }
+    fn seek(&self, _f: &OpenFile, _whence: Whence, _off: i64) -> Result<u64, i64> {
+        Err(ESPIPE)
+    }
+    fn getdents(&self, _f: &OpenFile, _buf: &mut [u8], _cookie: &mut u64) -> Result<usize, i64> {
+        Err(ENOTDIR)
+    }
+    fn ioctl(&self, _f: &OpenFile, _cmd: u32, _arg: usize) -> Result<i64, i64> {
+        Err(ENOTTY)
+    }
+    fn flush(&self, _f: &OpenFile) -> Result<(), i64> {
+        Ok(())
+    }
+    fn fsync(&self, _f: &OpenFile, _data_only: bool) -> Result<(), i64> {
+        Ok(())
+    }
+}
+
+// errno values used by default trait bodies. The broadly-used ones
+// already live in `kernel::fs`; re-exported here for readability.
+const EPERM: i64 = -1;
+const EINVAL_OP: i64 = super::super::EINVAL;
+const ENOTTY: i64 = -25;
+const ENOTDIR: i64 = -20;
+const ESPIPE: i64 = -29;
+const EACCES: i64 = -13;
+
+/// Default POSIX permission check: owner / group / other bits in
+/// `InodeMeta.mode`. uid 0 (root) bypasses all checks. The `execute`
+/// bit on a directory is interpreted as "search" per POSIX §4.5.
+///
+/// Drivers that need richer semantics (ACLs, capabilities) override
+/// `InodeOps::permission` directly.
+pub fn default_permission(inode: &Inode, cred: &Credential, access: Access) -> Result<(), i64> {
+    if cred.uid == 0 {
+        // Root bypass, with one twist: POSIX requires EXECUTE to still
+        // fail on a non-dir file with no execute bits set anywhere, so
+        // root can't "run" a data file. Matches Linux `generic_permission`.
+        if access.contains(Access::EXECUTE) && inode.kind != InodeKind::Dir {
+            let meta = inode.meta.read();
+            if meta.mode & 0o111 == 0 {
+                return Err(EACCES);
+            }
+        }
+        return Ok(());
+    }
+
+    let meta = inode.meta.read();
+    let mode = meta.mode as u32;
+    let bits = if cred.uid == meta.uid {
+        (mode >> 6) & 0o7
+    } else if cred.gid == meta.gid || cred.groups.iter().any(|&g| g == meta.gid) {
+        (mode >> 3) & 0o7
+    } else {
+        mode & 0o7
+    };
+
+    let want = access.bits();
+    if (bits & want) == want {
+        Ok(())
+    } else {
+        Err(EACCES)
+    }
+}
+
+/// Placeholder used by the default `InodeOps::getattr` implementations
+/// while we still don't have an `InodeMeta` snapshot helper. Kept as a
+/// private helper so callers inside this crate can reach for it
+/// without pulling in the whole stat-construction scaffolding.
+#[allow(dead_code)]
+pub(crate) fn meta_into_stat(meta: &InodeMeta, kind: InodeKind, fs_id: u64, ino: u64, out: &mut Stat) {
+    let kind_bits: u32 = match kind {
+        InodeKind::Reg => 0o100_000,
+        InodeKind::Dir => 0o040_000,
+        InodeKind::Link => 0o120_000,
+        InodeKind::Chr => 0o020_000,
+        InodeKind::Blk => 0o060_000,
+        InodeKind::Fifo => 0o010_000,
+        InodeKind::Sock => 0o140_000,
+    };
+    out.st_dev = fs_id;
+    out.st_ino = ino;
+    out.st_nlink = meta.nlink as u64;
+    out.st_mode = kind_bits | (meta.mode as u32 & 0o7_777);
+    out.st_uid = meta.uid;
+    out.st_gid = meta.gid;
+    out.st_rdev = meta.rdev;
+    out.st_size = meta.size as i64;
+    out.st_blksize = meta.blksize as i64;
+    out.st_blocks = meta.blocks as i64;
+    out.st_atime = meta.atime.sec;
+    out.st_atime_nsec = meta.atime.nsec as i64;
+    out.st_mtime = meta.mtime.sec;
+    out.st_mtime_nsec = meta.mtime.nsec as i64;
+    out.st_ctime = meta.ctime.sec;
+    out.st_ctime_nsec = meta.ctime.nsec as i64;
+}

--- a/kernel/src/fs/vfs/ops.rs
+++ b/kernel/src/fs/vfs/ops.rs
@@ -207,7 +207,9 @@ pub trait FileOps: Send + Sync {
         Err(EINVAL_OP)
     }
     fn write(&self, _f: &OpenFile, _buf: &[u8], _off: u64) -> Result<usize, i64> {
-        Err(EINVAL_OP)
+        // Read-only filesystems keep this default; signal "write not
+        // permitted" rather than "bad argument".
+        Err(EPERM)
     }
     fn seek(&self, _f: &OpenFile, _whence: Whence, _off: i64) -> Result<u64, i64> {
         Err(ESPIPE)

--- a/kernel/src/fs/vfs/super_block.rs
+++ b/kernel/src/fs/vfs/super_block.rs
@@ -13,9 +13,9 @@ use spin::Once;
 
 use crate::sync::BlockingMutex;
 
-use super::FsId;
 use super::inode::Inode;
 use super::ops::SuperOps;
+use super::FsId;
 
 /// Flags stored on a [`SuperBlock`]; a syscall bounces off them before
 /// calling into `*Ops`. Matches the Linux `SB_*` subset we need.

--- a/kernel/src/fs/vfs/super_block.rs
+++ b/kernel/src/fs/vfs/super_block.rs
@@ -1,0 +1,178 @@
+//! `SuperBlock` — one instance per mounted filesystem.
+//!
+//! Owns the root inode and brokers every syscall's access to the FS.
+//! The `sb_active` counter plus `draining` flag together close the
+//! `sys_umount` TOCTOU: a syscall enters via [`SbActiveGuard`] (commit
+//! then validate), and unmount commits `draining = true` before
+//! checking `sb_active == 0`.
+
+use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use alloc::sync::Arc;
+use spin::Once;
+
+use crate::sync::BlockingMutex;
+
+use super::FsId;
+use super::inode::Inode;
+use super::ops::SuperOps;
+
+/// Flags stored on a [`SuperBlock`]; a syscall bounces off them before
+/// calling into `*Ops`. Matches the Linux `SB_*` subset we need.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct SbFlags(pub u32);
+
+impl SbFlags {
+    pub const RDONLY: SbFlags = SbFlags(1 << 0);
+    pub const NOEXEC: SbFlags = SbFlags(1 << 1);
+    pub const NOSUID: SbFlags = SbFlags(1 << 2);
+    pub const NODEV: SbFlags = SbFlags(1 << 3);
+
+    pub const fn contains(self, other: SbFlags) -> bool {
+        (self.0 & other.0) == other.0
+    }
+}
+
+impl core::ops::BitOr for SbFlags {
+    type Output = SbFlags;
+    fn bitor(self, rhs: Self) -> Self {
+        SbFlags(self.0 | rhs.0)
+    }
+}
+
+/// Per-mount filesystem instance.
+///
+/// `root` is populated by `FileSystem::mount` via
+/// [`Once::call_once`]; before that returns the SuperBlock is not yet
+/// visible to the rest of the kernel, so the Once can't race.
+pub struct SuperBlock {
+    pub fs_id: FsId,
+    pub ops: Arc<dyn SuperOps>,
+    pub fs_type: &'static str,
+    pub root: Once<Arc<Inode>>,
+    pub block_size: u32,
+    pub flags: SbFlags,
+    /// Serialises cross-directory rename (`s_vfs_rename_mutex`): the
+    /// global tiebreaker that prevents two renames from deadlocking
+    /// when they'd each grab the other's directory rwsem.
+    pub rename_mutex: BlockingMutex<()>,
+    /// In-flight syscall pin count. Incremented by [`SbActiveGuard`];
+    /// `sys_umount` Phase A sets `draining = true` then spins on
+    /// `sb_active == 0`.
+    pub sb_active: AtomicUsize,
+    pub draining: AtomicBool,
+}
+
+impl SuperBlock {
+    pub fn new(
+        fs_id: FsId,
+        ops: Arc<dyn SuperOps>,
+        fs_type: &'static str,
+        block_size: u32,
+        flags: SbFlags,
+    ) -> Self {
+        Self {
+            fs_id,
+            ops,
+            fs_type,
+            root: Once::new(),
+            block_size,
+            flags,
+            rename_mutex: BlockingMutex::new(()),
+            sb_active: AtomicUsize::new(0),
+            draining: AtomicBool::new(false),
+        }
+    }
+}
+
+/// RAII pin that a syscall acquires before touching a [`SuperBlock`].
+/// Commit-then-validate: bump `sb_active` first, then check
+/// `draining`. If unmount racing won, roll back and return `ENOENT`.
+pub struct SbActiveGuard<'a> {
+    sb: &'a SuperBlock,
+}
+
+impl<'a> SbActiveGuard<'a> {
+    pub fn try_acquire(sb: &'a SuperBlock) -> Result<Self, i64> {
+        sb.sb_active.fetch_add(1, Ordering::SeqCst);
+        if sb.draining.load(Ordering::SeqCst) {
+            sb.sb_active.fetch_sub(1, Ordering::SeqCst);
+            return Err(super::super::ENOENT);
+        }
+        Ok(Self { sb })
+    }
+
+    pub fn sb(&self) -> &'a SuperBlock {
+        self.sb
+    }
+}
+
+impl Drop for SbActiveGuard<'_> {
+    fn drop(&mut self) {
+        self.sb.sb_active.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fs::vfs::ops::StatFs;
+    use crate::fs::vfs::{Inode, InodeKind, InodeMeta, InodeState};
+    use alloc::sync::Arc;
+
+    struct StubSuper;
+    impl SuperOps for StubSuper {
+        fn root_inode(&self) -> Arc<Inode> {
+            unreachable!("test stub")
+        }
+        fn statfs(&self) -> Result<StatFs, i64> {
+            Ok(StatFs::default())
+        }
+        fn unmount(&self) -> Result<(), i64> {
+            Ok(())
+        }
+    }
+
+    fn make_sb() -> Arc<SuperBlock> {
+        Arc::new(SuperBlock::new(
+            FsId(1),
+            Arc::new(StubSuper),
+            "stub",
+            4096,
+            SbFlags::default(),
+        ))
+    }
+
+    #[test]
+    fn guard_acquires_and_releases() {
+        let sb = make_sb();
+        {
+            let _g = SbActiveGuard::try_acquire(&sb).expect("acquire");
+            assert_eq!(sb.sb_active.load(Ordering::SeqCst), 1);
+        }
+        assert_eq!(sb.sb_active.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn guard_rejects_when_draining() {
+        let sb = make_sb();
+        sb.draining.store(true, Ordering::SeqCst);
+        let r = SbActiveGuard::try_acquire(&sb);
+        assert!(r.is_err());
+        assert_eq!(sb.sb_active.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn sbflags_bitor_and_contains() {
+        let f = SbFlags::RDONLY | SbFlags::NOEXEC;
+        assert!(f.contains(SbFlags::RDONLY));
+        assert!(f.contains(SbFlags::NOEXEC));
+        assert!(!f.contains(SbFlags::NOSUID));
+    }
+
+    // Suppress the InodeMeta/InodeState unused-import warning when
+    // compiled without the inode tests.
+    #[allow(dead_code)]
+    fn _types_exist(_m: InodeMeta, _s: InodeState, _k: InodeKind) {}
+}


### PR DESCRIPTION
Closes #230

## Summary

Lays the object-graph foundation for RFC 0002's Virtual Filesystem Layer — item 2 of 15 on the roadmap. Adds `kernel::fs::vfs` with the leaf value types, the four operation traits, and the five core objects (SuperBlock, Inode, Dentry, MountEdge, OpenFile). No drivers, no path resolution, no mount table — those land in later roadmap items.

- **Leaf types** (commit 1): FsId, Timespec, Credential, Access, DString, plus NAME_MAX / SYMLOOP_MAX. DString validates at construction per POSIX §4.5 (empty / >NAME_MAX / '/' / NUL → EINVAL or ENAMETOOLONG). Access is a hand-rolled transparent u32 wrapper; bitflags crate isn't in the dep graph.
- **Ops traits** (commit 2): FileSystem / SuperOps / InodeOps / FileOps with sensible defaults (EPERM on write paths, EINVAL/ESPIPE/ENOTDIR on non-dir file methods) so a minimal read-only FS only needs to override `lookup` + `getattr`. Stat layout is `#[repr(C)]` with a compile-time size/align check matching Linux `struct stat` (0x90, 8-byte) — closes Sec-B4 up front.
- **SuperBlock + SbActiveGuard** (commit 3): sb_active counter + draining flag behind a commit-then-validate RAII guard closes the sys_umount TOCTOU for every path-based syscall.
- **Inode + Dentry + MountEdge + OpenFile** (commit 4): Weak back-edges (Inode → SB, child Dentry → parent) break reference cycles; strong Arc<SuperBlock> on OpenFile is the anchor that closes OS-B6. Root dentries are self-parenting via `Arc::new_cyclic`. `ChildState::Loading(Arc<Semaphore>)` uses the semaphore primitive added in RFC 0002 item 1 to deduplicate concurrent first-lookup-of-a-name.

Send + Sync is asserted at compile time for every VFS type so a later refactor that wires these into Arc-shared state can't accidentally downgrade thread-safety.

Everything is `#[allow(dead_code)]` module-wide and nothing else in the kernel depends on `vfs::*` yet — by design, this is the type layout that later roadmap items build on.

## Test plan

- [x] `cargo check --target x86_64-unknown-none -p vibix -Zbuild-std=core,alloc,compiler_builtins` — clean (one pre-existing dead-code warning in `task/task.rs:296`).
- [ ] CI: host unit tests (DString / Access / SbActiveGuard / SbFlags / Inode construction / Dentry root-self-parenting / negative dentry / MountFlags / OpenFile pins SB).
- [ ] CI: integration tests pass (no VFS callers yet, so shouldn't regress).