### PR TITLE
syscall: wire VFS path-based open/stat family (RFC 0002 item 11/15)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -177,6 +177,10 @@ name = "syscall_open_mmap"
 harness = false
 
 [[test]]
+name = "syscall_vfs"
+harness = false
+
+[[test]]
 name = "vm_integration"
 harness = false
 

--- a/kernel/src/arch/x86_64/mod.rs
+++ b/kernel/src/arch/x86_64/mod.rs
@@ -7,6 +7,7 @@ pub mod interrupts;
 pub mod ist_guard;
 pub mod pic;
 pub mod syscall;
+pub mod syscalls;
 pub mod uaccess;
 
 /// Bring up arch-specific interrupt plumbing that doesn't depend on

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -276,10 +276,23 @@ pub unsafe extern "C" fn syscall_dispatch(
             written as i64
         }
 
-        // open(path, flags, mode) — pre-VFS: only `/dev/stdin`,
-        // `/dev/stdout`, `/dev/stderr`, and `/dev/serial` resolve, all
-        // backed by `SerialBackend`. Any other path returns -ENOENT.
+        // open(path, flags, mode) — VFS-backed; see `sys_open`.
         OPEN => sys_open(a0, a1, a2),
+
+        // stat(path, *statbuf) — follow symlinks, then write `struct stat`.
+        4 => super::syscalls::vfs::sys_stat_impl(a0, a1, /* nofollow */ false),
+
+        // fstat(fd, *statbuf)
+        5 => super::syscalls::vfs::sys_fstat_impl(a0, a1),
+
+        // lstat(path, *statbuf) — like stat but don't follow a final symlink.
+        6 => super::syscalls::vfs::sys_stat_impl(a0, a1, /* nofollow */ true),
+
+        // openat(dfd, path, flags, mode)
+        257 => super::syscalls::vfs::sys_openat_impl(a0 as i32, a1, a2, a3),
+
+        // newfstatat(dfd, path, *statbuf, flags)
+        262 => super::syscalls::vfs::sys_newfstatat_impl(a0 as i32, a1, a2, a3 as u32),
 
         // mmap(addr, len, prot, flags, fd, off) — anon-private and
         // anon-shared with full MAP_FIXED / MAP_GROWSDOWN support. See
@@ -459,10 +472,6 @@ pub unsafe extern "C" fn syscall_dispatch(
     }
 }
 
-/// Maximum path length accepted by `sys_open`, including the terminating
-/// NUL. Matches the longest special path we handle today.
-const OPEN_PATH_MAX: usize = 128;
-
 /// Atomic execve body: stage the new image into a fresh `AddressSpace`
 /// and only commit it once the load has fully succeeded.
 ///
@@ -544,6 +553,17 @@ pub fn exec_atomic(elf_bytes: &[u8]) -> Result<core::convert::Infallible, i64> {
     unsafe { jump_to_ring3(image.entry.as_u64(), crate::init_process::USER_STACK_TOP) }
 }
 
+/// Public wrapper around `copy_path_from_user` for use by the VFS
+/// syscall handlers in `super::syscalls::vfs`. Keeping one copy-in
+/// implementation guarantees every path syscall uses identical
+/// validation (user-range bound, NUL-termination, `ENAMETOOLONG`).
+pub(super) unsafe fn copy_path_from_user_pub(
+    uva: usize,
+    buf: &mut [u8],
+) -> Result<usize, i64> {
+    copy_path_from_user(uva, buf)
+}
+
 /// Copy a NUL-terminated path from user VA `uva` into `buf`. Returns
 /// the slice (without the NUL) on success, or a negative errno on
 /// failure. Mirrors Linux `strncpy_from_user` semantics: short path →
@@ -568,48 +588,15 @@ unsafe fn copy_path_from_user(uva: usize, buf: &mut [u8]) -> Result<usize, i64> 
     Err(crate::fs::ENAMETOOLONG)
 }
 
-/// `open(path, flags, mode)` — pre-VFS stub.
+/// `open(path, flags, mode)` — VFS-backed `open`.
 ///
