### PR TITLE
skill: rename tmux window via shared slug file (container case)

### DIFF
--- a/.claude/skills/auto-engineer/SKILL.md
+++ b/.claude/skills/auto-engineer/SKILL.md
@@ -87,15 +87,26 @@ git checkout -b <branch>   # m<N>-<slug> or <verb>-<slug>
 
 Then rename the tmux window so the human glancing at the terminal can see which
 issue this cycle is on. `<slug>` is the same short slug used in the branch name
-(3–4 words, kebab-case). Uses an OSC 2 escape written directly to `/dev/tty` so
-it bypasses Claude's Bash-tool stdout capture and reaches the underlying pty —
-tmux then intercepts the sequence and renames the window. Works from both the
-host and inside the auto-engineer Docker container. `scripts/auto-engineer.sh`
-disables `automatic-rename` on the launching window so tmux doesn't overwrite
-the name on the next tick.
+(3–4 words, kebab-case).
+
+The mechanism differs by environment because Claude's Bash tool has no
+controlling terminal, so neither OSC 2 escapes nor `/dev/tty` writes can reach
+the host tmux pane from inside the container:
+
+- **Inside the container**: write the slug to `$VIBIX_AE_SLUG_FILE` (set by
+  `scripts/auto-engineer.sh` to a bind-mounted path). A poller on the host tails
+  that file and runs `tmux rename-window "AE -> <slug>"` against the host tmux.
+- **On the host (no container)**: call `tmux rename-window` directly.
+- **Outside tmux entirely**: no-op.
+
+Unified command:
 
 ```sh
-printf '\033]2;AE -> <slug>\033\\' > /dev/tty 2>/dev/null || true
+if [ -n "${VIBIX_AE_SLUG_FILE:-}" ]; then
+    printf '%s' "<slug>" > "$VIBIX_AE_SLUG_FILE"
+elif [ -n "${TMUX:-}" ] && command -v tmux >/dev/null 2>&1; then
+    tmux rename-window "AE -> <slug>"
+fi
 ```
 
 ### 2. Delegate planning to a sub-agent

--- a/scripts/auto-engineer.sh
+++ b/scripts/auto-engineer.sh
@@ -73,21 +73,52 @@ else
     )
 fi
 
-# If we're inside tmux, disable automatic-rename on the current window for the
-# duration of the container run so the container's OSC 2 escapes (emitted by
-# auto-engineer to label the window "AE -> <slug>") aren't immediately
-# overwritten by tmux's pane_current_command heuristic. Restore on exit.
+# If we're inside tmux, disable automatic-rename on the current window so the
+# tmux window name auto-engineer chooses isn't immediately overwritten by
+# tmux's pane_current_command heuristic. Also start a background poller that
+# watches a shared slug file the container writes to, and renames the host
+# tmux window accordingly — Claude's Bash tool has no controlling terminal
+# inside the container, so OSC 2 via /dev/tty doesn't work; writing to a
+# shared file is the reliable cross-boundary signal. Restore on exit.
+tmux_pane_vol_opts=()
+slug_file=""
+poller_pid=""
 restore_tmux_rename=""
 if [ -n "${TMUX:-}" ] && command -v tmux >/dev/null 2>&1; then
     prev="$(tmux show-window-options -v automatic-rename 2>/dev/null || echo on)"
     tmux set-window-option automatic-rename off >/dev/null 2>&1 || true
     restore_tmux_rename="$prev"
-    trap 'tmux set-window-option automatic-rename "$restore_tmux_rename" >/dev/null 2>&1 || true' EXIT
+
+    slug_file="$(mktemp -t vibix-ae-slug.XXXXXX)"
+    tmux_pane_vol_opts+=(
+        -v "$slug_file:/tmp/vibix-ae-slug"
+        -e VIBIX_AE_SLUG_FILE=/tmp/vibix-ae-slug
+    )
+
+    (
+        last=""
+        while [ -e "$slug_file" ]; do
+            cur="$(cat "$slug_file" 2>/dev/null || true)"
+            if [ -n "$cur" ] && [ "$cur" != "$last" ]; then
+                tmux rename-window "AE -> $cur" >/dev/null 2>&1 || true
+                last="$cur"
+            fi
+            sleep 1
+        done
+    ) &
+    poller_pid=$!
+
+    trap '
+        [ -n "$poller_pid" ] && kill "$poller_pid" 2>/dev/null || true
+        [ -n "$slug_file" ] && rm -f "$slug_file" 2>/dev/null || true
+        tmux set-window-option automatic-rename "$restore_tmux_rename" >/dev/null 2>&1 || true
+    ' EXIT
 fi
 
 docker run --rm -it \
     ${docker_sec_opts[@]+"${docker_sec_opts[@]}"} \
     "${claude_vol_opts[@]}" \
+    ${tmux_pane_vol_opts[@]+"${tmux_pane_vol_opts[@]}"} \
     -e GITHUB_TOKEN \
     -e ANTHROPIC_API_KEY \
     -e GIT_AUTHOR_NAME \


### PR DESCRIPTION
## Summary
- Claude's Bash tool inside the container has no controlling terminal, so both OSC 2 escapes to stdout and writes to `/dev/tty` fail to reach the host tmux pane.
- Replace both mechanisms with a bind-mounted slug file. The container writes the slug; a background poller on the host tails the file and runs `tmux rename-window "AE -> <slug>"` directly against host tmux.
- Host-only (no container) path still calls `tmux rename-window` inline.

## Test plan
- [ ] Launch `scripts/auto-engineer.sh` in a tmux pane; confirm window renames to `AE -> <slug>` when the first cycle picks an issue, and updates as later cycles pick different issues.
- [ ] Ctrl-C the container; confirm slug tempfile is removed, poller is killed, and `automatic-rename` restores to its previous value.
- [ ] Running auto-engineer on the host (no Docker) still renames the window.