### PR TITLE
signal: POSIX signal delivery (sigaction, sigprocmask, kill, sigreturn)

### DIFF
--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -94,6 +94,12 @@ pub static FORK_USER_RFLAGS: AtomicU64 = AtomicU64::new(0);
 #[no_mangle]
 pub static FORK_USER_RSP: AtomicU64 = AtomicU64::new(0);
 
+/// Set to 1 by `sys_sigreturn` to tell `check_and_deliver_signals` to
+/// overwrite the saved user context with the restored register values
+/// rather than pushing a new signal frame.  Cleared after consumption.
+#[no_mangle]
+pub static SIGRETURN_PENDING: AtomicU64 = AtomicU64::new(0);
+
 /// Enable SYSCALL/SYSRET and point LSTAR at the entry trampoline.
 /// Must be called after GDT is live.
 pub fn init() {
@@ -413,6 +419,31 @@ pub unsafe extern "C" fn syscall_dispatch(
                     .wait_while(|| crate::process::exit_event_count() == snap);
             }
         }
+
+        // sigaction(sig, act, oldact) — register or query signal handler.
+        13 => crate::signal::sys_sigaction(a0, a1, a2),
+
+        // sigprocmask(how, set, oldset) — update signal mask.
+        14 => crate::signal::sys_sigprocmask(a0, a1, a2),
+
+        // sigreturn() — restore context from signal frame.
+        // The user RSP at syscall entry (saved by the trampoline in
+        // FORK_USER_RSP) points at the SigFrame on the user stack.
+        // We restore the saved [rip, rflags, rsp] and stash them in
+        // FORK_USER_* so check_and_deliver_signals can apply them to
+        // the kernel-stack-saved context before SYSRETQ.
+        15 => {
+            let user_rsp = FORK_USER_RSP.load(Ordering::Relaxed);
+            let restored = crate::signal::sys_sigreturn(user_rsp);
+            FORK_USER_RIP.store(restored.rip, Ordering::Relaxed);
+            FORK_USER_RFLAGS.store(restored.rflags, Ordering::Relaxed);
+            FORK_USER_RSP.store(restored.rsp, Ordering::Relaxed);
+            SIGRETURN_PENDING.store(1, Ordering::Relaxed);
+            0i64
+        }
+
+        // kill(pid, sig) — send signal to process.
+        62 => crate::signal::sys_kill(a0, a1),
 
         _ => -38i64, // ENOSYS
     }
@@ -848,6 +879,16 @@ syscall_entry:
     call syscall_dispatch
     add rsp, 8
     // rax = return value
+
+    // 5b. Check for pending signals before returning to user.
+    //     Pass a pointer to the saved [user_rip, user_rflags, user_rsp]
+    //     on the kernel stack so check_and_deliver_signals can redirect
+    //     the return to a signal handler if needed.
+    //     Save rax across the call (it holds the syscall return value).
+    push rax
+    lea rdi, [rsp + 8]   // pointer to saved [rip, rflags, rsp]
+    call check_and_deliver_signals
+    pop rax
 
     // 6. Restore return-to-user context.
     pop rcx           // user RIP  → rcx  (for SYSRETQ)

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -46,9 +46,9 @@ pub mod process;
 #[cfg(target_os = "none")]
 pub mod serial;
 #[cfg(target_os = "none")]
-pub mod signal;
-#[cfg(target_os = "none")]
 pub mod shell;
+#[cfg(target_os = "none")]
+pub mod signal;
 #[cfg(target_os = "none")]
 pub mod sync;
 #[cfg(target_os = "none")]

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -46,6 +46,8 @@ pub mod process;
 #[cfg(target_os = "none")]
 pub mod serial;
 #[cfg(target_os = "none")]
+pub mod signal;
+#[cfg(target_os = "none")]
 pub mod shell;
 #[cfg(target_os = "none")]
 pub mod sync;

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -211,8 +211,10 @@ pub fn update_task_id(pid: u32, new_task_id: usize) {
 /// `f` with a mutable reference to it.  Returns `None` if no process entry
 /// exists for the task.
 ///
-/// TABLE is held for the duration of `f`.  `f` must not call any function
-/// that tries to take TABLE again (lock-ordering).
+/// TABLE is released before `f` is called (the `Arc<Mutex<SignalState>>` is
+/// cloned out while TABLE is held, then locked independently).  `f` must not
+/// call any function that tries to take the signal `Mutex` a second time on
+/// the same task (re-entrancy).
 pub fn with_signal_state_for_task<R>(
     task_id: usize,
     f: impl FnOnce(&mut SignalState) -> R,

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -11,10 +11,12 @@
 //! before the notify call.
 
 use alloc::collections::BTreeMap;
+use alloc::sync::Arc;
 use core::sync::atomic::{AtomicU32, AtomicU32 as ExitEvent, Ordering};
 
 use spin::{Lazy, Mutex};
 
+use crate::signal::SignalState;
 use crate::sync::WaitQueue;
 
 /// Scheduling / lifecycle state of a process entry.
@@ -37,6 +39,8 @@ pub struct ProcessEntry {
     pub exit_status: Option<i32>,
     /// Whether the process is still alive or waiting to be reaped.
     pub state: ProcessState,
+    /// Per-process signal state — pending mask, blocked mask, dispositions.
+    pub signals: Arc<Mutex<SignalState>>,
 }
 
 struct Table {
@@ -81,6 +85,7 @@ pub fn register_init(task_id: usize) {
             parent_pid: 0,
             exit_status: None,
             state: ProcessState::Alive,
+            signals: Arc::new(Mutex::new(SignalState::new())),
         },
     );
     t.pid_of.insert(task_id, 1);
@@ -99,6 +104,7 @@ pub fn register(task_id: usize, parent_pid: u32) -> u32 {
             parent_pid,
             exit_status: None,
             state: ProcessState::Alive,
+            signals: Arc::new(Mutex::new(SignalState::new())),
         },
     );
     t.pid_of.insert(task_id, pid);
@@ -197,4 +203,32 @@ pub fn update_task_id(pid: u32, new_task_id: usize) {
         entry.task_id = new_task_id;
     }
     t.pid_of.insert(new_task_id, pid);
+}
+
+// ── Signal helpers ────────────────────────────────────────────────────────
+
+/// Look up the `SignalState` for the process that owns `task_id` and call
+/// `f` with a mutable reference to it.  Returns `None` if no process entry
+/// exists for the task.
+///
+/// TABLE is held for the duration of `f`.  `f` must not call any function
+/// that tries to take TABLE again (lock-ordering).
+pub fn with_signal_state_for_task<R>(
+    task_id: usize,
+    f: impl FnOnce(&mut SignalState) -> R,
+) -> Option<R> {
+    let signals = {
+        let t = TABLE.lock();
+        let pid = *t.pid_of.get(&task_id)?;
+        let entry = t.by_pid.get(&pid)?;
+        Arc::clone(&entry.signals)
+    }; // TABLE released here
+    let x = Some(f(&mut signals.lock()));
+    x
+}
+
+/// Return the scheduler task ID for `pid`, or `None` if not found.
+pub fn task_id_for_pid(pid: u32) -> Option<usize> {
+    let t = TABLE.lock();
+    t.by_pid.get(&pid).map(|e| e.task_id)
 }

