### PR TITLE
vfs: wire VfsBackend into FileDescTable and fork path (RFC 0002 item 9/15)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -183,3 +183,7 @@ harness = false
 [[test]]
 name = "syscall_mmap_family"
 harness = false
+
+[[test]]
+name = "vfs_backend"
+harness = false

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -102,6 +102,7 @@ pub const ENOTDIR: i64 = -20;
 pub const ELOOP: i64 = -40;
 pub const EACCES: i64 = -13;
 pub const EBUSY: i64 = -16;
+pub const EOVERFLOW: i64 = -75;
 
 /// Per-process file-descriptor array.
 ///

--- a/kernel/src/fs/vfs/backend.rs
+++ b/kernel/src/fs/vfs/backend.rs
@@ -1,0 +1,238 @@
+//! `VfsBackend` — adapts [`OpenFile`] into the [`FileBackend`] interface.
+//!
+//! This is the bridge between the VFS layer (RFC 0002) and the per-process
+//! file-descriptor table in [`crate::fs::FileDescTable`]. Each successful
+//! `sys_open` wraps the resulting `Arc<OpenFile>` in a `VfsBackend`, which
+//! is then stored as an `Arc<dyn FileBackend>` in the descriptor slot.
+//!
+//! ## POSIX open-file description semantics
+//!
+//! `FileDescTable::clone_for_fork` shallow-clones `Arc<FileDescription>`,
+//! which in turn shallow-clones `Arc<dyn FileBackend>`. For a `VfsBackend`
+//! that means the parent and child share the **same** `Arc<OpenFile>`,
+//! including the same `offset` mutex — exactly the POSIX guarantee that
+//! fork'd children share the open-file description with the parent.
+//!
+//! ## O_CLOEXEC
+//!
+//! The `O_CLOEXEC` flag lives on `FileDescription.flags`, not inside
+//! `VfsBackend`. `FileDescTable::close_cloexec` inspects that field and
+//! drops the `Arc<FileDescription>` (and thus the `VfsBackend` and
+//! `OpenFile`) when the flag is set. No special handling is needed here.
+
+use alloc::sync::Arc;
+
+use crate::fs::FileBackend;
+
+use super::open_file::OpenFile;
+
+/// Wraps an [`OpenFile`] as a [`FileBackend`] for the fd-table.
+///
+/// `read` and `write` delegate to [`FileOps`](super::ops::FileOps) on the
+/// `OpenFile`, advancing the shared file offset atomically under the
+/// `OpenFile.offset` mutex so that concurrent calls from threads sharing the
+/// same description serialise correctly.
+pub struct VfsBackend {
+    pub open_file: Arc<OpenFile>,
+}
+
+impl FileBackend for VfsBackend {
+    /// Read up to `buf.len()` bytes from the current file offset.
+    ///
+    /// Advances the shared offset by the number of bytes actually read.
+    /// Returns `Err(errno)` on I/O errors (e.g. `-EINVAL` for a
+    /// non-readable file type, `-EPERM` etc. from the underlying `FileOps`).
+    fn read(&self, buf: &mut [u8]) -> Result<usize, i64> {
+        let mut off = self.open_file.offset.lock();
+        let n = self.open_file.ops.read(&self.open_file, buf, *off)?;
+        *off += n as u64;
+        Ok(n)
+    }
+
+    /// Write `buf` at the current file offset.
+    ///
+    /// Advances the shared offset by the number of bytes written.
+    /// Returns `Err(errno)` on I/O errors (e.g. `-EPERM` for a
+    /// read-only filesystem).
+    fn write(&self, buf: &[u8]) -> Result<usize, i64> {
+        let mut off = self.open_file.offset.lock();
+        let n = self.open_file.ops.write(&self.open_file, buf, *off)?;
+        *off += n as u64;
+        Ok(n)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fs::vfs::dentry::Dentry;
+    use crate::fs::vfs::inode::{Inode, InodeKind, InodeMeta};
+    use crate::fs::vfs::open_file::OpenFile;
+    use crate::fs::vfs::ops::{FileOps, InodeOps, SetAttr, Stat, StatFs, SuperOps};
+    use crate::fs::vfs::super_block::{SbActiveGuard, SbFlags, SuperBlock};
+    use crate::fs::vfs::FsId;
+    use crate::fs::{flags, FileDescTable, FileDescription};
+    use alloc::sync::Arc;
+
+    // -----------------------------------------------------------------------
+    // Stubs
+    // -----------------------------------------------------------------------
+
+    struct StubInodeOps;
+    impl InodeOps for StubInodeOps {
+        fn getattr(&self, _inode: &Inode, _out: &mut Stat) -> Result<(), i64> {
+            Ok(())
+        }
+        fn setattr(&self, _inode: &Inode, _attr: &SetAttr) -> Result<(), i64> {
+            Ok(())
+        }
+    }
+
+    struct StubSuperOps;
+    impl SuperOps for StubSuperOps {
+        fn root_inode(&self) -> Arc<Inode> {
+            unreachable!("test stub")
+        }
+        fn statfs(&self) -> Result<StatFs, i64> {
+            Ok(StatFs::default())
+        }
+        fn unmount(&self) -> Result<(), i64> {
+            Ok(())
+        }
+    }
+
+    /// A `FileOps` stub that fills `buf` with a repeated byte pattern on
+    /// read and counts bytes written.
+    struct CountingOps {
+        fill_byte: u8,
+    }
+
+    impl FileOps for CountingOps {
+        fn read(&self, _f: &OpenFile, buf: &mut [u8], _off: u64) -> Result<usize, i64> {
+            for b in buf.iter_mut() {
+                *b = self.fill_byte;
+            }
+            Ok(buf.len())
+        }
+
+        fn write(&self, _f: &OpenFile, buf: &[u8], _off: u64) -> Result<usize, i64> {
+            Ok(buf.len())
+        }
+    }
+
+    fn make_open_file(fill_byte: u8) -> Arc<OpenFile> {
+        let sb = Arc::new(SuperBlock::new(
+            FsId(42),
+            Arc::new(StubSuperOps),
+            "stub",
+            512,
+            SbFlags::default(),
+        ));
+        let inode = Arc::new(Inode::new(
+            1,
+            Arc::downgrade(&sb),
+            Arc::new(StubInodeOps),
+            Arc::new(CountingOps { fill_byte }),
+            InodeKind::Reg,
+            InodeMeta::default(),
+        ));
+        let dentry = Dentry::new_root(inode.clone());
+        let file_ops: Arc<dyn FileOps> = Arc::new(CountingOps { fill_byte });
+        let guard = SbActiveGuard::try_acquire(&sb).expect("guard");
+        OpenFile::new(dentry, inode, file_ops, sb, 0, guard)
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn read_advances_offset() {
+        let of = make_open_file(0xAB);
+        let backend = VfsBackend {
+            open_file: of.clone(),
+        };
+        let mut buf = [0u8; 4];
+        let n = backend.read(&mut buf).expect("read must succeed");
+        assert_eq!(n, 4);
+        assert_eq!(buf, [0xABu8; 4]);
+        assert_eq!(*of.offset.lock(), 4, "offset must advance by bytes read");
+    }
+
+    #[test]
+    fn write_advances_offset() {
+        let of = make_open_file(0);
+        let backend = VfsBackend {
+            open_file: of.clone(),
+        };
+        let data = b"hello";
+        let n = backend.write(data).expect("write must succeed");
+        assert_eq!(n, 5);
+        assert_eq!(*of.offset.lock(), 5, "offset must advance by bytes written");
+    }
+
+    #[test]
+    fn fork_shares_open_file_description() {
+        // Build an fd table with a VfsBackend fd.
+        let of = make_open_file(0xCD);
+        let backend = Arc::new(VfsBackend {
+            open_file: of.clone(),
+        }) as Arc<dyn FileBackend>;
+        let mut parent = FileDescTable::new();
+        let desc = Arc::new(FileDescription { backend, flags: 0 });
+        let fd = parent.alloc_fd(desc).expect("alloc_fd");
+
+        // Fork — child shares the Arc<OpenFile>.
+        let child = parent.clone_for_fork();
+
+        // Read 3 bytes via the parent's fd.
+        let parent_backend = parent.get(fd).expect("parent fd open");
+        let mut buf = [0u8; 3];
+        parent_backend.read(&mut buf).unwrap();
+
+        // The shared offset must be visible to the child's backend.
+        let child_backend = child.get(fd).expect("child fd open");
+        // Downcast isn't available on dyn FileBackend, so we check the
+        // underlying OpenFile offset directly via our `of` reference.
+        assert_eq!(*of.offset.lock(), 3, "child sees parent's advanced offset");
+        // Child can read 2 more bytes.
+        let mut buf2 = [0u8; 2];
+        child_backend.read(&mut buf2).unwrap();
+        assert_eq!(*of.offset.lock(), 5, "offset advances further via child");
+    }
+
+    #[test]
+    fn close_cloexec_drops_vfs_backend() {
+        let of = make_open_file(0);
+        let backend = Arc::new(VfsBackend {
+            open_file: of.clone(),
+        }) as Arc<dyn FileBackend>;
+        let mut t = FileDescTable::new();
+        let cloexec_desc = Arc::new(FileDescription {
+            backend,
+            flags: flags::O_CLOEXEC,
+        });
+        let fd = t.alloc_fd(cloexec_desc).expect("alloc_fd");
+
+        // Allocate a non-cloexec fd too.
+        struct NullBackend;
+        impl FileBackend for NullBackend {
+            fn read(&self, _: &mut [u8]) -> Result<usize, i64> {
+                Ok(0)
+            }
+            fn write(&self, buf: &[u8]) -> Result<usize, i64> {
+                Ok(buf.len())
+            }
+        }
+        let null_desc = Arc::new(FileDescription {
+            backend: Arc::new(NullBackend) as Arc<dyn FileBackend>,
+            flags: 0,
+        });
+        let null_fd = t.alloc_fd(null_desc).expect("alloc null fd");
+
+        t.close_cloexec();
+
+        assert!(t.get(fd).is_err(), "O_CLOEXEC VfsBackend fd must be closed");
+        assert!(t.get(null_fd).is_ok(), "non-cloexec fd must survive");
+    }
+}

--- a/kernel/src/fs/vfs/backend.rs
+++ b/kernel/src/fs/vfs/backend.rs
@@ -139,7 +139,7 @@ mod tests {
         let dentry = Dentry::new_root(inode.clone());
         let file_ops: Arc<dyn FileOps> = Arc::new(CountingOps { fill_byte });
         let guard = SbActiveGuard::try_acquire(&sb).expect("guard");
-        OpenFile::new(dentry, inode, file_ops, sb, 0, guard)
+        OpenFile::new(dentry, inode, file_ops, sb.clone(), 0, guard)
     }
 
     // -----------------------------------------------------------------------

--- a/kernel/src/fs/vfs/backend.rs
+++ b/kernel/src/fs/vfs/backend.rs
@@ -22,7 +22,7 @@
 
 use alloc::sync::Arc;
 
-use crate::fs::FileBackend;
+use crate::fs::{FileBackend, EOVERFLOW};
 
 use super::open_file::OpenFile;
 
@@ -45,7 +45,7 @@ impl FileBackend for VfsBackend {
     fn read(&self, buf: &mut [u8]) -> Result<usize, i64> {
         let mut off = self.open_file.offset.lock();
         let n = self.open_file.ops.read(&self.open_file, buf, *off)?;
-        *off += n as u64;
+        *off = off.checked_add(n as u64).ok_or(EOVERFLOW)?;
         Ok(n)
     }
 
@@ -57,7 +57,7 @@ impl FileBackend for VfsBackend {
     fn write(&self, buf: &[u8]) -> Result<usize, i64> {
         let mut off = self.open_file.offset.lock();
         let n = self.open_file.ops.write(&self.open_file, buf, *off)?;
-        *off += n as u64;
+        *off = off.checked_add(n as u64).ok_or(EOVERFLOW)?;
         Ok(n)
     }
 }

--- a/kernel/src/fs/vfs/mod.rs
+++ b/kernel/src/fs/vfs/mod.rs
@@ -45,6 +45,7 @@
 
 use alloc::vec::Vec;
 
+pub mod backend;
 pub mod dentry;
 pub mod gc_queue;
 pub mod inode;
@@ -54,6 +55,7 @@ pub mod ops;
 pub mod path_walk;
 pub mod super_block;
 
+pub use backend::VfsBackend;
 pub use dentry::{ChildState, DFlags, Dentry, MountEdge, MountFlags};
 pub use gc_queue::{gc_drain, gc_drain_for, gc_overflow_count, gc_pending_count};
 pub use inode::{Inode, InodeKind, InodeMeta, InodeState};
@@ -202,6 +204,7 @@ const _: () = {
     assert_send_sync::<Dentry>();
     assert_send_sync::<MountEdge>();
     assert_send_sync::<OpenFile>();
+    assert_send_sync::<VfsBackend>();
 };
 
 #[cfg(test)]

--- a/kernel/tests/vfs_backend.rs
+++ b/kernel/tests/vfs_backend.rs
@@ -138,7 +138,7 @@ fn make_open_file(fill_byte: u8) -> Arc<OpenFile> {
         write_count: AtomicUsize::new(0),
     });
     let guard = SbActiveGuard::try_acquire(&sb).expect("guard");
-    OpenFile::new(dentry, inode, file_ops, sb, 0, guard)
+    OpenFile::new(dentry, inode, file_ops, sb.clone(), 0, guard)
 }
 
 // ---------------------------------------------------------------------------

--- a/kernel/tests/vfs_backend.rs
+++ b/kernel/tests/vfs_backend.rs
@@ -1,0 +1,258 @@
+//! Integration test for issue #237: VfsBackend wires Arc<OpenFile> into
+//! the per-process FileDescTable.
+//!
+//! Exercises the full chain:
+//!   FileDescTable → Arc<FileDescription> → VfsBackend → Arc<OpenFile> → FileOps
+//!
+//! Specifically:
+//! - read/write through a VfsBackend-backed fd advance the shared offset.
+//! - clone_for_fork shares the same Arc<OpenFile> (POSIX open-file description
+//!   semantics: parent and child see the same offset).
+//! - close_cloexec drops VfsBackend fds flagged O_CLOEXEC, leaves others.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use vibix::fs::vfs::dentry::Dentry;
+use vibix::fs::vfs::inode::{Inode, InodeKind, InodeMeta};
+use vibix::fs::vfs::open_file::OpenFile;
+use vibix::fs::vfs::ops::{FileOps, InodeOps, SetAttr, Stat, StatFs, SuperOps};
+use vibix::fs::vfs::super_block::{SbActiveGuard, SbFlags, SuperBlock};
+use vibix::fs::vfs::{FsId, VfsBackend};
+use vibix::fs::{flags, FileBackend, FileDescTable, FileDescription};
+use vibix::{
+    exit_qemu, serial_println, task,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("read_advances_offset", &(read_advances_offset as fn())),
+        ("write_advances_offset", &(write_advances_offset as fn())),
+        (
+            "fork_shares_open_file_description",
+            &(fork_shares_open_file_description as fn()),
+        ),
+        (
+            "close_cloexec_drops_vfs_backend",
+            &(close_cloexec_drops_vfs_backend as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Stubs
+// ---------------------------------------------------------------------------
+
+struct StubInodeOps;
+impl InodeOps for StubInodeOps {
+    fn getattr(&self, _inode: &Inode, _out: &mut Stat) -> Result<(), i64> {
+        Ok(())
+    }
+    fn setattr(&self, _inode: &Inode, _attr: &SetAttr) -> Result<(), i64> {
+        Ok(())
+    }
+}
+
+struct StubSuperOps;
+impl SuperOps for StubSuperOps {
+    fn root_inode(&self) -> Arc<Inode> {
+        unreachable!("test stub")
+    }
+    fn statfs(&self) -> Result<StatFs, i64> {
+        Ok(StatFs::default())
+    }
+    fn unmount(&self) -> Result<(), i64> {
+        Ok(())
+    }
+}
+
+/// `FileOps` stub that fills read buffers with `fill_byte` and counts writes.
+struct CountingOps {
+    fill_byte: u8,
+    write_count: AtomicUsize,
+}
+
+impl FileOps for CountingOps {
+    fn read(&self, _f: &OpenFile, buf: &mut [u8], _off: u64) -> Result<usize, i64> {
+        for b in buf.iter_mut() {
+            *b = self.fill_byte;
+        }
+        Ok(buf.len())
+    }
+
+    fn write(&self, _f: &OpenFile, buf: &[u8], _off: u64) -> Result<usize, i64> {
+        self.write_count.fetch_add(buf.len(), Ordering::Relaxed);
+        Ok(buf.len())
+    }
+}
+
+fn make_open_file(fill_byte: u8) -> Arc<OpenFile> {
+    let sb = Arc::new(SuperBlock::new(
+        FsId(99),
+        Arc::new(StubSuperOps),
+        "stub",
+        512,
+        SbFlags::default(),
+    ));
+    let inode = Arc::new(Inode::new(
+        1,
+        Arc::downgrade(&sb),
+        Arc::new(StubInodeOps),
+        Arc::new(CountingOps {
+            fill_byte,
+            write_count: AtomicUsize::new(0),
+        }),
+        InodeKind::Reg,
+        InodeMeta::default(),
+    ));
+    let dentry = Dentry::new_root(inode.clone());
+    let file_ops: Arc<dyn FileOps> = Arc::new(CountingOps {
+        fill_byte,
+        write_count: AtomicUsize::new(0),
+    });
+    let guard = SbActiveGuard::try_acquire(&sb).expect("guard");
+    OpenFile::new(dentry, inode, file_ops, sb, 0, guard)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Reading through a VfsBackend-backed fd advances the shared file offset.
+fn read_advances_offset() {
+    let of = make_open_file(0xAB);
+    let backend = Arc::new(VfsBackend {
+        open_file: of.clone(),
+    }) as Arc<dyn FileBackend>;
+    let mut t = FileDescTable::new();
+    let desc = Arc::new(FileDescription { backend, flags: 0 });
+    let fd = t.alloc_fd(desc).expect("alloc_fd");
+
+    let b = t.get(fd).expect("fd open");
+    let mut buf = [0u8; 8];
+    let n = b.read(&mut buf).expect("read");
+    assert_eq!(n, 8, "read must return buf.len()");
+    assert_eq!(buf, [0xABu8; 8], "buf must be filled with fill_byte");
+    assert_eq!(*of.offset.lock(), 8, "offset must advance by bytes read");
+}
+
+/// Writing through a VfsBackend-backed fd advances the shared file offset.
+fn write_advances_offset() {
+    let of = make_open_file(0);
+    let backend = Arc::new(VfsBackend {
+        open_file: of.clone(),
+    }) as Arc<dyn FileBackend>;
+    let mut t = FileDescTable::new();
+    let desc = Arc::new(FileDescription { backend, flags: 0 });
+    let fd = t.alloc_fd(desc).expect("alloc_fd");
+
+    let b = t.get(fd).expect("fd open");
+    let data = b"hello world";
+    let n = b.write(data).expect("write");
+    assert_eq!(n, data.len(), "write must return buf.len()");
+    assert_eq!(
+        *of.offset.lock(),
+        data.len() as u64,
+        "offset advances by bytes written"
+    );
+}
+
+/// `clone_for_fork` shares the Arc<OpenFile> (shared file description).
+///
+/// Both parent and child see the same underlying offset — writes via the
+/// parent advance the offset visible through the child's fd.
+fn fork_shares_open_file_description() {
+    let of = make_open_file(0xCD);
+    let backend = Arc::new(VfsBackend {
+        open_file: of.clone(),
+    }) as Arc<dyn FileBackend>;
+    let mut parent = FileDescTable::new();
+    let desc = Arc::new(FileDescription { backend, flags: 0 });
+    let fd = parent.alloc_fd(desc).expect("alloc_fd");
+
+    // Fork the fd table.
+    let child = parent.clone_for_fork();
+
+    // Read 3 bytes via parent.
+    let parent_b = parent.get(fd).expect("parent fd");
+    let mut buf = [0u8; 3];
+    parent_b.read(&mut buf).unwrap();
+    assert_eq!(*of.offset.lock(), 3, "parent read must advance offset");
+
+    // Child's fd backend wraps the *same* OpenFile, so its offset is 3.
+    let child_b = child.get(fd).expect("child fd");
+    let mut buf2 = [0u8; 2];
+    child_b.read(&mut buf2).unwrap();
+    assert_eq!(
+        *of.offset.lock(),
+        5,
+        "child read advances the shared offset"
+    );
+
+    // Closing a slot in the child does not affect the parent.
+    drop(child);
+    assert!(parent.get(fd).is_ok(), "parent fd must survive child drop");
+}
+
+/// `close_cloexec` drops VfsBackend fds marked O_CLOEXEC; leaves others.
+fn close_cloexec_drops_vfs_backend() {
+    struct NullBackend;
+    impl FileBackend for NullBackend {
+        fn read(&self, _: &mut [u8]) -> Result<usize, i64> {
+            Ok(0)
+        }
+        fn write(&self, buf: &[u8]) -> Result<usize, i64> {
+            Ok(buf.len())
+        }
+    }
+
+    let of = make_open_file(0);
+    let cloexec_backend = Arc::new(VfsBackend { open_file: of }) as Arc<dyn FileBackend>;
+    let mut t = FileDescTable::new();
+    let cloexec_desc = Arc::new(FileDescription {
+        backend: cloexec_backend,
+        flags: flags::O_CLOEXEC,
+    });
+    let cloexec_fd = t.alloc_fd(cloexec_desc).expect("alloc cloexec fd");
+
+    // A non-cloexec VfsBackend fd must survive exec.
+    let of2 = make_open_file(0);
+    let keep_backend = Arc::new(VfsBackend { open_file: of2 }) as Arc<dyn FileBackend>;
+    let keep_desc = Arc::new(FileDescription {
+        backend: keep_backend,
+        flags: 0,
+    });
+    let keep_fd = t.alloc_fd(keep_desc).expect("alloc keep fd");
+
+    t.close_cloexec();
+
+    assert!(t.get(cloexec_fd).is_err(), "O_CLOEXEC fd must be closed");
+    assert!(t.get(keep_fd).is_ok(), "non-cloexec fd must survive");
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -677,6 +677,7 @@ fn test_all() -> R<()> {
         "fd_table",
         "syscall_open_mmap",
         "vm_integration",
+        "vfs_backend",
     ] {
         cmd.arg("--test").arg(t);
     }


### PR DESCRIPTION
Closes #237

## Summary
- Adds `VfsBackend` — an `Arc<OpenFile>`-wrapping `FileBackend` adapter in `kernel/src/fs/vfs/backend.rs` that bridges the VFS layer to the per-process fd table without modifying `FileDescTable` or `SerialBackend`.
- `read`/`write` delegate to `FileOps` on the `OpenFile`, advancing the shared offset under `BlockingMutex` so concurrent threads serialise correctly (POSIX open-file description semantics).
- `clone_for_fork` and `close_cloexec` work by inheritance — no changes needed; `clone_for_fork` shallow-clones `Arc<FileDescription>` which shallow-clones `Arc<VfsBackend>` which shallow-clones `Arc<OpenFile>`, giving parent and child the same shared offset as POSIX requires.
- Adds `VfsBackend` to the `Send + Sync` compile-time assertion in `vfs/mod.rs`.

## Test plan
- [x] `cargo xtask build` — compiles cleanly (warning about `is_guard_hit` is pre-existing)
- [x] `cargo fmt --all -- --check` — passes
- [x] `cargo clippy -p xtask --all-targets -- -D warnings` — passes
- [x] New QEMU integration test `kernel/tests/vfs_backend.rs` covers: read/write offset advancement, `clone_for_fork` shared-description semantics, `close_cloexec` drops VfsBackend fds and leaves others
- [x] Inline `#[cfg(test)]` unit tests in `backend.rs` cover the same four cases for host-test environments (x86_64 CI)