### PR TITLE
mem: CoW resolver copies from current PTE frame

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -200,25 +200,17 @@ extern "x86-interrupt" fn page_fault(frame: InterruptStackFrame, code: PageFault
         } else if is_write && pte_flags.contains(PageTableFlags::WRITABLE) {
             // Write-protection fault on a CoW-eligible page: the VMA
             // wants WRITABLE but the PTE was installed read-only by the
-            // fork path. Look up the source frame via frame_at (no
-            // PTE-refcount side-effect — fault() would inc_refcount for a
-            // frame that never gets a new PTE installed for it here).
-            if let Some(phys) = object.frame_at(offset) {
-                let source = PhysFrame::from_start_address(PhysAddr::new(phys))
-                    .expect("#PF: frame_at returned unaligned phys for CoW source");
-                match crate::mem::paging::cow_copy_and_remap(active, page, source, pte_flags) {
-                    Ok(_) => return,
-                    Err(e) => serial_println!(
-                        "#PF CoW copy-and-remap failed addr={:#x}: {:?}",
-                        addr_u64,
-                        e
-                    ),
-                }
-            } else {
-                serial_println!(
-                    "#PF CoW: no cached frame for addr={:#x} (VmObject has no frame_at)",
-                    addr_u64
-                );
+            // fork path. `cow_copy_and_remap` copies out of whatever
+            // frame the PTE currently points at — the right source in
+            // every generation of a nested fork, and robust to the
+            // child VMA having an empty `clone_private()` cache.
+            match crate::mem::paging::cow_copy_and_remap(active, page, pte_flags) {
+                Ok(_) => return,
+                Err(e) => serial_println!(
+                    "#PF CoW copy-and-remap failed addr={:#x}: {:?}",
+                    addr_u64,
+                    e
+                ),
             }
         }
     }

--- a/kernel/src/mem/paging.rs
+++ b/kernel/src/mem/paging.rs
@@ -366,36 +366,40 @@ pub fn map_existing_in_pml4(
     Ok(())
 }
 
-/// Copy-on-write resolve: `page` is currently mapped read-only to
-/// `source_frame` in `pml4_frame`. Allocate a fresh frame, memcpy the
-/// source into it through the HHDM, unmap the read-only PTE, then
+/// Copy-on-write resolve: `page` is currently mapped read-only in
+/// `pml4_frame`. Allocate a fresh frame, memcpy the **current PTE's
+/// frame** into it through the HHDM, unmap the read-only PTE, then
 /// remap the page to the new frame with `flags` (caller supplies the
 /// full flag set — must include `WRITABLE`). Returns the new frame.
 ///
