### PR TITLE
m85: VFS multi-level directory support

### DIFF
--- a/kernel/src/fs/vfs/tarfs.rs
+++ b/kernel/src/fs/vfs/tarfs.rs
@@ -969,6 +969,35 @@ mod tests {
             .expect("remount after unmount must succeed");
     }
 
+    /// A deep file entry whose intermediate directories are absent from
+    /// the archive must still be resolvable — `split_parent` auto-creates
+    /// the missing `a/` and `a/b/` directory nodes.
+    #[test]
+    fn implicit_parent_dirs_are_auto_created() {
+        let mut archive: Vec<u8> = Vec::new();
+        // Only a file entry; no explicit "a/" or "a/b/" headers.
+        archive.extend_from_slice(&make_header(b"a/b/c.txt", 3, b'0', b"", 0o644));
+        archive.extend_from_slice(&pad_block(b"hey"));
+        archive.extend_from_slice(&[0u8; BLOCK * 2]);
+
+        let fs = TarFs::new_arc();
+        let sb = fs
+            .mount(
+                MountSource::Static(leak_archive(archive)),
+                MountFlags::default(),
+            )
+            .expect("mount deep-file archive");
+
+        let root = sb.root.get().unwrap().clone();
+        let a = root.ops.lookup(&root, b"a").expect("auto-created a/");
+        assert_eq!(a.kind, InodeKind::Dir);
+        let b = a.ops.lookup(&a, b"b").expect("auto-created a/b/");
+        assert_eq!(b.kind, InodeKind::Dir);
+        let c = b.ops.lookup(&b, b"c.txt").expect("a/b/c.txt");
+        assert_eq!(c.kind, InodeKind::Reg);
+        assert_eq!(c.meta.read().size, 3);
+    }
+
     /// While a mount is live the latch must refuse a second mount.
     #[test]
     fn double_mount_returns_ebusy() {

--- a/kernel/tests/vfs_hello.rs
+++ b/kernel/tests/vfs_hello.rs
@@ -135,10 +135,7 @@ fn build_nested_archive() -> Vec<u8> {
     let mut archive: Vec<u8> = Vec::new();
     archive.extend_from_slice(&make_dir_header(b"etc/"));
     archive.extend_from_slice(&make_dir_header(b"etc/init/"));
-    archive.extend_from_slice(&make_header(
-        b"etc/init/hello.txt",
-        payload.len() as u64,
-    ));
+    archive.extend_from_slice(&make_header(b"etc/init/hello.txt", payload.len() as u64));
     archive.extend_from_slice(&pad_block(payload));
     archive.extend_from_slice(&[0u8; BLOCK * 2]);
     archive
@@ -211,8 +208,7 @@ fn hello_read_through_vfs() {
 }
 
 fn nested_read_through_vfs() {
-    let archive: &'static [u8] =
-        alloc::boxed::Box::leak(build_nested_archive().into_boxed_slice());
+    let archive: &'static [u8] = alloc::boxed::Box::leak(build_nested_archive().into_boxed_slice());
 
     let fs = TarFs::new_arc();
     let sb = fs

--- a/kernel/tests/vfs_hello.rs
+++ b/kernel/tests/vfs_hello.rs
@@ -46,8 +46,13 @@ fn panic(info: &PanicInfo) -> ! {
 }
 
 fn run_tests() {
-    let tests: &[(&str, &dyn Testable)] =
-        &[("hello_read_through_vfs", &(hello_read_through_vfs as fn()))];
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("hello_read_through_vfs", &(hello_read_through_vfs as fn())),
+        (
+            "nested_read_through_vfs",
+            &(nested_read_through_vfs as fn()),
+        ),
+    ];
     serial_println!("running {} tests", tests.len());
     for (name, t) in tests {
         serial_println!("test {name}");
@@ -74,15 +79,25 @@ fn write_octal(out: &mut [u8], mut v: u64, digits: usize) {
 /// Build a single-entry USTAR header for a regular file named `name`
 /// of size `size` bytes.
 fn make_header(name: &[u8], size: u64) -> [u8; BLOCK] {
+    make_header_typed(name, size, b'0', 0o644)
+}
+
+/// Build a USTAR directory header for `name` (conventionally terminated
+/// by `/`). Directory entries carry size 0 and typeflag `'5'`.
+fn make_dir_header(name: &[u8]) -> [u8; BLOCK] {
+    make_header_typed(name, 0, b'5', 0o755)
+}
+
+fn make_header_typed(name: &[u8], size: u64, typeflag: u8, mode: u64) -> [u8; BLOCK] {
     let mut h = [0u8; BLOCK];
     let n = core::cmp::min(name.len(), 100);
     h[..n].copy_from_slice(&name[..n]);
-    write_octal(&mut h[100..108], 0o644, 7);
+    write_octal(&mut h[100..108], mode, 7);
     write_octal(&mut h[108..116], 0, 7);
     write_octal(&mut h[116..124], 0, 7);
     write_octal(&mut h[124..136], size, 11);
     write_octal(&mut h[136..148], 0, 11);
-    h[156] = b'0';
+    h[156] = typeflag;
     h[257..263].copy_from_slice(b"ustar\0");
     h[263..265].copy_from_slice(b"00");
 
@@ -107,6 +122,23 @@ fn build_hello_archive() -> Vec<u8> {
     let payload = b"Hello\n";
     let mut archive: Vec<u8> = Vec::new();
     archive.extend_from_slice(&make_header(b"hello", payload.len() as u64));
+    archive.extend_from_slice(&pad_block(payload));
+    archive.extend_from_slice(&[0u8; BLOCK * 2]);
+    archive
+}
+
+/// Build a USTAR archive that exercises multi-level path resolution:
+/// explicit directory entries `etc/` and `etc/init/`, followed by a
+/// regular file `etc/init/hello.txt` containing `"nested\n"`.
+fn build_nested_archive() -> Vec<u8> {
+    let payload = b"nested\n";
+    let mut archive: Vec<u8> = Vec::new();
+    archive.extend_from_slice(&make_dir_header(b"etc/"));
+    archive.extend_from_slice(&make_dir_header(b"etc/init/"));
+    archive.extend_from_slice(&make_header(
+        b"etc/init/hello.txt",
+        payload.len() as u64,
+    ));
     archive.extend_from_slice(&pad_block(payload));
     archive.extend_from_slice(&[0u8; BLOCK * 2]);
     archive
@@ -175,5 +207,64 @@ fn hello_read_through_vfs() {
     }
 
     // Keep Arc chain alive through the end of the test.
+    drop(fs);
+}
+
+fn nested_read_through_vfs() {
+    let archive: &'static [u8] =
+        alloc::boxed::Box::leak(build_nested_archive().into_boxed_slice());
+
+    let fs = TarFs::new_arc();
+    let sb = fs
+        .mount(MountSource::Static(archive), MountFlags::default())
+        .expect("tarfs mount of nested archive");
+
+    let root_inode = sb
+        .root
+        .get()
+        .cloned()
+        .expect("tarfs publishes a root inode at mount");
+    let root_dentry = Dentry::new_root(root_inode.clone());
+
+    let mut nd = NameIdata::new(
+        root_dentry.clone(),
+        root_dentry,
+        Credential::kernel(),
+        LookupFlags::default(),
+    )
+    .expect("seed namei");
+    path_walk(&mut nd, b"/etc/init/hello.txt", &NullMountResolver)
+        .expect("path_walk /etc/init/hello.txt");
+
+    let leaf_dentry = nd.path.dentry.clone();
+    let leaf_inode = nd.path.inode.clone();
+    assert_eq!(
+        leaf_inode.kind,
+        vibix::fs::vfs::InodeKind::Reg,
+        "/etc/init/hello.txt must resolve to a regular file"
+    );
+
+    let guard = SbActiveGuard::try_acquire(&sb).expect("sb_active guard");
+    let of = OpenFile::new(
+        leaf_dentry,
+        leaf_inode.clone(),
+        leaf_inode.file_ops.clone(),
+        sb.clone(),
+        0,
+        guard,
+    );
+
+    let mut buf = [0u8; 16];
+    let n = leaf_inode
+        .file_ops
+        .read(&of, &mut buf, 0)
+        .expect("FileOps::read /etc/init/hello.txt");
+    if n != 7 || &buf[..7] != b"nested\n" {
+        panic!(
+            "vfs_hello: expected /etc/init/hello.txt == b\"nested\\n\", got n={n}, bytes={:?}",
+            &buf[..core::cmp::min(n, buf.len())]
+        );
+    }
+
     drop(fs);
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -460,10 +460,22 @@ fn initrd_path() -> PathBuf {
 /// - bytes 124..136  size (octal, NUL-terminated, 0 for directories)
 /// - bytes 136..148  mtime (octal, NUL-terminated, 0 = epoch)
 /// - bytes 148..156  checksum (6 octal digits + NUL + space)
-/// - byte  156       typeflag ('5' = directory)
+/// - byte  156       typeflag ('5' = directory, '0' = regular file)
 /// - bytes 257..263  magic ("ustar\0")
 /// - bytes 263..265  version ("00")
 fn ustar_dir_block(name: &str) -> [u8; 512] {
+    ustar_header_block(name, b'5', 0o755, 0)
+}
+
+/// Build one USTAR regular-file header block (512 bytes).
+///
+/// Callers must follow the returned header with `size` bytes of file
+/// payload, padded with NULs to the next 512-byte boundary.
+fn ustar_file_block(name: &str, size: u64) -> [u8; 512] {
+    ustar_header_block(name, b'0', 0o644, size)
+}
+
+fn ustar_header_block(name: &str, typeflag: u8, mode: u16, size: u64) -> [u8; 512] {
     let mut block = [0u8; 512];
 
     // name field (bytes 0..100)
@@ -471,21 +483,23 @@ fn ustar_dir_block(name: &str) -> [u8; 512] {
     let copy_len = name_bytes.len().min(99);
     block[..copy_len].copy_from_slice(&name_bytes[..copy_len]);
 
-    // mode: 0755 for directories
-    block[100..107].copy_from_slice(b"0000755");
+    // mode: 7 octal digits + NUL
+    let mode_str = format!("{mode:07o}");
+    block[100..107].copy_from_slice(mode_str.as_bytes());
 
     // uid / gid: both 0
     block[108..115].copy_from_slice(b"0000000");
     block[116..123].copy_from_slice(b"0000000");
 
-    // size: 0 (11 octal digits + NUL)
-    block[124..135].copy_from_slice(b"00000000000");
+    // size: 11 octal digits + NUL
+    let size_str = format!("{size:011o}");
+    block[124..135].copy_from_slice(size_str.as_bytes());
 
     // mtime: 0 (epoch)
     block[136..147].copy_from_slice(b"00000000000");
 
-    // typeflag: '5' = directory
-    block[156] = b'5';
+    // typeflag
+    block[156] = typeflag;
 
     // USTAR magic and version
     block[257..263].copy_from_slice(b"ustar\0");
@@ -512,21 +526,23 @@ fn ustar_dir_block(name: &str) -> [u8; 512] {
 
 /// Build the minimal rootfs USTAR tarball at `target/rootfs.tar`.
 ///
-/// The tarball contains four empty directory entries required by RFC 0002
-/// §Initialization order:
-///   - `dev/`   — mount point for devfs
-///   - `tmp/`   — mount point for ramfs
-///   - `bin/`   — conventional userspace binary directory stub
-///   - `etc/`   — conventional configuration directory stub
+/// The tarball contains:
+///   - `dev/`, `tmp/`, `bin/`, `etc/` — stub mount points and directories
+///     required by RFC 0002 §Initialization order.
+///   - `etc/init/` — nested directory exercising multi-level path resolution
+///     (issue #85).
+///   - `etc/init/hello.txt` — nested regular file whose presence proves the
+///     full `path_walk` chain resolves `/etc/init/hello.txt` end-to-end.
 ///
 /// The tarball ends with two 512-byte all-zero blocks per the USTAR spec.
-/// Total size: 6 × 512 = 3072 bytes (deterministic, used for idempotency).
 fn ensure_initrd() -> R<PathBuf> {
     let path = initrd_path();
 
-    // The archive size is deterministic: 4 directory entries + 2 end blocks.
-    const DIRS: &[&str] = &["dev/", "tmp/", "bin/", "etc/"];
-    const EXPECTED_SIZE: u64 = ((DIRS.len() + 2) * 512) as u64;
+    const DIRS: &[&str] = &["dev/", "tmp/", "bin/", "etc/", "etc/init/"];
+    const NESTED_FILE: &str = "etc/init/hello.txt";
+    const NESTED_PAYLOAD: &[u8] = b"nested\n";
+    // DIRS headers + 1 file header + 1 padded data block + 2 end blocks.
+    const EXPECTED_SIZE: u64 = ((DIRS.len() + 1 + 1 + 2) * 512) as u64;
 
     let needs_write = match fs::metadata(&path) {
         Ok(m) => m.len() != EXPECTED_SIZE,
@@ -541,6 +557,10 @@ fn ensure_initrd() -> R<PathBuf> {
         for &dir in DIRS {
             data.extend_from_slice(&ustar_dir_block(dir));
         }
+        data.extend_from_slice(&ustar_file_block(NESTED_FILE, NESTED_PAYLOAD.len() as u64));
+        let mut payload_block = [0u8; 512];
+        payload_block[..NESTED_PAYLOAD.len()].copy_from_slice(NESTED_PAYLOAD);
+        data.extend_from_slice(&payload_block);
         // Two 512-byte zero blocks mark end-of-archive.
         data.extend_from_slice(&[0u8; 1024]);
         fs::write(&path, &data)?;


### PR DESCRIPTION
Closes #85

## Summary

- Extends `xtask ensure_initrd` to emit an `etc/init/` directory entry and an `etc/init/hello.txt` file (`"nested\n"`) in the rootfs USTAR tarball, so the initrd actually carries a multi-level path.
- Refactors the USTAR header builder in xtask into a shared `ustar_header_block` with thin `ustar_dir_block` / `ustar_file_block` wrappers, keeping the checksum math in one place.
- Extends `kernel/tests/vfs_hello.rs` with a second test case `nested_read_through_vfs` that mounts a USTAR archive with explicit `etc/` and `etc/init/` directory entries, walks `/etc/init/hello.txt` through `path_walk`, and asserts the contents.
- Adds a host unit test in `tarfs::tests` covering the implicit-parent branch of `split_parent` (a deep file entry with no explicit parent-dir headers).

The VFS path walker at `kernel/src/fs/vfs/path_walk.rs` already resolved multi-component paths — the gap closed by this PR was coverage: the rootfs had no nested entries and no integration test exercised more than one component. Per the issue, symlinks, hard links, mount points, and writable directory creation remain out of scope.

## Test plan

- [ ] `cargo xtask build` — kernel compiles
- [ ] `cargo xtask test` — host unit tests (including new `implicit_parent_dirs_are_auto_created`) and QEMU integration tests (including new `nested_read_through_vfs`) pass
- [ ] `cargo xtask smoke` — boot markers still present

(Local host is aarch64; CI exercises the full x86_64 toolchain.)

Verified locally:
- `cargo build -p xtask` succeeds.
- `cargo xtask initrd` produces a 4608-byte archive whose `tar -tvf` listing shows `dev/`, `tmp/`, `bin/`, `etc/`, `etc/init/`, `etc/init/hello.txt` (7 bytes) in order.
- Extracting the archive yields `etc/init/hello.txt` containing `nested\n`.