### PR TITLE
tests: assert task::exit reclaims intermediate page-table frames

### DIFF
--- a/kernel/tests/task_exit.rs
+++ b/kernel/tests/task_exit.rs
@@ -9,13 +9,18 @@
 extern crate alloc;
 
 use core::panic::PanicInfo;
+use core::ptr;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
+use vibix::mem::frame;
+use vibix::mem::vmatree::{Share, Vma};
+use vibix::mem::vmobject::AnonObject;
 use vibix::{
     exit_qemu, serial_println, task,
     test_harness::{test_panic_handler, Testable},
     QemuExitCode,
 };
+use x86_64::structures::paging::PageTableFlags;
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
@@ -35,6 +40,10 @@ fn run_tests() {
     let tests: &[(&str, &dyn Testable)] = &[
         ("exit_removes_task", &(exit_removes_task as fn())),
         ("exit_loop_no_leak", &(exit_loop_no_leak as fn())),
+        (
+            "exit_loop_no_intermediate_leak",
+            &(exit_loop_no_intermediate_leak as fn()),
+        ),
     ];
     serial_println!("running {} tests", tests.len());
     for (name, t) in tests {
@@ -120,4 +129,87 @@ fn exit_loop_no_leak() {
     let mut live = 0usize;
     task::for_each_task(|_| live += 1);
     assert_eq!(live, 1, "tasks leaking across exit loop");
+}
+
+// Lower-half VA in an L4 entry the bootstrap PML4 leaves untouched, so
+// every L3/L2/L1 intermediate the worker faults in is wholly owned by
+// its own PML4 and observable on reap.
+const VMA_BASE: usize = 0x0000_3000_0000_0000;
+const VMA_PAGES: usize = 8;
+
+static FAULT_WORKER_DONE: AtomicUsize = AtomicUsize::new(0);
+
+fn fault_worker() -> ! {
+    let prot_pte =
+        (PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE).bits();
+    task::install_vma_on_current(Vma::new(
+        VMA_BASE,
+        VMA_BASE + VMA_PAGES * 4096,
+        0x3, // PROT_READ | PROT_WRITE
+        prot_pte,
+        Share::Private,
+        AnonObject::new(Some(VMA_PAGES)),
+        0,
+    ));
+
+    for i in 0..VMA_PAGES {
+        let va = VMA_BASE + i * 4096;
+        unsafe { ptr::write_volatile(va as *mut u8, 0xCD) };
+    }
+
+    FAULT_WORKER_DONE.fetch_add(1, Ordering::SeqCst);
+    task::exit();
+}
+
+fn wait_for_fault_worker() {
+    for _ in 0..200 {
+        if FAULT_WORKER_DONE.load(Ordering::SeqCst) == 1 {
+            // Reap (and the Drop for AddressSpace that releases its
+            // intermediate page-table frames) lands on the next
+            // preempt_tick that drains pending_exit.
+            for _ in 0..10 {
+                x86_64::instructions::hlt();
+            }
+            return;
+        }
+        x86_64::instructions::hlt();
+    }
+    panic!("fault_worker never reached exit()");
+}
+
+// Regression for #146: every L3/L2/L1 intermediate page-table frame
+// allocated by faulting an AnonZero VMA must be returned to the global
+// allocator on `task::exit`. addrspace_drop.rs covers the same chain
+// via the Arc<RwLock<AddressSpace>> drop, but the wiring through
+// `task::exit` → `reap_pending` → drop is what userspace actually
+// triggers, so it gets its own assertion alongside the scheduler-side
+// leak check above.
+fn exit_loop_no_intermediate_leak() {
+    for _ in 0..2 {
+        FAULT_WORKER_DONE.store(0, Ordering::SeqCst);
+        task::spawn(fault_worker);
+        wait_for_fault_worker();
+    }
+
+    let baseline = frame::free_frames();
+
+    const ITERATIONS: usize = 32;
+    for i in 0..ITERATIONS {
+        FAULT_WORKER_DONE.store(0, Ordering::SeqCst);
+        task::spawn(fault_worker);
+        wait_for_fault_worker();
+        assert_eq!(
+            FAULT_WORKER_DONE.load(Ordering::SeqCst),
+            1,
+            "fault_worker {i} never reached exit()"
+        );
+    }
+
+    let after = frame::free_frames();
+    assert!(
+        after >= baseline,
+        "intermediate page-table leak across {ITERATIONS} task::exit cycles: \
+         baseline={baseline}, after={after}, delta={}",
+        baseline as isize - after as isize,
+    );
 }


### PR DESCRIPTION
Closes #146

## Summary
- Add `exit_loop_no_intermediate_leak` to `kernel/tests/task_exit.rs`. The new worker installs an 8-page `AnonZero` VMA at `0x0000_3000_0000_0000` (an L4 entry the bootstrap PML4 leaves untouched), faults every page so the resolver allocates L3 / L2 / L1 intermediate page-table frames under that subtree, then calls `task::exit()`.
- Across 32 spawn-exit cycles the free-frame count returned by `vibix::mem::frame::free_frames()` must not drop below the post-warm-up baseline.
- The existing walker (`free_user_page_tables` in `kernel/src/mem/paging.rs`, wired through `Drop for AddressSpace`) already does the reclaim — `addrspace_drop.rs` (#161) covers it via the `Arc<RwLock<AddressSpace>>` drop. This PR adds the coverage #146 explicitly asked for: the `task::exit` → `reap_pending` → `Drop` path that userspace actually triggers.

## Test plan
- [x] `cargo xtask build` clean (only the pre-existing `is_guard_hit` warning).
- [x] `cargo fmt --all` clean.
- [ ] CI host tests + `cargo xtask test` (QEMU) execute the new `exit_loop_no_intermediate_leak` integration test on x86_64 — local env is aarch64 so this can only run in CI.
- [ ] CI smoke.