### PR TITLE
xtask: simplify initrd code — redundant comments, magic check, test coverage

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -533,9 +533,22 @@ fn ensure_initrd() -> R<PathBuf> {
     // DIRS headers + 2 file headers + 2 padded data blocks + 2 end blocks.
     const EXPECTED_SIZE: u64 = ((DIRS.len() + 2 + 2 + 2) * 512) as u64;
 
+    // Size-only isn't sufficient — a file of the right length but wrong content
+    // would silently produce a bad rootfs. Also verify the USTAR magic at offset
+    // 257 (mirrors the pattern used in ensure_test_disk).
     let needs_write = match fs::metadata(&path) {
-        Ok(m) => m.len() != EXPECTED_SIZE,
-        Err(_) => true,
+        Ok(m) if m.len() == EXPECTED_SIZE => {
+            let mut magic = [0u8; 6];
+            fs::File::open(&path)
+                .and_then(|mut f| {
+                    use std::io::{Read, Seek, SeekFrom};
+                    f.seek(SeekFrom::Start(257))?;
+                    f.read_exact(&mut magic)
+                })
+                .map(|()| magic != *b"ustar\0")
+                .unwrap_or(true)
+        }
+        _ => true,
     };
 
     if needs_write {
@@ -1024,6 +1037,9 @@ mod tests {
             })
             .sum();
         assert_eq!(computed, stored);
+        // Checksum field is 6 octal digits + NUL + space (8 bytes total)
+        assert_eq!(block[154], 0, "byte 154 must be NUL");
+        assert_eq!(block[155], b' ', "byte 155 must be space");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Rebased onto current main. The original first bullet (dropping redundant comments from `ustar_dir_block`) became moot after main's refactor introduced a shared `ustar_header_block` helper. The two remaining changes are still useful:

- Strengthen `ensure_initrd`'s idempotency check to verify the USTAR magic bytes (`"ustar\0"` at offset 257), matching the pattern in `ensure_test_disk`. Size-only wasn't sufficient to detect a corrupt or stale file of the right length.
- Extend `ustar_dir_block_checksum_valid` to assert the NUL+space terminator at bytes 154–155, fully verifying the 8-byte checksum field format rather than just the numeric value.

## Test plan

- [x] `cargo test --package xtask` — 23 tests pass
- [x] `cargo clippy --package xtask --all-targets -- -D warnings` — clean