### PR TITLE
mem/elf: extract USERSPACE_INIT_MODULE_SUFFIX constant (#176)

### DIFF
--- a/kernel/src/mem/elf.rs
+++ b/kernel/src/mem/elf.rs
@@ -16,6 +16,13 @@ const PF_W: u32 = 1 << 1;
 const ELF_MAGIC: [u8; 4] = [0x7f, b'E', b'L', b'F'];
 const ELFCLASS64: u8 = 2;
 
+/// Path suffix the Limine config publishes for the PID 1 init ELF.
+/// Module lookup uses `ends_with` so an absolute-path prefix won't
+/// break matching. Keeping the string in one place prevents drift
+/// between the byte-scan and ELF-summary helpers.
+#[cfg(target_os = "none")]
+const USERSPACE_INIT_MODULE_SUFFIX: &[u8] = b"/boot/userspace_init.elf";
+
 #[repr(C)]
 #[derive(Clone, Copy)]
 struct Elf64Ehdr {
@@ -193,7 +200,7 @@ pub(crate) fn first_loaded_module_bytes() -> Option<&'static [u8]> {
     let file = resp
         .modules()
         .iter()
-        .find(|f| f.path().to_bytes().ends_with(b"/boot/userspace_init.elf"))?;
+        .find(|f| f.path().to_bytes().ends_with(USERSPACE_INIT_MODULE_SUFFIX))?;
     let base = file.addr();
     let size = file.size() as usize;
     // SAFETY: Limine places module payloads in EXECUTABLE_AND_MODULES
@@ -224,7 +231,7 @@ pub(crate) fn first_loaded_module_elf_summary() -> Option<(VirtAddr, usize)> {
     let file = resp
         .modules()
         .iter()
-        .find(|f| f.path().to_bytes().ends_with(b"/boot/userspace_init.elf"))?;
+        .find(|f| f.path().to_bytes().ends_with(USERSPACE_INIT_MODULE_SUFFIX))?;
     let base = file.addr();
     let size = file.size() as usize;
     if size < core::mem::size_of::<Elf64Ehdr>() {


### PR DESCRIPTION
Closes #176

## Summary

- Hoists the duplicated `/boot/userspace_init.elf` byte-suffix literal in `kernel/src/mem/elf.rs` to a file-private `USERSPACE_INIT_MODULE_SUFFIX` constant so the two `ends_with(...)` call sites in `first_loaded_module_bytes` and `first_loaded_module_elf_summary` can't drift.
- The `userspace_hello.elf` literal in `hello_module_bytes` is a different module with only a single site; left as-is per the issue's scope.

## Test plan

- [x] `cargo check --target x86_64-unknown-none` clean.
- [x] `cargo fmt --all -- --check` clean.
- [ ] CI: `cargo xtask test` + `cargo xtask smoke` verify boot still finds the init module through the new constant.