### PR TITLE
tests: assert USER_ACCESSIBLE on entry PTE in userspace_loader test

### DIFF
--- a/kernel/tests/userspace_loader.rs
+++ b/kernel/tests/userspace_loader.rs
@@ -10,6 +10,7 @@ use vibix::{
     test_harness::{test_panic_handler, Testable},
     QemuExitCode,
 };
+use x86_64::structures::paging::PageTableFlags;
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
@@ -54,10 +55,30 @@ fn load_user_elf_maps_lower_half_segments() {
         image.entry.as_u64()
     );
     assert!(image.segments > 0, "at least one PT_LOAD must map");
+
+    // The entry PTE must be present *and* USER_ACCESSIBLE. A regression
+    // that maps lower-half segments without the U bit would leave the
+    // returned `LoadedImage` metadata intact while silently breaking
+    // ring-3 execution — walking the leaf PTE catches that.
+    let (frame, flags) = vibix::mem::paging::translate_in_pml4(pml4, image.entry)
+        .expect("entry VA must be mapped in new PML4");
+    assert!(
+        flags.contains(PageTableFlags::PRESENT),
+        "entry PTE must be PRESENT, got {:?}",
+        flags
+    );
+    assert!(
+        flags.contains(PageTableFlags::USER_ACCESSIBLE),
+        "entry PTE missing USER_ACCESSIBLE: {:?}",
+        flags
+    );
+
     serial_println!(
-        "load_user_elf: entry={:#x} segments={}",
+        "load_user_elf: entry={:#x} segments={} frame={:#x} flags={:?}",
         image.entry.as_u64(),
-        image.segments
+        image.segments,
+        frame.start_address().as_u64(),
+        flags
     );
 }
 


### PR DESCRIPTION
Closes #177

## Summary

The `load_user_elf_maps_lower_half_segments` integration test previously
only checked the returned `LoadedImage` metadata (entry address and
segment count). A regression that mapped lower-half segments without
`USER_ACCESSIBLE` would still pass, silently breaking ring-3 execution.

Walk the leaf PTE via the existing `paging::translate_in_pml4` helper
(already public and used elsewhere for PT walks) and assert PRESENT +
USER_ACCESSIBLE on the entry VA's mapping. No new public API surface.

## Test plan

- [x] Test target compiles clean (`cargo build --target x86_64-unknown-none --test userspace_loader`)
- [ ] CI's QEMU run of `userspace_loader` passes with the added assertions,
      confirming the real loader still sets USER_ACCESSIBLE