### PR TITLE
sync: add IrqLock<T> primitive and migrate ISR-reachable statics

### DIFF
--- a/kernel/src/input.rs
+++ b/kernel/src/input.rs
@@ -66,15 +66,20 @@ pub use kernel_side::*;
 #[cfg(target_os = "none")]
 mod kernel_side {
     use super::RingBuffer;
+    use crate::sync::IrqLock;
     use core::sync::atomic::{AtomicU64, Ordering};
     use pc_keyboard::{layouts::Us104Key, DecodedKey, HandleControl, Keyboard, ScancodeSet1};
     use spin::{Lazy, Mutex};
-    use x86_64::instructions::interrupts::{self, without_interrupts};
+    use x86_64::instructions::interrupts;
 
     /// Scancodes land here from the keyboard ISR. Sized at 128: a human
     /// typist can't overflow it, and firmware key-repeat bursts are well
     /// under that between consumer polls.
-    static SCANCODES: Mutex<RingBuffer<u8, 128>> = Mutex::new(RingBuffer::new());
+    ///
+    /// [`IrqLock`] because the keyboard ISR pushes while task context
+    /// pops — a plain `spin::Mutex` would deadlock if the IRQ landed on
+    /// the same CPU during a consumer's pop.
+    static SCANCODES: IrqLock<RingBuffer<u8, 128>> = IrqLock::new(RingBuffer::new());
 
     /// Count of scancodes dropped because the ring was full when the ISR
     /// tried to push. Surface via `scancode_overflows()`; a non-zero
@@ -98,7 +103,7 @@ mod kernel_side {
     }
 
     pub fn try_read_scancode() -> Option<u8> {
-        without_interrupts(|| SCANCODES.lock().pop())
+        SCANCODES.lock().pop()
     }
 
     /// Non-blocking counterpart to [`read_key`]. Drains any queued

--- a/kernel/src/sync/irqlock.rs
+++ b/kernel/src/sync/irqlock.rs
@@ -1,0 +1,239 @@
+//! IRQ-masking spinlock.
+//!
+//! An [`IrqLock<T>`] is a thin wrapper around `spin::Mutex<T>` that
+//! disables local interrupts for the duration the guard is held. It's
+//! the primitive for data shared between task context and an ISR:
+//!
+//! - Task-context acquire: reads the current `RFLAGS.IF`, clears it,
+//!   takes the spin lock.
+//! - ISR-context acquire: IF is already clear (interrupt gates), so
+//!   the save/restore is a no-op — the lock is simply acquired.
+//! - Guard drop: releases the spin lock, *then* restores the saved
+//!   IF. Release-before-sti is deliberate — if we sti'd while still
+//!   holding the lock, a pending IRQ could observe the ISR's view of
+//!   the data mid-update.
+//!
+//! This mirrors Linux's `spin_lock_irqsave` semantics. Prefer
+//! [`IrqLock`] over pairing `spin::Mutex` with hand-rolled
+//! `interrupts::disable()` / `interrupts::enable()` bookends — the
+//! automatic drop makes it impossible to forget the restore, and
+//! `are_enabled()` + `disable()` on acquire correctly nests when
+//! IRQs are already disabled.
+//!
+//! # When *not* to use
+//!
+//! - If the lock is held across a scheduling point (`block_current`,
+//!   `yield`, or any blocking-primitive acquire), use
+//!   [`super::BlockingMutex`] instead. Parking with IF disabled would
+//!   hang the kernel.
+//! - If the data is only ever touched from task context, a plain
+//!   `spin::Mutex` is cheaper — no IF read/write on every acquire —
+//!   and the module comment for the lock should state that invariant
+//!   so future code doesn't paper an ISR path onto it.
+
+use core::ops::{Deref, DerefMut};
+
+/// Wrapper around `spin::Mutex<T>` that disables interrupts while held.
+///
+/// Interface mirrors `spin::Mutex` — `lock`, `try_lock`, `is_locked`.
+/// The returned [`IrqLockGuard`] derefs to `T` and releases the lock
+/// and restores the prior interrupt-flag state on drop.
+pub struct IrqLock<T: ?Sized> {
+    inner: spin::Mutex<T>,
+}
+
+/// RAII guard for an [`IrqLock`]. Releases the inner spin lock then
+/// restores the interrupt-flag to the value it held before `lock()`
+/// was called.
+pub struct IrqLockGuard<'a, T: ?Sized + 'a> {
+    // `Option` so `Drop` can take the inner guard and drop it *before*
+    // restoring IF — the order matters (see module docs).
+    guard: Option<spin::MutexGuard<'a, T>>,
+    prev_if: bool,
+}
+
+impl<T> IrqLock<T> {
+    /// Create a new [`IrqLock`] wrapping `value`.
+    pub const fn new(value: T) -> Self {
+        Self {
+            inner: spin::Mutex::new(value),
+        }
+    }
+}
+
+impl<T: ?Sized> IrqLock<T> {
+    /// Disable interrupts (saving the prior state), then acquire the
+    /// spin lock. The returned guard keeps IRQs masked until dropped.
+    pub fn lock(&self) -> IrqLockGuard<'_, T> {
+        let prev_if = arch_if::save_and_disable();
+        let guard = self.inner.lock();
+        IrqLockGuard {
+            guard: Some(guard),
+            prev_if,
+        }
+    }
+
+    /// Try to acquire the lock without blocking. Returns `None` if
+    /// already held by someone else; on success, behaves like
+    /// [`lock`](Self::lock).
+    pub fn try_lock(&self) -> Option<IrqLockGuard<'_, T>> {
+        let prev_if = arch_if::save_and_disable();
+        match self.inner.try_lock() {
+            Some(guard) => Some(IrqLockGuard {
+                guard: Some(guard),
+                prev_if,
+            }),
+            None => {
+                arch_if::restore(prev_if);
+                None
+            }
+        }
+    }
+
+    /// Whether the lock is currently held. Advisory only — the state
+    /// may change immediately after the check.
+    pub fn is_locked(&self) -> bool {
+        self.inner.is_locked()
+    }
+}
+
+impl<T: ?Sized> Deref for IrqLockGuard<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        self.guard.as_ref().expect("guard present until drop")
+    }
+}
+
+impl<T: ?Sized> DerefMut for IrqLockGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        self.guard.as_mut().expect("guard present until drop")
+    }
+}
+
+impl<T: ?Sized> Drop for IrqLockGuard<'_, T> {
+    fn drop(&mut self) {
+        // Release the spin lock first. Restoring IF before drop would
+        // let a pending IRQ observe the data under the (still held)
+        // lock semantics and deadlock-via-reentry.
+        self.guard = None;
+        arch_if::restore(self.prev_if);
+    }
+}
+
+/// Thin abstraction over the interrupt-flag save/restore primitives so
+/// host `#[cfg(test)]` builds can stub them with an [`AtomicBool`].
+#[cfg(target_os = "none")]
+mod arch_if {
+    use x86_64::instructions::interrupts;
+
+    #[inline(always)]
+    pub(super) fn save_and_disable() -> bool {
+        let prev = interrupts::are_enabled();
+        interrupts::disable();
+        prev
+    }
+
+    #[inline(always)]
+    pub(super) fn restore(prev: bool) {
+        if prev {
+            interrupts::enable();
+        }
+    }
+}
+
+#[cfg(not(target_os = "none"))]
+mod arch_if {
+    use core::sync::atomic::{AtomicBool, Ordering};
+
+    // Host stub: a single process-wide "interrupts enabled" flag used
+    // by unit tests to validate save/restore ordering. Real kernels
+    // use the CPU flag.
+    static IF_STATE: AtomicBool = AtomicBool::new(true);
+
+    pub(super) fn save_and_disable() -> bool {
+        IF_STATE.swap(false, Ordering::SeqCst)
+    }
+
+    pub(super) fn restore(prev: bool) {
+        IF_STATE.store(prev, Ordering::SeqCst);
+    }
+
+    #[cfg(test)]
+    pub(super) fn test_is_enabled() -> bool {
+        IF_STATE.load(Ordering::SeqCst)
+    }
+
+    #[cfg(test)]
+    pub(super) fn test_set(enabled: bool) {
+        IF_STATE.store(enabled, Ordering::SeqCst);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lock_unlock_value_round_trip() {
+        arch_if::test_set(true);
+        let m = IrqLock::new(42u32);
+        {
+            let mut g = m.lock();
+            assert_eq!(*g, 42);
+            *g = 99;
+        }
+        assert_eq!(*m.lock(), 99);
+    }
+
+    #[test]
+    fn try_lock_fails_while_held() {
+        arch_if::test_set(true);
+        let m = IrqLock::new(0u8);
+        let g = m.lock();
+        assert!(m.try_lock().is_none());
+        drop(g);
+        assert!(m.try_lock().is_some());
+    }
+
+    #[test]
+    fn guard_masks_ifs_during_critical_section() {
+        arch_if::test_set(true);
+        let m = IrqLock::new(());
+        {
+            let _g = m.lock();
+            assert!(!arch_if::test_is_enabled(), "IF must be disabled in guard");
+        }
+        assert!(arch_if::test_is_enabled(), "IF must be restored on drop");
+    }
+
+    #[test]
+    fn guard_restores_prior_if_state_when_already_disabled() {
+        arch_if::test_set(false);
+        let m = IrqLock::new(());
+        {
+            let _g = m.lock();
+            assert!(!arch_if::test_is_enabled());
+        }
+        // Prior IF was disabled — drop must NOT enable it.
+        assert!(
+            !arch_if::test_is_enabled(),
+            "IF must stay disabled when prior state was disabled"
+        );
+    }
+
+    #[test]
+    fn try_lock_failure_restores_if_state() {
+        arch_if::test_set(true);
+        let m = IrqLock::new(());
+        let _held = m.lock();
+        // Before calling try_lock, IF is false (held by _held). The
+        // contention path must not leave IF clobbered — specifically,
+        // it must not leave the nested save stuck at `false`.
+        let attempt = m.try_lock();
+        assert!(attempt.is_none());
+        // _held still in scope, so IF still false (correct).
+        assert!(!arch_if::test_is_enabled());
+        drop(_held);
+        assert!(arch_if::test_is_enabled());
+    }
+}

--- a/kernel/src/sync/mod.rs
+++ b/kernel/src/sync/mod.rs
@@ -48,6 +48,24 @@
 //! queue (see `crate::input`'s keyboard ring) and let a kernel task
 //! drain it and call `notify_one` from task context.
 //!
+//! ## Picking a mutual-exclusion primitive
+//!
+//! - **ISR-reachable data** → [`IrqLock`]. Disables local IRQs for the
+//!   duration the guard is held, so a task-context holder can't be
+//!   interrupted by an ISR that also wants the lock (classic
+//!   deadlock-by-reentry). Mirrors Linux's `spin_lock_irqsave`.
+//! - **Task-context only** → plain `spin::Mutex`. Cheapest option; no
+//!   IF save/restore on every acquire. Any static guarded by a plain
+//!   `spin::Mutex` should carry a comment stating that invariant so a
+//!   future ISR path onto it doesn't silently introduce a deadlock.
+//! - **Held across a scheduling point** (`block_current`, `yield`,
+//!   any blocking-primitive acquire) → [`BlockingMutex`]. Spinning or
+//!   parking with IRQs masked would hang the kernel.
+//!
+//! For brief "mask IRQs around this read" patterns where a full
+//! [`IrqLock`] is overkill, [`without_interrupts`] re-exports
+//! `x86_64`'s closure form.
+//!
 //! ## Lock order
 //!
 //! The primitives here establish a strict acquisition order so that
@@ -63,6 +81,7 @@
 //! Nothing acquires `WaitQueue.inner` while already holding a data
 //! lock or `SCHED`, so the graph is a DAG.
 
+pub mod irqlock;
 pub mod mpmc;
 pub mod mutex;
 pub mod rwlock;
@@ -70,7 +89,11 @@ pub mod semaphore;
 pub mod spsc;
 pub mod waitqueue;
 
+pub use irqlock::{IrqLock, IrqLockGuard};
 pub use mutex::{BlockingMutex, MutexGuard};
 pub use rwlock::{BlockingRwLock, RwLockReadGuard, RwLockWriteGuard};
 pub use semaphore::Semaphore;
 pub use waitqueue::WaitQueue;
+
+#[cfg(target_os = "none")]
+pub use x86_64::instructions::interrupts::without_interrupts;

--- a/kernel/src/time.rs
+++ b/kernel/src/time.rs
@@ -8,7 +8,9 @@ use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 use core::fmt;
 use core::sync::atomic::{AtomicU64, Ordering};
-use spin::{Mutex, Once};
+use spin::Once;
+
+use crate::sync::IrqLock;
 
 /// PIT oscillator frequency, in Hz. Divisor = this / desired Hz.
 #[cfg(target_os = "none")]
@@ -24,7 +26,13 @@ static TICKS: AtomicU64 = AtomicU64::new(0);
 /// may accumulate multiple task ids (unlikely at 100 Hz but cheap to
 /// support). Drained by `preempt_tick` each PIT IRQ; see
 /// `drain_expired`.
-static WAKEUPS: Mutex<BTreeMap<u64, Vec<usize>>> = Mutex::new(BTreeMap::new());
+///
+/// Reachable from both task context (`enqueue_wakeup`) and ISR
+/// context (`drain_expired` from the PIT handler), so it uses
+/// [`IrqLock`] to mask IRQs while held — a plain `spin::Mutex` would
+/// deadlock if the timer IRQ landed on the same CPU while a task
+/// held the lock.
+static WAKEUPS: IrqLock<BTreeMap<u64, Vec<usize>>> = IrqLock::new(BTreeMap::new());
 
 /// Calibrated TSC frequency in Hz. Set once by [`calibrate_tsc`]; left
 /// unset when `RDTSCP` is unavailable, in which case [`uptime_ns`]

--- a/kernel/src/time.rs
+++ b/kernel/src/time.rs
@@ -10,7 +10,14 @@ use core::fmt;
 use core::sync::atomic::{AtomicU64, Ordering};
 use spin::Once;
 
+#[cfg(target_os = "none")]
 use crate::sync::IrqLock;
+
+// Host builds: `sync` is cfg-gated to `target_os = "none"`, so substitute
+// a plain `spin::Mutex` with the same interface for the WAKEUPS static
+// below. No ISR concurrency exists on host, so IF masking is moot.
+#[cfg(not(target_os = "none"))]
+use spin::Mutex as IrqLock;
 
 /// PIT oscillator frequency, in Hz. Divisor = this / desired Hz.
 #[cfg(target_os = "none")]


### PR DESCRIPTION
Closes #49

## Summary

- New `IrqLock<T>` primitive in `kernel/src/sync/irqlock.rs` with
  Linux `spin_lock_irqsave` semantics: save IF on acquire, restore on
  guard drop, release the inner `spin::Mutex` *before* re-enabling
  interrupts so a pending IRQ can't observe a mid-update state under
  still-held lock semantics.
- Extended `sync/mod.rs` module doc with the picking rule: ISR-reachable
  → `IrqLock`; task-only → `spin::Mutex` with an invariant comment;
  across a scheduling point → `BlockingMutex`. Also re-exports
  `x86_64::instructions::interrupts::without_interrupts` for brief
  closure-form IRQ masking.
- Migrated the two ISR-reachable statics that were previously protected
  by convention: `WAKEUPS` (time.rs, drained by the PIT IRQ) and
  `SCANCODES` (input.rs, pushed by the keyboard ISR). Dropped the
  now-redundant `without_interrupts(|| SCANCODES.lock().pop())` wrapper.

`REAPER_VICTIMS` in `task/mod.rs` intentionally stays a plain
`spin::Mutex` — it's only touched from task context (exit pushes with
IRQs already masked via the context-switch sequencing; the reaper drains
in its own task). The existing doc comment already states that
invariant and is an example of the new "task-only spin::Mutex" rule.

**Out of scope for this PR, filed as follow-ups:**
- SCHED migration — requires reworking `block_current`/`exit`/`wake`
  around `context_switch` sequencing (the current IF save/restore
  straddles the switch; naive IrqLock migration would invert it).
- Remaining tree-wide audit of ~40 `spin::Mutex` sites
  (PCI config, MAPPER, HHDM_OFFSET, virtio_blk, VFS mount tables, heap,
  fd_table, klog ring, serial::COM1, etc.) — most are task-only; each
  needs an invariant comment or a targeted migration.

## Test plan

- [x] `cargo xtask build` — kernel compiles clean (only pre-existing
  `is_guard_hit` dead-code warning)
- [ ] CI runs host unit tests, including the five new `irqlock::tests`
  cases covering value round-trip, try-lock-while-held, IF-masked
  during critical section, prior-state preservation, and IF-restore
  on try-lock failure (host builds stub `arch_if` with an `AtomicBool`
  so these run without hardware)
- [ ] CI runs QEMU integration tests — keyboard input still drains
  (`SCANCODES`) and timed wakeups still fire (`WAKEUPS`)