### PR TITLE
ci: pin anthropics/claude-code-action to immutable SHA

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@1c8b699d43e9bfed42b48ef15da85d89bab70960 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/file-bug.yml
+++ b/.github/workflows/file-bug.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 1
 
       - name: File bug via Claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@1c8b699d43e9bfed42b48ef15da85d89bab70960 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |

--- a/.github/workflows/issue-backfill.yml
+++ b/.github/workflows/issue-backfill.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 50   # enough history to see recent momentum
 
       - name: Run Claude Code — propose up to 5 next issues
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@1c8b699d43e9bfed42b48ef15da85d89bab70960 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |


### PR DESCRIPTION
Closes #194

## Summary

- Replace `anthropics/claude-code-action@v1` with `@1c8b699d43e9bfed42b48ef15da85d89bab70960 # v1` in all three Claude-driven workflows (`claude.yml`, `issue-backfill.yml`, `file-bug.yml`).
- A mutable tag can be force-moved by the upstream owner or an attacker with write access; a full commit SHA cannot. The trailing `# v1` comment preserves upgrade legibility for humans and Dependabot.
- SHA was obtained by dereferencing the annotated `v1` tag on `anthropics/claude-code-action` to its underlying commit object.

## Test plan

- [x] `grep -n "anthropics/claude-code-action" .github/workflows/*.yml` shows the pinned SHA in all three workflow files.
- [ ] Next scheduled `issue-backfill` run resolves and runs the action successfully.
- [ ] Next `@claude` comment trigger on a PR successfully runs `claude.yml`.
- [ ] Next main-branch CI failure successfully files a bug via `file-bug.yml`.

Note: the issue body mentioned `ci.yml (file-bug job)`, but the file-bug logic has since moved to its own `file-bug.yml` workflow. Scope matches the issue intent (all workflows that `use` the action).