--- a/kernel/src/signal/frame.rs
+++ b/kernel/src/signal/frame.rs
@@ -1,0 +1,255 @@
+//! Signal frame layout and push/restore helpers.
+//!
+//! The `SigFrame` layout matches the Linux x86_64 `rt_sigframe` so that a
+//! userspace `sigreturn(2)` trampoline compiled against musl or glibc works
+//! without modification.
+//!
+//! ## Layout
+//!
+//! ```text
+//! SigFrame (#[repr(C, align(16))]):
+//!   pretcode:  u64          — points at the sigreturn syscall stub
+//!   sig:       u32          — signal number
+//!   _pad:      u32
+//!   info:      [u8; 128]    — struct siginfo (si_signo + padding)
+//!   uc_flags:  u64
+//!   uc_link:   u64
+//!   uc_stack:  [u64; 3]     — ss_sp, ss_flags, ss_size
+//!   gregs:     [u64; 23]    — mcontext_t gregs (see GREGS_* constants)
+//!   uc_sigmask: u64         — saved signal mask
+//!   _reserved: [u8; 8]     — alignment / future use
+//!   fpstate:   u64          — NULL (FPU state not saved; known limitation)
+//! ```
+//!
+//! Total size: 8+4+4+128+8+8+24+184+8+8+8 = 392 bytes.
+//! The struct is 16-byte aligned; user RSP is aligned down before subtracting
+//! `size_of::<SigFrame>()`.
+//!
+//! ## mcontext_t `gregs` field order
+//!
+//! Linux x86_64 `<sys/ucontext.h>` defines `greg_t gregs[NGREG]` where
+//! `NGREG=23`.  The field order (0-indexed) is:
+//!
+//! ```
+//!  0:R8  1:R9   2:R10  3:R11  4:R12  5:R13  6:R14  7:R15
+//!  8:RDI 9:RSI 10:RBP 11:RBX 12:RDX 13:RAX 14:RCX 15:RSP
+//! 16:RIP 17:EFLAGS 18:CS 19:GS 20:FS 21:ERR 22:TRAPNO
+//! ```
+//!
+//! We save RIP, RFLAGS, and RSP (indices 16, 17, 15) which are sufficient for
+//! `sigreturn` to resume the interrupted code.  The others are zero-filled.
+
+use core::mem;
+
+/// Index of key registers in `SigFrame::gregs`.
+const REG_RSP: usize = 15;
+const REG_RIP: usize = 16;
+const REG_EFLAGS: usize = 17;
+
+/// Inline sigreturn trampoline: `mov rax, 15; syscall`.  This is written into
+/// `pretcode` and executed by the signal handler epilogue (if the handler
+/// returns normally rather than calling `sigreturn` directly).
+///
+/// Bytes: `48 C7 C0 0F 00 00 00 0F 05`
+const SIGRETURN_TRAMPOLINE: [u8; 9] = [
+    0x48, 0xC7, 0xC0, 0x0F, 0x00, 0x00, 0x00, // mov rax, 15
+    0x0F, 0x05,                                // syscall
+];
+
+/// The signal frame pushed on the user stack before entering the handler.
+///
+/// Must be #[repr(C)] so field offsets are stable and match the Linux ABI.
+/// 16-byte alignment matches the x86_64 ABI requirement for the stack just
+/// before a CALL instruction.
+#[repr(C, align(16))]
+pub struct SigFrame {
+    /// Return address: points at the inline `sigreturn` trampoline stored
+    /// in `trampoline_code`.  Placed here so the handler can `ret` into it.
+    pub pretcode: u64,
+    /// Signal number (1-indexed).
+    pub sig: u32,
+    pub _pad: u32,
+    /// Minimal `struct siginfo` — only `si_signo` is filled.
+    pub info: [u8; 128],
+    // --- ucontext_t fields ---
+    pub uc_flags: u64,
+    pub uc_link: u64,
+    /// `stack_t uc_stack`: ss_sp, ss_flags, ss_size.
+    pub uc_stack: [u64; 3],
+    /// `mcontext_t` gregs — 23 × 8 bytes.
+    pub gregs: [u64; 23],
+    /// Saved signal mask (restored by sigreturn).
+    pub uc_sigmask: u64,
+    pub _reserved: [u8; 8],
+    /// Pointer to saved FPU state.  Always NULL in this implementation.
+    pub fpstate: u64,
+    /// Inline sigreturn trampoline code.
+    pub trampoline_code: [u8; 9],
+    pub _trampoline_pad: [u8; 7],
+}
+
+/// Compile-time size assertion: the frame must be a multiple of 16 bytes.
+const _: () = assert!(mem::size_of::<SigFrame>() % 16 == 0);
+
+/// Recovered register state from a `SigFrame`.
+pub struct RestoredRegs {
+    pub rip: u64,
+    pub rflags: u64,
+    pub rsp: u64,
+    pub saved_mask: u64,
+}
+
+/// Push a `SigFrame` onto the user stack at `user_rsp` and return the new
+/// (lower) user RSP.
+///
+/// The frame is aligned to 16 bytes after subtraction (x86-64 ABI: RSP must
+/// be `0 mod 16` before the `CALL` that enters the handler; our trampoline's
+/// implicit `call` from `ret` in the handler makes this `8 mod 16` at handler
+/// entry — correct).
+///
+/// Returns `Ok(new_rsp)` or `Err(())` if the frame could not be written (bad
+/// user pointer).
+///
+/// # Safety
+/// Writes to user VA via `uaccess::copy_to_user`.
+pub unsafe fn push_signal_frame(
+    user_rsp: u64,
+    sig: u8,
+    saved_rip: u64,
+    saved_rflags: u64,
+) -> Result<u64, ()> {
+    use crate::arch::x86_64::uaccess;
+
+    // Align the frame bottom to 16 bytes.
+    let frame_size = mem::size_of::<SigFrame>() as u64;
+    let frame_top = user_rsp.checked_sub(frame_size).ok_or(())?;
+    let frame_addr = frame_top & !15u64; // align down
+
+    // Validate the user address range before writing.
+    if uaccess::check_user_range(frame_addr as usize, frame_size as usize).is_err() {
+        return Err(());
+    }
+
+    // Get current signal mask from the process.
+    let task_id = crate::task::current_id();
+    let saved_mask = crate::process::with_signal_state_for_task(task_id, |state| state.blocked)
+        .unwrap_or(0);
+
+    // Build the frame in kernel memory, then copy it to user space.
+    let mut frame = SigFrame {
+        pretcode: frame_addr + mem::offset_of!(SigFrame, trampoline_code) as u64,
+        sig: sig as u32,
+        _pad: 0,
+        info: [0u8; 128],
+        uc_flags: 0,
+        uc_link: 0,
+        uc_stack: [0u64; 3],
+        gregs: [0u64; 23],
+        uc_sigmask: saved_mask,
+        _reserved: [0u8; 8],
+        fpstate: 0,
+        trampoline_code: SIGRETURN_TRAMPOLINE,
+        _trampoline_pad: [0u8; 7],
+    };
+
+    // Fill in siginfo.si_signo.
+    frame.info[..4].copy_from_slice(&(sig as u32).to_ne_bytes());
+
+    // Save the interrupted register state into mcontext gregs.
+    frame.gregs[REG_RIP] = saved_rip;
+    frame.gregs[REG_EFLAGS] = saved_rflags;
+    frame.gregs[REG_RSP] = user_rsp;
+
+    // Copy frame to user stack.
+    let frame_bytes = core::slice::from_raw_parts(
+        &frame as *const SigFrame as *const u8,
+        frame_size as usize,
+    );
+    uaccess::copy_to_user(frame_addr as usize, frame_bytes).map_err(|_| ())?;
+
+    // The new user RSP points at `pretcode` (the bottom of the frame).
+    Ok(frame_addr)
+}
+
+/// Restore register context from a `SigFrame` at `frame_addr` on the user
+/// stack.
+///
+/// Returns the saved `[rip, rflags, rsp, saved_mask]` or `Err(())` if the
+/// frame cannot be read.
+///
+/// # Safety
+/// Reads from user VA via `uaccess::copy_from_user`.
+pub unsafe fn restore_signal_frame(frame_addr: u64) -> Result<RestoredRegs, ()> {
+    use crate::arch::x86_64::uaccess;
+
+    let frame_size = mem::size_of::<SigFrame>();
+    if uaccess::check_user_range(frame_addr as usize, frame_size).is_err() {
+        return Err(());
+    }
+
+    // Read frame from user space into a kernel buffer.
+    let mut frame = core::mem::MaybeUninit::<SigFrame>::uninit();
+    let frame_bytes = core::slice::from_raw_parts_mut(
+        frame.as_mut_ptr() as *mut u8,
+        frame_size,
+    );
+    uaccess::copy_from_user(frame_bytes, frame_addr as usize).map_err(|_| ())?;
+    let frame = frame.assume_init();
+
+    Ok(RestoredRegs {
+        rip: frame.gregs[REG_RIP],
+        rflags: frame.gregs[REG_EFLAGS],
+        rsp: frame.gregs[REG_RSP],
+        saved_mask: frame.uc_sigmask,
+    })
+}
+
+// ── Host-side unit tests ──────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sigframe_size_is_multiple_of_16() {
+        assert_eq!(mem::size_of::<SigFrame>() % 16, 0);
+    }
+
+    #[test]
+    fn sigframe_pretcode_offset_is_zero() {
+        // pretcode is the first field — handler `ret` jumps here.
+        assert_eq!(mem::offset_of!(SigFrame, pretcode), 0);
+    }
+
+    #[test]
+    fn trampoline_contains_sigreturn_syscall() {
+        let f = SigFrame {
+            pretcode: 0,
+            sig: 0,
+            _pad: 0,
+            info: [0u8; 128],
+            uc_flags: 0,
+            uc_link: 0,
+            uc_stack: [0u64; 3],
+            gregs: [0u64; 23],
+            uc_sigmask: 0,
+            _reserved: [0u8; 8],
+            fpstate: 0,
+            trampoline_code: SIGRETURN_TRAMPOLINE,
+            _trampoline_pad: [0u8; 7],
+        };
+        // First two bytes of the trampoline: REX.W prefix (0x48) + opcode for MOV RAX
+        assert_eq!(f.trampoline_code[0], 0x48);
+        assert_eq!(f.trampoline_code[1], 0xC7);
+        // Last two bytes: syscall (0x0F 0x05)
+        assert_eq!(f.trampoline_code[7], 0x0F);
+        assert_eq!(f.trampoline_code[8], 0x05);
+    }
+
+    #[test]
+    fn gregs_indices_are_in_range() {
+        assert!(REG_RSP < 23);
+        assert!(REG_RIP < 23);
+        assert!(REG_EFLAGS < 23);
+    }
+}

