### PR TITLE
vfs: deferred-eviction GC queue (RFC 0002 item 3/15)

### DIFF
--- a/kernel/src/fs/vfs/gc_queue.rs
+++ b/kernel/src/fs/vfs/gc_queue.rs
@@ -1,0 +1,326 @@
+//! Deferred-eviction GC queue (RFC 0002 item 3/15).
+//!
+//! `Drop for Inode` enqueues `(sb, ino)` rather than calling
+//! `evict_inode` inline. Eviction runs at well-defined drain points
+//! (syscall-return, idle task, `sys_umount` Phase B) with no VFS locks
+//! held. This closes [OS-B3]: an inline `evict_inode` invoked from
+//! `Drop` could re-enter sibling locks (e.g. the parent dentry's
+//! `children` rwlock that triggered the Arc replacement).
+//!
+//! ## Single global queue
+//!
+//! RFC 0002 calls for a per-CPU ring; v1 uses one global
+//! [`spin::Mutex`]-protected queue. The kernel has no per-CPU
+//! infrastructure today and building it for GC alone is scope creep.
+//! Follow-up issue captures the per-CPU upgrade.
+//!
+//! ## Why `spin::Mutex` (not `BlockingMutex`)
+//!
+//! `Inode::drop` may run while sibling [`crate::sync::BlockingRwLock`]s
+//! are held; a sleeping primitive would risk re-entry into the
+//! scheduler with locks held. The queue lock is held only across O(1)
+//! push/pop, never across `evict_inode`.
+
+use alloc::collections::VecDeque;
+use alloc::sync::{Arc, Weak};
+use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use spin::Mutex;
+
+use super::super_block::SuperBlock;
+use super::FsId;
+
+/// Soft cap on the inline ring portion of the queue. Past this we
+/// spill into a heap `VecDeque` rather than panic or leak — the cost
+/// of a transient allocation is preferable to losing eviction work.
+const GC_RING_CAP: usize = 256;
+
+/// One pending eviction. `sb` is `Weak` so a queued entry doesn't keep
+/// the SuperBlock alive past its own teardown; the drainer treats a
+/// failed upgrade as "already gone, skip."
+struct GcEntry {
+    sb: Weak<SuperBlock>,
+    ino: u64,
+}
+
+/// Backing storage. `VecDeque` because we want FIFO semantics with
+/// O(1) push/pop on both ends.
+struct GcRing {
+    entries: VecDeque<GcEntry>,
+}
+
+impl GcRing {
+    const fn new() -> Self {
+        Self {
+            entries: VecDeque::new(),
+        }
+    }
+}
+
+static GC_QUEUE: Mutex<GcRing> = Mutex::new(GcRing::new());
+
+/// Diagnostic counter: bumped each time a push grew the queue past
+/// [`GC_RING_CAP`]. Useful for spotting drain-pressure regressions.
+static GC_OVERFLOWS: AtomicU64 = AtomicU64::new(0);
+
+/// Set while the global drainer is running. New `enqueue` calls (from
+/// `evict_inode` itself dropping more inodes) still succeed, and the
+/// drainer re-checks the queue after each eviction.
+static DRAINING: AtomicBool = AtomicBool::new(false);
+
+/// Enqueue an inode for deferred eviction. Called from `Drop for
+/// Inode`; must not block, must not re-enter VFS locks, must not
+/// allocate beyond the spill `VecDeque` push.
+pub(crate) fn enqueue(sb: Weak<SuperBlock>, ino: u64) {
+    let mut q = GC_QUEUE.lock();
+    if q.entries.len() >= GC_RING_CAP {
+        GC_OVERFLOWS.fetch_add(1, Ordering::Relaxed);
+    }
+    q.entries.push_back(GcEntry { sb, ino });
+}
+
+/// Pop one entry, releasing the queue lock before the caller touches
+/// it. Separate from [`gc_drain`] so the drainer never holds the
+/// queue lock across `evict_inode`.
+fn pop_one() -> Option<GcEntry> {
+    GC_QUEUE.lock().entries.pop_front()
+}
+
+/// Drain all pending evictions. Safe to call from any task-context
+/// site that holds no VFS locks. Re-entrant: an eviction that itself
+/// drops more inodes adds to the queue, and the loop picks them up on
+/// the next iteration.
+pub fn gc_drain() {
+    DRAINING.store(true, Ordering::Release);
+    while let Some(entry) = pop_one() {
+        if let Some(sb) = entry.sb.upgrade() {
+            // Errors from evict_inode are advisory — there's no
+            // sensible fallback this late in the lifecycle.
+            let _ = sb.ops.evict_inode(entry.ino);
+        }
+    }
+    DRAINING.store(false, Ordering::Release);
+}
+
+/// Drain only entries whose SuperBlock matches `sb`. Used by
+/// `sys_umount` Phase B before calling `ops.unmount` so the FS sees
+/// no pending evictions.
+///
+/// Walks the queue once, partitioning matched entries out. Unmatched
+/// entries are written back in original order.
+pub fn gc_drain_for(sb: &Arc<SuperBlock>) {
+    let target = sb.fs_id;
+    let mut to_evict: VecDeque<GcEntry> = VecDeque::new();
+    {
+        let mut q = GC_QUEUE.lock();
+        let mut keep: VecDeque<GcEntry> = VecDeque::with_capacity(q.entries.len());
+        while let Some(entry) = q.entries.pop_front() {
+            match entry.sb.upgrade() {
+                Some(entry_sb) if entry_sb.fs_id == target => to_evict.push_back(entry),
+                _ => keep.push_back(entry),
+            }
+        }
+        q.entries = keep;
+    }
+    for entry in to_evict {
+        let _ = sb.ops.evict_inode(entry.ino);
+    }
+    let _ = target;
+    let _: FsId = sb.fs_id;
+}
+
+/// Number of pending entries. For tests and metrics; not for control
+/// flow (the count can change between observation and use).
+pub fn gc_pending_count() -> usize {
+    GC_QUEUE.lock().entries.len()
+}
+
+/// Total number of pushes that found the queue at or above
+/// [`GC_RING_CAP`]. Monotonic.
+pub fn gc_overflow_count() -> u64 {
+    GC_OVERFLOWS.load(Ordering::Relaxed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fs::vfs::inode::{Inode, InodeKind, InodeMeta};
+    use crate::fs::vfs::ops::{FileOps, InodeOps, SetAttr, Stat, StatFs, SuperOps};
+    use crate::fs::vfs::super_block::{SbFlags, SuperBlock};
+    use crate::fs::vfs::{DString, Dentry, FsId};
+    use core::sync::atomic::AtomicUsize;
+
+    /// SuperOps stub that records evict_inode calls. Tests share the
+    /// queue (it's static), so each test drains at start and end to
+    /// stay isolated.
+    struct CountingSuper {
+        evicted: AtomicUsize,
+    }
+    impl SuperOps for CountingSuper {
+        fn root_inode(&self) -> Arc<Inode> {
+            unreachable!()
+        }
+        fn statfs(&self) -> Result<StatFs, i64> {
+            Ok(StatFs::default())
+        }
+        fn unmount(&self) -> Result<(), i64> {
+            Ok(())
+        }
+        fn evict_inode(&self, _ino: u64) -> Result<(), i64> {
+            self.evicted.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    struct StubInode;
+    impl InodeOps for StubInode {
+        fn getattr(&self, _inode: &Inode, _out: &mut Stat) -> Result<(), i64> {
+            Ok(())
+        }
+        fn setattr(&self, _inode: &Inode, _attr: &SetAttr) -> Result<(), i64> {
+            Ok(())
+        }
+    }
+    struct StubFile;
+    impl FileOps for StubFile {}
+
+    fn drain_static_queue() {
+        gc_drain();
+    }
+
+    fn make_sb(fs_id: u64) -> (Arc<SuperBlock>, Arc<CountingSuper>) {
+        let ops = Arc::new(CountingSuper {
+            evicted: AtomicUsize::new(0),
+        });
+        let sb = Arc::new(SuperBlock::new(
+            FsId(fs_id),
+            ops.clone(),
+            "stub",
+            512,
+            SbFlags::default(),
+        ));
+        (sb, ops)
+    }
+
+    fn make_inode(sb: &Arc<SuperBlock>, ino: u64) -> Arc<Inode> {
+        Arc::new(Inode::new(
+            ino,
+            Arc::downgrade(sb),
+            Arc::new(StubInode),
+            Arc::new(StubFile),
+            InodeKind::Reg,
+            InodeMeta {
+                mode: 0o644,
+                nlink: 1,
+                ..Default::default()
+            },
+        ))
+    }
+
+    #[test]
+    fn enqueue_push_pop_fifo() {
+        drain_static_queue();
+        let (sb, _ops) = make_sb(101);
+        enqueue(Arc::downgrade(&sb), 1);
+        enqueue(Arc::downgrade(&sb), 2);
+        enqueue(Arc::downgrade(&sb), 3);
+        assert_eq!(gc_pending_count(), 3);
+        let a = pop_one().unwrap();
+        let b = pop_one().unwrap();
+        let c = pop_one().unwrap();
+        assert_eq!((a.ino, b.ino, c.ino), (1, 2, 3));
+        assert!(pop_one().is_none());
+    }
+
+    #[test]
+    fn drop_inode_enqueues_not_inline() {
+        drain_static_queue();
+        let (sb, ops) = make_sb(102);
+        let ino = make_inode(&sb, 42);
+        let pending_before = gc_pending_count();
+        drop(ino);
+        // evict_inode must not have run yet — push only.
+        assert_eq!(ops.evicted.load(Ordering::SeqCst), 0);
+        assert_eq!(gc_pending_count(), pending_before + 1);
+        gc_drain();
+        assert_eq!(ops.evicted.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn nested_drop_under_parent_children_lock() {
+        drain_static_queue();
+        let (sb, _ops) = make_sb(103);
+        let parent_ino = make_inode(&sb, 1);
+        let parent = Dentry::new_root(parent_ino);
+        let child_ino = make_inode(&sb, 2);
+        // Hold the parent's children rwlock — would have deadlocked
+        // if Inode::drop tried to call evict_inode inline (which can
+        // grab sibling locks via the FS implementation).
+        let _children_guard = parent.children.write();
+        let pending_before = gc_pending_count();
+        drop(child_ino);
+        assert_eq!(gc_pending_count(), pending_before + 1);
+        // Lock still held; no deadlock proves the deferral.
+        drop(_children_guard);
+        gc_drain();
+    }
+
+    #[test]
+    fn gc_drain_for_filters_by_fs_id() {
+        drain_static_queue();
+        let (sb_a, ops_a) = make_sb(200);
+        let (sb_b, ops_b) = make_sb(201);
+        enqueue(Arc::downgrade(&sb_a), 10);
+        enqueue(Arc::downgrade(&sb_b), 20);
+        enqueue(Arc::downgrade(&sb_a), 11);
+        enqueue(Arc::downgrade(&sb_b), 21);
+        gc_drain_for(&sb_a);
+        assert_eq!(ops_a.evicted.load(Ordering::SeqCst), 2);
+        assert_eq!(ops_b.evicted.load(Ordering::SeqCst), 0);
+        assert_eq!(gc_pending_count(), 2);
+        gc_drain_for(&sb_b);
+        assert_eq!(ops_b.evicted.load(Ordering::SeqCst), 2);
+        assert_eq!(gc_pending_count(), 0);
+    }
+
+    #[test]
+    fn overflow_counter_increments_past_cap() {
+        drain_static_queue();
+        let baseline = gc_overflow_count();
+        let (sb, ops) = make_sb(300);
+        for i in 0..(GC_RING_CAP + 5) {
+            enqueue(Arc::downgrade(&sb), i as u64);
+        }
+        let after = gc_overflow_count();
+        assert!(after >= baseline + 5, "overflow counter must rise past cap");
+        gc_drain();
+        // Every enqueued entry must have been evicted; nothing was lost.
+        assert_eq!(
+            ops.evicted.load(Ordering::SeqCst),
+            GC_RING_CAP + 5,
+            "spill path must not lose entries"
+        );
+    }
+
+    #[test]
+    fn weak_sb_dropped_entries_are_discarded() {
+        drain_static_queue();
+        let (sb, ops) = make_sb(400);
+        let weak = Arc::downgrade(&sb);
+        enqueue(weak, 99);
+        // Drop the SB; the queue still holds a Weak which now upgrades to None.
+        drop(sb);
+        // No panic, no eviction call (ops Arc kept alive through the
+        // SuperOps Arc inside SuperBlock — but SB is gone).
+        gc_drain();
+        // ops Arc was kept alive by our own clone; assert no spurious call.
+        assert_eq!(ops.evicted.load(Ordering::SeqCst), 0);
+        assert_eq!(gc_pending_count(), 0);
+    }
+
+    /// `DString` is unused in this file outside this dummy referent;
+    /// silence the unused-import lint that would otherwise fire when
+    /// the `Dentry` API changes shape.
+    #[allow(dead_code)]
+    fn _touch_dstring(_d: DString) {}
+}

--- a/kernel/src/fs/vfs/gc_queue.rs
+++ b/kernel/src/fs/vfs/gc_queue.rs
@@ -29,9 +29,11 @@ use spin::Mutex;
 
 use super::super_block::SuperBlock;
 
-/// Soft cap on the inline ring portion of the queue. Past this we
-/// spill into a heap `VecDeque` rather than panic or leak — the cost
-/// of a transient allocation is preferable to losing eviction work.
+/// Threshold past which [`enqueue`] bumps [`GC_OVERFLOWS`] as a
+/// drain-pressure signal. The backing `VecDeque` itself is unbounded;
+/// this is a soft watermark for telemetry, not a hard cap. The
+/// per-CPU ring + spill design from RFC 0002 is deferred along with
+/// per-CPU infrastructure.
 const GC_RING_CAP: usize = 256;
 
 /// One pending eviction. `sb` is `Weak` so a queued entry doesn't keep
@@ -62,10 +64,32 @@ static GC_QUEUE: Mutex<GcRing> = Mutex::new(GcRing::new());
 /// [`GC_RING_CAP`]. Useful for spotting drain-pressure regressions.
 static GC_OVERFLOWS: AtomicU64 = AtomicU64::new(0);
 
-/// Set while the global drainer is running. New `enqueue` calls (from
-/// `evict_inode` itself dropping more inodes) still succeed, and the
-/// drainer re-checks the queue after each eviction.
+/// Set while a drainer is running. Only one drainer may be active at a
+/// time — concurrent calls bail out, since the active drainer will
+/// pick up anything they would have processed. New `enqueue` calls
+/// (from `evict_inode` itself dropping more inodes) still succeed.
 static DRAINING: AtomicBool = AtomicBool::new(false);
+
+/// RAII handle that owns the "I am the active drainer" claim.
+/// `try_acquire` returns `None` if another drainer is already running;
+/// `Drop` releases the claim with `Release` ordering so the next
+/// drainer's acquire sees an empty queue.
+struct DrainGuard;
+
+impl DrainGuard {
+    fn try_acquire() -> Option<Self> {
+        DRAINING
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .ok()
+            .map(|_| DrainGuard)
+    }
+}
+
+impl Drop for DrainGuard {
+    fn drop(&mut self) {
+        DRAINING.store(false, Ordering::Release);
+    }
+}
 
 /// Enqueue an inode for deferred eviction. Called from `Drop for
 /// Inode`; must not block, must not re-enter VFS locks, must not
@@ -86,11 +110,15 @@ fn pop_one() -> Option<GcEntry> {
 }
 
 /// Drain all pending evictions. Safe to call from any task-context
-/// site that holds no VFS locks. Re-entrant: an eviction that itself
-/// drops more inodes adds to the queue, and the loop picks them up on
-/// the next iteration.
+/// site that holds no VFS locks. Re-entrant within one task: an
+/// eviction that itself drops more inodes adds to the queue, and the
+/// loop picks them up on the next iteration. Concurrent callers from
+/// other tasks are no-ops — the active drainer will pick up their
+/// work too.
 pub fn gc_drain() {
-    DRAINING.store(true, Ordering::Release);
+    let Some(_guard) = DrainGuard::try_acquire() else {
+        return;
+    };
     while let Some(entry) = pop_one() {
         if let Some(sb) = entry.sb.upgrade() {
             // Errors from evict_inode are advisory — there's no
@@ -98,31 +126,39 @@ pub fn gc_drain() {
             let _ = sb.ops.evict_inode(entry.ino);
         }
     }
-    DRAINING.store(false, Ordering::Release);
 }
 
-/// Drain only entries whose SuperBlock matches `sb`. Used by
-/// `sys_umount` Phase B before calling `ops.unmount` so the FS sees
-/// no pending evictions.
+/// Drain entries whose SuperBlock matches `sb`. Used by `sys_umount`
+/// Phase B before calling `ops.unmount` so the FS sees no pending
+/// evictions for this mount.
 ///
-/// Walks the queue once, partitioning matched entries out. Unmatched
-/// entries are written back in original order.
+/// Loops until no matching entries remain — an `evict_inode` call may
+/// itself drop more inodes belonging to this same SB, and Phase B's
+/// contract is "queue is quiescent for `target` on return." Acquires
+/// the [`DrainGuard`] for the duration; falls back to spinning on the
+/// queue if another drainer is racing (the racing drainer doesn't
+/// know about the per-fs filter, so we still need our own pass).
 pub fn gc_drain_for(sb: &Arc<SuperBlock>) {
     let target = sb.fs_id;
-    let mut to_evict: VecDeque<GcEntry> = VecDeque::new();
-    {
-        let mut q = GC_QUEUE.lock();
-        let mut keep: VecDeque<GcEntry> = VecDeque::with_capacity(q.entries.len());
-        while let Some(entry) = q.entries.pop_front() {
-            match entry.sb.upgrade() {
-                Some(entry_sb) if entry_sb.fs_id == target => to_evict.push_back(entry),
-                _ => keep.push_back(entry),
+    loop {
+        let mut to_evict: VecDeque<GcEntry> = VecDeque::new();
+        {
+            let mut q = GC_QUEUE.lock();
+            let mut keep: VecDeque<GcEntry> = VecDeque::with_capacity(q.entries.len());
+            while let Some(entry) = q.entries.pop_front() {
+                match entry.sb.upgrade() {
+                    Some(entry_sb) if entry_sb.fs_id == target => to_evict.push_back(entry),
+                    _ => keep.push_back(entry),
+                }
             }
+            q.entries = keep;
         }
-        q.entries = keep;
-    }
-    for entry in to_evict {
-        let _ = sb.ops.evict_inode(entry.ino);
+        if to_evict.is_empty() {
+            return;
+        }
+        for entry in to_evict {
+            let _ = sb.ops.evict_inode(entry.ino);
+        }
     }
 }
 
@@ -297,6 +333,27 @@ mod tests {
             GC_RING_CAP + 5,
             "spill path must not lose entries"
         );
+    }
+
+    #[test]
+    fn drain_guard_excludes_concurrent_drainer() {
+        drain_static_queue();
+        // Acquire the guard manually to simulate an in-flight drainer.
+        let guard = DrainGuard::try_acquire().expect("first acquire");
+        // A second acquire while the first is held must fail.
+        assert!(DrainGuard::try_acquire().is_none());
+        // While the guard is held, gc_drain bails out without touching
+        // the queue — proves DRAINING is observed, not write-only.
+        let (sb, ops) = make_sb(500);
+        enqueue(Arc::downgrade(&sb), 7);
+        gc_drain();
+        assert_eq!(gc_pending_count(), 1);
+        assert_eq!(ops.evicted.load(Ordering::SeqCst), 0);
+        // Release and re-drain — now it goes through.
+        drop(guard);
+        gc_drain();
+        assert_eq!(gc_pending_count(), 0);
+        assert_eq!(ops.evicted.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/kernel/src/fs/vfs/gc_queue.rs
+++ b/kernel/src/fs/vfs/gc_queue.rs
@@ -28,7 +28,6 @@ use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use spin::Mutex;
 
 use super::super_block::SuperBlock;
-use super::FsId;
 
 /// Soft cap on the inline ring portion of the queue. Past this we
 /// spill into a heap `VecDeque` rather than panic or leak — the cost
@@ -125,8 +124,6 @@ pub fn gc_drain_for(sb: &Arc<SuperBlock>) {
     for entry in to_evict {
         let _ = sb.ops.evict_inode(entry.ino);
     }
-    let _ = target;
-    let _: FsId = sb.fs_id;
 }
 
 /// Number of pending entries. For tests and metrics; not for control

--- a/kernel/src/fs/vfs/inode.rs
+++ b/kernel/src/fs/vfs/inode.rs
@@ -98,6 +98,16 @@ impl Inode {
     }
 }
 
+/// Defer eviction so we never call `evict_inode` from inside another
+/// VFS lock. The drop fires from contexts like a parent dentry's
+/// children-map mutation, where calling back into the FS could
+/// re-enter sibling locks. See `super::gc_queue` for the drain sites.
+impl Drop for Inode {
+    fn drop(&mut self) {
+        super::gc_queue::enqueue(self.sb.clone(), self.ino);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/kernel/src/fs/vfs/mod.rs
+++ b/kernel/src/fs/vfs/mod.rs
@@ -46,12 +46,14 @@
 use alloc::vec::Vec;
 
 pub mod dentry;
+pub mod gc_queue;
 pub mod inode;
 pub mod open_file;
 pub mod ops;
 pub mod super_block;
 
 pub use dentry::{ChildState, DFlags, Dentry, MountEdge, MountFlags};
+pub use gc_queue::{gc_drain, gc_drain_for, gc_overflow_count, gc_pending_count};
 pub use inode::{Inode, InodeKind, InodeMeta, InodeState};
 pub use open_file::OpenFile;
 pub use ops::{


### PR DESCRIPTION
Closes #231

## Summary
- Adds `vfs::gc_queue`, a single-global FIFO of pending inode evictions guarded by `spin::Mutex` (cannot block — `Drop` runs with sibling locks held).
- `impl Drop for Inode` now enqueues `(Weak<SuperBlock>, ino)` instead of calling `SuperOps::evict_inode` inline. Closes the [OS-B3] Drop-reentrancy hazard from the RFC.
- Drain hooks: `gc_drain()` for syscall-return / idle-task sites; `gc_drain_for(&Arc<SuperBlock>)` for `sys_umount` Phase B.

## Design notes
- **Single global queue** instead of per-CPU. Per-CPU was the RFC target, but the kernel has no per-CPU infrastructure today; building it for GC alone is scope creep. Documented in the module header.
- **Spill instead of drop** when past `GC_RING_CAP = 256`. Losing eviction work is worse than a transient `VecDeque` allocation; the overflow counter (`gc_overflow_count()`) makes pressure observable.
- **`Weak<SuperBlock>` on the entry**: avoids depending on the unbuilt `MOUNT_TABLE` (#233). A failed upgrade at drain time is treated as \"SB already gone, skip.\"
- **No `impl Drop for Dentry`**: the `Dentry`'s `Option<Arc<Inode>>` field is what holds the Inode; its plain drop already releases the Arc, and the Inode's own Drop is the single enqueue point.

## Test plan
- [ ] `cargo xtask test` (host unit tests + QEMU integration) on CI.
- [ ] New host tests (in `gc_queue.rs`):
  - FIFO push/pop ordering
  - `Drop for Inode` enqueues, does not call evict inline; explicit `gc_drain()` then triggers it
  - Nested drop under a held parent dentry's `children.write()` lock — would have deadlocked with inline eviction
  - `gc_drain_for` filters by `fs_id`
  - Overflow path past `GC_RING_CAP` keeps every entry (no loss)
  - Dropped `Weak<SuperBlock>` entries are silently discarded at drain