### PR TITLE
fs: fix fd/syscall correctness bugs (read EBADF, write Ok(0) loop, O_CLOEXEC per-fd)

### DIFF
--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -198,12 +198,8 @@ pub unsafe extern "C" fn syscall_dispatch(
             let fd = a0 as u32;
             let buf_va = a1 as usize;
             let len = a2 as usize;
-            if len == 0 {
-                return 0;
-            }
-            if let Err(e) = uaccess::check_user_range(buf_va, len) {
-                return e.as_errno();
-            }
+            // Validate the fd BEFORE checking len==0: POSIX requires
+            // read(invalid_fd, buf, 0) to return EBADF, not 0.
             // Get the backend without holding the fd-table lock during I/O.
             let backend = {
                 let tbl = crate::task::current_fd_table();
@@ -213,6 +209,12 @@ pub unsafe extern "C" fn syscall_dispatch(
                 };
                 x
             };
+            if len == 0 {
+                return 0;
+            }
+            if let Err(e) = uaccess::check_user_range(buf_va, len) {
+                return e.as_errno();
+            }
             // Read into a kernel bounce buffer, then copy to user.
             let mut chunk = [0u8; 256];
             let n = core::cmp::min(chunk.len(), len);
@@ -259,6 +261,13 @@ pub unsafe extern "C" fn syscall_dispatch(
                     Err(e) => return e.as_errno(),
                 }
                 match backend.write(&chunk[..n]) {
+                    Ok(0) => {
+                        // Short-write / end-of-stream: return however many
+                        // bytes we've written so far rather than looping
+                        // forever. (A backend that always returns Ok(0) for
+                        // non-empty input would loop indefinitely otherwise.)
+                        break;
+                    }
                     Ok(nw) => written += nw,
                     Err(e) => return e,
                 }
@@ -583,17 +592,19 @@ unsafe fn sys_open(path_uva: u64, flags: u64, _mode: u64) -> i64 {
         return ENOENT;
     }
 
-    // Mask caller-supplied flags down to the bits our fd table honors.
-    let safe_flags =
-        (flags as u32) & (oflags::O_RDONLY | oflags::O_WRONLY | oflags::O_RDWR | oflags::O_CLOEXEC);
+    // Split caller flags: access mode goes into FileDescription.flags;
+    // O_CLOEXEC goes into the per-fd slot flags (so dup() can clear it
+    // without touching the shared description).
+    let access_flags = (flags as u32) & (oflags::O_RDONLY | oflags::O_WRONLY | oflags::O_RDWR);
+    let fd_flags = (flags as u32) & oflags::O_CLOEXEC;
 
     let backend: Arc<dyn FileBackend> = Arc::new(SerialBackend);
     let desc = Arc::new(FileDescription {
         backend,
-        flags: safe_flags,
+        flags: access_flags,
     });
     let tbl = crate::task::current_fd_table();
-    let result = tbl.lock().alloc_fd(desc);
+    let result = tbl.lock().alloc_fd_with_flags(desc, fd_flags);
     match result {
         Ok(fd) => fd as i64,
         Err(e) => e,

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -106,11 +106,18 @@ pub const EOVERFLOW: i64 = -75;
 
 /// Per-process file-descriptor array.
 ///
-/// `slots[fd]` is `Some(Arc<FileDescription>)` when `fd` is open, `None`
+/// Each open slot holds `(description, fd_flags)`:
+/// - `description` — the shared open-file description (backend + access mode).
+/// - `fd_flags` — **per-fd** flags, currently only `O_CLOEXEC` / `FD_CLOEXEC`.
+///   These must NOT live on `FileDescription` because `dup()` clones the
+///   `Arc<FileDescription>`, but POSIX requires `dup()`-created fds to start
+///   with `FD_CLOEXEC` cleared.
+///
+/// `slots[fd]` is `Some((Arc<FileDescription>, u32))` when `fd` is open, `None`
 /// otherwise. The array grows lazily; unallocated entries past the current
 /// length are implicitly closed.
 pub struct FileDescTable {
-    slots: Vec<Option<Arc<FileDescription>>>,
+    slots: Vec<Option<(Arc<FileDescription>, u32)>>,
 }
 
 impl FileDescTable {
@@ -127,18 +134,27 @@ impl FileDescTable {
         stderr: Arc<dyn FileBackend>,
     ) -> Self {
         let mut t = Self::new();
-        t.slots.push(Some(Arc::new(FileDescription {
-            backend: stdin,
-            flags: flags::O_RDONLY,
-        })));
-        t.slots.push(Some(Arc::new(FileDescription {
-            backend: stdout,
-            flags: flags::O_WRONLY,
-        })));
-        t.slots.push(Some(Arc::new(FileDescription {
-            backend: stderr,
-            flags: flags::O_WRONLY,
-        })));
+        t.slots.push(Some((
+            Arc::new(FileDescription {
+                backend: stdin,
+                flags: flags::O_RDONLY,
+            }),
+            0,
+        )));
+        t.slots.push(Some((
+            Arc::new(FileDescription {
+                backend: stdout,
+                flags: flags::O_WRONLY,
+            }),
+            0,
+        )));
+        t.slots.push(Some((
+            Arc::new(FileDescription {
+                backend: stderr,
+                flags: flags::O_WRONLY,
+            }),
+            0,
+        )));
         t
     }
 
@@ -153,11 +169,16 @@ impl FileDescTable {
         }
     }
 
-    /// Close every fd marked `O_CLOEXEC`. Called by the `exec()` path.
+    /// Close every fd whose per-fd `FD_CLOEXEC` flag is set. Called by the
+    /// `exec()` path.
+    ///
+    /// `FD_CLOEXEC` is a per-fd attribute stored in the slot's `fd_flags`,
+    /// not in `FileDescription.flags`, so `dup()`-created fds (which share
+    /// the same `Arc<FileDescription>`) are not affected.
     pub fn close_cloexec(&mut self) {
         for slot in self.slots.iter_mut() {
-            if let Some(d) = slot {
-                if d.flags & flags::O_CLOEXEC != 0 {
+            if let Some((_, fd_flags)) = slot {
+                if *fd_flags & flags::O_CLOEXEC != 0 {
                     *slot = None;
                 }
             }
@@ -166,11 +187,19 @@ impl FileDescTable {
 
     /// Allocate the lowest free fd slot and return its number.
     ///
+    /// `fd_flags` holds per-fd flags (e.g. `O_CLOEXEC`). These are stored
+    /// separately from `FileDescription.flags` so that `dup()` can clear
+    /// `FD_CLOEXEC` on the new fd without affecting the original.
+    ///
     /// Returns `EMFILE` if all `MAX_FD` slots are occupied.
-    pub fn alloc_fd(&mut self, desc: Arc<FileDescription>) -> Result<u32, i64> {
+    pub fn alloc_fd_with_flags(
+        &mut self,
+        desc: Arc<FileDescription>,
+        fd_flags: u32,
+    ) -> Result<u32, i64> {
         for (i, slot) in self.slots.iter_mut().enumerate() {
             if slot.is_none() {
-                *slot = Some(desc);
+                *slot = Some((desc, fd_flags));
                 return Ok(i as u32);
             }
         }
@@ -178,8 +207,14 @@ impl FileDescTable {
             return Err(EMFILE);
         }
         let fd = self.slots.len() as u32;
-        self.slots.push(Some(desc));
+        self.slots.push(Some((desc, fd_flags)));
         Ok(fd)
+    }
+
+    /// Allocate with no per-fd flags. Convenience wrapper for callers that
+    /// do not need `O_CLOEXEC` on the new fd.
+    pub fn alloc_fd(&mut self, desc: Arc<FileDescription>) -> Result<u32, i64> {
+        self.alloc_fd_with_flags(desc, 0)
     }
 
     /// Release fd `fd`. Returns `EBADF` if the fd was not open.
@@ -198,7 +233,7 @@ impl FileDescTable {
         self.slots
             .get(fd as usize)
             .and_then(Option::as_ref)
-            .map(|d| d.backend.clone())
+            .map(|(d, _)| d.backend.clone())
             .ok_or(EBADF)
     }
 
@@ -214,14 +249,18 @@ impl FileDescTable {
         self.slots
             .get(fd as usize)
             .and_then(Option::as_ref)
-            .cloned()
+            .map(|(d, _)| d.clone())
             .ok_or(EBADF)
     }
 
     /// Duplicate `oldfd` to the lowest free fd. Returns the new fd number.
+    ///
+    /// The new fd starts with `FD_CLOEXEC` cleared, as required by POSIX
+    /// (dup-created fds do not inherit the close-on-exec flag).
     pub fn dup(&mut self, oldfd: u32) -> Result<u32, i64> {
         let desc = self.get_desc(oldfd)?;
-        self.alloc_fd(desc)
+        // fd_flags = 0: new fd has FD_CLOEXEC cleared (POSIX dup semantics).
+        self.alloc_fd_with_flags(desc, 0)
     }
 
     /// Make `newfd` an alias for `oldfd`'s description. Returns `newfd`.
@@ -232,6 +271,8 @@ impl FileDescTable {
     ///   reassignment (POSIX `dup2` semantics).
     /// - Returns `EBADF` if `oldfd` is not open.
     /// - Returns `EINVAL` if `newfd >= MAX_FD`.
+    ///
+    /// The new fd starts with `FD_CLOEXEC` cleared (POSIX `dup2` semantics).
     pub fn dup2(&mut self, oldfd: u32, newfd: u32) -> Result<u32, i64> {
         if newfd as usize >= MAX_FD {
             return Err(EINVAL);
@@ -246,7 +287,8 @@ impl FileDescTable {
         while self.slots.len() <= newfd as usize {
             self.slots.push(None);
         }
-        self.slots[newfd as usize] = Some(desc);
+        // fd_flags = 0: new fd has FD_CLOEXEC cleared (POSIX dup2 semantics).
+        self.slots[newfd as usize] = Some((desc, 0));
         Ok(newfd)
     }
 }
@@ -464,17 +506,32 @@ mod tests {
     #[test]
     fn close_cloexec_only_closes_flagged() {
         let mut t = make_table();
-        let cloexec_desc = Arc::new(FileDescription {
-            backend: null(),
-            flags: flags::O_CLOEXEC,
-        });
-        t.alloc_fd(cloexec_desc).unwrap(); // fd 3, flagged
+        // Allocate fd 3 with FD_CLOEXEC set in per-fd flags (not in FileDescription.flags).
+        t.alloc_fd_with_flags(null_desc(), flags::O_CLOEXEC).unwrap();
+        // Allocate fd 4 without FD_CLOEXEC.
+        t.alloc_fd(null_desc()).unwrap();
         t.close_cloexec();
-        // fd 3 (O_CLOEXEC) should be gone
+        // fd 3 (FD_CLOEXEC set) should be gone.
         assert_eq!(t.get(3).err(), Some(EBADF));
-        // fd 0/1/2 (not O_CLOEXEC) should survive
+        // fd 4 (no FD_CLOEXEC) should survive.
+        assert!(t.get(4).is_ok());
+        // fd 0/1/2 (stdio, no FD_CLOEXEC) should survive.
         assert!(t.get(0).is_ok());
         assert!(t.get(1).is_ok());
         assert!(t.get(2).is_ok());
+    }
+
+    #[test]
+    fn dup_clears_cloexec() {
+        let mut t = make_table();
+        // Open fd 3 with FD_CLOEXEC set.
+        t.alloc_fd_with_flags(null_desc(), flags::O_CLOEXEC).unwrap();
+        // dup(3) → fd 4; the dup'd fd must NOT inherit FD_CLOEXEC.
+        let new_fd = t.dup(3).unwrap();
+        assert_eq!(new_fd, 4);
+        // After close_cloexec: fd 3 closed, fd 4 survives.
+        t.close_cloexec();
+        assert_eq!(t.get(3).err(), Some(EBADF));
+        assert!(t.get(4).is_ok());
     }
 }

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -507,7 +507,8 @@ mod tests {
     fn close_cloexec_only_closes_flagged() {
         let mut t = make_table();
         // Allocate fd 3 with FD_CLOEXEC set in per-fd flags (not in FileDescription.flags).
-        t.alloc_fd_with_flags(null_desc(), flags::O_CLOEXEC).unwrap();
+        t.alloc_fd_with_flags(null_desc(), flags::O_CLOEXEC)
+            .unwrap();
         // Allocate fd 4 without FD_CLOEXEC.
         t.alloc_fd(null_desc()).unwrap();
         t.close_cloexec();
@@ -525,7 +526,8 @@ mod tests {
     fn dup_clears_cloexec() {
         let mut t = make_table();
         // Open fd 3 with FD_CLOEXEC set.
-        t.alloc_fd_with_flags(null_desc(), flags::O_CLOEXEC).unwrap();
+        t.alloc_fd_with_flags(null_desc(), flags::O_CLOEXEC)
+            .unwrap();
         // dup(3) → fd 4; the dup'd fd must NOT inherit FD_CLOEXEC.
         let new_fd = t.dup(3).unwrap();
         assert_eq!(new_fd, 4);

--- a/kernel/tests/fd_table.rs
+++ b/kernel/tests/fd_table.rs
@@ -162,11 +162,11 @@ fn clone_for_fork_independent() {
 /// close_cloexec() closes O_CLOEXEC fds and leaves others intact.
 fn close_cloexec() {
     let mut t = make_table();
-    let flagged = Arc::new(FileDescription {
-        backend: null(),
-        flags: flags::O_CLOEXEC,
-    });
-    let fd = t.alloc_fd(flagged).unwrap();
+    // FD_CLOEXEC is a per-fd flag — pass it via alloc_fd_with_flags, NOT
+    // via FileDescription.flags (which only holds access-mode bits).
+    let fd = t
+        .alloc_fd_with_flags(null_desc(), flags::O_CLOEXEC)
+        .unwrap();
     assert_eq!(fd, 3);
     t.close_cloexec();
     assert_eq!(

--- a/kernel/tests/vfs_backend.rs
+++ b/kernel/tests/vfs_backend.rs
@@ -236,9 +236,11 @@ fn close_cloexec_drops_vfs_backend() {
     let mut t = FileDescTable::new();
     let cloexec_desc = Arc::new(FileDescription {
         backend: cloexec_backend,
-        flags: flags::O_CLOEXEC,
+        flags: 0,
     });
-    let cloexec_fd = t.alloc_fd(cloexec_desc).expect("alloc cloexec fd");
+    let cloexec_fd = t
+        .alloc_fd_with_flags(cloexec_desc, flags::O_CLOEXEC)
+        .expect("alloc cloexec fd");
 
     // A non-cloexec VfsBackend fd must survive exec.
     let of2 = make_open_file(0);


### PR DESCRIPTION
Closes #186
Closes #199
Closes #200
Closes #201

## Summary

Four POSIX correctness bugs in the fd table and syscall layer (all from Cursor Bugbot findings on PR #197):

- **#199** — `read(invalid_fd, buf, 0)` returned 0 instead of `EBADF`: the `len==0` early-return ran before the fd-table lookup. Fix: validate fd first, then check `len==0`.
- **#201** — write loop hung forever if `FileBackend::write` returned `Ok(0)`: `written` never advanced. Fix: break on `Ok(0)` and return bytes written so far (short-write semantics).
- **#200** — `O_CLOEXEC` stored in `FileDescription.flags` broke `dup()`: `dup` clones the `Arc<FileDescription>`, so both fds shared `FD_CLOEXEC`; exec would close both. Fix: add per-fd `fd_flags: u32` to the `FileDescTable` slot tuple. `FD_CLOEXEC` lives in `fd_flags`; `FileDescription.flags` holds only access-mode bits. `dup()` and `dup2()` set `fd_flags=0` on the new fd.
- **#186** — write already returned `EBADF` for unsupported fds (fd lookup precedes the `len==0` check). Confirmed in current code with a comment; no code change needed.

## Test plan

- [ ] `cargo xtask build` — compiles clean (confirmed locally)
- [ ] `cargo xtask test` — host unit tests including new `dup_clears_cloexec` and updated `close_cloexec_only_closes_flagged`, plus QEMU `fd_table` integration test (updated `close_cloexec` test)
- [ ] `cargo xtask smoke` — all 29 markers present