### PR TITLE
vfs: push MountSource::RamdiskModule unsafe to the callsite

### DIFF
--- a/kernel/src/fs/vfs/init.rs
+++ b/kernel/src/fs/vfs/init.rs
@@ -69,12 +69,8 @@ pub fn init() {
     // early-boot without the ISO, or any future build that omits it).
     #[cfg(target_os = "none")]
     let root_edge = {
-        if let Some((ptr, len)) = find_rootfs_module() {
-            // SAFETY (inside tarfs): Limine places module payloads in
-            // EXECUTABLE_AND_MODULES memory, preserved for the kernel's
-            // lifetime. TarFs::mount() converts the raw pointer to a slice
-            // with an internal `unsafe` block.
-            let source = MountSource::RamdiskModule(ptr, len);
+        if let Some(module_bytes) = find_rootfs_module() {
+            let source = MountSource::RamdiskModule(module_bytes);
             let edge = mount(
                 source,
                 &bootstrap,
@@ -124,16 +120,25 @@ pub fn init() {
     crate::serial_println!("vfs: mounted ramfs at /tmp");
 }
 
-/// Locate the rootfs tarball module from the Limine module response.
-/// Returns `(ptr, len)` if found, `None` otherwise.
+/// Locate the rootfs tarball module from the Limine module response and
+/// convert the raw bootloader pointer into a `&'static [u8]`.
+///
+/// # Safety of the `unsafe` block
+///
+/// Limine guarantees that module payloads reside in
+/// `EXECUTABLE_AND_MODULES` memory, which it preserves for the kernel's
+/// entire lifetime. `file.addr()` and `file.size()` come directly from
+/// the validated bootloader response and form a valid, non-overlapping
+/// byte range. The resulting slice is therefore sound for `'static`.
 #[cfg(target_os = "none")]
-fn find_rootfs_module() -> Option<(*const u8, usize)> {
+fn find_rootfs_module() -> Option<&'static [u8]> {
     let resp = crate::boot::MODULE_REQUEST.get_response()?;
     let file = resp
         .modules()
         .iter()
         .find(|f| f.path().to_bytes().ends_with(b"/boot/rootfs.tar"))?;
-    Some((file.addr(), file.size() as usize))
+    // SAFETY: see doc comment above.
+    Some(unsafe { core::slice::from_raw_parts(file.addr(), file.size() as usize) })
 }
 
 /// Create a subdirectory `name` under `parent`, wrap it in a fresh

--- a/kernel/src/fs/vfs/ops.rs
+++ b/kernel/src/fs/vfs/ops.rs
@@ -26,12 +26,13 @@ pub enum MountSource<'a> {
     Path(&'a [u8]),
     /// Static byte slice with 'static lifetime (initrd tarball).
     Static(&'static [u8]),
-    /// Raw pointer + length from a Limine ramdisk module. The bytes
-    /// are expected to live for the kernel's lifetime. Non-`Send`
-    /// because the pointer is only meaningful on the mount thread;
-    /// the driver copies the `(ptr, len)` pair into its own state
-    /// under its own safety contract.
-    RamdiskModule(*const u8, usize),
+    /// Byte slice backed by a Limine ramdisk module. The caller is
+    /// responsible for converting the bootloader's raw pointer + length
+    /// into a `&'static [u8]` via an `unsafe` block at the callsite
+    /// (see `vfs::init::find_rootfs_module`). Kept distinct from
+    /// [`Static`](Self::Static) so logging/tracing can tell apart test
+    /// fixtures from live boot modules.
+    RamdiskModule(&'static [u8]),
 }
 
 impl core::fmt::Debug for MountSource<'_> {
@@ -40,11 +41,9 @@ impl core::fmt::Debug for MountSource<'_> {
             MountSource::None => f.write_str("None"),
             MountSource::Path(p) => f.debug_tuple("Path").field(p).finish(),
             MountSource::Static(s) => f.debug_tuple("Static").field(&s.len()).finish(),
-            MountSource::RamdiskModule(ptr, len) => f
-                .debug_tuple("RamdiskModule")
-                .field(&(*ptr as usize))
-                .field(len)
-                .finish(),
+            MountSource::RamdiskModule(s) => {
+                f.debug_tuple("RamdiskModule").field(&s.len()).finish()
+            }
         }
     }
 }

--- a/kernel/src/fs/vfs/tarfs.rs
+++ b/kernel/src/fs/vfs/tarfs.rs
@@ -54,20 +54,19 @@ struct TarNode {
 pub struct TarSuper {
     fs_id: u64,
     nodes: Vec<TarNode>,
-    base: *const u8,
-    len: usize,
+    /// The backing archive bytes. Held as a `'static` slice so all
+    /// inode data (offsets into this buffer) remains valid for the
+    /// kernel's lifetime without raw-pointer bookkeeping.
+    archive: &'static [u8],
     /// Back-reference to the owning `TarFs` so `unmount` can clear the
     /// `mounted` latch. `Weak` breaks the `TarFs → Arc<SuperBlock> →
     /// TarSuper → TarFs` cycle.
     owner: Weak<TarFs>,
 }
 
-unsafe impl Send for TarSuper {}
-unsafe impl Sync for TarSuper {}
-
 impl TarSuper {
     fn slice(&self) -> &[u8] {
-        unsafe { core::slice::from_raw_parts(self.base, self.len) }
+        self.archive
     }
 
     fn node(&self, ino: u64) -> Result<&TarNode, i64> {
@@ -92,7 +91,7 @@ impl SuperOps for TarSuper {
         Ok(StatFs {
             f_type: 0x7461_7266, // 'tarf'
             f_bsize: BLOCK as u64,
-            f_blocks: (self.len / BLOCK) as u64,
+            f_blocks: (self.archive.len() / BLOCK) as u64,
             f_bfree: 0,
             f_bavail: 0,
             f_files: self.nodes.len().saturating_sub(1) as u64,
@@ -621,8 +620,8 @@ fn install_symlink(nodes: &mut Vec<TarNode>, entry: &RawEntry<'_>) -> Result<(),
 ///
 /// Constructed once per kernel boot and handed to `mount_table::mount`.
 /// The archive source is supplied via [`MountSource::Static`] for
-/// test fixtures and [`MountSource::RamdiskModule`] for the live
-/// kernel (wiring in #240).
+/// test fixtures and [`MountSource::RamdiskModule`] for live boot
+/// (wired from `vfs::init::find_rootfs_module`).
 pub struct TarFs {
     mounted: AtomicBool,
     /// Self-reference. Populated by [`TarFs::new_arc`] so the
@@ -654,13 +653,10 @@ impl FileSystem for TarFs {
         // Validate source and parse the archive *before* taking the
         // single-mount latch. An invalid source or malformed archive
         // must not burn the TarFs instance — see issue #274.
-        let (base, len): (*const u8, usize) = match source {
-            MountSource::Static(bytes) => (bytes.as_ptr(), bytes.len()),
-            MountSource::RamdiskModule(p, n) => (p, n),
+        let bytes: &[u8] = match source {
+            MountSource::Static(b) | MountSource::RamdiskModule(b) => b,
             _ => return Err(EINVAL),
         };
-
-        let bytes = unsafe { core::slice::from_raw_parts(base, len) };
         let nodes = build_nodes(bytes)?;
 
         // Parsing succeeded — claim the single-mount latch.
@@ -675,8 +671,7 @@ impl FileSystem for TarFs {
         let super_ops: Arc<TarSuper> = Arc::new(TarSuper {
             fs_id: alloc_fs_id().0,
             nodes,
-            base,
-            len,
+            archive: bytes,
             owner: self.self_ref.clone(),
         });
 


### PR DESCRIPTION
Closes #275

## Summary

- `MountSource::RamdiskModule(*const u8, usize)` → `RamdiskModule(&'static [u8])`: the variant now carries a proper Rust reference instead of a raw pointer pair, making it `Send + Sync` without manual `unsafe impl`.
- `find_rootfs_module()` now returns `Option<&'static [u8]>` and owns the single `unsafe { from_raw_parts(...) }` block, co-located with the safety proof (Limine EXECUTABLE_AND_MODULES memory, kernel lifetime).
- `TarSuper` stores `archive: &'static [u8]` instead of `(base: *const u8, len: usize)`, removing the internal `unsafe from_raw_parts` in `TarSuper::slice()` and the `unsafe impl Send for TarSuper / unsafe impl Sync for TarSuper` declarations.
- The `mount()` match arm in `tarfs.rs` collapses to `MountSource::Static(b) | MountSource::RamdiskModule(b) => b` — a single safe slice, no unsafe.

## Test plan

- [ ] `cargo xtask build` — library compiles without errors
- [ ] CI `cargo fmt --check` passes (no formatting changes)
- [ ] CI host unit tests pass (tarfs tests exercise `MountSource::Static`; `RamdiskModule` path covered by the QEMU integration test)
- [ ] CI QEMU integration tests pass including `rootfs_module` (exercises the tarfs-at-/ boot path end-to-end)