### PR TITLE
serial: acquire COM1 mutex in SerialBackend::write to fix smoke flake (#303)

### DIFF
--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -281,43 +281,12 @@ impl FileBackend for SerialBackend {
         Ok(buf.len())
     }
 
+    /// Write path acquires `COM1.lock()` inside `without_interrupts` via
+    /// `crate::serial::write_bytes`. No deadlock risk: this call chain
+    /// never calls `serial_println!` or re-enters the COM1 mutex.
     fn write(&self, buf: &[u8]) -> Result<usize, i64> {
-        serial_write_bytes(buf);
+        crate::serial::write_bytes(buf);
         Ok(buf.len())
-    }
-}
-
-/// Write `buf` to COM1, spinning on THRE for each byte.
-///
-/// Duplicates the inner loop from `arch::x86_64::syscall` so that the serial
-/// backend can be used from any context without going through the `Mutex`-
-/// protected `serial::_print` path (which would deadlock if a print is already
-/// in progress on the same CPU).
-#[cfg(target_os = "none")]
-fn serial_write_bytes(buf: &[u8]) {
-    const COM1_DATA: u16 = 0x3F8;
-    const COM1_LSR: u16 = 0x3F8 + 5;
-    for &b in buf {
-        unsafe {
-            loop {
-                let lsr: u8;
-                core::arch::asm!(
-                    "in al, dx",
-                    out("al") lsr,
-                    in("dx") COM1_LSR,
-                    options(nomem, nostack, preserves_flags),
-                );
-                if lsr & 0x20 != 0 {
-                    break;
-                }
-            }
-            core::arch::asm!(
-                "out dx, al",
-                in("dx") COM1_DATA,
-                in("al") b,
-                options(nomem, nostack, preserves_flags),
-            );
-        }
     }
 }
 

--- a/kernel/src/serial.rs
+++ b/kernel/src/serial.rs
@@ -57,6 +57,28 @@ pub fn _print(args: fmt::Arguments) {
     let _ = COM1.lock().write_fmt(args);
 }
 
+/// Write an arbitrary byte slice to COM1, holding the mutex for the
+/// entire transfer.
+///
+/// Uses [`SerialPort::send_raw`] (THRE-spin per byte) inside
+/// `without_interrupts` so no IRQ can interleave bytes mid-string and
+/// the lock is never contended against the ISR RX path.
+///
+/// # Deadlock safety
+///
+/// `without_interrupts` blocks the IRQ4 serial ISR for the duration.
+/// No callee on the `SerialBackend::write` → `write_bytes` path calls
+/// `serial_println!` or re-acquires `COM1`, so there is no reentrancy
+/// hazard.
+pub(crate) fn write_bytes(buf: &[u8]) {
+    without_interrupts(|| {
+        let mut port = COM1.lock();
+        for &b in buf {
+            port.send_raw(b);
+        }
+    });
+}
+
 #[macro_export]
 macro_rules! serial_print {
     ($($arg:tt)*) => ($crate::serial::_print(format_args!($($arg)*)));


### PR DESCRIPTION
Closes #303

## Summary

- `SerialBackend::write` called a lock-free `serial_write_bytes` helper that drove COM1 ports directly via inline `asm!`. Timer ISRs and other tasks print via `serial_println!` → `serial::_print`, which holds `COM1.lock()`. The race between the two paths spliced bytes into 22-byte smoke-test marker strings, breaking `output.contains(m)`.
- Add `serial::write_bytes(buf: &[u8])` that holds `COM1.lock()` inside `without_interrupts` for the full transfer, using `SerialPort::send_raw` per byte. Deadlock-free: nothing on the `SerialBackend::write` call path holds or re-acquires `COM1`.
- Delete the old lockless `serial_write_bytes` function and update the comment that cited a (now-refuted) reentrancy deadlock concern.

## Test plan

- [ ] `cargo xtask build` — compiles cleanly (confirmed locally, no Rust errors)
- [ ] `cargo xtask test` — host unit + QEMU integration tests on CI (x86_64 runner)
- [ ] `cargo xtask smoke` — must pass with all 29 markers present; this is the acceptance gate for #303