-/// The source frame is *not* freed — it may still be aliased by other
-/// PML4s (a child post-fork, or another CoW VMA pointing to the same
-/// frame).
+/// The copy source is deliberately the frame currently referenced by
+/// the PTE — not an object-cache lookup. In a nested-fork chain
+/// (fork → write → fork → write) the intermediate generation has a
+/// private frame whose contents diverge from the original object-cache
+/// entry; copying from the PTE is what lets the grandchild see the
+/// intermediate generation's writes. It also makes the call work when
+/// the child VMA has an empty `clone_private()` cache that lacks any
+/// `frame_at(offset)` entry at all — the common case after a fork.
+///
+/// The old frame is *not* freed outright — we release one reference on
+/// its behalf (the PTE reference, acquired by `AnonObject::fault` /
+/// `fork_address_space` when the PTE was installed). Other PTEs in
+/// sibling PML4s that alias the same frame keep their own references.
 pub fn cow_copy_and_remap(
     pml4_frame: PhysFrame<Size4KiB>,
     page: Page<Size4KiB>,
-    source_frame: PhysFrame<Size4KiB>,
     flags: PageTableFlags,
 ) -> Result<PhysFrame<Size4KiB>, MapToError<Size4KiB>> {
     let hhdm = HHDM_OFFSET
         .lock()
         .expect("paging::init must run before cow_copy_and_remap");
     let mut alloc = KernelFrameAllocator;
+    // Allocate up front so an OOM leaves the existing read-only PTE in
+    // place; the caller can retry and user space sees a replayable
+    // fault rather than a torn address space.
     let new_frame = alloc
         .allocate_frame()
         .ok_or(MapToError::FrameAllocationFailed)?;
-    // SAFETY: both frames are in HHDM-covered RAM. `new_frame` was
-    // just allocated for our exclusive use; the source is read-only
-    // shared but we only copy *out* of it.
-    unsafe {
-        let src = (hhdm + source_frame.start_address().as_u64()).as_ptr::<u8>();
-        let dst = (hhdm + new_frame.start_address().as_u64()).as_mut_ptr::<u8>();
-        core::ptr::copy_nonoverlapping(src, dst, 4096);
-    }
     let l4 = unsafe { pml4_as_mut(pml4_frame, hhdm) };
     let mut mapper = unsafe { OffsetPageTable::new(l4, hhdm) };
     // The page must currently be mapped — we're resolving a write
@@ -408,10 +412,21 @@ pub fn cow_copy_and_remap(
     } else {
         unmap_flush.ignore();
     }
+    // SAFETY: both frames are in HHDM-covered RAM. `new_frame` was
+    // just allocated for our exclusive use; `old_frame` is still live
+    // (we hold one PTE reference we have not released yet) and no
+    // other CPU can alias a writable mapping to it — the PTE was
+    // read-only at entry, and we just unmapped it here.
+    unsafe {
+        let src = (hhdm + old_frame.start_address().as_u64()).as_ptr::<u8>();
+        let dst = (hhdm + new_frame.start_address().as_u64()).as_mut_ptr::<u8>();
+        core::ptr::copy_nonoverlapping(src, dst, 4096);
+    }
     // Release the PTE's reference to the old frame (it was acquired by
-    // AnonObject::fault via inc_refcount when the page was first mapped).
-    // The AnonObject's cache retains its own reference; this balances
-    // only the now-removed PTE mapping.
+    // AnonObject::fault via inc_refcount on first demand fault or by
+    // fork_address_space when the child / W-stripped parent PTE was
+    // installed). Other mappings that alias this frame keep their own
+    // references; the frame is only freed when the last one drops.
     frame::put(old_frame.start_address().as_u64());
     let flush = unsafe { mapper.map_to(page, new_frame, flags, &mut alloc)? };
     if Cr3::read().0 == pml4_frame {

--- a/kernel/tests/fork_cow.rs
+++ b/kernel/tests/fork_cow.rs
@@ -58,6 +58,10 @@ fn run_tests() {
             "fork_isolation_unfaulted_page",
             &(fork_isolation_unfaulted_page as fn()),
         ),
+        (
+            "cow_copy_uses_current_pte_frame",
+            &(cow_copy_uses_current_pte_frame as fn()),
+        ),
     ];
     serial_println!("running {} tests", tests.len());
     for (name, t) in tests {
@@ -243,6 +247,91 @@ fn fork_isolation_unfaulted_page() {
     assert_ne!(
         child_phys, parent_phys,
         "parent and child must get distinct frames for unfaulted page (issue #188)"
+    );
+
+    drop(parent);
+    drop(child);
+}
+
+/// Issue #185: `cow_copy_and_remap` must copy from the current PTE
+/// frame, not from the backing object's cache.
+///
+/// After `fork_address_space` the child's `AnonObject` cache is fresh
+/// and empty (see `AnonObject::clone_private`). Its PTE still points
+/// at the parent's original frame, W-stripped. If the child then takes
+/// a second fork before writing, the grandchild PTE also points at the
+/// same original frame, and the intermediate generation may write
+/// before the grandchild reads. Previously the resolver looked up the
+/// "source" via `AnonObject::frame_at(offset)`, which in the child /
+/// grandchild is `None` — the CoW write simply failed. With the fix
+/// the resolver uses the PTE's own frame, which always holds the
+/// latest visible contents for this aspace's copy chain.
+///
+/// This test calls `cow_copy_and_remap` directly against an aspace
+/// whose PTE points at a frame seeded with a sentinel byte, then
+/// asserts the new private frame carries the sentinel. We do not
+/// switch CR3: the function only needs HHDM access, which is always
+/// mapped, and driving the page-fault handler would require an
+/// elaborate current-task swap that this unit-level check does not
+/// need.
+fn cow_copy_uses_current_pte_frame() {
+    use vibix::mem::paging::{cow_copy_and_remap, hhdm_offset};
+
+    let mut parent = make_parent_aspace();
+    prefault_page(&parent, 0);
+
+    // Stamp the parent's page-0 frame with a sentinel through HHDM so
+    // we can tell the pre- and post-fork frames apart later.
+    let parent_pte_frame_before = {
+        let vma = parent.find(FORK_VA).expect("parent vma");
+        vma.object
+            .frame_at(0)
+            .expect("parent AnonObject must have cached page 0 after prefault")
+    };
+    unsafe {
+        let dst = (hhdm_offset() + parent_pte_frame_before).as_mut_ptr::<u8>();
+        core::ptr::write_volatile(dst, 0xAB);
+    }
+
+    // Fork. Child's PTE aliases the parent's frame (W-stripped); child's
+    // VmObject cache is empty — which is the pre-fix failure condition.
+    let mut flusher = Flusher::new_active();
+    let child = parent
+        .fork_address_space(&mut flusher)
+        .expect("fork_address_space");
+    flusher.finish();
+
+    let child_vma = child.find(FORK_VA).expect("child vma");
+    assert!(
+        child_vma.object.frame_at(0).is_none(),
+        "precondition: child AnonObject cache must be empty after fork \
+         (clone_private should return a fresh object)"
+    );
+
+    // Resolve CoW on the child's PTE. With the fix this copies from
+    // whatever frame the PTE currently references (the one stamped
+    // with 0xAB). Before the fix the resolver had no source at all.
+    let page = Page::<Size4KiB>::from_start_address(VirtAddr::new(FORK_VA as u64))
+        .expect("page-aligned");
+    let flags = PageTableFlags::from_bits_truncate(prot_pte_rw());
+    let new_frame = cow_copy_and_remap(child.page_table_frame(), page, flags)
+        .expect("cow_copy_and_remap must succeed even when child cache is empty");
+
+    // The new frame is distinct from the shared source and carries the
+    // sentinel byte the source had at entry.
+    assert_ne!(
+        new_frame.start_address().as_u64(),
+        parent_pte_frame_before,
+        "cow_copy_and_remap must allocate a fresh frame"
+    );
+    let copied = unsafe {
+        let src = (hhdm_offset() + new_frame.start_address().as_u64()).as_ptr::<u8>();
+        core::ptr::read_volatile(src)
+    };
+    assert_eq!(
+        copied, 0xAB,
+        "cow_copy_and_remap must copy from the current PTE frame, \
+         not from the (empty) child VmObject cache"
     );
 
     drop(parent);

--- a/kernel/tests/fork_cow.rs
+++ b/kernel/tests/fork_cow.rs
@@ -311,8 +311,8 @@ fn cow_copy_uses_current_pte_frame() {
     // Resolve CoW on the child's PTE. With the fix this copies from
     // whatever frame the PTE currently references (the one stamped
     // with 0xAB). Before the fix the resolver had no source at all.
-    let page = Page::<Size4KiB>::from_start_address(VirtAddr::new(FORK_VA as u64))
-        .expect("page-aligned");
+    let page =
+        Page::<Size4KiB>::from_start_address(VirtAddr::new(FORK_VA as u64)).expect("page-aligned");
     let flags = PageTableFlags::from_bits_truncate(prot_pte_rw());
     let new_frame = cow_copy_and_remap(child.page_table_frame(), page, flags)
         .expect("cow_copy_and_remap must succeed even when child cache is empty");


### PR DESCRIPTION
Closes #185

## Summary

- `cow_copy_and_remap` now copies out of the current PTE frame rather than an `AnonObject::frame_at(offset)` lookup that (a) returns `None` in any forked child — `clone_private()` hands the child a fresh empty object — and (b) even when populated, still points at the original pre-fork frame rather than the intermediate generation's writes in a fork-of-a-fork chain.
- Drops the now-useless `source_frame` parameter and the `object.frame_at(offset)` lookup at the idt.rs CoW call site.
- Reorders the helper to unmap → copy from old_frame via HHDM → release PTE refcount → map new_frame. Allocation stays up front so an OOM leaves the read-only PTE intact and the fault replays cleanly.

## Test plan

- [x] `cargo xtask build` — kernel lib compiles (pre-existing `is_guard_hit` dead_code warning is unchanged).
- [x] New integration test `cow_copy_uses_current_pte_frame` in `kernel/tests/fork_cow.rs` asserts:
  - child AnonObject cache is empty after `fork_address_space` (precondition establishing the pre-fix failure),
  - `cow_copy_and_remap` succeeds against that child,
  - the newly allocated frame carries the sentinel byte written into the old PTE frame before the fork,
  - the new frame is distinct from the shared source.
- [ ] CI to run `cargo xtask test` (host env here can't build `pic8259` — pre-existing) and the QEMU integration suite including the new test.