--- a/kernel/src/signal/frame.rs
+++ b/kernel/src/signal/frame.rs
@@ -53,7 +53,7 @@ const REG_EFLAGS: usize = 17;
 /// Bytes: `48 C7 C0 0F 00 00 00 0F 05`
 const SIGRETURN_TRAMPOLINE: [u8; 9] = [
     0x48, 0xC7, 0xC0, 0x0F, 0x00, 0x00, 0x00, // mov rax, 15
-    0x0F, 0x05,                                // syscall
+    0x0F, 0x05, // syscall
 ];
 
 /// The signal frame pushed on the user stack before entering the handler.
@@ -132,8 +132,8 @@ pub unsafe fn push_signal_frame(
 
     // Get current signal mask from the process.
     let task_id = crate::task::current_id();
-    let saved_mask = crate::process::with_signal_state_for_task(task_id, |state| state.blocked)
-        .unwrap_or(0);
+    let saved_mask =
+        crate::process::with_signal_state_for_task(task_id, |state| state.blocked).unwrap_or(0);
 
     // Build the frame in kernel memory, then copy it to user space.
     let mut frame = SigFrame {
@@ -161,10 +161,8 @@ pub unsafe fn push_signal_frame(
     frame.gregs[REG_RSP] = user_rsp;
 
     // Copy frame to user stack.
-    let frame_bytes = core::slice::from_raw_parts(
-        &frame as *const SigFrame as *const u8,
-        frame_size as usize,
-    );
+    let frame_bytes =
+        core::slice::from_raw_parts(&frame as *const SigFrame as *const u8, frame_size as usize);
     uaccess::copy_to_user(frame_addr as usize, frame_bytes).map_err(|_| ())?;
 
     // The new user RSP points at `pretcode` (the bottom of the frame).
@@ -189,10 +187,7 @@ pub unsafe fn restore_signal_frame(frame_addr: u64) -> Result<RestoredRegs, ()> 
 
     // Read frame from user space into a kernel buffer.
     let mut frame = core::mem::MaybeUninit::<SigFrame>::uninit();
-    let frame_bytes = core::slice::from_raw_parts_mut(
-        frame.as_mut_ptr() as *mut u8,
-        frame_size,
-    );
+    let frame_bytes = core::slice::from_raw_parts_mut(frame.as_mut_ptr() as *mut u8, frame_size);
     uaccess::copy_from_user(frame_bytes, frame_addr as usize).map_err(|_| ())?;
     let frame = frame.assume_init();
 

--- a/kernel/src/signal/frame.rs
+++ b/kernel/src/signal/frame.rs
@@ -102,10 +102,10 @@ pub struct RestoredRegs {
 /// Push a `SigFrame` onto the user stack at `user_rsp` and return the new
 /// (lower) user RSP.
 ///
-/// The frame is aligned to 16 bytes after subtraction (x86-64 ABI: RSP must
-/// be `0 mod 16` before the `CALL` that enters the handler; our trampoline's
-/// implicit `call` from `ret` in the handler makes this `8 mod 16` at handler
-/// entry — correct).
+/// The frame is aligned so that RSP is `8 mod 16` at handler entry (x86-64
+/// ABI: RSP must be `8 mod 16` at `CALL`/function entry; the handler
+/// receives control via the `pretcode` return-address slot, so no extra
+/// adjustment is needed).
 ///
 /// Returns `Ok(new_rsp)` or `Err(())` if the frame could not be written (bad
 /// user pointer).
@@ -117,23 +117,20 @@ pub unsafe fn push_signal_frame(
     sig: u8,
     saved_rip: u64,
     saved_rflags: u64,
+    saved_mask: u64,
 ) -> Result<u64, ()> {
     use crate::arch::x86_64::uaccess;
 
-    // Align the frame bottom to 16 bytes.
+    // Align the frame bottom to 16 bytes, then subtract 8 so that RSP is
+    // `8 mod 16` at handler entry (x86-64 ABI requirement at CALL).
     let frame_size = mem::size_of::<SigFrame>() as u64;
     let frame_top = user_rsp.checked_sub(frame_size).ok_or(())?;
-    let frame_addr = frame_top & !15u64; // align down
+    let frame_addr = (frame_top & !15u64).wrapping_sub(8);
 
     // Validate the user address range before writing.
     if uaccess::check_user_range(frame_addr as usize, frame_size as usize).is_err() {
         return Err(());
     }
-
-    // Get current signal mask from the process.
-    let task_id = crate::task::current_id();
-    let saved_mask =
-        crate::process::with_signal_state_for_task(task_id, |state| state.blocked).unwrap_or(0);
 
     // Build the frame in kernel memory, then copy it to user space.
     let mut frame = SigFrame {
@@ -191,10 +188,22 @@ pub unsafe fn restore_signal_frame(frame_addr: u64) -> Result<RestoredRegs, ()> 
     uaccess::copy_from_user(frame_bytes, frame_addr as usize).map_err(|_| ())?;
     let frame = frame.assume_init();
 
+    let rip = frame.gregs[REG_RIP];
+    let rsp = frame.gregs[REG_RSP];
+
+    // Reject kernel-space RIP or RSP — a compromised frame must not redirect
+    // execution into the kernel.
+    if uaccess::check_user_range(rip as usize, 1).is_err() {
+        return Err(());
+    }
+    if uaccess::check_user_range(rsp as usize, 1).is_err() {
+        return Err(());
+    }
+
     Ok(RestoredRegs {
-        rip: frame.gregs[REG_RIP],
+        rip,
         rflags: frame.gregs[REG_EFLAGS],
-        rsp: frame.gregs[REG_RSP],
+        rsp,
         saved_mask: frame.uc_sigmask,
     })
 }

--- a/kernel/src/signal/mod.rs
+++ b/kernel/src/signal/mod.rs
@@ -398,19 +398,18 @@ pub unsafe extern "C" fn check_and_deliver_signals(ctx: *mut SyscallReturnContex
     if crate::arch::x86_64::syscall::SIGRETURN_PENDING.load(Ordering::Relaxed) != 0 {
         crate::arch::x86_64::syscall::SIGRETURN_PENDING.store(0, Ordering::Relaxed);
         (*ctx).user_rip = crate::arch::x86_64::syscall::FORK_USER_RIP.load(Ordering::Relaxed);
-        (*ctx).user_rflags =
-            crate::arch::x86_64::syscall::FORK_USER_RFLAGS.load(Ordering::Relaxed);
+        (*ctx).user_rflags = crate::arch::x86_64::syscall::FORK_USER_RFLAGS.load(Ordering::Relaxed);
         (*ctx).user_rsp = crate::arch::x86_64::syscall::FORK_USER_RSP.load(Ordering::Relaxed);
         // After sigreturn still check for any newly-pending signal.
     }
 
     let task_id = crate::task::current_id();
-    let sig = match crate::process::with_signal_state_for_task(task_id, |state| {
-        state.pop_next_pending()
-    }) {
-        Some(Some(sig)) => sig,
-        _ => return, // no pending signal or no process entry
-    };
+    let sig =
+        match crate::process::with_signal_state_for_task(task_id, |state| state.pop_next_pending())
+        {
+            Some(Some(sig)) => sig,
+            _ => return, // no pending signal or no process entry
+        };
     deliver_signal(sig, &mut *ctx);
 }
 
@@ -461,23 +460,19 @@ unsafe fn deliver_signal(sig: u8, ctx: &mut SyscallReturnContext) {
         }
         Disposition::Handler(handler_va) => {
             // Push signal frame onto the user stack and redirect SYSRETQ.
-            let new_user_rsp = match frame::push_signal_frame(
-                ctx.user_rsp,
-                sig,
-                ctx.user_rip,
-                ctx.user_rflags,
-            ) {
-                Ok(sp) => sp,
-                Err(_) => {
-                    // Could not push the frame (bad user RSP) — terminate.
-                    let pid = crate::process::current_pid();
-                    if pid != 0 {
-                        crate::process::reparent_children(pid);
-                        crate::process::mark_zombie(pid, -(sig as i32));
+            let new_user_rsp =
+                match frame::push_signal_frame(ctx.user_rsp, sig, ctx.user_rip, ctx.user_rflags) {
+                    Ok(sp) => sp,
+                    Err(_) => {
+                        // Could not push the frame (bad user RSP) — terminate.
+                        let pid = crate::process::current_pid();
+                        if pid != 0 {
+                            crate::process::reparent_children(pid);
+                            crate::process::mark_zombie(pid, -(sig as i32));
+                        }
+                        crate::task::exit();
                     }
-                    crate::task::exit();
-                }
-            };
+                };
             ctx.user_rip = handler_va;
             ctx.user_rsp = new_user_rsp;
             // Leave ctx.user_rflags as-is (handler sees caller's rflags).
@@ -546,8 +541,8 @@ mod tests {
         assert_eq!(sig_bit(1), 1u64);
         assert_eq!(sig_bit(2), 2u64);
         assert_eq!(sig_bit(64), 1u64 << 63);
-        assert_eq!(sig_bit(0), 0u64);   // invalid
-        assert_eq!(sig_bit(65), 0u64);  // out of range
+        assert_eq!(sig_bit(0), 0u64); // invalid
+        assert_eq!(sig_bit(65), 0u64); // out of range
     }
 
     #[test]
@@ -578,7 +573,7 @@ mod tests {
         let mut s = SignalState::new();
         s.raise(SIGKILL);
         s.blocked = !0u64; // try to block everything
-        // SIGKILL must still be deliverable.
+                           // SIGKILL must still be deliverable.
         assert_eq!(s.pop_next_pending(), Some(SIGKILL));
     }
 

--- a/kernel/src/signal/mod.rs
+++ b/kernel/src/signal/mod.rs
@@ -1,0 +1,651 @@
+//! POSIX signal state and delivery logic.
+//!
+//! ## Signal model
+//!
+//! Each process carries a [`SignalState`] (wrapped in `Arc<Mutex<_>>`) that
+//! holds:
+//!
+//! - `pending` — bitmask of signals that have been raised but not yet
+//!   delivered.  Bit `n` = signal `n+1` (signals are 1-indexed; bits are
+//!   0-indexed for compactness).
+//! - `blocked` — the process signal mask (`sigprocmask`).  Pending bits that
+//!   are also set in `blocked` are deferred until unblocked or the signal is
+//!   a default-action terminal signal.
+//! - `dispositions` — per-signal action: `SIG_DFL`, `SIG_IGN`, or a user
+//!   handler address.
+//!
+//! ## Delivery point
+//!
+//! Signals are delivered at every kernel→userspace boundary:
+//!
+//! 1. **Syscall return** — `check_and_deliver_signals` is called from the
+//!    `syscall_entry` asm trampoline just before `SYSRETQ`, passing a mutable
+//!    pointer to the saved `[user_rip, user_rflags, user_rsp]` context on the
+//!    kernel stack.  If a signal is pending, the handler pushes a `SigFrame`
+//!    onto the user stack and rewrites those saved values so `SYSRETQ` lands
+//!    in the signal handler rather than the original user RIP.
+//!
+//! 2. **Exception return from ring-3** — the `#PF` handler (and future
+//!    `#GP`) calls [`deliver_fault_signal`] which directly modifies the
+//!    `InterruptStackFrame` so `IRETQ` redirects to the signal handler.
+//!
+//! ## Limitations (known, tracked as follow-ups)
+//!
+//! - FPU state (`fpstate_ptr` in `SigFrame`) is always null — signals
+//!   delivered to a task using SSE/x87 will see corrupted FP registers.
+//! - `SA_NODEFER` and `SA_RESTART` flags are not honoured.
+//! - Real-time signals (`SIGRTMIN`..`SIGRTMAX`) are not implemented.
+//! - `sigaltstack` is not implemented.
+//! - Multi-threaded signal delivery is not implemented (single-CPU, single-
+//!   threaded for now).
+
+pub mod frame;
+
+use crate::arch::x86_64::uaccess;
+
+// ── Signal numbers (Linux x86_64) ────────────────────────────────────────
+
+pub const SIGHUP: u8 = 1;
+pub const SIGINT: u8 = 2;
+pub const SIGQUIT: u8 = 3;
+pub const SIGILL: u8 = 4;
+pub const SIGTRAP: u8 = 5;
+pub const SIGABRT: u8 = 6;
+pub const SIGBUS: u8 = 7;
+pub const SIGFPE: u8 = 8;
+pub const SIGKILL: u8 = 9;
+pub const SIGUSR1: u8 = 10;
+pub const SIGSEGV: u8 = 11;
+pub const SIGUSR2: u8 = 12;
+pub const SIGPIPE: u8 = 13;
+pub const SIGALRM: u8 = 14;
+pub const SIGTERM: u8 = 15;
+pub const SIGCHLD: u8 = 17;
+pub const SIGCONT: u8 = 18;
+pub const SIGSTOP: u8 = 19;
+pub const SIGTSTP: u8 = 20;
+
+/// Maximum signal number supported.  Linux defines 64 but we only need the
+/// standard 31 for now.  The bitmask is a `u64` so the representation is
+/// future-proof.
+pub const NSIG: u8 = 64;
+
+// ── Sigaction disposition ─────────────────────────────────────────────────
+
+/// `SIG_DFL` — default action for the signal.
+pub const SIG_DFL: u64 = 0;
+/// `SIG_IGN` — ignore the signal.
+pub const SIG_IGN: u64 = 1;
+
+/// Per-signal disposition.
+#[derive(Clone, Copy, Debug)]
+pub enum Disposition {
+    /// Default kernel action (see [`default_action`]).
+    Default,
+    /// Ignore — no action taken.
+    Ignore,
+    /// Call the userspace handler at this VA.
+    Handler(u64),
+}
+
+impl Disposition {
+    fn from_handler_ptr(ptr: u64) -> Self {
+        match ptr {
+            SIG_DFL => Disposition::Default,
+            SIG_IGN => Disposition::Ignore,
+            va => Disposition::Handler(va),
+        }
+    }
+
+    fn to_handler_ptr(self) -> u64 {
+        match self {
+            Disposition::Default => SIG_DFL,
+            Disposition::Ignore => SIG_IGN,
+            Disposition::Handler(va) => va,
+        }
+    }
+}
+
+/// What the kernel does when a signal's disposition is `SIG_DFL`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum DefaultAction {
+    /// Terminate the process (exit with signal number as status).
+    Terminate,
+    /// Ignore — no action.
+    Ignore,
+    /// Stop the process (not yet implemented; treated as Ignore).
+    Stop,
+    /// Continue a stopped process (not yet implemented; treated as Ignore).
+    Continue,
+}
+
+/// Return the default action for signal `sig` (1-indexed).
+pub fn default_action(sig: u8) -> DefaultAction {
+    match sig {
+        SIGCHLD | SIGCONT => DefaultAction::Continue,
+        SIGSTOP | SIGTSTP => DefaultAction::Stop,
+        SIGURG | 28 => DefaultAction::Ignore, // SIGWINCH=28, SIGURG=23
+        _ => DefaultAction::Terminate,
+    }
+}
+
+const SIGURG: u8 = 23;
+
+// ── Signal mask helpers ───────────────────────────────────────────────────
+
+/// Convert a 1-indexed signal number to a bitmask bit.  Returns `0` for
+/// out-of-range signal numbers.
+#[inline]
+pub fn sig_bit(sig: u8) -> u64 {
+    if sig == 0 || sig > NSIG {
+        0
+    } else {
+        1u64 << (sig - 1)
+    }
+}
+
+/// True if `sig` cannot be caught, blocked, or ignored (SIGKILL / SIGSTOP).
+#[inline]
+pub fn is_unblockable(sig: u8) -> bool {
+    sig == SIGKILL || sig == SIGSTOP
+}
+
+// ── sigprocmask `how` values ──────────────────────────────────────────────
+
+pub const SIG_BLOCK: u64 = 0;
+pub const SIG_UNBLOCK: u64 = 1;
+pub const SIG_SETMASK: u64 = 2;
+
+// ── Per-process signal state ──────────────────────────────────────────────
+
+/// Per-process signal state — one instance per `ProcessEntry`, shared via
+/// `Arc<Mutex<SignalState>>`.
+pub struct SignalState {
+    /// Bitmask of pending (raised, not yet delivered) signals.
+    pub pending: u64,
+    /// Current signal mask — bits set here are blocked (deferred).
+    /// SIGKILL and SIGSTOP cannot be blocked regardless of this value.
+    pub blocked: u64,
+    /// Per-signal disposition table (indexed 0 = signal 1).
+    pub dispositions: [Disposition; NSIG as usize],
+}
+
+impl SignalState {
+    pub fn new() -> Self {
+        let mut dispositions = [Disposition::Default; NSIG as usize];
+        // SIGCHLD: default is to ignore (SIG_DFL for SIGCHLD means ignore
+        // on Linux unless SA_NOCLDWAIT / SA_NOCLDSTOP is used).
+        dispositions[(SIGCHLD - 1) as usize] = Disposition::Ignore;
+        Self {
+            pending: 0,
+            blocked: 0,
+            dispositions,
+        }
+    }
+
+    /// Raise signal `sig` on this process: set the pending bit.
+    pub fn raise(&mut self, sig: u8) {
+        self.pending |= sig_bit(sig);
+    }
+
+    /// Return the lowest-numbered signal that is both pending and not blocked
+    /// (unless it is SIGKILL/SIGSTOP which bypass the blocked mask), then
+    /// clear the pending bit.
+    ///
+    /// Returns `None` if no actionable signal is pending.
+    pub fn pop_next_pending(&mut self) -> Option<u8> {
+        // Deliverable = pending & (~blocked | unblockable_bits)
+        let unblockable = sig_bit(SIGKILL) | sig_bit(SIGSTOP);
+        let deliverable = self.pending & (!self.blocked | unblockable);
+        if deliverable == 0 {
+            return None;
+        }
+        // Lowest-numbered pending signal first (POSIX requirement for
+        // non-real-time signals).
+        let bit = deliverable & deliverable.wrapping_neg(); // lowest set bit
+        self.pending &= !bit;
+        // Convert bit position back to 1-indexed signal number.
+        Some(bit.trailing_zeros() as u8 + 1)
+    }
+
+    /// Apply `sigprocmask(how, set)` and return the old mask.
+    ///
+    /// Always strips SIGKILL and SIGSTOP from the result (they cannot be
+    /// blocked).
+    pub fn update_mask(&mut self, how: u64, set: u64) -> u64 {
+        let old = self.blocked;
+        let unblockable = sig_bit(SIGKILL) | sig_bit(SIGSTOP);
+        let new_mask = match how {
+            SIG_BLOCK => old | set,
+            SIG_UNBLOCK => old & !set,
+            SIG_SETMASK => set,
+            _ => old, // invalid `how` — leave mask unchanged
+        };
+        self.blocked = new_mask & !unblockable;
+        old
+    }
+}
+
+// ── Process-level helpers ─────────────────────────────────────────────────
+
+/// Raise signal `sig` on the process with the given `task_id`.
+///
+/// Looks up the process entry to find the `Arc<Mutex<SignalState>>`, sets
+/// the pending bit, then wakes the task if it is currently blocked.
+pub fn raise_signal_on_task(task_id: usize, sig: u8) {
+    crate::process::with_signal_state_for_task(task_id, |state| {
+        state.raise(sig);
+    });
+    // Wake the target task in case it is sleeping — it will check for
+    // pending signals at its next syscall return.
+    crate::task::wake(task_id);
+}
+
+/// Raise signal `sig` on the process identified by `pid`.  Returns `-ESRCH`
+/// if the pid is not found, `-EINVAL` for an out-of-range signal.
+pub fn raise_signal_on_pid(pid: u32, sig: u8) -> i64 {
+    if sig > NSIG {
+        return -22; // EINVAL
+    }
+    match crate::process::task_id_for_pid(pid) {
+        Some(task_id) => {
+            raise_signal_on_task(task_id, sig);
+            0
+        }
+        None => -3, // ESRCH
+    }
+}
+
+// ── Syscall handlers ──────────────────────────────────────────────────────
+
+/// `sigaction(sig, act_uva, oldact_uva)` — register or query a signal
+/// handler.
+///
+/// `act_uva` and `oldact_uva` are user pointers to `struct sigaction`
+/// (Linux x86_64 layout: `sa_handler: u64, sa_flags: u64, sa_restorer: u64,
+/// sa_mask: u64`).  Only `sa_handler` is read / written; the rest are stored
+/// as zero for now (no SA_RESTART / SA_SIGINFO support).
+///
+/// # Safety
+/// `act_uva` and `oldact_uva` are user VA pointers validated via
+/// `uaccess::check_user_range`.
+pub unsafe fn sys_sigaction(sig: u64, act_uva: u64, oldact_uva: u64) -> i64 {
+    let sig = sig as u8;
+    if sig == 0 || sig > NSIG || is_unblockable(sig) && act_uva != 0 {
+        return -22; // EINVAL
+    }
+
+    let task_id = crate::task::current_id();
+    let result = crate::process::with_signal_state_for_task(task_id, |state| {
+        let old_disp = state.dispositions[(sig - 1) as usize];
+
+        // Write old disposition to userspace if requested.
+        if oldact_uva != 0 {
+            let mut sa: [u8; 32] = [0u8; 32];
+            let handler_ptr = old_disp.to_handler_ptr();
+            sa[..8].copy_from_slice(&handler_ptr.to_ne_bytes());
+            if uaccess::copy_to_user(oldact_uva as usize, &sa).is_err() {
+                return -14i64; // EFAULT
+            }
+        }
+
+        // Install new disposition if provided.
+        if act_uva != 0 {
+            let mut sa: [u8; 32] = [0u8; 32];
+            if uaccess::copy_from_user(&mut sa, act_uva as usize).is_err() {
+                return -14i64; // EFAULT
+            }
+            let handler_ptr = u64::from_ne_bytes(sa[..8].try_into().unwrap());
+            state.dispositions[(sig - 1) as usize] = Disposition::from_handler_ptr(handler_ptr);
+        }
+
+        0i64
+    });
+    result.unwrap_or(-3) // ESRCH if no process entry
+}
+
+/// `sigprocmask(how, set_uva, oldset_uva)` — update the signal mask.
+///
+/// `set_uva` and `oldset_uva` are user pointers to `sigset_t` (u64 on
+/// Linux x86_64).
+///
+/// # Safety
+/// Pointers are validated via `uaccess`.
+pub unsafe fn sys_sigprocmask(how: u64, set_uva: u64, oldset_uva: u64) -> i64 {
+    let task_id = crate::task::current_id();
+    let result = crate::process::with_signal_state_for_task(task_id, |state| {
+        // Read new mask from user if provided.
+        let new_mask = if set_uva != 0 {
+            let mut buf = [0u8; 8];
+            if uaccess::copy_from_user(&mut buf, set_uva as usize).is_err() {
+                return -14i64; // EFAULT
+            }
+            u64::from_ne_bytes(buf)
+        } else {
+            0
+        };
+
+        let old_mask = state.update_mask(how, new_mask);
+
+        if oldset_uva != 0 {
+            if uaccess::copy_to_user(oldset_uva as usize, &old_mask.to_ne_bytes()).is_err() {
+                return -14i64; // EFAULT
+            }
+        }
+        0i64
+    });
+    result.unwrap_or(-3) // ESRCH
+}
+
+/// `kill(pid, sig)` — send signal `sig` to process `pid`.
+///
+/// `pid == 0` sends to the process group (not yet implemented — treated as
+/// ESRCH).  Negative `pid` is not yet supported.
+pub fn sys_kill(pid: u64, sig: u64) -> i64 {
+    let pid = pid as i32;
+    let sig = sig as u8;
+    if sig > NSIG {
+        return -22; // EINVAL
+    }
+    if pid <= 0 {
+        return -3; // ESRCH — process group kill not implemented
+    }
+    raise_signal_on_pid(pid as u32, sig)
+}
+
+// ── Delivery at syscall return ────────────────────────────────────────────
+
+/// Kernel-stack layout pushed by the `syscall_entry` asm trampoline
+/// immediately before calling `syscall_dispatch`.
+///
+/// The trampoline pushes (in order, so lowest address is last pushed):
+///   `[rsp+0]`  = user RIP  (rcx at entry)
+///   `[rsp+8]`  = user RFLAGS (r11 at entry)
+///   `[rsp+16]` = user RSP
+///
+/// `check_and_deliver_signals` receives `rsp` as the pointer to this layout
+/// and may rewrite any of these fields to redirect the return to a signal
+/// handler.
+#[repr(C)]
+pub struct SyscallReturnContext {
+    pub user_rip: u64,
+    pub user_rflags: u64,
+    pub user_rsp: u64,
+}
+
+/// Called from the `syscall_entry` asm trampoline between steps 5 and 6
+/// (after `syscall_dispatch` returns, before `pop rcx / sysretq`).
+///
+/// Two responsibilities:
+///
+/// 1. **sigreturn**: if `SIGRETURN_PENDING` is set (syscall 15 just ran),
+///    overwrite `ctx` with the restored user context from `FORK_USER_*`
+///    statics and clear the flag.
+///
+/// 2. **signal delivery**: if a signal is pending for the current process,
+///    pop the lowest pending signal, look up its disposition, and either
+///    push a `SigFrame` + redirect `ctx->user_rip` (user handler), exit the
+///    process (default terminate), or do nothing (ignored).
+///
+/// # Safety
+/// `ctx` must point to the [`SyscallReturnContext`] fields on the current
+/// task's kernel stack.  Called only from `syscall_entry` with IF disabled.
+#[no_mangle]
+pub unsafe extern "C" fn check_and_deliver_signals(ctx: *mut SyscallReturnContext) {
+    use core::sync::atomic::Ordering;
+
+    // Handle sigreturn: restore saved context from FORK_USER_* statics.
+    if crate::arch::x86_64::syscall::SIGRETURN_PENDING.load(Ordering::Relaxed) != 0 {
+        crate::arch::x86_64::syscall::SIGRETURN_PENDING.store(0, Ordering::Relaxed);
+        (*ctx).user_rip = crate::arch::x86_64::syscall::FORK_USER_RIP.load(Ordering::Relaxed);
+        (*ctx).user_rflags =
+            crate::arch::x86_64::syscall::FORK_USER_RFLAGS.load(Ordering::Relaxed);
+        (*ctx).user_rsp = crate::arch::x86_64::syscall::FORK_USER_RSP.load(Ordering::Relaxed);
+        // After sigreturn still check for any newly-pending signal.
+    }
+
+    let task_id = crate::task::current_id();
+    let sig = match crate::process::with_signal_state_for_task(task_id, |state| {
+        state.pop_next_pending()
+    }) {
+        Some(Some(sig)) => sig,
+        _ => return, // no pending signal or no process entry
+    };
+    deliver_signal(sig, &mut *ctx);
+}
+
+/// Deliver signal `sig` by either redirecting return-to-user context to the
+/// handler or terminating the process for default-terminate signals.
+///
+/// # Safety
+/// `ctx` must point to valid kernel-stack-saved user context.
+unsafe fn deliver_signal(sig: u8, ctx: &mut SyscallReturnContext) {
+    let task_id = crate::task::current_id();
+
+    let disp = crate::process::with_signal_state_for_task(task_id, |state| {
+        // While delivering, block this signal (equivalent to SA_NODEFER=off
+        // default: block the signal being delivered).
+        state.blocked |= sig_bit(sig);
+        state.dispositions[(sig - 1) as usize]
+    });
+
+    let disp = match disp {
+        Some(d) => d,
+        None => return,
+    };
+
+    match disp {
+        Disposition::Ignore => {
+            // Unblock the signal again (we blocked it above).
+            let _ = crate::process::with_signal_state_for_task(task_id, |state| {
+                state.blocked &= !sig_bit(sig);
+                ()
+            });
+        }
+        Disposition::Default => {
+            let _ = crate::process::with_signal_state_for_task(task_id, |state| {
+                state.blocked &= !sig_bit(sig);
+                ()
+            });
+            match default_action(sig) {
+                DefaultAction::Terminate => {
+                    let pid = crate::process::current_pid();
+                    if pid != 0 {
+                        crate::process::reparent_children(pid);
+                        crate::process::mark_zombie(pid, -(sig as i32));
+                    }
+                    crate::task::exit();
+                }
+                _ => {} // Ignore / Stop / Continue — no-op for now
+            }
+        }
+        Disposition::Handler(handler_va) => {
+            // Push signal frame onto the user stack and redirect SYSRETQ.
+            let new_user_rsp = match frame::push_signal_frame(
+                ctx.user_rsp,
+                sig,
+                ctx.user_rip,
+                ctx.user_rflags,
+            ) {
+                Ok(sp) => sp,
+                Err(_) => {
+                    // Could not push the frame (bad user RSP) — terminate.
+                    let pid = crate::process::current_pid();
+                    if pid != 0 {
+                        crate::process::reparent_children(pid);
+                        crate::process::mark_zombie(pid, -(sig as i32));
+                    }
+                    crate::task::exit();
+                }
+            };
+            ctx.user_rip = handler_va;
+            ctx.user_rsp = new_user_rsp;
+            // Leave ctx.user_rflags as-is (handler sees caller's rflags).
+        }
+    }
+}
+
+/// `sigreturn()` — restore register context from the `SigFrame` on the user
+/// stack and resume the interrupted code.
+///
+/// Reads the `SigFrame` at `user_rsp` (which is the value of RSP when the
+/// signal handler was invoked — the frame's `pretcode` word is at `[rsp]`
+/// followed by the frame itself), restores `user_rip`, `user_rflags`,
+/// `user_rsp` from it, and also restores the saved signal mask.
+///
+/// The caller must write the returned [`SigReturnRegs`] back into the
+/// kernel-stack-saved context so `SYSRETQ` returns to the right place.
+///
+/// # Safety
+/// `user_rsp` must point to a valid `SigFrame` in user space.
+pub unsafe fn sys_sigreturn(user_rsp: u64) -> SigReturnRegs {
+    match frame::restore_signal_frame(user_rsp) {
+        Ok(restored) => {
+            // Restore the signal mask that was saved when we delivered.
+            let task_id = crate::task::current_id();
+            let _ = crate::process::with_signal_state_for_task(task_id, |state| {
+                // The saved mask in the frame is what blocked was set to
+                // before delivery.  Restore it and unblock the signal that
+                // was temporarily added.
+                state.blocked = restored.saved_mask;
+                ()
+            });
+            SigReturnRegs {
+                rip: restored.rip,
+                rflags: restored.rflags,
+                rsp: restored.rsp,
+            }
+        }
+        Err(_) => {
+            // Corrupt frame — kill the process.
+            let pid = crate::process::current_pid();
+            if pid != 0 {
+                crate::process::reparent_children(pid);
+                crate::process::mark_zombie(pid, -(SIGSEGV as i32));
+            }
+            crate::task::exit();
+        }
+    }
+}
+
+/// The register values to restore after `sigreturn`.
+pub struct SigReturnRegs {
+    pub rip: u64,
+    pub rflags: u64,
+    pub rsp: u64,
+}
+
+// ── Host-side unit tests ──────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sig_bit_is_1_indexed() {
+        assert_eq!(sig_bit(1), 1u64);
+        assert_eq!(sig_bit(2), 2u64);
+        assert_eq!(sig_bit(64), 1u64 << 63);
+        assert_eq!(sig_bit(0), 0u64);   // invalid
+        assert_eq!(sig_bit(65), 0u64);  // out of range
+    }
+
+    #[test]
+    fn pop_next_pending_lowest_first() {
+        let mut s = SignalState::new();
+        s.raise(SIGTERM);
+        s.raise(SIGUSR1);
+        s.raise(SIGINT);
+        // SIGINT=2 < SIGUSR1=10 < SIGTERM=15
+        assert_eq!(s.pop_next_pending(), Some(SIGINT));
+        assert_eq!(s.pop_next_pending(), Some(SIGUSR1));
+        assert_eq!(s.pop_next_pending(), Some(SIGTERM));
+        assert_eq!(s.pop_next_pending(), None);
+    }
+
+    #[test]
+    fn blocked_signals_are_deferred() {
+        let mut s = SignalState::new();
+        s.raise(SIGUSR1);
+        s.blocked = sig_bit(SIGUSR1); // block it
+        assert_eq!(s.pop_next_pending(), None);
+        s.blocked = 0; // unblock
+        assert_eq!(s.pop_next_pending(), Some(SIGUSR1));
+    }
+
+    #[test]
+    fn sigkill_bypasses_blocked_mask() {
+        let mut s = SignalState::new();
+        s.raise(SIGKILL);
+        s.blocked = !0u64; // try to block everything
+        // SIGKILL must still be deliverable.
+        assert_eq!(s.pop_next_pending(), Some(SIGKILL));
+    }
+
+    #[test]
+    fn update_mask_block() {
+        let mut s = SignalState::new();
+        let old = s.update_mask(SIG_BLOCK, sig_bit(SIGUSR1));
+        assert_eq!(old, 0);
+        assert_eq!(s.blocked, sig_bit(SIGUSR1));
+    }
+
+    #[test]
+    fn update_mask_unblock() {
+        let mut s = SignalState::new();
+        s.blocked = sig_bit(SIGUSR1) | sig_bit(SIGUSR2);
+        let old = s.update_mask(SIG_UNBLOCK, sig_bit(SIGUSR1));
+        assert_eq!(old, sig_bit(SIGUSR1) | sig_bit(SIGUSR2));
+        assert_eq!(s.blocked, sig_bit(SIGUSR2));
+    }
+
+    #[test]
+    fn update_mask_setmask() {
+        let mut s = SignalState::new();
+        s.blocked = sig_bit(SIGUSR1);
+        let old = s.update_mask(SIG_SETMASK, sig_bit(SIGUSR2));
+        assert_eq!(old, sig_bit(SIGUSR1));
+        assert_eq!(s.blocked, sig_bit(SIGUSR2));
+    }
+
+    #[test]
+    fn sigkill_cannot_be_blocked() {
+        let mut s = SignalState::new();
+        s.update_mask(SIG_SETMASK, !0u64);
+        assert_eq!(s.blocked & sig_bit(SIGKILL), 0);
+        assert_eq!(s.blocked & sig_bit(SIGSTOP), 0);
+    }
+
+    #[test]
+    fn disposition_roundtrip() {
+        assert!(matches!(
+            Disposition::from_handler_ptr(SIG_DFL),
+            Disposition::Default
+        ));
+        assert!(matches!(
+            Disposition::from_handler_ptr(SIG_IGN),
+            Disposition::Ignore
+        ));
+        let va = 0xDEAD_BEEF_0000_0000u64;
+        let d = Disposition::from_handler_ptr(va);
+        assert!(matches!(d, Disposition::Handler(_)));
+        assert_eq!(d.to_handler_ptr(), va);
+    }
+
+    #[test]
+    fn default_action_terminate() {
+        assert_eq!(default_action(SIGTERM), DefaultAction::Terminate);
+        assert_eq!(default_action(SIGKILL), DefaultAction::Terminate);
+        assert_eq!(default_action(SIGSEGV), DefaultAction::Terminate);
+    }
+
+    #[test]
+    fn default_action_ignore_for_sigchld() {
+        // SIGCHLD disposition starts as Ignore in SignalState::new().
+        let s = SignalState::new();
+        assert!(matches!(
+            s.dispositions[(SIGCHLD - 1) as usize],
+            Disposition::Ignore
+        ));
+    }
+}

--- a/kernel/src/signal/mod.rs
+++ b/kernel/src/signal/mod.rs
@@ -122,7 +122,8 @@ pub enum DefaultAction {
 /// Return the default action for signal `sig` (1-indexed).
 pub fn default_action(sig: u8) -> DefaultAction {
     match sig {
-        SIGCHLD | SIGCONT => DefaultAction::Continue,
+        SIGCHLD => DefaultAction::Ignore,
+        SIGCONT => DefaultAction::Continue,
         SIGSTOP | SIGTSTP => DefaultAction::Stop,
         SIGURG | 28 => DefaultAction::Ignore, // SIGWINCH=28, SIGURG=23
         _ => DefaultAction::Terminate,
@@ -315,17 +316,16 @@ pub unsafe fn sys_sigprocmask(how: u64, set_uva: u64, oldset_uva: u64) -> i64 {
     let task_id = crate::task::current_id();
     let result = crate::process::with_signal_state_for_task(task_id, |state| {
         // Read new mask from user if provided.
-        let new_mask = if set_uva != 0 {
+        let old_mask = if set_uva != 0 {
             let mut buf = [0u8; 8];
             if uaccess::copy_from_user(&mut buf, set_uva as usize).is_err() {
                 return -14i64; // EFAULT
             }
-            u64::from_ne_bytes(buf)
+            let new_mask = u64::from_ne_bytes(buf);
+            state.update_mask(how, new_mask)
         } else {
-            0
+            state.blocked
         };
-
-        let old_mask = state.update_mask(how, new_mask);
 
         if oldset_uva != 0 {
             if uaccess::copy_to_user(oldset_uva as usize, &old_mask.to_ne_bytes()).is_err() {
@@ -421,17 +421,18 @@ pub unsafe extern "C" fn check_and_deliver_signals(ctx: *mut SyscallReturnContex
 unsafe fn deliver_signal(sig: u8, ctx: &mut SyscallReturnContext) {
     let task_id = crate::task::current_id();
 
-    let disp = crate::process::with_signal_state_for_task(task_id, |state| {
-        // While delivering, block this signal (equivalent to SA_NODEFER=off
-        // default: block the signal being delivered).
-        state.blocked |= sig_bit(sig);
-        state.dispositions[(sig - 1) as usize]
-    });
-
-    let disp = match disp {
-        Some(d) => d,
-        None => return,
-    };
+    // Capture the pre-delivery mask and block the signal in one lock window.
+    // The pre-delivery mask is what sigreturn must restore; capturing it before
+    // setting the block bit ensures uc_sigmask in the frame is correct.
+    let (disp, pre_block_mask) =
+        match crate::process::with_signal_state_for_task(task_id, |state| {
+            let pre = state.blocked;
+            state.blocked |= sig_bit(sig);
+            (state.dispositions[(sig - 1) as usize], pre)
+        }) {
+            Some(pair) => pair,
+            None => return,
+        };
 
     match disp {
         Disposition::Ignore => {
@@ -460,19 +461,24 @@ unsafe fn deliver_signal(sig: u8, ctx: &mut SyscallReturnContext) {
         }
         Disposition::Handler(handler_va) => {
             // Push signal frame onto the user stack and redirect SYSRETQ.
-            let new_user_rsp =
-                match frame::push_signal_frame(ctx.user_rsp, sig, ctx.user_rip, ctx.user_rflags) {
-                    Ok(sp) => sp,
-                    Err(_) => {
-                        // Could not push the frame (bad user RSP) — terminate.
-                        let pid = crate::process::current_pid();
-                        if pid != 0 {
-                            crate::process::reparent_children(pid);
-                            crate::process::mark_zombie(pid, -(sig as i32));
-                        }
-                        crate::task::exit();
+            let new_user_rsp = match frame::push_signal_frame(
+                ctx.user_rsp,
+                sig,
+                ctx.user_rip,
+                ctx.user_rflags,
+                pre_block_mask,
+            ) {
+                Ok(sp) => sp,
+                Err(_) => {
+                    // Could not push the frame (bad user RSP) — terminate.
+                    let pid = crate::process::current_pid();
+                    if pid != 0 {
+                        crate::process::reparent_children(pid);
+                        crate::process::mark_zombie(pid, -(sig as i32));
                     }
-                };
+                    crate::task::exit();
+                }
+            };
             ctx.user_rip = handler_va;
             ctx.user_rsp = new_user_rsp;
             // Leave ctx.user_rflags as-is (handler sees caller's rflags).


### PR DESCRIPTION
Closes #126

## Summary
- Adds `kernel/src/signal/mod.rs`: per-process `SignalState` (pending/blocked bitmasks + disposition table), `sigaction`, `sigprocmask`, `kill`, `sigreturn` syscall handlers, and `check_and_deliver_signals` hooked into the `syscall_entry` trampoline before `SYSRETQ`.
- Adds `kernel/src/signal/frame.rs`: `SigFrame` / `ucontext` layout matching the Linux x86_64 `rt_sigframe` ABI; `push_signal_frame` writes the frame onto the user stack; `restore_signal_frame` reads it back on `sigreturn`.
- Extends `kernel/src/process/mod.rs`: adds `Arc<Mutex<SignalState>>` to `ProcessEntry`; new helpers `with_signal_state_for_task` and `task_id_for_pid`.
- Wires syscall numbers 13 (`sigaction`), 14 (`sigprocmask`), 15 (`sigreturn`), 62 (`kill`) in `syscall.rs`; adds `SIGRETURN_PENDING` static for the sigreturn handshake.

Known limitations (tracked as follow-up):
- FPU state not saved in `SigFrame` (`fpstate_ptr = NULL`) — SSE/x87 corrupt across signal handler.
- `SA_NODEFER` / `SA_RESTART` / `SA_SIGINFO` not honoured.
- `sigaltstack` not implemented.
- `kill(0, sig)` / process-group kill not implemented.

## Test plan
- [x] `cargo xtask build` — kernel compiles clean (one pre-existing `is_guard_hit` warning)
- [x] Host unit tests for signal logic (`signal::tests` and `signal::frame::tests`) cover: bitmask ops, `pop_next_pending` ordering, unblockable signals (SIGKILL/SIGSTOP bypass blocked mask), `sigprocmask` `SIG_BLOCK`/`SIG_UNBLOCK`/`SIG_SETMASK`, disposition roundtrip, `SigFrame` size/alignment, trampoline byte encoding
- [ ] Host unit test runner blocked by pre-existing `pic8259` aarch64 build failure (unrelated to this PR; CI on x86_64 runs them fine)