### PR TITLE
mem: regression test for vma_flags split propagation (#222)

### DIFF
--- a/kernel/src/mem/vmatree.rs
+++ b/kernel/src/mem/vmatree.rs
@@ -599,14 +599,8 @@ mod tests {
         v.vma_flags = VMA_GROWSDOWN;
         t.insert(v);
         t.unmap_range(K, 3 * K);
-        let vs: alloc::vec::Vec<_> = t
-            .iter()
-            .map(|v| (v.start, v.end, v.vma_flags))
-            .collect();
-        assert_eq!(
-            vs,
-            [(0, K, VMA_GROWSDOWN), (3 * K, 4 * K, VMA_GROWSDOWN)],
-        );
+        let vs: alloc::vec::Vec<_> = t.iter().map(|v| (v.start, v.end, v.vma_flags)).collect();
+        assert_eq!(vs, [(0, K, VMA_GROWSDOWN), (3 * K, 4 * K, VMA_GROWSDOWN)],);
     }
 
     #[test]

--- a/kernel/src/mem/vmatree.rs
+++ b/kernel/src/mem/vmatree.rs
@@ -587,6 +587,28 @@ mod tests {
         assert_eq!(vs, [(0, K, 0), (3 * K, 4 * K, 3 * K)]);
     }
 
+    // Regression for #222: a partial-range unmap on a VMA carrying
+    // behaviour bits (`VMA_GROWSDOWN` here) must propagate those bits
+    // into both halves. `Vma::split_at` is private; drive it through
+    // the public `unmap_range` carve, which is the production caller.
+    #[test]
+    fn unmap_range_preserves_vma_flags_on_split() {
+        let obj = stub();
+        let mut t = VmaTree::new();
+        let mut v = vma(0, 4 * K, RW, obj, 0);
+        v.vma_flags = VMA_GROWSDOWN;
+        t.insert(v);
+        t.unmap_range(K, 3 * K);
+        let vs: alloc::vec::Vec<_> = t
+            .iter()
+            .map(|v| (v.start, v.end, v.vma_flags))
+            .collect();
+        assert_eq!(
+            vs,
+            [(0, K, VMA_GROWSDOWN), (3 * K, 4 * K, VMA_GROWSDOWN)],
+        );
+    }
+
     #[test]
     fn unmap_range_drops_fully_contained() {
         let obj = stub();


### PR DESCRIPTION
Closes #222

## Summary
- The `Vma::split_at` fix has already landed (lines 159/169 propagate `self.vma_flags` into both halves with the comment "preserve behaviour flags on split"). What's still missing is the test that locks that behaviour down so a future refactor can't silently regress it.
- Adds `unmap_range_preserves_vma_flags_on_split`: builds a single 4-page `VMA_GROWSDOWN` VMA, unmaps the middle two pages via `VmaTree::unmap_range` (the public production caller of `split_at`), and asserts both surviving halves still carry `VMA_GROWSDOWN`.
- Audit of other VMA constructors confirmed the propagation surface is contained: `Vma::new` deliberately sets `vma_flags: 0` (callers set behaviour bits afterwards), and the fork path in `addrspace.rs` already snapshots-and-replays `vma_flags` explicitly.

## Test plan
- [ ] `cargo xtask test` — the new test passes alongside the existing `unmap_range_*` suite.
- [ ] `cargo xtask smoke` — no regression on the boot path (this change is test-only).