### PR TITLE
loader: reject PT_LOAD whose page-aligned end reaches USER_VA_END

### DIFF
--- a/kernel/src/mem/loader.rs
+++ b/kernel/src/mem/loader.rs
@@ -25,6 +25,7 @@ use x86_64::VirtAddr;
 
 use alloc::sync::Arc;
 
+use super::addrspace::USER_VA_END;
 use super::elf;
 use super::paging;
 use super::tlb::Flusher;
@@ -52,6 +53,12 @@ pub enum LoadError {
     /// Wraps the underlying `paging::map` error so callers can tell
     /// `FrameAllocationFailed` from `PageAlreadyMapped` etc.
     MapFailed(MapToError<Size4KiB>),
+    /// A `PT_LOAD` segment's page-aligned end lands at or past
+    /// `USER_VA_END` (`0x0000_8000_0000_0000`). `LoadedImage::image_end`
+    /// is eventually wrapped in `VirtAddr::new`, which panics on the
+    /// first non-canonical lower-half address. Reject at load time so
+    /// the panic can't be reached from a malformed user ELF.
+    SegmentEndsAtUserVaEnd,
 }
 
 /// Result of a successful load: the entry point, segment count, and the
@@ -142,11 +149,21 @@ pub fn load_user_elf(bytes: &[u8], pml4: PhysFrame<Size4KiB>) -> Result<LoadedIm
     let mut image_end = 0u64;
     let mut err: Option<LoadError> = None;
     for seg in parsed.load_segments() {
+        let seg_end = (seg.vaddr.as_u64() + seg.memsz + PAGE_SIZE - 1) & !(PAGE_SIZE - 1);
+        // Reject before mapping: `image_end` is later fed to
+        // `VirtAddr::new` (set_brk_start, exec), which panics at
+        // USER_VA_END. Prior segments in the same ELF may already be
+        // mapped in `pml4` — the caller drops the partial PML4 on
+        // error, matching the existing MapFailed / SegmentNotLowerHalf
+        // paths.
+        if seg_end >= USER_VA_END {
+            err = Some(LoadError::SegmentEndsAtUserVaEnd);
+            break;
+        }
         if let Err(e) = map_user_segment(bytes, seg, pml4) {
             err = Some(e);
             break;
         }
-        let seg_end = (seg.vaddr.as_u64() + seg.memsz + PAGE_SIZE - 1) & !(PAGE_SIZE - 1);
         if seg_end > image_end {
             image_end = seg_end;
         }

--- a/kernel/tests/userspace_loader.rs
+++ b/kernel/tests/userspace_loader.rs
@@ -34,6 +34,10 @@ fn run_tests() {
             "load_user_elf_rejects_upper_half",
             &(load_user_elf_rejects_upper_half as fn()),
         ),
+        (
+            "load_user_elf_rejects_segment_ending_at_user_va_end",
+            &(load_user_elf_rejects_segment_ending_at_user_va_end as fn()),
+        ),
     ];
     serial_println!("running {} tests", tests.len());
     for (name, t) in tests {
@@ -119,4 +123,48 @@ fn load_user_elf_rejects_upper_half() {
         result
     );
     serial_println!("load_user_elf correctly rejected upper-half ELF");
+}
+
+fn load_user_elf_rejects_segment_ending_at_user_va_end() {
+    // PT_LOAD whose last byte (page-aligned) lands exactly at
+    // USER_VA_END = 0x0000_8000_0000_0000 — the first non-canonical
+    // lower-half address. `VirtAddr::new(image.image_end)` would
+    // panic if the loader reported it back to the caller, so the
+    // loader must reject at parse time.
+    const EHDR: usize = 64;
+    const PHDR: usize = 56;
+    let mut bytes = [0u8; EHDR + PHDR];
+
+    bytes[0..4].copy_from_slice(&[0x7f, b'E', b'L', b'F']);
+    bytes[4] = 2; // ELFCLASS64
+    bytes[5] = 1; // little-endian
+    bytes[6] = 1; // ELF version
+    bytes[16..18].copy_from_slice(&2u16.to_le_bytes()); // ET_EXEC
+    bytes[18..20].copy_from_slice(&0x3eu16.to_le_bytes()); // EM_X86_64
+    bytes[20..24].copy_from_slice(&1u32.to_le_bytes()); // e_version
+                                                        // Entry inside the segment, canonical lower-half.
+    bytes[24..32].copy_from_slice(&0x0000_7fff_ffff_f000u64.to_le_bytes());
+    bytes[32..40].copy_from_slice(&(EHDR as u64).to_le_bytes()); // e_phoff
+    bytes[52..54].copy_from_slice(&(EHDR as u16).to_le_bytes()); // e_ehsize
+    bytes[54..56].copy_from_slice(&(PHDR as u16).to_le_bytes()); // e_phentsize
+    bytes[56..58].copy_from_slice(&1u16.to_le_bytes()); // e_phnum = 1
+
+    let p = EHDR;
+    bytes[p..p + 4].copy_from_slice(&1u32.to_le_bytes()); // PT_LOAD
+    bytes[p + 4..p + 8].copy_from_slice(&5u32.to_le_bytes()); // R+X
+                                                              // p_vaddr = USER_VA_END - 0x1000, so page-aligned end == USER_VA_END.
+    bytes[p + 16..p + 24].copy_from_slice(&0x0000_7fff_ffff_f000u64.to_le_bytes());
+    bytes[p + 40..p + 48].copy_from_slice(&0x1000u64.to_le_bytes()); // p_memsz
+
+    let pml4 = vibix::mem::paging::new_task_pml4();
+    let result = vibix::mem::loader::load_user_elf(&bytes, pml4);
+    assert!(
+        matches!(
+            result,
+            Err(vibix::mem::loader::LoadError::SegmentEndsAtUserVaEnd)
+        ),
+        "expected SegmentEndsAtUserVaEnd, got {:?}",
+        result
+    );
+    serial_println!("load_user_elf correctly rejected segment ending at USER_VA_END");
 }


### PR DESCRIPTION
Closes #212

## Summary

\`LoadedImage::image_end\` is eventually passed to \`VirtAddr::new\`
(\`kernel/src/init_process.rs:68\` and \`kernel/src/arch/x86_64/syscall.rs:500\`).
\`x86_64::VirtAddr::new\` panics on non-canonical inputs, and
\`USER_VA_END = 0x0000_8000_0000_0000\` is the first non-canonical
lower-half address. A PT_LOAD segment whose page-aligned end lands
exactly at \`USER_VA_END\` therefore turned a malformed user ELF
into a kernel panic.

Add \`LoadError::SegmentEndsAtUserVaEnd\` and check
\`seg_end >= USER_VA_END\` in \`load_user_elf\` **before** mapping the
segment, so the offending page is never installed in the per-process
PML4. Prior segments from the same ELF may already be mapped on this
error path — same contract as existing \`MapFailed\` /
\`SegmentNotLowerHalf\` branches; callers drop the partial PML4.

## Test plan

- [x] \`cargo build --target x86_64-unknown-none --test userspace_loader\` compiles clean
- [ ] CI's QEMU run of \`userspace_loader\` exercises the new
      \`load_user_elf_rejects_segment_ending_at_user_va_end\` case