### PR TITLE
tests: assert mmap rejects unknown flag bits with EINVAL

### DIFF
--- a/kernel/tests/syscall_mmap_family.rs
+++ b/kernel/tests/syscall_mmap_family.rs
@@ -55,6 +55,10 @@ fn run_tests() {
             &(mmap_requires_exactly_one_share as fn()),
         ),
         (
+            "mmap_unknown_flag_bits_einval",
+            &(mmap_unknown_flag_bits_einval as fn()),
+        ),
+        (
             "mmap_shared_anon_succeeds",
             &(mmap_shared_anon_succeeds as fn()),
         ),
@@ -160,6 +164,23 @@ fn mmap_requires_exactly_one_share() {
         0,
     );
     assert_eq!(r, EINVAL);
+}
+
+fn mmap_unknown_flag_bits_einval() {
+    // Any flag bit outside MAP_SHARED|PRIVATE|FIXED|FIXED_NOREPLACE|
+    // ANONYMOUS|GROWSDOWN|STACK must fail with EINVAL — silently
+    // accepting unknown bits (MAP_LOCKED, MAP_HUGETLB, …) gives callers
+    // a successful mapping with none of the requested semantics applied.
+    const UNKNOWN_FLAG: u32 = 1u32 << 31;
+    let r = mmap(
+        0,
+        4096,
+        PROT_READ | PROT_WRITE,
+        MAP_ANONYMOUS | MAP_PRIVATE | UNKNOWN_FLAG,
+        -1,
+        0,
+    );
+    assert_eq!(r, EINVAL, "expected EINVAL for unknown flag bit, got {}", r);
 }
 
 fn mmap_shared_anon_succeeds() {


### PR DESCRIPTION
Closes #204

## Summary

The unknown-flag rejection for `mmap` already landed with the RFC 0001
mmap surface in #228 (`kernel/src/arch/x86_64/syscall.rs:664-673` builds
a `known` mask and returns `EINVAL` when any extra bit is set). No
regression test pinned that behaviour, so a refactor dropping or
inverting the mask would silently re-introduce the original Cursor
Bugbot finding on commit 516f9ae: callers passing `MAP_LOCKED` /
`MAP_HUGETLB` / etc. would get a successful mapping with none of those
semantics applied.

Add one integration test to \`kernel/tests/syscall_mmap_family.rs\`
that mmaps with bit 31 set (clearly outside the known mask
\`SHARED|PRIVATE|FIXED|FIXED_NOREPLACE|ANONYMOUS|GROWSDOWN|STACK\`)
and asserts \`EINVAL\`.

## Test plan

- [x] \`cargo build --target x86_64-unknown-none --test syscall_mmap_family\` compiles clean
- [ ] CI's QEMU run of \`syscall_mmap_family\` passes with the new \`mmap_unknown_flag_bits_einval\` case