### PR TITLE
skill: auto-engineer renames tmux window to AE -> <slug> per cycle

### DIFF
--- a/.claude/skills/auto-engineer/SKILL.md
+++ b/.claude/skills/auto-engineer/SKILL.md
@@ -85,6 +85,17 @@ git checkout main && git pull
 git checkout -b <branch>   # m<N>-<slug> or <verb>-<slug>
 ```
 
+Then rename the tmux window so the human glancing at the terminal can see which
+issue this cycle is on. `<slug>` is the same short slug used in the branch name
+(3–4 words, kebab-case). Uses an OSC 2 escape so it works both on the host and
+from inside the auto-engineer Docker container — tmux intercepts the sequence
+from the pane's stdout and renames the window (requires tmux's default
+`allow-rename on`). No-op outside tmux.
+
+```sh
+printf '\033]2;AE -> <slug>\033\\'
+```
+
 ### 2. Delegate planning to a sub-agent
 
 Use the `Agent` tool with `subagent_type: "Plan"`. Pass the full issue body, its label list, and any linked issues you fetched. Ask for:

--- a/scripts/auto-engineer.sh
+++ b/scripts/auto-engineer.sh
@@ -73,6 +73,18 @@ else
     )
 fi
 
+# If we're inside tmux, disable automatic-rename on the current window for the
+# duration of the container run so the container's OSC 2 escapes (emitted by
+# auto-engineer to label the window "AE -> <slug>") aren't immediately
+# overwritten by tmux's pane_current_command heuristic. Restore on exit.
+restore_tmux_rename=""
+if [ -n "${TMUX:-}" ] && command -v tmux >/dev/null 2>&1; then
+    prev="$(tmux show-window-options -v automatic-rename 2>/dev/null || echo on)"
+    tmux set-window-option automatic-rename off >/dev/null 2>&1 || true
+    restore_tmux_rename="$prev"
+    trap 'tmux set-window-option automatic-rename "$restore_tmux_rename" >/dev/null 2>&1 || true' EXIT
+fi
+
 docker run --rm -it \
     ${docker_sec_opts[@]+"${docker_sec_opts[@]}"} \
     "${claude_vol_opts[@]}" \


### PR DESCRIPTION
## Summary
- Auto-engineer emits an OSC 2 escape in step 1 of each cycle so the host tmux window shows which issue is being worked on (`AE -> <slug>`). Works from both the host and inside the Docker container.
- `scripts/auto-engineer.sh` disables `automatic-rename` on the current tmux window before `docker run` and restores it on exit, so tmux doesn't immediately overwrite the OSC 2 name with `pane_current_command`.

## Test plan
- [ ] Run `scripts/auto-engineer.sh` inside a tmux pane; confirm window renames to `AE -> <slug>` once the first cycle picks an issue.
- [ ] Kill the container (Ctrl-C); confirm `automatic-rename` restores to its previous value.
- [ ] Running on the host (no Docker) with auto-engineer still emits the escape cleanly.