### PR TITLE
syscall: make execve atomic on ELF load failure (#209)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -149,6 +149,10 @@ name = "addrspace_drop"
 harness = false
 
 [[test]]
+name = "execve_atomic"
+harness = false
+
+[[test]]
 name = "fork_cow"
 harness = false
 

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -341,74 +341,19 @@ pub unsafe extern "C" fn syscall_dispatch(
         }
 
         // execve(path, argv, envp) — path and argv/envp are ignored; the
-        // kernel loads the `userspace_hello.elf` ramdisk module into the
-        // current address space and jumps to ring-3. Never returns on
-        // success.
+        // kernel loads the `userspace_hello.elf` ramdisk module into a
+        // freshly-staged address space and atomically swaps it in on
+        // success. On failure the old address space is preserved so the
+        // caller continues running and observes the `-ENOEXEC` return.
         59 => {
             let elf_bytes = match crate::mem::userspace_hello_elf_bytes() {
                 Some(b) => b,
                 None => return -8, // ENOEXEC — hello module not present
             };
-
-            // Clear all user VMAs and reset the address space.
-            {
-                crate::task::current_address_space()
-                    .write()
-                    .clear_for_exec();
+            match exec_atomic(elf_bytes) {
+                Ok(never) => match never {},
+                Err(e) => e,
             }
-
-            // Close O_CLOEXEC fds as POSIX requires on exec.
-            crate::task::current_fd_table().lock().close_cloexec();
-
-            // Load the new ELF with VMA tracking so AddressSpace::drop can
-            // reclaim the data frames when the exec'd process exits. Without
-            // VMA entries the leaf frames are orphaned permanently.
-            let pml4 = crate::task::current_cr3();
-            let aspace = crate::task::current_address_space();
-            let image = match crate::mem::loader::load_user_elf_with_vmas(
-                elf_bytes,
-                pml4,
-                &mut aspace.write(),
-            ) {
-                Ok(img) => img,
-                Err(_) => return -8, // ENOEXEC
-            };
-
-            // Set the heap base to immediately after the new ELF image.
-            use x86_64::VirtAddr;
-            aspace.write().set_brk_start(VirtAddr::new(image.image_end));
-
-            // Map a fresh user stack page and register it as a VMA so the
-            // exec'd process's stack frame is also reclaimed on exit.
-            use crate::mem::vmatree::{Share, Vma};
-            use crate::mem::vmobject::{AnonObject, VmObject};
-            use x86_64::structures::paging::{Page, PageTableFlags, Size4KiB};
-            let stack_flags = PageTableFlags::PRESENT
-                | PageTableFlags::WRITABLE
-                | PageTableFlags::USER_ACCESSIBLE
-                | PageTableFlags::NO_EXECUTE;
-            let stack_page = Page::<Size4KiB>::containing_address(VirtAddr::new(
-                crate::init_process::USER_STACK_PAGE_VA,
-            ));
-            let stack_frame = crate::mem::paging::map_in_pml4(pml4, stack_page, stack_flags)
-                .expect("exec: user stack mapping failed");
-
-            let stack_obj = AnonObject::new(Some(1));
-            stack_obj.insert_existing_frame(0, stack_frame.start_address().as_u64());
-            let stack_start = crate::init_process::USER_STACK_PAGE_VA as usize;
-            let stack_vma = Vma::new(
-                stack_start,
-                stack_start + 4096,
-                0x3,
-                stack_flags.bits(),
-                Share::Private,
-                stack_obj as alloc::sync::Arc<dyn VmObject>,
-                0,
-            );
-            aspace.write().insert(stack_vma);
-
-            // Switch to the new image — never returns.
-            unsafe { jump_to_ring3(image.entry.as_u64(), crate::init_process::USER_STACK_TOP) }
         }
 
         // exit(status) — tear down the process and switch to the next task.
@@ -476,6 +421,87 @@ pub unsafe extern "C" fn syscall_dispatch(
 /// Maximum path length accepted by `sys_open`, including the terminating
 /// NUL. Matches the longest special path we handle today.
 const OPEN_PATH_MAX: usize = 128;
+
+/// Atomic execve body: stage the new image into a fresh `AddressSpace`
+/// and only commit it once the load has fully succeeded.
+///
+/// Returns `Err(-ENOEXEC)` (or `-ENOMEM`) on failure, leaving the
+/// caller's address space untouched so the syscall return lands on
+/// still-valid user code. Returns `Ok(_)` only by way of `jump_to_ring3`,
+/// which never returns; the `Infallible` ok variant lets the caller
+/// match exhaustively without a panic-on-unreachable arm.
+///
+/// The atomicity story: the new `AddressSpace` is built top-to-bottom
+/// in a separate PML4 (own `try_new_empty`). If anything before the
+/// CR3 swap fails, dropping the staged `AddressSpace` reclaims its
+/// PML4 + intermediate page tables. (Leaf data frames mapped by a
+/// partially-completed `load_user_elf` aren't tracked by the staged
+/// VMA list yet, so they leak on early-segment failure — small and
+/// bounded by ELF size; tracked separately as a follow-up.)
+#[cfg(target_os = "none")]
+pub fn exec_atomic(elf_bytes: &[u8]) -> Result<core::convert::Infallible, i64> {
+    use crate::mem::addrspace::AddressSpace;
+    use crate::mem::vmatree::{Share, Vma};
+    use crate::mem::vmobject::{AnonObject, VmObject};
+    use x86_64::structures::paging::{Page, PageTableFlags, Size4KiB};
+    use x86_64::VirtAddr;
+
+    // 1. Build a fresh AddressSpace with its own PML4.
+    let mut new_aspace = AddressSpace::try_new_empty().map_err(|_| -12i64)?;
+    let new_pml4 = new_aspace.page_table_frame();
+
+    // 2. Load the ELF into the new PML4 with VMA tracking. On Err the
+    //    staged AddressSpace drops at the `?` boundary, freeing its
+    //    page tables; the caller's address space is untouched.
+    let image = crate::mem::loader::load_user_elf_with_vmas(elf_bytes, new_pml4, &mut new_aspace)
+        .map_err(|_| -8i64)?;
+
+    new_aspace.set_brk_start(VirtAddr::new(image.image_end));
+
+    // 3. Map and register the user stack page in the staged space.
+    let stack_flags = PageTableFlags::PRESENT
+        | PageTableFlags::WRITABLE
+        | PageTableFlags::USER_ACCESSIBLE
+        | PageTableFlags::NO_EXECUTE;
+    let stack_page = Page::<Size4KiB>::containing_address(VirtAddr::new(
+        crate::init_process::USER_STACK_PAGE_VA,
+    ));
+    let stack_frame =
+        crate::mem::paging::map_in_pml4(new_pml4, stack_page, stack_flags).map_err(|_| -12i64)?;
+
+    let stack_obj = AnonObject::new(Some(1));
+    stack_obj.insert_existing_frame(0, stack_frame.start_address().as_u64());
+    let stack_start = crate::init_process::USER_STACK_PAGE_VA as usize;
+    let stack_vma = Vma::new(
+        stack_start,
+        stack_start + 4096,
+        0x3,
+        stack_flags.bits(),
+        Share::Private,
+        stack_obj as alloc::sync::Arc<dyn VmObject>,
+        0,
+    );
+    new_aspace.insert(stack_vma);
+
+    // 4. Commit. After this point we cannot fail back to the caller —
+    //    the old address space is still alive on the task until we
+    //    write CR3 and drop the returned Arc.
+    crate::task::current_fd_table().lock().close_cloexec();
+    let new_aspace_arc = alloc::sync::Arc::new(spin::RwLock::new(new_aspace));
+    let old_aspace = crate::task::replace_current_address_space(new_aspace_arc, new_pml4);
+
+    unsafe {
+        x86_64::registers::control::Cr3::write(
+            new_pml4,
+            x86_64::registers::control::Cr3Flags::empty(),
+        );
+    }
+    // Now safe to release the old PML4 + its frames.
+    drop(old_aspace);
+
+    // Never returns.
+    unsafe { jump_to_ring3(image.entry.as_u64(), crate::init_process::USER_STACK_TOP) }
+}
 
 /// Copy a NUL-terminated path from user VA `uva` into `buf`. Returns
 /// the slice (without the NUL) on success, or a negative errno on

--- a/kernel/tests/execve_atomic.rs
+++ b/kernel/tests/execve_atomic.rs
@@ -1,0 +1,130 @@
+//! Integration test for #209: `execve` (syscall nr=59) must be atomic —
+//! a malformed ELF must leave the caller's address space intact and
+//! return `-ENOEXEC` so userspace continues running rather than faulting
+//! into unmapped code.
+//!
+//! The test drives the staging path directly via the public
+//! `arch::x86_64::syscall::exec_atomic` hook, bypassing the syscall
+//! gate (which would require a real ring-3 process). A worker task
+//! captures its current address-space `Arc` pointer, calls `exec_atomic`
+//! with garbage bytes, asserts the call returns `Err(-8)` (ENOEXEC),
+//! and asserts the address-space `Arc` is identity-equal before and
+//! after — i.e. the failed exec did not swap a new PML4 in.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use vibix::arch::x86_64::syscall::exec_atomic;
+use vibix::{
+    exit_qemu, serial_println, task,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[(
+        "exec_atomic_preserves_aspace_on_garbage_elf",
+        &(exec_atomic_preserves_aspace_on_garbage_elf as fn()),
+    )];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+static WORKER_OBSERVED_ENOEXEC: AtomicUsize = AtomicUsize::new(0);
+static WORKER_ASPACE_PRESERVED: AtomicUsize = AtomicUsize::new(0);
+static WORKER_DONE: AtomicUsize = AtomicUsize::new(0);
+
+fn exec_worker() -> ! {
+    // Snapshot the address-space Arc pointer before attempting exec.
+    let before = task::current_address_space();
+    let before_ptr = Arc::as_ptr(&before) as usize;
+    drop(before);
+
+    // Garbage that cannot parse as ELF64 — `try_parse_elf64` rejects
+    // and `load_user_elf_with_vmas` returns `Err(LoadError::NotElf64)`,
+    // which the syscall arm maps to ENOEXEC (-8).
+    let garbage = [0u8; 64];
+    match exec_atomic(&garbage) {
+        Ok(_never) => {
+            // exec_atomic returned Ok? That means the swap committed
+            // (and we never come back via a normal return because
+            // jump_to_ring3 is `!`). Reaching here is impossible.
+            unreachable!("exec_atomic returned Ok with garbage bytes");
+        }
+        Err(code) => {
+            if code == -8 {
+                WORKER_OBSERVED_ENOEXEC.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+    }
+
+    // After the failed exec, the task's address space Arc must still
+    // identify the original space. A successful swap would have
+    // installed a new Arc with a different pointer.
+    let after = task::current_address_space();
+    let after_ptr = Arc::as_ptr(&after) as usize;
+    drop(after);
+    if after_ptr == before_ptr {
+        WORKER_ASPACE_PRESERVED.fetch_add(1, Ordering::SeqCst);
+    }
+
+    WORKER_DONE.fetch_add(1, Ordering::SeqCst);
+    task::exit();
+}
+
+fn exec_atomic_preserves_aspace_on_garbage_elf() {
+    WORKER_OBSERVED_ENOEXEC.store(0, Ordering::SeqCst);
+    WORKER_ASPACE_PRESERVED.store(0, Ordering::SeqCst);
+    WORKER_DONE.store(0, Ordering::SeqCst);
+
+    task::spawn(exec_worker);
+
+    for _ in 0..200 {
+        if WORKER_DONE.load(Ordering::SeqCst) == 1 {
+            for _ in 0..4 {
+                x86_64::instructions::hlt();
+            }
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+
+    assert_eq!(
+        WORKER_DONE.load(Ordering::SeqCst),
+        1,
+        "exec_worker never finished"
+    );
+    assert_eq!(
+        WORKER_OBSERVED_ENOEXEC.load(Ordering::SeqCst),
+        1,
+        "exec_atomic with garbage bytes did not return -ENOEXEC"
+    );
+    assert_eq!(
+        WORKER_ASPACE_PRESERVED.load(Ordering::SeqCst),
+        1,
+        "address-space Arc swapped despite failed exec — atomicity broken"
+    );
+}


### PR DESCRIPTION
Closes #209

## Summary
- The execve syscall (nr=59) used to call `clear_for_exec` on the current address space *before* attempting `load_user_elf_with_vmas`. If the ELF was rejected, the old image was already gone and the syscall returned -ENOEXEC into unmapped user code, immediately faulting the caller. This change stages the new image into a fresh `AddressSpace` (own PML4) and only commits on a successful load + stack mapping.
- The commit point is a single `replace_current_address_space` + `Cr3::write` window — same pattern `init_ring3_entry` already uses. The old AddressSpace stays alive on the task across the swap and is dropped after CR3 is updated, so any IRQ that lands in the gap can still walk valid kernel-half tables.
- Refactored the body into `exec_atomic(elf_bytes: &[u8])` (pub) so the integration test can drive the staging logic without going through the SYSCALL gate.

## Test plan
- [ ] `cargo xtask build`, `cargo xtask test`, `cargo xtask smoke` all green on CI.
- [ ] `execve_atomic::exec_atomic_preserves_aspace_on_garbage_elf` passes — a worker task observes -ENOEXEC and finds its `current_address_space()` Arc pointer unchanged across the failed exec.
- [ ] Existing `userspace_loader` smoke (the success path through the same code) still boots and runs `/init`.

## Known follow-up
A partially-mapped `load_user_elf` (segments mapped before a later segment errors) leaks its leaf data frames on the failure path, because `Drop for AddressSpace` only walks tracked VMAs. The leak is bounded by ELF size; flagged as a follow-up rather than expanding scope here.