-/// Resolves only the four special device paths listed below, each
-/// backed by `SerialBackend`. Any other path returns `-ENOENT` so that
-/// userspace gets the real "no such file" signal rather than `-ENOSYS`.
-/// `mode` is accepted but unused (there is nothing to create yet).
-unsafe fn sys_open(path_uva: u64, flags: u64, _mode: u64) -> i64 {
-    use crate::fs::{flags as oflags, FileBackend, FileDescription, SerialBackend, ENOENT};
-    use alloc::sync::Arc;
-
-    let mut buf = [0u8; OPEN_PATH_MAX];
-    let n = match copy_path_from_user(path_uva as usize, &mut buf) {
-        Ok(n) => n,
-        Err(e) => return e,
-    };
-    let path = &buf[..n];
-
-    let is_special = matches!(
-        path,
-        b"/dev/stdin" | b"/dev/stdout" | b"/dev/stderr" | b"/dev/serial"
-    );
-    if !is_special {
-        return ENOENT;
-    }
-
-    // Split caller flags: access mode goes into FileDescription.flags;
-    // O_CLOEXEC goes into the per-fd slot flags (so dup() can clear it
-    // without touching the shared description).
-    let access_flags = (flags as u32) & (oflags::O_RDONLY | oflags::O_WRONLY | oflags::O_RDWR);
-    let fd_flags = (flags as u32) & oflags::O_CLOEXEC;
-
-    let backend: Arc<dyn FileBackend> = Arc::new(SerialBackend);
-    let desc = Arc::new(FileDescription {
-        backend,
-        flags: access_flags,
-    });
-    let tbl = crate::task::current_fd_table();
-    let result = tbl.lock().alloc_fd_with_flags(desc, fd_flags);
-    match result {
-        Ok(fd) => fd as i64,
-        Err(e) => e,
-    }
+/// Equivalent to `openat(AT_FDCWD, path, flags, mode)`. Delegates to
+/// [`crate::arch::x86_64::syscalls::vfs::sys_openat_impl`]; see that
+/// function for the full semantics including the `/dev/{stdin,stdout,
+/// stderr,serial}` legacy-compat fallback for callers that open before
+/// `/dev/serial` has been wired into devfs.
+unsafe fn sys_open(path_uva: u64, flags: u64, mode: u64) -> i64 {
+    super::syscalls::vfs::sys_openat_impl(super::syscalls::vfs::AT_FDCWD, path_uva, flags, mode)
 }
 
 /// Build `prot_pte` from user-visible `prot_user` bits. `PROT_WRITE`
@@ -945,6 +932,9 @@ pub mod syscall_nr {
     pub const LSEEK: u64 = 8;
     pub const CLOSE: u64 = 3;
     pub const FSTAT: u64 = 5;
+    pub const STAT: u64 = 4;
+    pub const LSTAT: u64 = 6;
+    pub const NEWFSTATAT: u64 = 262;
 }
 
 #[cfg(test)]
@@ -977,9 +967,12 @@ mod tests {
 
         // Filesystem
         assert_eq!(syscall_nr::OPEN, 2, "SYS_open must be 2");
+        assert_eq!(syscall_nr::STAT, 4, "SYS_stat must be 4");
         assert_eq!(syscall_nr::FSTAT, 5, "SYS_fstat must be 5");
+        assert_eq!(syscall_nr::LSTAT, 6, "SYS_lstat must be 6");
         assert_eq!(syscall_nr::GETDENTS64, 217, "SYS_getdents64 must be 217");
         assert_eq!(syscall_nr::OPENAT, 257, "SYS_openat must be 257");
+        assert_eq!(syscall_nr::NEWFSTATAT, 262, "SYS_newfstatat must be 262");
 
         // Signals
         assert_eq!(syscall_nr::SIGRETURN, 15, "SYS_rt_sigreturn must be 15");

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -557,10 +557,7 @@ pub fn exec_atomic(elf_bytes: &[u8]) -> Result<core::convert::Infallible, i64> {
 /// syscall handlers in `super::syscalls::vfs`. Keeping one copy-in
 /// implementation guarantees every path syscall uses identical
 /// validation (user-range bound, NUL-termination, `ENAMETOOLONG`).
-pub(super) unsafe fn copy_path_from_user_pub(
-    uva: usize,
-    buf: &mut [u8],
-) -> Result<usize, i64> {
+pub(super) unsafe fn copy_path_from_user_pub(uva: usize, buf: &mut [u8]) -> Result<usize, i64> {
     copy_path_from_user(uva, buf)
 }
 

--- a/kernel/src/arch/x86_64/syscalls/mod.rs
+++ b/kernel/src/arch/x86_64/syscalls/mod.rs
@@ -1,0 +1,7 @@
+//! Grouped syscall implementations called from `syscall::syscall_dispatch`.
+//!
+//! Kept separate so that each subsystem (VFS, in the future: time, IPC, …)
+//! lives in its own file and syscall.rs can stay focused on the trampoline
+//! and register plumbing.
+
+pub mod vfs;

--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -1,0 +1,288 @@
+//! VFS-backed path syscalls: `open`, `openat`, `stat`, `fstat`, `lstat`,
+//! `newfstatat`.
+//!
+//! Scope (RFC 0002 item 11/15, issue #238, read-path subset):
+//!
+//! - No `O_CREAT` — any `open` that would create returns `-EPERM` via
+//!   the default `InodeOps::create` trait body. `open` on a non-existent
+//!   path returns `-ENOENT`.
+//! - No `chdir` / per-process cwd yet (tracked in #239) — relative paths
+//!   resolve against the namespace root until that lands.
+//! - Legacy compat: `/dev/stdin`, `/dev/stdout`, `/dev/stderr`,
+//!   `/dev/serial` still short-circuit to [`SerialBackend`] so the
+//!   boot-time init binary keeps working until a real `/dev/serial`
+//!   character device is wired up.
+//!
+//! All handlers share:
+//! - `copy_path_from_user` for bounded user-path copy-in.
+//! - `resolve_inode` / `resolve_and_open` for path_walk + SB pinning.
+//! - `write_stat` for the userspace `struct stat` copy-out.
+
+use alloc::sync::Arc;
+
+use super::super::syscall::copy_path_from_user_pub;
+use super::super::uaccess;
+use crate::fs::vfs::ops::{Stat, meta_into_stat};
+use crate::fs::vfs::path_walk::{path_walk, LookupFlags, NameIdata};
+use crate::fs::vfs::super_block::SbActiveGuard;
+use crate::fs::vfs::{
+    root as vfs_root, GlobalMountResolver, Inode, InodeKind, OpenFile, VfsBackend,
+};
+use crate::fs::vfs::Credential;
+use crate::fs::{flags as oflags, FileBackend, FileDescription, EBADF, EINVAL, ENOENT, ENOTDIR};
+
+/// Linux x86_64 value of the "use the current working directory"
+/// sentinel for `*at` syscalls. Sign-extended as an `i32`, negative,
+/// so it never collides with a live fd number.
+pub const AT_FDCWD: i32 = -100;
+
+/// `AT_SYMLINK_NOFOLLOW` — the `*at` flag that asks the resolver to
+/// stop on a trailing symlink rather than following it.
+pub const AT_SYMLINK_NOFOLLOW: u32 = 0x100;
+
+/// `AT_EMPTY_PATH` — treat an empty `path` as a reference to the file
+/// behind `dfd` (used by `fstatat(fd, "", &st, AT_EMPTY_PATH)`).
+pub const AT_EMPTY_PATH: u32 = 0x1000;
+
+/// Same bound as `sys_open`'s legacy buffer. Keeps a copy-in within a
+/// single kernel stack frame.
+const OPEN_PATH_MAX: usize = 128;
+
+/// Resolve a user path to an `Arc<Inode>` via `path_walk`.
+///
+/// `follow` controls whether a terminal symlink is followed
+/// (`stat` vs `lstat`). Returns `(inode, sb_guard_holder)` on success —
+/// the holder is an `Arc<SbActiveGuard>`-equivalent: we return the
+/// `NameIdata`'s `edges` vector so the caller's `Arc<SuperBlock>`
+/// references keep the SB alive for the duration of the `getattr` call.
+fn resolve_inode(path: &[u8], follow: bool) -> Result<(Arc<Inode>, NameIdata), i64> {
+    let root = vfs_root().ok_or(ENOENT)?;
+    let mut flags = LookupFlags::default();
+    if follow {
+        flags = flags | LookupFlags::FOLLOW;
+    } else {
+        flags = flags | LookupFlags::NOFOLLOW;
+    }
+    let mut nd = NameIdata::new(root.clone(), root, Credential::kernel(), flags)?;
+    path_walk(&mut nd, path, &GlobalMountResolver)?;
+    let inode = nd.path.inode.clone();
+    Ok((inode, nd))
+}
+
+/// Fill `out` from `inode.ops.getattr`, then copy out to user.
+fn stat_into_user(inode: &Arc<Inode>, user_statbuf: u64) -> i64 {
+    if user_statbuf == 0 {
+        return EINVAL;
+    }
+    if let Err(e) = uaccess::check_user_range(user_statbuf as usize, core::mem::size_of::<Stat>()) {
+        return e.as_errno();
+    }
+    // Zero-init to avoid padding infoleak (Sec-B4 per RFC 0002).
+    let mut st = Stat::default();
+    if let Err(e) = inode.ops.getattr(inode, &mut st) {
+        return e;
+    }
+    // Drivers that don't fill fs_id/ino should get sane defaults from
+    // `meta_into_stat` — but any driver implementing its own getattr is
+    // expected to set them. We re-apply from the inode as a safety net
+    // so a stubbed getattr that returned Ok without touching `out`
+    // still emits a coherent stat.
+    if st.st_ino == 0 {
+        let meta = inode.meta.read();
+        let fs_id = inode.sb.upgrade().map(|s| s.fs_id.0).unwrap_or(0);
+        meta_into_stat(&meta, inode.kind, fs_id, inode.ino, &mut st);
+    }
+    let bytes = unsafe {
+        core::slice::from_raw_parts(
+            &st as *const Stat as *const u8,
+            core::mem::size_of::<Stat>(),
+        )
+    };
+    match unsafe { uaccess::copy_to_user(user_statbuf as usize, bytes) } {
+        Ok(()) => 0,
+        Err(e) => e.as_errno(),
+    }
+}
+
+/// Install `backend` into the current fd table. `flags` contains the
+/// caller's `O_*` flags; access-mode bits go into `FileDescription.flags`
+/// and `O_CLOEXEC` is split into the per-fd slot via `alloc_fd_with_flags`.
+fn install_fd(backend: Arc<dyn FileBackend>, flags: u32) -> i64 {
+    let access_flags = flags & (oflags::O_RDONLY | oflags::O_WRONLY | oflags::O_RDWR);
+    let fd_flags = flags & oflags::O_CLOEXEC;
+    let desc = Arc::new(FileDescription {
+        backend,
+        flags: access_flags,
+    });
+    let tbl = crate::task::current_fd_table();
+    let result = tbl.lock().alloc_fd_with_flags(desc, fd_flags);
+    match result {
+        Ok(fd) => fd as i64,
+        Err(e) => e,
+    }
+}
+
+/// `/dev/{stdin,stdout,stderr,serial}` legacy compat: returns a
+/// `SerialBackend`-backed description when path matches. None otherwise.
+fn legacy_dev_backend(path: &[u8], flags: u64) -> Option<i64> {
+    let is_special = matches!(
+        path,
+        b"/dev/stdin" | b"/dev/stdout" | b"/dev/stderr" | b"/dev/serial"
+    );
+    if !is_special {
+        return None;
+    }
+    let safe_flags =
+        (flags as u32) & (oflags::O_RDONLY | oflags::O_WRONLY | oflags::O_RDWR | oflags::O_CLOEXEC);
+    let backend: Arc<dyn FileBackend> = Arc::new(crate::fs::SerialBackend);
+    Some(install_fd(backend, safe_flags))
+}
+
+/// Shared `open` body: used by `sys_open` (dfd == AT_FDCWD) and
+/// `sys_openat`.
+///
+/// `dfd` is accepted but only `AT_FDCWD` is honored today — passing a
+/// real fd for a relative path returns `-EINVAL` because per-process
+/// cwd / fd-rooted walks don't exist yet (#239).
+pub unsafe fn sys_openat_impl(dfd: i32, path_uva: u64, flags: u64, _mode: u64) -> i64 {
+    // 1. Copy the user path.
+    let mut buf = [0u8; OPEN_PATH_MAX];
+    let n = match copy_path_from_user_pub(path_uva as usize, &mut buf) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    let path = &buf[..n];
+
+    // 2. O_CREAT not supported in this iteration. Fail loudly rather
+    //    than silently ignore — matches the O_EXCL defensive posture
+    //    in tarfs/ramfs today.
+    if (flags as u32) & oflags::O_CREAT != 0 {
+        return crate::fs::EACCES; // EPERM analogue: "creation not permitted yet"
+    }
+
+    // 3. Legacy /dev/{stdin,stdout,stderr,serial} fast path. Bypasses
+    //    the VFS so a smoke boot that opens these before the devfs
+    //    character devices exist keeps working.
+    if let Some(r) = legacy_dev_backend(path, flags) {
+        return r;
+    }
+
+    // 4. `*at` preconditions. Non-AT_FDCWD dfd is out of scope for the
+    //    read-path subset; absolute paths ignore dfd entirely.
+    let is_absolute = path.first() == Some(&b'/');
+    if dfd != AT_FDCWD && !is_absolute {
+        return EINVAL;
+    }
+
+    // 5. Walk.
+    let follow = (flags as u32) & oflags::O_NOFOLLOW == 0;
+    let (inode, nd) = match resolve_inode(path, follow) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
+    // 6. O_DIRECTORY check.
+    if (flags as u32) & oflags::O_DIRECTORY != 0 && inode.kind != InodeKind::Dir {
+        return ENOTDIR;
+    }
+
+    // 7. Build the OpenFile. The edge list in `nd` keeps the SB alive
+    //    until we've successfully acquired our own `SbActiveGuard`.
+    let sb = match inode.sb.upgrade() {
+        Some(s) => s,
+        None => return ENOENT,
+    };
+    let guard = match SbActiveGuard::try_acquire(&sb) {
+        Ok(g) => g,
+        Err(e) => return e,
+    };
+    // `OpenFile::new` takes `sb: Arc<SuperBlock>` by value and
+    // `guard: SbActiveGuard<'_>` also by value. Cloning the `Arc` for
+    // the `sb` argument keeps `sb` live for the `guard`'s lifetime.
+    let sb_for_of = sb.clone();
+    let of = OpenFile::new(
+        nd.path.dentry.clone(),
+        inode.clone(),
+        inode.file_ops.clone(),
+        sb_for_of,
+        flags as u32,
+        guard,
+    );
+    let backend: Arc<dyn FileBackend> = Arc::new(VfsBackend { open_file: of });
+    let fd_flags = (flags as u32)
+        & (oflags::O_RDONLY | oflags::O_WRONLY | oflags::O_RDWR | oflags::O_CLOEXEC);
+    install_fd(backend, fd_flags)
+}
+
+/// `stat(path, *statbuf)` (follow=true) / `lstat(path, *statbuf)`
+/// (follow=false — `nofollow=true` here flips the sense).
+pub unsafe fn sys_stat_impl(path_uva: u64, statbuf_uva: u64, nofollow: bool) -> i64 {
+    let mut buf = [0u8; OPEN_PATH_MAX];
+    let n = match copy_path_from_user_pub(path_uva as usize, &mut buf) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    let path = &buf[..n];
+
+    let (inode, _nd) = match resolve_inode(path, !nofollow) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    stat_into_user(&inode, statbuf_uva)
+}
+
+/// `fstat(fd, *statbuf)` — read `struct stat` of the file behind an
+/// already-open fd.
+pub unsafe fn sys_fstat_impl(fd_raw: u64, statbuf_uva: u64) -> i64 {
+    let fd = fd_raw as u32;
+    let tbl = crate::task::current_fd_table();
+    let backend = match tbl.lock().get(fd) {
+        Ok(b) => b,
+        Err(_) => return EBADF,
+    };
+    // Non-VFS backends (SerialBackend on fds 0/1/2 before execve) have
+    // no Inode; fstat on them yields -EINVAL per POSIX for "no such
+    // attribute". This matches Linux's `generic_file_fstat` on a
+    // pipe/socket fd whose inode lookup returns nothing useful.
+    let vfs = match backend.as_vfs() {
+        Some(v) => v,
+        None => return EINVAL,
+    };
+    stat_into_user(&vfs.open_file.inode, statbuf_uva)
+}
+
+/// `newfstatat(dfd, path, *statbuf, flags)` — the `*at` form of stat.
+///
+/// Supports `AT_SYMLINK_NOFOLLOW` and `AT_EMPTY_PATH`. Rejects any
+/// other flag bit with `-EINVAL` so future additions (`AT_NO_AUTOMOUNT`
+/// etc.) have to be whitelisted explicitly.
+pub unsafe fn sys_newfstatat_impl(dfd: i32, path_uva: u64, statbuf_uva: u64, flags: u32) -> i64 {
+    let known = AT_SYMLINK_NOFOLLOW | AT_EMPTY_PATH;
+    if flags & !known != 0 {
+        return EINVAL;
+    }
+
+    let mut buf = [0u8; OPEN_PATH_MAX];
+    let n = match copy_path_from_user_pub(path_uva as usize, &mut buf) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    let path = &buf[..n];
+
+    // AT_EMPTY_PATH + empty path + fd: stat the file behind dfd.
+    if flags & AT_EMPTY_PATH != 0 && path.is_empty() {
+        return sys_fstat_impl(dfd as u64, statbuf_uva);
+    }
+
+    let is_absolute = path.first() == Some(&b'/');
+    if dfd != AT_FDCWD && !is_absolute {
+        return EINVAL;
+    }
+
+    let follow = flags & AT_SYMLINK_NOFOLLOW == 0;
+    let (inode, _nd) = match resolve_inode(path, follow) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    stat_into_user(&inode, statbuf_uva)
+}

--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -153,11 +153,15 @@ pub unsafe fn sys_openat_impl(dfd: i32, path_uva: u64, flags: u64, _mode: u64) -
     };
     let path = &buf[..n];
 
-    // 2. O_CREAT not supported in this iteration. Fail loudly rather
-    //    than silently ignore — matches the O_EXCL defensive posture
-    //    in tarfs/ramfs today.
-    if (flags as u32) & oflags::O_CREAT != 0 {
-        return crate::fs::EACCES; // EPERM analogue: "creation not permitted yet"
+    // 2. Mutating create/truncate flags not supported in the read-path
+    //    subset. Fail loudly so userspace gets a clear signal rather than
+    //    a silent no-op.
+    let flags32 = flags as u32;
+    if flags32 & oflags::O_CREAT != 0 {
+        return crate::fs::EACCES;
+    }
+    if flags32 & oflags::O_TRUNC != 0 {
+        return crate::fs::EACCES;
     }
 
     // 3. Legacy /dev/{stdin,stdout,stderr,serial} fast path. Bypasses
@@ -234,6 +238,10 @@ pub unsafe fn sys_stat_impl(path_uva: u64, statbuf_uva: u64, nofollow: bool) -> 
 /// `fstat(fd, *statbuf)` — read `struct stat` of the file behind an
 /// already-open fd.
 pub unsafe fn sys_fstat_impl(fd_raw: u64, statbuf_uva: u64) -> i64 {
+    // Linux fd space fits in u32; values above that are always invalid.
+    if fd_raw > u32::MAX as u64 {
+        return EBADF;
+    }
     let fd = fd_raw as u32;
     let tbl = crate::task::current_fd_table();
     let backend = match tbl.lock().get(fd) {
@@ -269,8 +277,13 @@ pub unsafe fn sys_newfstatat_impl(dfd: i32, path_uva: u64, statbuf_uva: u64, fla
     };
     let path = &buf[..n];
 
-    // AT_EMPTY_PATH + empty path + fd: stat the file behind dfd.
+    // AT_EMPTY_PATH + empty path + real fd: stat the file behind dfd.
+    // AT_FDCWD (-100) is not a valid fd for this purpose — reject it
+    // until per-process cwd semantics land (#239).
     if flags & AT_EMPTY_PATH != 0 && path.is_empty() {
+        if dfd == AT_FDCWD {
+            return EINVAL;
+        }
         return sys_fstat_impl(dfd as u64, statbuf_uva);
     }
 

--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -22,13 +22,13 @@ use alloc::sync::Arc;
 
 use super::super::syscall::copy_path_from_user_pub;
 use super::super::uaccess;
-use crate::fs::vfs::ops::{Stat, meta_into_stat};
+use crate::fs::vfs::ops::{meta_into_stat, Stat};
 use crate::fs::vfs::path_walk::{path_walk, LookupFlags, NameIdata};
 use crate::fs::vfs::super_block::SbActiveGuard;
+use crate::fs::vfs::Credential;
 use crate::fs::vfs::{
     root as vfs_root, GlobalMountResolver, Inode, InodeKind, OpenFile, VfsBackend,
 };
-use crate::fs::vfs::Credential;
 use crate::fs::{flags as oflags, FileBackend, FileDescription, EBADF, EINVAL, ENOENT, ENOTDIR};
 
 /// Linux x86_64 value of the "use the current working directory"
@@ -209,8 +209,8 @@ pub unsafe fn sys_openat_impl(dfd: i32, path_uva: u64, flags: u64, _mode: u64) -
         guard,
     );
     let backend: Arc<dyn FileBackend> = Arc::new(VfsBackend { open_file: of });
-    let fd_flags = (flags as u32)
-        & (oflags::O_RDONLY | oflags::O_WRONLY | oflags::O_RDWR | oflags::O_CLOEXEC);
+    let fd_flags =
+        (flags as u32) & (oflags::O_RDONLY | oflags::O_WRONLY | oflags::O_RDWR | oflags::O_CLOEXEC);
     install_fd(backend, fd_flags)
 }
 

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -19,6 +19,15 @@ pub mod vfs;
 pub trait FileBackend: Send + Sync {
     fn read(&self, buf: &mut [u8]) -> Result<usize, i64>;
     fn write(&self, buf: &[u8]) -> Result<usize, i64>;
+
+    /// Downcast to [`vfs::VfsBackend`] for fd-keyed syscalls that need the
+    /// underlying `OpenFile` (e.g. `fstat`, `fstatat` with `AT_EMPTY_PATH`).
+    /// Non-VFS backends (`SerialBackend`, test stubs) return `None` and
+    /// trigger the caller's `-EINVAL`/`-ENOTTY` path.
+    #[cfg(target_os = "none")]
+    fn as_vfs(&self) -> Option<&vfs::VfsBackend> {
+        None
+    }
 }
 
 /// Open-file flags. Values match the Linux x86_64 ABI exactly so userspace

--- a/kernel/src/fs/vfs/backend.rs
+++ b/kernel/src/fs/vfs/backend.rs
@@ -37,6 +37,10 @@ pub struct VfsBackend {
 }
 
 impl FileBackend for VfsBackend {
+    fn as_vfs(&self) -> Option<&VfsBackend> {
+        Some(self)
+    }
+
     /// Read up to `buf.len()` bytes from the current file offset.
     ///
     /// Advances the shared offset by the number of bytes actually read.

--- a/kernel/src/fs/vfs/path_walk.rs
+++ b/kernel/src/fs/vfs/path_walk.rs
@@ -271,11 +271,25 @@ pub fn path_walk(nd: &mut NameIdata, path: &[u8], mounts: &dyn MountResolver) ->
 
             let name = DString::try_from_bytes(comp)?;
             let child_inode = nd.path.inode.ops.lookup(&nd.path.inode, comp)?;
-            let child_dentry = Dentry::new(
-                name.clone(),
-                Arc::downgrade(&nd.path.dentry),
-                Some(child_inode.clone()),
-            );
+            // Reuse a cached dentry if the parent already has one for this
+            // name — the cached dentry may have a `.mount` slot populated
+            // (e.g. `/dev` after init mounts devfs there). A fresh dentry
+            // would miss that and fail to cross the mount boundary.
+            let cached = {
+                let children = nd.path.dentry.children.read();
+                if let Some(crate::fs::vfs::dentry::ChildState::Resolved(d)) = children.get(&name) {
+                    Some(d.clone())
+                } else {
+                    None
+                }
+            };
+            let child_dentry = cached.unwrap_or_else(|| {
+                Dentry::new(
+                    name.clone(),
+                    Arc::downgrade(&nd.path.dentry),
+                    Some(child_inode.clone()),
+                )
+            });
             nd.path = Path {
                 dentry: child_dentry,
                 inode: child_inode,

--- a/kernel/tests/syscall_vfs.rs
+++ b/kernel/tests/syscall_vfs.rs
@@ -1,0 +1,256 @@
+//! Integration test for issue #238: VFS-backed path syscalls — `open`,
+//! `openat`, `stat`, `fstat`, `lstat`, `newfstatat`.
+//!
+//! Exercises the syscall dispatcher arms end-to-end through real
+//! ramfs/devfs mounts on the booted kernel. The path_walk resolver is
+//! the production `GlobalMountResolver`; the fd table is the one
+//! `task::init()` wires up for the boot task.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use core::ptr;
+
+use vibix::arch::x86_64::syscall::syscall_dispatch;
+use vibix::fs::vfs::ops::Stat;
+use vibix::fs::{EBADF, EINVAL, ENOENT, ENOTDIR};
+use vibix::mem::vmatree::{Share, Vma};
+use vibix::mem::vmobject::AnonObject;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+use x86_64::structures::paging::PageTableFlags;
+
+const SYS_OPEN: u64 = 2;
+const SYS_STAT: u64 = 4;
+const SYS_FSTAT: u64 = 5;
+const SYS_LSTAT: u64 = 6;
+const SYS_CLOSE: u64 = 3;
+const SYS_OPENAT: u64 = 257;
+const SYS_NEWFSTATAT: u64 = 262;
+
+const AT_FDCWD_U64: u64 = (-100i64) as u64;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    vibix::task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("stat_root_returns_dir", &(stat_root_returns_dir as fn())),
+        ("stat_enoent_on_missing", &(stat_enoent_on_missing as fn())),
+        ("fstat_ebadf_on_closed", &(fstat_ebadf_on_closed as fn())),
+        (
+            "openat_atfdcwd_absolute",
+            &(openat_atfdcwd_absolute as fn()),
+        ),
+        (
+            "openat_rejects_relative_without_atfdcwd",
+            &(openat_rejects_relative_without_atfdcwd as fn()),
+        ),
+        (
+            "newfstatat_rejects_unknown_flag",
+            &(newfstatat_rejects_unknown_flag as fn()),
+        ),
+        (
+            "newfstatat_empty_path_needs_at_empty_path",
+            &(newfstatat_empty_path_needs_at_empty_path as fn()),
+        ),
+        ("lstat_same_as_stat_on_dir", &(lstat_same_as_stat_on_dir as fn())),
+        (
+            "open_o_directory_on_nondir_enotdir",
+            &(open_o_directory_on_nondir_enotdir as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+// --- User-staging helpers ------------------------------------------------
+
+const USER_PAGE_VA: usize = 0x0000_2000_0000_0000;
+const USER_PAGE_LEN: usize = 8 * 4096;
+
+fn install_user_staging_vma() {
+    static INSTALLED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+    if INSTALLED.swap(true, core::sync::atomic::Ordering::SeqCst) {
+        return;
+    }
+    let prot_pte =
+        (PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE).bits();
+    vibix::task::install_vma_on_current(Vma::new(
+        USER_PAGE_VA,
+        USER_PAGE_VA + USER_PAGE_LEN,
+        0x3,
+        prot_pte,
+        Share::Private,
+        AnonObject::new(Some(USER_PAGE_LEN / 4096)),
+        0,
+    ));
+    unsafe {
+        // Touch every page to force demand-fault before any syscall
+        // runs against these VAs.
+        let dst = USER_PAGE_VA as *mut u8;
+        let mut i = 0;
+        while i < USER_PAGE_LEN {
+            ptr::write_volatile(dst.add(i), 0);
+            i += 4096;
+        }
+    }
+}
+
+/// Copy a NUL-terminated path into the staging page at offset 0.
+fn stage_path(bytes: &[u8]) -> u64 {
+    install_user_staging_vma();
+    assert!(bytes.len() < 128);
+    unsafe {
+        let dst = USER_PAGE_VA as *mut u8;
+        for (i, b) in bytes.iter().enumerate() {
+            ptr::write_volatile(dst.add(i), *b);
+        }
+        ptr::write_volatile(dst.add(bytes.len()), 0);
+    }
+    USER_PAGE_VA as u64
+}
+
+/// Reserve the second half of the staging page as a `struct stat`
+/// destination so path + stat live on the same VA.
+fn statbuf_uva() -> u64 {
+    install_user_staging_vma();
+    (USER_PAGE_VA + 4096) as u64
+}
+
+fn read_stat() -> Stat {
+    unsafe { ptr::read_volatile(statbuf_uva() as *const Stat) }
+}
+
+// --- Tests ---------------------------------------------------------------
+
+fn stat_root_returns_dir() {
+    let path = stage_path(b"/");
+    let r = unsafe { syscall_dispatch(SYS_STAT, path, statbuf_uva(), 0, 0, 0, 0) };
+    assert_eq!(r, 0, "stat(\"/\") should succeed, got {}", r);
+    let st = read_stat();
+    // S_IFDIR == 0o040_000.
+    assert_eq!(
+        st.st_mode & 0o170_000,
+        0o040_000,
+        "root should be a directory, st_mode={:#o}",
+        st.st_mode
+    );
+}
+
+fn stat_enoent_on_missing() {
+    let path = stage_path(b"/no-such-thing");
+    let r = unsafe { syscall_dispatch(SYS_STAT, path, statbuf_uva(), 0, 0, 0, 0) };
+    assert_eq!(r, ENOENT, "expected ENOENT, got {}", r);
+}
+
+fn fstat_ebadf_on_closed() {
+    let r = unsafe { syscall_dispatch(SYS_FSTAT, 9999, statbuf_uva(), 0, 0, 0, 0) };
+    assert_eq!(r, EBADF, "expected EBADF on closed fd, got {}", r);
+}
+
+fn openat_atfdcwd_absolute() {
+    // /dev/serial is a legacy-compat path, served by the SerialBackend
+    // fast path in both `open` and `openat`.
+    let path = stage_path(b"/dev/serial");
+    let fd = unsafe { syscall_dispatch(SYS_OPENAT, AT_FDCWD_U64, path, 2, 0, 0, 0) };
+    assert!(fd >= 3, "openat(/dev/serial) should give fd>=3, got {}", fd);
+    let cr = unsafe { syscall_dispatch(SYS_CLOSE, fd as u64, 0, 0, 0, 0, 0) };
+    assert_eq!(cr, 0, "close fresh fd failed: {}", cr);
+}
+
+fn openat_rejects_relative_without_atfdcwd() {
+    // dfd != AT_FDCWD and path is relative: no per-process cwd yet, so
+    // return EINVAL rather than silently treating dfd as ignored.
+    let path = stage_path(b"relative/path");
+    let r = unsafe { syscall_dispatch(SYS_OPENAT, 5u64, path, 0, 0, 0, 0) };
+    assert_eq!(r, EINVAL, "expected EINVAL, got {}", r);
+}
+
+fn newfstatat_rejects_unknown_flag() {
+    // 0x40000 is AT_RECURSIVE — not a flag we know, must be rejected.
+    let path = stage_path(b"/");
+    let r = unsafe {
+        syscall_dispatch(
+            SYS_NEWFSTATAT,
+            AT_FDCWD_U64,
+            path,
+            statbuf_uva(),
+            0x40000,
+            0,
+            0,
+        )
+    };
+    assert_eq!(r, EINVAL, "unknown flag must yield EINVAL, got {}", r);
+}
+
+fn newfstatat_empty_path_needs_at_empty_path() {
+    // Empty path without AT_EMPTY_PATH → ENOENT from path_walk.
+    let path = stage_path(b"");
+    let r = unsafe {
+        syscall_dispatch(
+            SYS_NEWFSTATAT,
+            AT_FDCWD_U64,
+            path,
+            statbuf_uva(),
+            0,
+            0,
+            0,
+        )
+    };
+    assert_eq!(r, ENOENT, "empty path without AT_EMPTY_PATH → ENOENT, got {}", r);
+}
+
+fn lstat_same_as_stat_on_dir() {
+    // With no symlinks in play, lstat(/) == stat(/).
+    let path = stage_path(b"/");
+    let r1 = unsafe { syscall_dispatch(SYS_STAT, path, statbuf_uva(), 0, 0, 0, 0) };
+    assert_eq!(r1, 0);
+    let st1 = read_stat();
+
+    let path2 = stage_path(b"/");
+    let r2 = unsafe { syscall_dispatch(SYS_LSTAT, path2, statbuf_uva(), 0, 0, 0, 0) };
+    assert_eq!(r2, 0);
+    let st2 = read_stat();
+    assert_eq!(st1.st_ino, st2.st_ino);
+    assert_eq!(st1.st_mode, st2.st_mode);
+}
+
+fn open_o_directory_on_nondir_enotdir() {
+    // /dev/serial is a character file via SerialBackend; but since the
+    // legacy fast-path bypasses the VFS and returns a SerialBackend fd
+    // directly, O_DIRECTORY can't be checked there. Use a devfs file
+    // that is a real char inode: /dev/null.
+    //
+    // Actually since devfs is mounted at /dev and exposes null/zero/
+    // console/tty as char inodes, /dev/null with O_DIRECTORY must
+    // return ENOTDIR.
+    const O_DIRECTORY: u64 = 0o200000;
+    let path = stage_path(b"/dev/null");
+    let r = unsafe { syscall_dispatch(SYS_OPEN, path, O_DIRECTORY, 0, 0, 0, 0) };
+    assert_eq!(
+        r, ENOTDIR,
+        "O_DIRECTORY on char file must be ENOTDIR, got {}",
+        r
+    );
+}

--- a/kernel/tests/syscall_vfs.rs
+++ b/kernel/tests/syscall_vfs.rs
@@ -71,7 +71,10 @@ fn run_tests() {
             "newfstatat_empty_path_needs_at_empty_path",
             &(newfstatat_empty_path_needs_at_empty_path as fn()),
         ),
-        ("lstat_same_as_stat_on_dir", &(lstat_same_as_stat_on_dir as fn())),
+        (
+            "lstat_same_as_stat_on_dir",
+            &(lstat_same_as_stat_on_dir as fn()),
+        ),
         (
             "open_o_directory_on_nondir_enotdir",
             &(open_o_directory_on_nondir_enotdir as fn()),
@@ -207,18 +210,12 @@ fn newfstatat_rejects_unknown_flag() {
 fn newfstatat_empty_path_needs_at_empty_path() {
     // Empty path without AT_EMPTY_PATH → ENOENT from path_walk.
     let path = stage_path(b"");
-    let r = unsafe {
-        syscall_dispatch(
-            SYS_NEWFSTATAT,
-            AT_FDCWD_U64,
-            path,
-            statbuf_uva(),
-            0,
-            0,
-            0,
-        )
-    };
-    assert_eq!(r, ENOENT, "empty path without AT_EMPTY_PATH → ENOENT, got {}", r);
+    let r = unsafe { syscall_dispatch(SYS_NEWFSTATAT, AT_FDCWD_U64, path, statbuf_uva(), 0, 0, 0) };
+    assert_eq!(
+        r, ENOENT,
+        "empty path without AT_EMPTY_PATH → ENOENT, got {}",
+        r
+    );
 }
 
 fn lstat_same_as_stat_on_dir() {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -807,6 +807,7 @@ fn test_all() -> R<()> {
         "smep_smap",
         "fd_table",
         "syscall_open_mmap",
+        "syscall_vfs",
         "vm_integration",
         "vfs_backend",
         "vfs_hello",


### PR DESCRIPTION
Closes #238

## Summary

- Implements the read-path subset of the VFS syscall layer: `open`, `openat`, `stat`, `fstat`, `lstat`, `newfstatat`.
- Adds `FileBackend::as_vfs()` downcast so fd-keyed stat syscalls can reach the `OpenFile`'s inode.
- Pins new Linux x86_64 syscall numbers: `STAT=4`, `LSTAT=6`, `NEWFSTATAT=262` (extends the ABI-regression test from issue #278).
- Handlers live in a new `arch::x86_64::syscalls::vfs` submodule; the dispatcher in `syscall.rs` just routes to them.

## Scope (what's in and what's not)

**In:** path_walk through the `GlobalMountResolver`, `SbActiveGuard` acquisition, `VfsBackend`-wrapped `OpenFile` installation into the fd table, `struct stat` copy-out with zero-init against padding infoleak, `O_DIRECTORY` / `O_NOFOLLOW` honoring, `AT_EMPTY_PATH` / `AT_SYMLINK_NOFOLLOW` handling.

**Deliberately out of scope (follow-ups):**

- `O_CREAT` and all namespace mutators (`mkdir`/`rmdir`/`unlink`/`rename`/`link`/`symlink`) — the write-path subset comes in a later PR.
- `chdir` / `getcwd` and fd-rooted relative walks — blocked on #239 (per-process cwd). For now: `dfd != AT_FDCWD` + relative path returns `EINVAL` rather than silently misinterpreting the dfd.
- `getdents64`, `lseek`, `readlink` — separate follow-ups.

**Legacy compat:** `/dev/{stdin,stdout,stderr,serial}` still short-circuits to `SerialBackend` before the VFS walk, so the pre-devfs smoke boot keeps working.

## Test plan

- [ ] `cargo xtask build` — clean
- [ ] `cargo xtask test` — new `syscall_vfs` integration test boots under QEMU and exercises every new dispatcher arm through the real ramfs/devfs graph wired up by `vibix::init()`
- [ ] `cargo xtask smoke` — boot path still reaches every `SMOKE_MARKERS` line
- [ ] Existing `syscall_open_mmap` tests still pass: `/dev/stdout` returns a fd via legacy compat, `/nonexistent` returns ENOENT via real path_walk
- [ ] ABI-regression test extended to cover STAT/LSTAT/NEWFSTATAT