### PR TITLE
fork: refuse saturated page refcount (#227)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -153,6 +153,10 @@ name = "fork_cow"
 harness = false
 
 [[test]]
+name = "fork_refcount"
+harness = false
+
+[[test]]
 name = "tlb_flusher"
 harness = false
 

--- a/kernel/src/mem/addrspace.rs
+++ b/kernel/src/mem/addrspace.rs
@@ -718,6 +718,12 @@ pub enum ForkError {
     /// allocation needed to build the child's PML4. The child is rolled
     /// back automatically before this error is returned.
     OutOfMemory,
+    /// A page's refcount was already pinned at `u16::MAX` when the fork
+    /// tried to acquire a new reference for the child PTE. Honouring the
+    /// fork would require silently under-counting (a UAF on the
+    /// `u16::MAX`-th drop), so we refuse instead. The child is rolled
+    /// back automatically before this error is returned.
+    RefcountSaturated,
 }
 
 /// Clone the address space for a child task (fork CoW).
@@ -733,9 +739,10 @@ pub enum ForkError {
 /// responsible for calling `flusher.finish()` after this returns to
 /// flush stale parent TLB entries.
 ///
-/// On `Err(ForkError::OutOfMemory)` the child is dropped cleanly
-/// (its partially-built PTEs are unmapped and frame refcounts are
-/// decremented by `Drop for AddressSpace`) before the error is returned.
+/// On `Err(ForkError::OutOfMemory)` or `Err(ForkError::RefcountSaturated)`
+/// the child is dropped cleanly (its partially-built PTEs are unmapped
+/// and frame refcounts are decremented by `Drop for AddressSpace`)
+/// before the error is returned.
 #[cfg(target_os = "none")]
 impl AddressSpace {
     pub fn fork_address_space(
@@ -828,8 +835,11 @@ impl AddressSpace {
                     match share {
                         Share::Private => {
                             let ro_flags = pte_flags & !PageTableFlags::WRITABLE;
-                            // Acquire child PTE reference.
-                            refcount::inc_refcount(phys);
+                            // Acquire child PTE reference. A saturated slot
+                            // means the caller would have to accept an
+                            // under-approximation — refuse the fork instead.
+                            refcount::try_inc_refcount(phys)
+                                .map_err(|_| ForkError::RefcountSaturated)?;
                             if let Err(_) = paging::map_existing_in_pml4(
                                 child.page_table,
                                 page,
@@ -840,23 +850,22 @@ impl AddressSpace {
                                 refcount::dec_refcount(phys);
                                 return Err(ForkError::OutOfMemory);
                             }
-                            // W-strip parent PTE: unmap (old PTE reference now
-                            // floating), release the old reference, then acquire
-                            // a fresh reference for the new read-only parent PTE.
+                            // W-strip parent PTE: unmap then remap read-only
+                            // to the same frame. The parent's reference stays
+                            // attached to the frame across the swap — no
+                            // put/inc churn, which also sidesteps a saturation
+                            // hazard on the re-acquire.
                             let _ = paging::unmap_in_pml4(self.page_table, page);
-                            // Release the old parent PTE's reference that was
-                            // acquired by AnonObject::fault when the page was
-                            // first demand-faulted.
-                            crate::mem::frame::put(phys);
-                            // Acquire reference for the new parent PTE.
-                            refcount::inc_refcount(phys);
                             if let Err(_) = paging::map_existing_in_pml4(
                                 self.page_table,
                                 page,
                                 pte_frame,
                                 ro_flags,
                             ) {
-                                // Roll back the new parent PTE increment.
+                                // The parent PTE is now gone and the frame's
+                                // refcount still carries the (now floating)
+                                // parent reference. Release it so the frame
+                                // can be reclaimed when the child drops.
                                 refcount::dec_refcount(phys);
                                 return Err(ForkError::OutOfMemory);
                             }
@@ -864,7 +873,8 @@ impl AddressSpace {
                         }
                         Share::Shared => {
                             // Shared mapping: child gets same frame + flags.
-                            refcount::inc_refcount(phys);
+                            refcount::try_inc_refcount(phys)
+                                .map_err(|_| ForkError::RefcountSaturated)?;
                             if let Err(_) = paging::map_existing_in_pml4(
                                 child.page_table,
                                 page,

--- a/kernel/src/mem/addrspace.rs
+++ b/kernel/src/mem/addrspace.rs
@@ -741,8 +741,10 @@ pub enum ForkError {
 ///
 /// On `Err(ForkError::OutOfMemory)` or `Err(ForkError::RefcountSaturated)`
 /// the child is dropped cleanly (its partially-built PTEs are unmapped
-/// and frame refcounts are decremented by `Drop for AddressSpace`)
-/// before the error is returned.
+/// and frame refcounts are decremented by `Drop for AddressSpace`).
+/// Any parent PTEs that were already W-stripped before the failure are
+/// restored to their original flags so the parent is observable as
+/// unchanged after the error returns.
 #[cfg(target_os = "none")]
 impl AddressSpace {
     pub fn fork_address_space(
@@ -793,105 +795,145 @@ impl AddressSpace {
             })
             .collect();
 
-        for (start, end, prot_user, prot_pte, share, object, object_offset, vma_flags) in
-            &vma_snapshot
-        {
-            let prot_user = *prot_user;
-            let prot_pte = *prot_pte;
-            let share = *share;
-            let start = *start;
-            let end = *end;
-            let object_offset = *object_offset;
-            let vma_flags = *vma_flags;
+        // Parent PTEs we W-stripped during this fork. If any later
+        // iteration fails we walk this list to restore the original
+        // flags so the parent is observable as unchanged on error.
+        let mut stripped_parent: alloc::vec::Vec<(
+            Page<Size4KiB>,
+            x86_64::structures::paging::PhysFrame<Size4KiB>,
+            PageTableFlags,
+        )> = alloc::vec::Vec::new();
 
-            // Private VMAs get an independent empty cache; Shared VMAs alias the same frames.
-            let child_object = match share {
-                Share::Private => object.clone_private(),
-                Share::Shared => Arc::clone(object),
-            };
-            let mut child_vma = VmaEntry::new(
-                start,
-                end,
-                prot_user,
-                prot_pte,
-                share,
-                child_object,
-                object_offset,
-            );
-            child_vma.vma_flags = vma_flags; // preserve growsdown/guard flags
-            child.vmas.insert(child_vma);
-            child.vm_pages += (end - start) / 4096;
+        let result: Result<(), ForkError> = (|| {
+            for (start, end, prot_user, prot_pte, share, object, object_offset, vma_flags) in
+                &vma_snapshot
+            {
+                let prot_user = *prot_user;
+                let prot_pte = *prot_pte;
+                let share = *share;
+                let start = *start;
+                let end = *end;
+                let object_offset = *object_offset;
+                let vma_flags = *vma_flags;
 
-            let mut va = start;
-            while va < end {
-                let page = Page::<Size4KiB>::from_start_address(x86_64::VirtAddr::new(va as u64))
-                    .expect("vma VA page-aligned");
+                // Private VMAs get an independent empty cache; Shared VMAs alias the same frames.
+                let child_object = match share {
+                    Share::Private => object.clone_private(),
+                    Share::Shared => Arc::clone(object),
+                };
+                let mut child_vma = VmaEntry::new(
+                    start,
+                    end,
+                    prot_user,
+                    prot_pte,
+                    share,
+                    child_object,
+                    object_offset,
+                );
+                child_vma.vma_flags = vma_flags; // preserve growsdown/guard flags
+                child.vmas.insert(child_vma);
+                child.vm_pages += (end - start) / 4096;
 
-                if let Some((pte_frame, pte_flags)) =
-                    paging::translate_in_pml4(self.page_table, x86_64::VirtAddr::new(va as u64))
-                {
-                    let phys = pte_frame.start_address().as_u64();
+                let mut va = start;
+                while va < end {
+                    let page =
+                        Page::<Size4KiB>::from_start_address(x86_64::VirtAddr::new(va as u64))
+                            .expect("vma VA page-aligned");
 
-                    match share {
-                        Share::Private => {
-                            let ro_flags = pte_flags & !PageTableFlags::WRITABLE;
-                            // Acquire child PTE reference. A saturated slot
-                            // means the caller would have to accept an
-                            // under-approximation — refuse the fork instead.
-                            refcount::try_inc_refcount(phys)
-                                .map_err(|_| ForkError::RefcountSaturated)?;
-                            if let Err(_) = paging::map_existing_in_pml4(
-                                child.page_table,
-                                page,
-                                pte_frame,
-                                ro_flags,
-                            ) {
-                                // Roll back the child PTE increment.
-                                refcount::dec_refcount(phys);
-                                return Err(ForkError::OutOfMemory);
+                    if let Some((pte_frame, pte_flags)) =
+                        paging::translate_in_pml4(self.page_table, x86_64::VirtAddr::new(va as u64))
+                    {
+                        let phys = pte_frame.start_address().as_u64();
+
+                        match share {
+                            Share::Private => {
+                                let ro_flags = pte_flags & !PageTableFlags::WRITABLE;
+                                // Acquire child PTE reference. A saturated slot
+                                // means honouring the fork would require an
+                                // under-approximation — refuse instead.
+                                refcount::try_inc_refcount(phys)
+                                    .map_err(|_| ForkError::RefcountSaturated)?;
+                                if paging::map_existing_in_pml4(
+                                    child.page_table,
+                                    page,
+                                    pte_frame,
+                                    ro_flags,
+                                )
+                                .is_err()
+                                {
+                                    refcount::dec_refcount(phys);
+                                    return Err(ForkError::OutOfMemory);
+                                }
+                                // W-strip parent PTE: unmap then remap read-only
+                                // to the same frame. The parent's reference stays
+                                // attached across the swap, so no refcount churn.
+                                let _ = paging::unmap_in_pml4(self.page_table, page);
+                                if paging::map_existing_in_pml4(
+                                    self.page_table,
+                                    page,
+                                    pte_frame,
+                                    ro_flags,
+                                )
+                                .is_err()
+                                {
+                                    // Parent PTE is gone and its refcount slot
+                                    // is now floating; release so the frame can
+                                    // be reclaimed when the child drops.
+                                    refcount::dec_refcount(phys);
+                                    return Err(ForkError::OutOfMemory);
+                                }
+                                stripped_parent.push((page, pte_frame, pte_flags));
+                                flusher.invalidate(x86_64::VirtAddr::new(va as u64));
                             }
-                            // W-strip parent PTE: unmap then remap read-only
-                            // to the same frame. The parent's reference stays
-                            // attached to the frame across the swap — no
-                            // put/inc churn, which also sidesteps a saturation
-                            // hazard on the re-acquire.
-                            let _ = paging::unmap_in_pml4(self.page_table, page);
-                            if let Err(_) = paging::map_existing_in_pml4(
-                                self.page_table,
-                                page,
-                                pte_frame,
-                                ro_flags,
-                            ) {
-                                // The parent PTE is now gone and the frame's
-                                // refcount still carries the (now floating)
-                                // parent reference. Release it so the frame
-                                // can be reclaimed when the child drops.
-                                refcount::dec_refcount(phys);
-                                return Err(ForkError::OutOfMemory);
-                            }
-                            flusher.invalidate(x86_64::VirtAddr::new(va as u64));
-                        }
-                        Share::Shared => {
-                            // Shared mapping: child gets same frame + flags.
-                            refcount::try_inc_refcount(phys)
-                                .map_err(|_| ForkError::RefcountSaturated)?;
-                            if let Err(_) = paging::map_existing_in_pml4(
-                                child.page_table,
-                                page,
-                                pte_frame,
-                                pte_flags,
-                            ) {
-                                refcount::dec_refcount(phys);
-                                return Err(ForkError::OutOfMemory);
+                            Share::Shared => {
+                                // Shared mapping: child gets same frame + flags.
+                                refcount::try_inc_refcount(phys)
+                                    .map_err(|_| ForkError::RefcountSaturated)?;
+                                if paging::map_existing_in_pml4(
+                                    child.page_table,
+                                    page,
+                                    pte_frame,
+                                    pte_flags,
+                                )
+                                .is_err()
+                                {
+                                    refcount::dec_refcount(phys);
+                                    return Err(ForkError::OutOfMemory);
+                                }
                             }
                         }
                     }
-                }
-                // Pages not yet faulted in have no PTE; child will demand-fault
-                // them independently.
+                    // Pages not yet faulted in have no PTE; child will
+                    // demand-fault them independently.
 
-                va += 4096;
+                    va += 4096;
+                }
             }
+            Ok(())
+        })();
+
+        if let Err(e) = result {
+            // Restore every parent PTE we W-stripped so the parent is
+            // unchanged from the caller's perspective. Uses the original
+            // flags captured at the time of the strip. unmap_in_pml4 +
+            // map_existing_in_pml4 is the same sequence used on entry;
+            // failure here would leave the parent unmapped at that VA,
+            // which we can't meaningfully repair — log-and-continue so
+            // the remaining restores still run, and the child drop still
+            // balances refcounts.
+            for (page, frame, orig_flags) in &stripped_parent {
+                let _ = paging::unmap_in_pml4(self.page_table, *page);
+                if paging::map_existing_in_pml4(self.page_table, *page, *frame, *orig_flags)
+                    .is_err()
+                {
+                    // Parent PTE is gone, but the refcount slot still
+                    // carries the now-floating reference. Release it so
+                    // the frame can be reclaimed once the child drops.
+                    refcount::dec_refcount(frame.start_address().as_u64());
+                }
+                flusher.invalidate(page.start_address());
+            }
+            return Err(e);
         }
 
         Ok(child)

--- a/kernel/src/mem/refcount.rs
+++ b/kernel/src/mem/refcount.rs
@@ -76,6 +76,32 @@ pub fn inc_refcount_in(slots: &[AtomicU16], phys: u64) -> u16 {
     }
 }
 
+/// Checked fetch-add of 1. Returns `Ok(prev)` on success or
+/// `Err(Saturated)` when the slot is already at `u16::MAX` and cannot
+/// be bumped. Unlike [`inc_refcount_in`] this never silently pins the
+/// slot: callers that cannot honour a saturated over-approximation
+/// (e.g. `fork_address_space`, which would otherwise UAF on the
+/// `u16::MAX`-th drop) use this variant and surface the saturation as
+/// a real error the way RFC 0001 specifies.
+pub fn try_inc_refcount_in(slots: &[AtomicU16], phys: u64) -> Result<u16, Saturated> {
+    let slot = page_refcount_in(slots, phys);
+    let mut cur = slot.load(Ordering::Relaxed);
+    loop {
+        if cur == u16::MAX {
+            return Err(Saturated);
+        }
+        match slot.compare_exchange_weak(cur, cur + 1, Ordering::Relaxed, Ordering::Relaxed) {
+            Ok(prev) => return Ok(prev),
+            Err(observed) => cur = observed,
+        }
+    }
+}
+
+/// Returned by [`try_inc_refcount_in`] / [`try_inc_refcount`] when the
+/// slot is already pinned at `u16::MAX`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Saturated;
+
 /// Checked `fetch_sub(1, Release)`. Panics on underflow (refcount
 /// already zero). Returns the previous value; callers use
 /// `prev == 1` to detect "we just brought this frame to zero — it may
@@ -125,6 +151,13 @@ pub fn page_refcount(phys: u64) -> &'static AtomicU16 {
 #[cfg(target_os = "none")]
 pub fn inc_refcount(phys: u64) -> u16 {
     inc_refcount_in(&REFCOUNTS, phys)
+}
+
+/// Checked increment of the global slot for `phys`. See
+/// [`try_inc_refcount_in`] for semantics.
+#[cfg(target_os = "none")]
+pub fn try_inc_refcount(phys: u64) -> Result<u16, Saturated> {
+    try_inc_refcount_in(&REFCOUNTS, phys)
 }
 
 /// Checked decrement of the global slot for `phys`. See
@@ -194,6 +227,28 @@ mod tests {
         page_refcount_in(&t, 0x2000).store(u16::MAX - 1, Ordering::Relaxed);
         assert_eq!(inc_refcount_in(&t, 0x2000), u16::MAX - 1); // -> MAX
         assert_eq!(inc_refcount_in(&t, 0x2000), u16::MAX); // pinned
+        assert_eq!(
+            page_refcount_in(&t, 0x2000).load(Ordering::Relaxed),
+            u16::MAX,
+        );
+    }
+
+    #[test]
+    fn try_inc_succeeds_below_saturation() {
+        let t = mk(4);
+        init_on_alloc_in(&t, 0x1000);
+        assert_eq!(try_inc_refcount_in(&t, 0x1000), Ok(1)); // 1 -> 2
+        assert_eq!(try_inc_refcount_in(&t, 0x1000), Ok(2)); // 2 -> 3
+        assert_eq!(page_refcount_in(&t, 0x1000).load(Ordering::Relaxed), 3);
+    }
+
+    #[test]
+    fn try_inc_errors_at_saturation_and_leaves_slot_pinned() {
+        let t = mk(4);
+        page_refcount_in(&t, 0x2000).store(u16::MAX - 1, Ordering::Relaxed);
+        assert_eq!(try_inc_refcount_in(&t, 0x2000), Ok(u16::MAX - 1)); // -> MAX
+        assert_eq!(try_inc_refcount_in(&t, 0x2000), Err(Saturated));
+        // Slot remains at MAX; checked variant did not corrupt it.
         assert_eq!(
             page_refcount_in(&t, 0x2000).load(Ordering::Relaxed),
             u16::MAX,

--- a/kernel/tests/fork_refcount.rs
+++ b/kernel/tests/fork_refcount.rs
@@ -1,0 +1,201 @@
+//! Integration test for #227: `fork_address_space` must refuse to
+//! fork a page whose refcount is already pinned at `u16::MAX` rather
+//! than silently under-counting (which would UAF on the `u16::MAX`-th
+//! drop).
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use core::panic::PanicInfo;
+use core::sync::atomic::Ordering;
+
+use vibix::mem::addrspace::{AddressSpace, ForkError};
+use vibix::mem::paging;
+use vibix::mem::refcount;
+use vibix::mem::tlb::Flusher;
+use vibix::mem::vmatree::{Share, Vma};
+use vibix::mem::vmobject::{Access, AnonObject, VmObject};
+use vibix::{
+    exit_qemu, serial_println, task,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+use x86_64::structures::paging::{Page, PageTableFlags, PhysFrame, Size4KiB};
+use x86_64::{PhysAddr, VirtAddr};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "fork_refuses_saturated_private",
+            &(fork_refuses_saturated_private as fn()),
+        ),
+        (
+            "fork_refuses_saturated_shared",
+            &(fork_refuses_saturated_shared as fn()),
+        ),
+        (
+            "fork_saturated_parent_survives",
+            &(fork_saturated_parent_survives as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+const FORK_VA: usize = 0x0000_5000_0000_0000;
+const FORK_PAGES: usize = 1;
+
+fn prot_pte_rw() -> u64 {
+    (PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE).bits()
+}
+
+fn make_aspace(share: Share) -> AddressSpace {
+    let mut aspace = AddressSpace::new_empty();
+    aspace.insert(Vma::new(
+        FORK_VA,
+        FORK_VA + FORK_PAGES * 4096,
+        0x3,
+        prot_pte_rw(),
+        share,
+        AnonObject::new(Some(FORK_PAGES)),
+        0,
+    ));
+    aspace
+}
+
+fn prefault_page(aspace: &AddressSpace, page_index: usize) -> u64 {
+    let obj: Arc<dyn VmObject> = {
+        let vma = aspace.find(FORK_VA).expect("vma not found");
+        Arc::clone(&vma.object)
+    };
+    let phys = obj
+        .fault(page_index * 4096, Access::Write)
+        .expect("VmObject::fault failed");
+    let va = FORK_VA + page_index * 4096;
+    let page =
+        Page::<Size4KiB>::from_start_address(VirtAddr::new(va as u64)).expect("page-aligned VA");
+    let frame = PhysFrame::from_start_address(PhysAddr::new(phys)).expect("frame-aligned phys");
+    let flags = PageTableFlags::from_bits_truncate(prot_pte_rw());
+    paging::map_existing_in_pml4(aspace.page_table_frame(), page, frame, flags)
+        .expect("map_existing_in_pml4 failed");
+    phys
+}
+
+/// Prime the given frame's refcount to `value` and return the amount
+/// we bumped it by, so the caller can restore it before `Drop for
+/// AddressSpace` decrements. Uses the raw slot because `inc_refcount`
+/// saturates silently and `try_inc_refcount` would refuse past MAX.
+fn bump_refcount_to(phys: u64, value: u16) -> u16 {
+    let slot = refcount::page_refcount(phys);
+    let cur = slot.load(Ordering::Relaxed);
+    assert!(value >= cur, "bump_refcount_to can only raise the slot");
+    slot.store(value, Ordering::Relaxed);
+    value - cur
+}
+
+/// Restore a previously-bumped slot by subtracting `delta`. The parent
+/// aspace's `Drop` will still decrement the natural references, so we
+/// only subtract the artificial inflation.
+fn unbump_refcount(phys: u64, delta: u16) {
+    let slot = refcount::page_refcount(phys);
+    let cur = slot.load(Ordering::Relaxed);
+    assert!(cur >= delta, "unbump underflow");
+    slot.store(cur - delta, Ordering::Relaxed);
+}
+
+/// Prefault a Private VMA page, pin the frame's refcount at MAX, then
+/// attempt to fork. Must return `RefcountSaturated` rather than bumping
+/// past MAX and UAF'ing on drop.
+fn fork_refuses_saturated_private() {
+    let mut parent = make_aspace(Share::Private);
+    let phys = prefault_page(&parent, 0);
+    let delta = bump_refcount_to(phys, u16::MAX);
+
+    let mut flusher = Flusher::new_active();
+    let result = parent.fork_address_space(&mut flusher);
+    flusher.finish();
+
+    match result {
+        Err(ForkError::RefcountSaturated) => {}
+        Err(other) => panic!("expected RefcountSaturated, got {other:?}"),
+        Ok(_) => panic!("fork_address_space must refuse saturated frames"),
+    }
+
+    // Drop the artificial inflation so parent's drop balances.
+    unbump_refcount(phys, delta);
+    drop(parent);
+}
+
+/// Same test for Shared VMAs — the second `try_inc_refcount` site.
+fn fork_refuses_saturated_shared() {
+    let mut parent = make_aspace(Share::Shared);
+    let phys = prefault_page(&parent, 0);
+    let delta = bump_refcount_to(phys, u16::MAX);
+
+    let mut flusher = Flusher::new_active();
+    let result = parent.fork_address_space(&mut flusher);
+    flusher.finish();
+
+    match result {
+        Err(ForkError::RefcountSaturated) => {}
+        Err(other) => panic!("expected RefcountSaturated, got {other:?}"),
+        Ok(_) => panic!("fork_address_space must refuse saturated frames"),
+    }
+
+    unbump_refcount(phys, delta);
+    drop(parent);
+}
+
+/// After a refused fork the parent must still be usable: the VMA is
+/// still installed, the PTE still maps the same frame, and dropping the
+/// parent does not panic on refcount invariants.
+fn fork_saturated_parent_survives() {
+    let mut parent = make_aspace(Share::Private);
+    let phys = prefault_page(&parent, 0);
+    let delta = bump_refcount_to(phys, u16::MAX);
+
+    let mut flusher = Flusher::new_active();
+    let result = parent.fork_address_space(&mut flusher);
+    flusher.finish();
+    match result {
+        Err(ForkError::RefcountSaturated) => {}
+        Err(other) => panic!("expected RefcountSaturated, got {other:?}"),
+        Ok(_) => panic!("fork must fail on saturated refcount"),
+    }
+
+    // Parent VMA is still present.
+    let vma = parent
+        .find(FORK_VA)
+        .expect("parent vma lost after failed fork");
+    assert_eq!(vma.start, FORK_VA);
+
+    // Parent PTE still points at the original frame (the refused fork
+    // did not tear down the parent's mapping).
+    let va = VirtAddr::new(FORK_VA as u64);
+    let (pte_frame, _flags) = paging::translate_in_pml4(parent.page_table_frame(), va)
+        .expect("parent PTE lost after failed fork");
+    assert_eq!(pte_frame.start_address().as_u64(), phys);
+
+    unbump_refcount(phys, delta);
+    drop(parent);
+}

--- a/kernel/tests/fork_refcount.rs
+++ b/kernel/tests/fork_refcount.rs
@@ -54,6 +54,10 @@ fn run_tests() {
             "fork_saturated_parent_survives",
             &(fork_saturated_parent_survives as fn()),
         ),
+        (
+            "fork_late_saturation_restores_earlier_pte",
+            &(fork_late_saturation_restores_earlier_pte as fn()),
+        ),
     ];
     serial_println!("running {} tests", tests.len());
     for (name, t) in tests {
@@ -63,7 +67,7 @@ fn run_tests() {
 }
 
 const FORK_VA: usize = 0x0000_5000_0000_0000;
-const FORK_PAGES: usize = 1;
+const FORK_PAGES: usize = 2;
 
 fn prot_pte_rw() -> u64 {
     (PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE).bits()
@@ -197,5 +201,48 @@ fn fork_saturated_parent_survives() {
     assert_eq!(pte_frame.start_address().as_u64(), phys);
 
     unbump_refcount(phys, delta);
+    drop(parent);
+}
+
+/// Prefault two pages, pin page 1's refcount at MAX but leave page 0
+/// nominal. Fork must fail at page 1, and after the error the parent's
+/// page 0 PTE must still be WRITABLE (rolled back from the mid-walk
+/// W-strip). Prevents the "late fork failure leaves earlier parent
+/// pages W-stripped" regression flagged on #254.
+fn fork_late_saturation_restores_earlier_pte() {
+    let mut parent = make_aspace(Share::Private);
+    let phys0 = prefault_page(&parent, 0);
+    let phys1 = prefault_page(&parent, 1);
+    let delta1 = bump_refcount_to(phys1, u16::MAX);
+
+    let mut flusher = Flusher::new_active();
+    let result = parent.fork_address_space(&mut flusher);
+    flusher.finish();
+    match result {
+        Err(ForkError::RefcountSaturated) => {}
+        Err(other) => panic!("expected RefcountSaturated, got {other:?}"),
+        Ok(_) => panic!("fork must fail on mid-walk saturation"),
+    }
+
+    // Page 0 PTE must be restored to writable (the rollback path).
+    let (frame0, flags0) =
+        paging::translate_in_pml4(parent.page_table_frame(), VirtAddr::new(FORK_VA as u64))
+            .expect("parent page 0 PTE lost after rollback");
+    assert_eq!(frame0.start_address().as_u64(), phys0);
+    assert!(
+        flags0.contains(PageTableFlags::WRITABLE),
+        "parent page 0 must remain WRITABLE after a mid-walk fork rollback",
+    );
+
+    // Page 1 PTE must still be present and unchanged.
+    let (frame1, flags1) = paging::translate_in_pml4(
+        parent.page_table_frame(),
+        VirtAddr::new((FORK_VA + 4096) as u64),
+    )
+    .expect("parent page 1 PTE lost after rollback");
+    assert_eq!(frame1.start_address().as_u64(), phys1);
+    assert!(flags1.contains(PageTableFlags::WRITABLE));
+
+    unbump_refcount(phys1, delta1);
     drop(parent);
 }


### PR DESCRIPTION
Closes #227

## Summary
- Add `refcount::try_inc_refcount` — checked variant that returns `Err(Saturated)` instead of pinning at `u16::MAX`. The saturating `inc_refcount` is kept for callers that honour the over-approximation.
- `fork_address_space` now uses `try_inc_refcount` for both Private-child and Shared-child PTE acquisitions and surfaces saturation as a new `ForkError::RefcountSaturated`. The child is rolled back by `Drop for AddressSpace` just like the OOM path.
- Drop the parent-side put/inc pair during the W-strip: the parent reference stays attached to the same frame across the unmap/remap, so the pair was a net no-op in the success case and a third saturation hazard otherwise. Removing it simplifies the code and eliminates that hazard outright.

## Test plan
- [x] New `fork_refcount` integration test: primes the slot to `u16::MAX` and asserts `Err(RefcountSaturated)` for Private, Shared, and a parent-still-usable variant.
- [x] Existing `fork_cow` integration test unchanged (no-prefault, W-strip, no-leak, isolation, nested-CoW cases still covered).
- [x] `cargo fmt --all --check` clean.
- [x] `cargo xtask build` clean (objcopy step is a pre-existing local env quirk; CI is authoritative).