### PR TITLE
shell: command history + Ctrl+C/L (#112)

### DIFF
--- a/kernel/src/input.rs
+++ b/kernel/src/input.rs
@@ -82,11 +82,14 @@ mod kernel_side {
     /// may be desynced.
     static OVERFLOWS: AtomicU64 = AtomicU64::new(0);
 
+    // MapLettersToUnicode translates Ctrl+A..Z to U+0001..U+001A, which
+    // is what the shell's line editor expects for Ctrl+C (0x03) and
+    // Ctrl+L (0x0C). Ignore would swallow those combos entirely.
     static KEYBOARD: Lazy<Mutex<Keyboard<Us104Key, ScancodeSet1>>> = Lazy::new(|| {
         Mutex::new(Keyboard::new(
             ScancodeSet1::new(),
             Us104Key,
-            HandleControl::Ignore,
+            HandleControl::MapLettersToUnicode,
         ))
     });
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -45,7 +45,7 @@ pub mod ksymtab;
 pub mod process;
 #[cfg(target_os = "none")]
 pub mod serial;
-#[cfg(target_os = "none")]
+#[cfg(any(test, target_os = "none"))]
 pub mod shell;
 #[cfg(target_os = "none")]
 pub mod signal;

--- a/kernel/src/shell/line_editor.rs
+++ b/kernel/src/shell/line_editor.rs
@@ -1,0 +1,382 @@
+//! Pure-logic line editor with a bounded history ring.
+//!
+//! Owns the current input line, a ring of prior lines, and a cursor into
+//! that ring for up/down traversal. The caller feeds `Input` events and
+//! drains `Effect`s the shell emits to its output (serial). No I/O or
+//! kernel dependencies live here so the whole thing is host-testable.
+//!
+//! History semantics match a subset of GNU readline:
+//! - Up arrow walks backwards through history, replacing the current
+//!   line. The in-progress line (if any) is stashed on first up-arrow
+//!   and restored when the user presses down-arrow past the newest
+//!   history entry.
+//! - Enter commits the trimmed-nonempty line to history, resets the
+//!   history cursor to "not browsing", and clears the stash.
+//! - Ctrl+C clears the current line without committing and resets the
+//!   cursor.
+//! - Ctrl+L asks the caller to clear the screen; the editor itself is
+//!   unchanged.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+/// Capacity of the history ring. 32 matches the minimal-shell issue's
+/// explicit suggestion; each slot holds at most `MAX_LINE_LEN` bytes
+/// (256), so worst-case ~8 KiB — fine against a 16 MiB heap.
+pub const HISTORY_CAP: usize = 32;
+
+/// Same cap the caller uses when dropping over-long input. Re-exposed
+/// here so the editor can refuse to push over-length strings into
+/// history even if a future caller forgets the check.
+pub const MAX_LINE_LEN: usize = 256;
+
+/// An event fed to [`LineEditor::on_input`]. Callers translate raw
+/// input sources (serial bytes + ANSI escape state machine, PS/2
+/// decoded keys) into these before passing them in.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Input {
+    /// A printable character (non-control).
+    Char(char),
+    /// Backspace / DEL.
+    Backspace,
+    /// Enter / return.
+    Enter,
+    /// Ctrl+C — cancel current line.
+    Interrupt,
+    /// Ctrl+L — clear screen.
+    ClearScreen,
+    /// Up arrow.
+    HistoryPrev,
+    /// Down arrow.
+    HistoryNext,
+}
+
+/// Side effect the caller must emit. Kept as a simple enum instead of a
+/// direct serial writer so tests can assert on the sequence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Effect {
+    /// Emit a single printable character.
+    Put(char),
+    /// Erase the last character on the terminal (backspace-space-backspace).
+    EraseChar,
+    /// Caller should dispatch `line` as a command, then emit a fresh prompt.
+    Dispatch(String),
+    /// Emit CRLF and a fresh prompt (e.g. after Ctrl+C).
+    Newline,
+    /// VT100 clear screen + cursor home, then redraw prompt + `line` so
+    /// the user sees any in-progress input they hadn't yet submitted.
+    ClearScreen { line: String },
+    /// Erase the entire current input line on the terminal (N backspace-space-backspaces)
+    /// then rewrite `new` in its place. Used after history navigation.
+    Replace { old_len: usize, new: String },
+}
+
+pub struct LineEditor {
+    line: String,
+    history: Vec<String>,
+    /// `None` when not browsing. Otherwise an index into `history`
+    /// counted from the *oldest* end (0 = oldest), same layout as the
+    /// Vec itself. We push newest-to-back, so "previous" = decrementing
+    /// the index toward `history.len() - 1` downwards from len.
+    cursor: Option<usize>,
+    /// The line the user was composing when they first pressed up.
+    /// Restored when they walk back past the newest history entry.
+    stash: Option<String>,
+}
+
+impl LineEditor {
+    pub fn new() -> Self {
+        Self {
+            line: String::new(),
+            history: Vec::new(),
+            cursor: None,
+            stash: None,
+        }
+    }
+
+    pub fn line(&self) -> &str {
+        &self.line
+    }
+
+    #[cfg(test)]
+    pub fn history(&self) -> &[String] {
+        &self.history
+    }
+
+    pub fn on_input(&mut self, ev: Input) -> Vec<Effect> {
+        match ev {
+            Input::Char(c) if !c.is_control() => self.insert_char(c),
+            Input::Char(_) => Vec::new(),
+            Input::Backspace => self.backspace(),
+            Input::Enter => self.enter(),
+            Input::Interrupt => self.interrupt(),
+            Input::ClearScreen => alloc::vec![Effect::ClearScreen {
+                line: self.line.clone(),
+            }],
+            Input::HistoryPrev => self.history_prev(),
+            Input::HistoryNext => self.history_next(),
+        }
+    }
+
+    fn insert_char(&mut self, c: char) -> Vec<Effect> {
+        if self.line.len() + c.len_utf8() > MAX_LINE_LEN {
+            return Vec::new();
+        }
+        self.line.push(c);
+        alloc::vec![Effect::Put(c)]
+    }
+
+    fn backspace(&mut self) -> Vec<Effect> {
+        if self.line.pop().is_some() {
+            alloc::vec![Effect::EraseChar]
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn enter(&mut self) -> Vec<Effect> {
+        let committed = core::mem::take(&mut self.line);
+        self.cursor = None;
+        self.stash = None;
+        let trimmed = committed.trim_start();
+        if !trimmed.is_empty() && trimmed.len() <= MAX_LINE_LEN {
+            // Dedupe: don't push a line identical to the most recent.
+            if self.history.last().map(|s| s.as_str()) != Some(trimmed) {
+                if self.history.len() == HISTORY_CAP {
+                    self.history.remove(0);
+                }
+                self.history.push(String::from(trimmed));
+            }
+        }
+        alloc::vec![Effect::Dispatch(committed)]
+    }
+
+    fn interrupt(&mut self) -> Vec<Effect> {
+        self.line.clear();
+        self.cursor = None;
+        self.stash = None;
+        alloc::vec![Effect::Newline]
+    }
+
+    fn history_prev(&mut self) -> Vec<Effect> {
+        if self.history.is_empty() {
+            return Vec::new();
+        }
+        let next_cursor = match self.cursor {
+            None => {
+                self.stash = Some(self.line.clone());
+                self.history.len() - 1
+            }
+            Some(0) => return Vec::new(),
+            Some(n) => n - 1,
+        };
+        self.cursor = Some(next_cursor);
+        let old_len = self.line.len();
+        let new = self.history[next_cursor].clone();
+        self.line = new.clone();
+        alloc::vec![Effect::Replace { old_len, new }]
+    }
+
+    fn history_next(&mut self) -> Vec<Effect> {
+        let cursor = match self.cursor {
+            None => return Vec::new(),
+            Some(n) => n,
+        };
+        let old_len = self.line.len();
+        if cursor + 1 >= self.history.len() {
+            // Walk off the newest — restore stash.
+            self.cursor = None;
+            let new = self.stash.take().unwrap_or_default();
+            self.line = new.clone();
+            alloc::vec![Effect::Replace { old_len, new }]
+        } else {
+            self.cursor = Some(cursor + 1);
+            let new = self.history[cursor + 1].clone();
+            self.line = new.clone();
+            alloc::vec![Effect::Replace { old_len, new }]
+        }
+    }
+}
+
+impl Default for LineEditor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    fn feed_line(ed: &mut LineEditor, s: &str) {
+        for c in s.chars() {
+            ed.on_input(Input::Char(c));
+        }
+        ed.on_input(Input::Enter);
+    }
+
+    #[test]
+    fn char_and_backspace_round_trip() {
+        let mut ed = LineEditor::new();
+        ed.on_input(Input::Char('h'));
+        ed.on_input(Input::Char('i'));
+        assert_eq!(ed.line(), "hi");
+        let effs = ed.on_input(Input::Backspace);
+        assert_eq!(effs, alloc::vec![Effect::EraseChar]);
+        assert_eq!(ed.line(), "h");
+    }
+
+    #[test]
+    fn enter_commits_nonempty_to_history() {
+        let mut ed = LineEditor::new();
+        feed_line(&mut ed, "uptime");
+        feed_line(&mut ed, "help");
+        assert_eq!(ed.history(), &["uptime".to_string(), "help".to_string()]);
+        assert_eq!(ed.line(), "");
+    }
+
+    #[test]
+    fn enter_skips_empty_and_dedupes_consecutive_duplicates() {
+        let mut ed = LineEditor::new();
+        ed.on_input(Input::Enter);
+        feed_line(&mut ed, "help");
+        feed_line(&mut ed, "help");
+        feed_line(&mut ed, "   ");
+        assert_eq!(ed.history(), &["help".to_string()]);
+    }
+
+    #[test]
+    fn up_arrow_walks_history_backwards() {
+        let mut ed = LineEditor::new();
+        feed_line(&mut ed, "one");
+        feed_line(&mut ed, "two");
+        feed_line(&mut ed, "three");
+        ed.on_input(Input::HistoryPrev);
+        assert_eq!(ed.line(), "three");
+        ed.on_input(Input::HistoryPrev);
+        assert_eq!(ed.line(), "two");
+        ed.on_input(Input::HistoryPrev);
+        assert_eq!(ed.line(), "one");
+        // Past oldest is a no-op.
+        ed.on_input(Input::HistoryPrev);
+        assert_eq!(ed.line(), "one");
+    }
+
+    #[test]
+    fn down_arrow_restores_stash_past_newest() {
+        let mut ed = LineEditor::new();
+        feed_line(&mut ed, "one");
+        feed_line(&mut ed, "two");
+        ed.on_input(Input::Char('p'));
+        ed.on_input(Input::Char('a'));
+        ed.on_input(Input::Char('r'));
+        ed.on_input(Input::Char('t'));
+        assert_eq!(ed.line(), "part");
+        ed.on_input(Input::HistoryPrev);
+        assert_eq!(ed.line(), "two");
+        ed.on_input(Input::HistoryPrev);
+        assert_eq!(ed.line(), "one");
+        ed.on_input(Input::HistoryNext);
+        assert_eq!(ed.line(), "two");
+        ed.on_input(Input::HistoryNext);
+        // Walked off newest — stash "part" restored.
+        assert_eq!(ed.line(), "part");
+        // Further down-arrow is a no-op.
+        ed.on_input(Input::HistoryNext);
+        assert_eq!(ed.line(), "part");
+    }
+
+    #[test]
+    fn down_arrow_with_no_history_cursor_is_noop() {
+        let mut ed = LineEditor::new();
+        feed_line(&mut ed, "one");
+        ed.on_input(Input::Char('x'));
+        let effs = ed.on_input(Input::HistoryNext);
+        assert!(effs.is_empty());
+        assert_eq!(ed.line(), "x");
+    }
+
+    #[test]
+    fn ctrl_c_clears_line_and_resets_cursor() {
+        let mut ed = LineEditor::new();
+        feed_line(&mut ed, "one");
+        ed.on_input(Input::HistoryPrev);
+        assert_eq!(ed.line(), "one");
+        let effs = ed.on_input(Input::Interrupt);
+        assert_eq!(effs, alloc::vec![Effect::Newline]);
+        assert_eq!(ed.line(), "");
+        // After Ctrl+C, a fresh up-arrow should stash the (empty) line.
+        ed.on_input(Input::HistoryPrev);
+        assert_eq!(ed.line(), "one");
+        ed.on_input(Input::HistoryNext);
+        assert_eq!(ed.line(), "");
+    }
+
+    #[test]
+    fn ctrl_l_emits_clear_effect_with_current_line() {
+        let mut ed = LineEditor::new();
+        ed.on_input(Input::Char('x'));
+        let effs = ed.on_input(Input::ClearScreen);
+        assert_eq!(
+            effs,
+            alloc::vec![Effect::ClearScreen {
+                line: "x".to_string(),
+            }]
+        );
+        // Line content preserved so subsequent chars append normally.
+        assert_eq!(ed.line(), "x");
+    }
+
+    #[test]
+    fn history_ring_wraps_at_capacity() {
+        let mut ed = LineEditor::new();
+        for i in 0..(HISTORY_CAP + 5) {
+            feed_line(&mut ed, &alloc::format!("cmd{}", i));
+        }
+        assert_eq!(ed.history().len(), HISTORY_CAP);
+        // Oldest surviving entry is cmd5.
+        assert_eq!(ed.history().first().unwrap(), "cmd5");
+        assert_eq!(
+            ed.history().last().unwrap(),
+            &alloc::format!("cmd{}", HISTORY_CAP + 4)
+        );
+    }
+
+    #[test]
+    fn enter_clears_history_cursor() {
+        let mut ed = LineEditor::new();
+        feed_line(&mut ed, "one");
+        feed_line(&mut ed, "two");
+        ed.on_input(Input::HistoryPrev);
+        assert_eq!(ed.line(), "two");
+        ed.on_input(Input::Enter);
+        // Next up-arrow should now re-stash (empty) and start from newest.
+        ed.on_input(Input::HistoryPrev);
+        assert_eq!(ed.line(), "two");
+    }
+
+    #[test]
+    fn replace_effect_carries_old_len() {
+        let mut ed = LineEditor::new();
+        feed_line(&mut ed, "hello");
+        ed.on_input(Input::Char('a'));
+        ed.on_input(Input::Char('b'));
+        let effs = ed.on_input(Input::HistoryPrev);
+        assert_eq!(
+            effs,
+            alloc::vec![Effect::Replace {
+                old_len: 2,
+                new: "hello".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn control_chars_via_char_are_ignored() {
+        let mut ed = LineEditor::new();
+        let effs = ed.on_input(Input::Char('\x07'));
+        assert!(effs.is_empty());
+        assert_eq!(ed.line(), "");
+    }
+}

--- a/kernel/src/shell/mod.rs
+++ b/kernel/src/shell/mod.rs
@@ -5,210 +5,292 @@
 //! input is pending the task `hlt`s — the keyboard or UART ISR wakes
 //! the CPU on the next byte, and the PIT preempt tick rotates other
 //! tasks in meanwhile.
+//!
+//! Line-editing state (history ring, current line) lives in the
+//! [`line_editor`] submodule as pure logic so it's host-unit-testable.
 
-use alloc::string::String;
-use core::sync::atomic::{AtomicBool, Ordering};
+pub mod line_editor;
 
-use pc_keyboard::DecodedKey;
+#[cfg(target_os = "none")]
+mod kernel_side {
+    use core::sync::atomic::{AtomicBool, Ordering};
 
-use crate::mem::{frame, heap, FRAME_SIZE};
-use crate::task::TaskStateView;
-use crate::{input, pci, serial, serial_print, serial_println, task, time};
+    use pc_keyboard::{DecodedKey, KeyCode};
 
-/// Flipped to `true` the first time the shell's `run` enters its main
-/// loop. Integration tests poll this to confirm the shell actually
-/// started; `main` doesn't care.
-pub static SHELL_ONLINE: AtomicBool = AtomicBool::new(false);
+    use super::line_editor::{Effect, Input, LineEditor};
+    use crate::mem::{frame, heap, FRAME_SIZE};
+    use crate::task::TaskStateView;
+    use crate::{input, pci, serial, serial_print, serial_println, task, time};
 
-const PROMPT: &str = "vibix> ";
-/// Maximum line length in bytes. Additional keystrokes past this cap
-/// are silently dropped so a stuck key or keyboard auto-repeat can't
-/// grow the input buffer unchecked against the 16 MiB heap ceiling.
-const MAX_LINE_LEN: usize = 256;
+    /// Flipped to `true` the first time the shell's `run` enters its main
+    /// loop. Integration tests poll this to confirm the shell actually
+    /// started; `main` doesn't care.
+    pub static SHELL_ONLINE: AtomicBool = AtomicBool::new(false);
 
-/// Task entry point. Spawn as `task::spawn(shell::run)`.
-pub fn run() -> ! {
-    serial_println!("shell: prompt online");
-    SHELL_ONLINE.store(true, Ordering::SeqCst);
-    prompt();
+    const PROMPT: &str = "vibix> ";
 
-    let mut line = String::new();
-    loop {
-        if let Some(c) = next_char() {
-            on_char(c, &mut line);
-        } else {
-            // Nothing in either input ring. Halt until the next IRQ
-            // (keyboard or UART byte wakes us; PIT rotates us out on
-            // slice expiry).
-            x86_64::instructions::hlt();
-        }
+    /// Serial-side ANSI CSI state. Serial arrow keys arrive as three
+    /// bytes `ESC [ A..D`; xterm sometimes prefixes with `O` instead of
+    /// `[`, so we accept both.
+    #[derive(Clone, Copy, Eq, PartialEq)]
+    enum Ansi {
+        Ground,
+        Esc,
+        Csi,
     }
-}
 
-/// Pull the next character from whichever input source has one ready.
-/// Serial is polled first so headless operation feels responsive even
-/// when both rings accumulate simultaneously.
-fn next_char() -> Option<char> {
-    if let Some(b) = serial::try_read_byte() {
-        return Some(b as char);
-    }
-    match input::try_read_key()? {
-        DecodedKey::Unicode(c) => Some(c),
-        _ => None,
-    }
-}
+    /// Task entry point. Spawn as `task::spawn(shell::run)`.
+    pub fn run() -> ! {
+        serial_println!("shell: prompt online");
+        SHELL_ONLINE.store(true, Ordering::SeqCst);
+        prompt();
 
-fn on_char(c: char, line: &mut String) {
-    match c {
-        '\r' | '\n' => {
-            serial_print!("\r\n");
-            // Only strip leading whitespace so `echo` can round-trip
-            // user-entered trailing spaces.
-            dispatch(line.trim_start());
-            line.clear();
-            prompt();
-        }
-        // Backspace (0x08) or DEL (0x7f) — both map to "erase one char".
-        '\x08' | '\x7f' => {
-            if line.pop().is_some() {
-                serial_print!("\x08 \x08");
-            }
-        }
-        c if !c.is_control() => {
-            if line.len() + c.len_utf8() <= MAX_LINE_LEN {
-                line.push(c);
-                serial_print!("{}", c);
-            }
-        }
-        _ => {}
-    }
-}
-
-fn prompt() {
-    serial_print!("{}", PROMPT);
-}
-
-fn dispatch(line: &str) {
-    if line.is_empty() {
-        return;
-    }
-    let (cmd, rest) = match line.split_once(' ') {
-        Some((c, r)) => (c, r),
-        None => (line, ""),
-    };
-    match cmd {
-        "help" => cmd_help(),
-        "uptime" => cmd_uptime(),
-        "time" => cmd_time(),
-        "mem" => cmd_mem(),
-        "tasks" => cmd_tasks(),
-        "pci" => cmd_pci(),
-        "echo" => serial_println!("{}", rest),
-        "panic" => panic!("shell: panic builtin invoked"),
-        _ => serial_println!("unknown command: {} (try `help`)", cmd),
-    }
-}
-
-fn cmd_help() {
-    serial_println!("builtins:");
-    serial_println!("  help            show this list");
-    serial_println!("  uptime          milliseconds since boot");
-    serial_println!("  time            seconds since boot, ms precision");
-    serial_println!("  mem             heap + free-frame counters");
-    serial_println!("  tasks           live task ids and remaining slices");
-    serial_println!("  pci             enumerated PCI devices on bus 0");
-    serial_println!("  echo <args>     echo the rest of the line");
-    serial_println!("  panic           trigger a kernel panic (test aid)");
-}
-
-fn cmd_uptime() {
-    let ms = time::uptime_ms();
-    serial_println!("uptime: {} ms ({}.{:03} s)", ms, ms / 1000, ms % 1000);
-}
-
-fn cmd_time() {
-    let ns = time::uptime_ns();
-    let secs = ns / 1_000_000_000;
-    let ms = (ns % 1_000_000_000) / 1_000_000;
-    serial_println!("time: {}.{:03} s", secs, ms);
-}
-
-fn cmd_mem() {
-    let h = heap::stats();
-    serial_println!(
-        "heap:   used {} B, free {} B, mapped {} KiB",
-        h.used,
-        h.free,
-        h.mapped / 1024,
-    );
-    let free = frame::free_frames();
-    serial_println!(
-        "frames: {} free ({} KiB)",
-        free,
-        (free as u64 * FRAME_SIZE) / 1024,
-    );
-}
-
-fn cmd_pci() {
-    let n = pci::device_count();
-    if n == 0 {
-        serial_println!("pci: no devices enumerated (scan not yet run?)");
-        return;
-    }
-    serial_println!("pci: {} device(s) on bus 0", n);
-    for d in pci::devices() {
-        serial_println!(
-            "  {:02x}:{:02x}.{:x}  {:04x}:{:04x}  class {:02x}:{:02x} pi={:02x}  {}",
-            d.addr.bus,
-            d.addr.device,
-            d.addr.function,
-            d.vendor_id,
-            d.device_id,
-            d.class,
-            d.subclass,
-            d.prog_if,
-            d.class_name(),
-        );
-        // Walk BARs skipping the high-dword slot that follows a 64-bit
-        // memory BAR — that slot holds raw upper address bits, not a
-        // self-describing BAR, and calling is_io/is_64bit/addr on it
-        // produces nonsense (e.g. a set low bit would mislabel it as io).
-        let mut i = 0;
-        while i < d.bars.len() {
-            let bar = d.bars[i];
-            if bar.is_empty() {
-                i += 1;
-                continue;
-            }
-            if bar.is_io() {
-                serial_println!("     bar{}: {:#010x} (io)", i, bar.addr());
-                i += 1;
-            } else if bar.is_64bit() && i + 1 < d.bars.len() {
-                let full = bar.addr64(d.bars[i + 1]);
-                serial_println!("     bar{}: {:#018x} (mem64)", i, full);
-                i += 2;
+        let mut editor = LineEditor::new();
+        let mut ansi = Ansi::Ground;
+        loop {
+            if let Some(ev) = next_input(&mut ansi) {
+                for eff in editor.on_input(ev) {
+                    emit(eff);
+                }
             } else {
-                serial_println!("     bar{}: {:#010x} (mem32)", i, bar.addr());
-                i += 1;
+                // Nothing in either input ring. Halt until the next IRQ
+                // (keyboard or UART byte wakes us; PIT rotates us out on
+                // slice expiry).
+                x86_64::instructions::hlt();
             }
         }
     }
+
+    /// Pull the next editor event from whichever input source has one
+    /// ready. Serial is polled first so headless operation feels
+    /// responsive even when both rings accumulate simultaneously. The
+    /// `ansi` state machine is threaded across calls so multi-byte
+    /// escape sequences on serial survive across `hlt` gaps.
+    fn next_input(ansi: &mut Ansi) -> Option<Input> {
+        if let Some(b) = serial::try_read_byte() {
+            return serial_byte(b, ansi);
+        }
+        let key = input::try_read_key()?;
+        match key {
+            DecodedKey::Unicode(c) => char_to_input(c),
+            DecodedKey::RawKey(KeyCode::ArrowUp) => Some(Input::HistoryPrev),
+            DecodedKey::RawKey(KeyCode::ArrowDown) => Some(Input::HistoryNext),
+            DecodedKey::RawKey(_) => None,
+        }
+    }
+
+    /// Translate a serial byte through the CSI state machine. On
+    /// completion of an arrow escape, return the corresponding `Input`.
+    /// Unrecognised finals drop the sequence silently.
+    fn serial_byte(b: u8, ansi: &mut Ansi) -> Option<Input> {
+        match (*ansi, b) {
+            (Ansi::Ground, 0x1b) => {
+                *ansi = Ansi::Esc;
+                None
+            }
+            (Ansi::Esc, b'[') | (Ansi::Esc, b'O') => {
+                *ansi = Ansi::Csi;
+                None
+            }
+            (Ansi::Esc, _) => {
+                // Bare ESC followed by non-CSI: drop, reset.
+                *ansi = Ansi::Ground;
+                None
+            }
+            (Ansi::Csi, b'A') => {
+                *ansi = Ansi::Ground;
+                Some(Input::HistoryPrev)
+            }
+            (Ansi::Csi, b'B') => {
+                *ansi = Ansi::Ground;
+                Some(Input::HistoryNext)
+            }
+            (Ansi::Csi, b'C') | (Ansi::Csi, b'D') => {
+                // Left/right — deferred per issue #112.
+                *ansi = Ansi::Ground;
+                None
+            }
+            (Ansi::Csi, _) => {
+                // Unrecognised CSI final — drop and resync.
+                *ansi = Ansi::Ground;
+                None
+            }
+            (Ansi::Ground, _) => char_to_input(b as char),
+        }
+    }
+
+    /// Map a single decoded character to an editor event. Ctrl+C/L
+    /// arrive as U+0003/U+000C because the keyboard layer is configured
+    /// with `HandleControl::MapLettersToUnicode`.
+    fn char_to_input(c: char) -> Option<Input> {
+        match c {
+            '\r' | '\n' => Some(Input::Enter),
+            '\x08' | '\x7f' => Some(Input::Backspace),
+            '\x03' => Some(Input::Interrupt),
+            '\x0c' => Some(Input::ClearScreen),
+            c if !c.is_control() => Some(Input::Char(c)),
+            _ => None,
+        }
+    }
+
+    fn emit(eff: Effect) {
+        match eff {
+            Effect::Put(c) => serial_print!("{}", c),
+            Effect::EraseChar => serial_print!("\x08 \x08"),
+            Effect::Newline => {
+                serial_print!("\r\n");
+                prompt();
+            }
+            Effect::Dispatch(line) => {
+                serial_print!("\r\n");
+                dispatch(line.trim_start());
+                prompt();
+            }
+            Effect::ClearScreen { line } => {
+                // VT100: clear whole screen, home cursor, redraw prompt
+                // and whatever the user had typed so far.
+                serial_print!("\x1b[2J\x1b[H");
+                prompt();
+                serial_print!("{}", line);
+            }
+            Effect::Replace { old_len, new } => {
+                for _ in 0..old_len {
+                    serial_print!("\x08 \x08");
+                }
+                serial_print!("{}", new);
+            }
+        }
+    }
+
+    fn prompt() {
+        serial_print!("{}", PROMPT);
+    }
+
+    fn dispatch(line: &str) {
+        if line.is_empty() {
+            return;
+        }
+        let (cmd, rest) = match line.split_once(' ') {
+            Some((c, r)) => (c, r),
+            None => (line, ""),
+        };
+        match cmd {
+            "help" => cmd_help(),
+            "uptime" => cmd_uptime(),
+            "time" => cmd_time(),
+            "mem" => cmd_mem(),
+            "tasks" => cmd_tasks(),
+            "pci" => cmd_pci(),
+            "echo" => serial_println!("{}", rest),
+            "panic" => panic!("shell: panic builtin invoked"),
+            _ => serial_println!("unknown command: {} (try `help`)", cmd),
+        }
+    }
+
+    fn cmd_help() {
+        serial_println!("builtins:");
+        serial_println!("  help            show this list");
+        serial_println!("  uptime          milliseconds since boot");
+        serial_println!("  time            seconds since boot, ms precision");
+        serial_println!("  mem             heap + free-frame counters");
+        serial_println!("  tasks           live task ids and remaining slices");
+        serial_println!("  pci             enumerated PCI devices on bus 0");
+        serial_println!("  echo <args>     echo the rest of the line");
+        serial_println!("  panic           trigger a kernel panic (test aid)");
+    }
+
+    fn cmd_uptime() {
+        let ms = time::uptime_ms();
+        serial_println!("uptime: {} ms ({}.{:03} s)", ms, ms / 1000, ms % 1000);
+    }
+
+    fn cmd_time() {
+        let ns = time::uptime_ns();
+        let secs = ns / 1_000_000_000;
+        let ms = (ns % 1_000_000_000) / 1_000_000;
+        serial_println!("time: {}.{:03} s", secs, ms);
+    }
+
+    fn cmd_mem() {
+        let h = heap::stats();
+        serial_println!(
+            "heap:   used {} B, free {} B, mapped {} KiB",
+            h.used,
+            h.free,
+            h.mapped / 1024,
+        );
+        let free = frame::free_frames();
+        serial_println!(
+            "frames: {} free ({} KiB)",
+            free,
+            (free as u64 * FRAME_SIZE) / 1024,
+        );
+    }
+
+    fn cmd_pci() {
+        let n = pci::device_count();
+        if n == 0 {
+            serial_println!("pci: no devices enumerated (scan not yet run?)");
+            return;
+        }
+        serial_println!("pci: {} device(s) on bus 0", n);
+        for d in pci::devices() {
+            serial_println!(
+                "  {:02x}:{:02x}.{:x}  {:04x}:{:04x}  class {:02x}:{:02x} pi={:02x}  {}",
+                d.addr.bus,
+                d.addr.device,
+                d.addr.function,
+                d.vendor_id,
+                d.device_id,
+                d.class,
+                d.subclass,
+                d.prog_if,
+                d.class_name(),
+            );
+            // Walk BARs skipping the high-dword slot that follows a 64-bit
+            // memory BAR — that slot holds raw upper address bits, not a
+            // self-describing BAR, and calling is_io/is_64bit/addr on it
+            // produces nonsense (e.g. a set low bit would mislabel it as io).
+            let mut i = 0;
+            while i < d.bars.len() {
+                let bar = d.bars[i];
+                if bar.is_empty() {
+                    i += 1;
+                    continue;
+                }
+                if bar.is_io() {
+                    serial_println!("     bar{}: {:#010x} (io)", i, bar.addr());
+                    i += 1;
+                } else if bar.is_64bit() && i + 1 < d.bars.len() {
+                    let full = bar.addr64(d.bars[i + 1]);
+                    serial_println!("     bar{}: {:#018x} (mem64)", i, full);
+                    i += 2;
+                } else {
+                    serial_println!("     bar{}: {:#010x} (mem32)", i, bar.addr());
+                    i += 1;
+                }
+            }
+        }
+    }
+
+    fn cmd_tasks() {
+        task::for_each_task(|t| {
+            let tag = match t.state {
+                TaskStateView::Running => "[run]",
+                TaskStateView::Ready => "[rdy]",
+                TaskStateView::Blocked => "[blk]",
+            };
+            serial_println!(
+                "  task {:>3} {} slice={} ms prio={} nice={}",
+                t.id,
+                tag,
+                t.slice_remaining_ms,
+                t.priority,
+                t.nice,
+            );
+        });
+    }
 }
 
-fn cmd_tasks() {
-    task::for_each_task(|t| {
-        let tag = match t.state {
-            TaskStateView::Running => "[run]",
-            TaskStateView::Ready => "[rdy]",
-            TaskStateView::Blocked => "[blk]",
-        };
-        serial_println!(
-            "  task {:>3} {} slice={} ms prio={} nice={}",
-            t.id,
-            tag,
-            t.slice_remaining_ms,
-            t.priority,
-            t.nice,
-        );
-    });
-}
+#[cfg(target_os = "none")]
+pub use kernel_side::{run, SHELL_ONLINE};


### PR DESCRIPTION
Closes #112

## Summary

- New `shell::line_editor` module: pure-logic `LineEditor` owning the current line, a 32-slot history ring, and a cursor-into-history. Translates `Input` events (chars, backspace, enter, arrows, Ctrl+C/L) into `Effect`s the serial adapter emits. Host-unit-testable.
- Kernel-side adapter in `shell/mod.rs` threads an ANSI CSI state machine across loop iterations so serial `ESC [ A/B` become up/down; PS/2 `DecodedKey::RawKey(ArrowUp/Down)` feeds the same path. Left/right arrow deferred per the issue's "can be ignored" language.
- Flips `HandleControl::Ignore` → `HandleControl::MapLettersToUnicode` in the keyboard state machine so Ctrl+C (`0x03`) and Ctrl+L (`0x0C`) reach the shell as control characters instead of being swallowed.
- Ctrl+C clears the in-progress line and re-prompts without dispatching. Ctrl+L emits `ESC [ 2 J ESC [ H` and redraws prompt + any mid-typed input.
- History: up arrow stashes the in-progress line and walks backwards; down arrow walks forwards and restores the stash when stepping past the newest entry. Consecutive duplicates are deduped, empty lines are skipped, ring wraps at 32 entries.

## Test plan

- [x] `cargo xtask build` / `cargo check` on kernel library.
- [ ] CI: `cargo xtask test` runs `cargo test --package vibix --lib` which exercises the new `line_editor` host tests (ring wraparound, stash/restore, Ctrl+C reset, Ctrl+L, dedupe, replace-effect).
- [ ] CI: `cargo xtask smoke` boots the kernel and confirms the shell still reaches `SHELL_ONLINE`.
- [ ] Manual (post-merge): connect to serial, type a few commands, confirm up/down walks history and Ctrl+C/L behave.