### PR TITLE
test(rootfs): assert /etc/hostname content end-to-end

### DIFF
--- a/kernel/tests/rootfs_module.rs
+++ b/kernel/tests/rootfs_module.rs
@@ -4,14 +4,13 @@
 //! After `vibix::init()`, `vfs::init::root()` should point to a TarFs root
 //! populated from the `rootfs.tar` module declared in `limine.conf`. This test
 //! walks `/etc` through the global VFS namespace and verifies it resolves to a
-//! directory, exercising the full
+//! directory, then opens `/etc/hostname` and reads back the payload bytes —
+//! proving the tar file content survives end-to-end through the full
 //!
 //!   boot module → TarFs::mount (MountSource::RamdiskModule) → SuperBlock
-//!     → path_walk("/etc") → Inode (Dir)
+//!     → path_walk("/etc/hostname") → Inode (Reg) → FileOps::read → bytes
 //!
-//! chain end-to-end. The initrd produced by `cargo xtask initrd` contains
-//! `etc/` as a directory stub (no files inside), so we assert directory kind
-//! rather than reading file content.
+//! chain.
 
 #![no_std]
 #![no_main]
@@ -20,7 +19,9 @@ extern crate alloc;
 
 use core::panic::PanicInfo;
 
+use vibix::fs::vfs::open_file::OpenFile;
 use vibix::fs::vfs::path_walk::{path_walk, LookupFlags, NameIdata};
+use vibix::fs::vfs::super_block::SbActiveGuard;
 use vibix::fs::vfs::{Credential, GlobalMountResolver, InodeKind};
 use vibix::{
     exit_qemu, serial_println,
@@ -42,10 +43,16 @@ fn panic(info: &PanicInfo) -> ! {
 }
 
 fn run_tests() {
-    let tests: &[(&str, &dyn Testable)] = &[(
-        "rootfs_etc_is_directory",
-        &(rootfs_etc_is_directory as fn()),
-    )];
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "rootfs_etc_is_directory",
+            &(rootfs_etc_is_directory as fn()),
+        ),
+        (
+            "rootfs_etc_hostname_content",
+            &(rootfs_etc_hostname_content as fn()),
+        ),
+    ];
     serial_println!("running {} tests", tests.len());
     for (name, t) in tests {
         serial_println!("test {name}");
@@ -72,6 +79,59 @@ fn rootfs_etc_is_directory() {
         panic!(
             "rootfs_module: /etc must be a directory, got kind={:?}",
             etc_inode.kind
+        );
+    }
+}
+
+fn rootfs_etc_hostname_content() {
+    let root =
+        vibix::fs::vfs::root().expect("rootfs_module: vfs root not populated after vibix::init()");
+
+    let mut nd = NameIdata::new(
+        root.clone(),
+        root,
+        Credential::kernel(),
+        LookupFlags::default(),
+    )
+    .expect("rootfs_module: seed namei");
+
+    path_walk(&mut nd, b"/etc/hostname", &GlobalMountResolver)
+        .expect("rootfs_module: path_walk /etc/hostname");
+
+    let hostname_dentry = nd.path.dentry.clone();
+    let hostname_inode = nd.path.inode.clone();
+    if hostname_inode.kind != InodeKind::Reg {
+        panic!(
+            "rootfs_module: /etc/hostname must be a regular file, got kind={:?}",
+            hostname_inode.kind
+        );
+    }
+
+    let sb = hostname_inode
+        .sb
+        .upgrade()
+        .expect("rootfs_module: /etc/hostname superblock still live");
+    let guard = SbActiveGuard::try_acquire(&sb).expect("rootfs_module: sb_active guard");
+    let of = OpenFile::new(
+        hostname_dentry,
+        hostname_inode.clone(),
+        hostname_inode.file_ops.clone(),
+        sb.clone(),
+        0,
+        guard,
+    );
+
+    const EXPECTED: &[u8] = b"vibix\n";
+    let mut buf = [0u8; 16];
+    let n = hostname_inode
+        .file_ops
+        .read(&of, &mut buf, 0)
+        .expect("rootfs_module: FileOps::read /etc/hostname");
+    if n != EXPECTED.len() || &buf[..n] != EXPECTED {
+        panic!(
+            "rootfs_module: /etc/hostname content mismatch; expected {:?} got n={n} bytes={:?}",
+            EXPECTED,
+            &buf[..core::cmp::min(n, buf.len())]
         );
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -532,6 +532,9 @@ fn ustar_header_block(name: &str, typeflag: u8, mode: u16, size: u64) -> [u8; 51
 ///     required by RFC 0002 §Initialization order.
 ///   - `etc/init/` — nested directory exercising multi-level path resolution
 ///     (issue #85).
+///   - `etc/hostname` — top-level regular file whose content (`b"vibix\n"`)
+///     is asserted by `kernel/tests/rootfs_module.rs` to prove the tar
+///     payload survives end-to-end through `MountSource::RamdiskModule`.
 ///   - `etc/init/hello.txt` — nested regular file whose presence proves the
 ///     full `path_walk` chain resolves `/etc/init/hello.txt` end-to-end.
 ///
@@ -540,10 +543,12 @@ fn ensure_initrd() -> R<PathBuf> {
     let path = initrd_path();
 
     const DIRS: &[&str] = &["dev/", "tmp/", "bin/", "etc/", "etc/init/"];
+    const HOSTNAME_FILE: &str = "etc/hostname";
+    const HOSTNAME_PAYLOAD: &[u8] = b"vibix\n";
     const NESTED_FILE: &str = "etc/init/hello.txt";
     const NESTED_PAYLOAD: &[u8] = b"nested\n";
-    // DIRS headers + 1 file header + 1 padded data block + 2 end blocks.
-    const EXPECTED_SIZE: u64 = ((DIRS.len() + 1 + 1 + 2) * 512) as u64;
+    // DIRS headers + 2 file headers + 2 padded data blocks + 2 end blocks.
+    const EXPECTED_SIZE: u64 = ((DIRS.len() + 2 + 2 + 2) * 512) as u64;
 
     let needs_write = match fs::metadata(&path) {
         Ok(m) => m.len() != EXPECTED_SIZE,
@@ -558,6 +563,13 @@ fn ensure_initrd() -> R<PathBuf> {
         for &dir in DIRS {
             data.extend_from_slice(&ustar_dir_block(dir));
         }
+        data.extend_from_slice(&ustar_file_block(
+            HOSTNAME_FILE,
+            HOSTNAME_PAYLOAD.len() as u64,
+        ));
+        let mut hostname_block = [0u8; 512];
+        hostname_block[..HOSTNAME_PAYLOAD.len()].copy_from_slice(HOSTNAME_PAYLOAD);
+        data.extend_from_slice(&hostname_block);
         data.extend_from_slice(&ustar_file_block(NESTED_FILE, NESTED_PAYLOAD.len() as u64));
         let mut payload_block = [0u8; 512];
         payload_block[..NESTED_PAYLOAD.len()].copy_from_slice(NESTED_PAYLOAD);

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -985,10 +985,11 @@ mod tests {
         let path = ensure_initrd().expect("ensure_initrd failed");
         assert!(path.exists());
         let data = fs::read(&path).unwrap();
-        // 4 dir entries + 2 end-of-archive blocks
-        assert_eq!(data.len(), 6 * 512);
+        // 5 dir headers + 2 file headers + 2 padded file data blocks +
+        // 2 end-of-archive zero blocks = 11 * 512
+        assert_eq!(data.len(), 11 * 512);
         // Last 1024 bytes are the end-of-archive marker (all zeros)
-        assert!(data[4 * 512..].iter().all(|&b| b == 0));
+        assert!(data[data.len() - 1024..].iter().all(|&b| b == 0));
     }
 
     #[test]


### PR DESCRIPTION
Closes #297

## Summary

- Add `etc/hostname` (6 bytes: `vibix\n`) to the USTAR archive built by `xtask::ensure_initrd()`.
- Extend `kernel/tests/rootfs_module.rs` with a second test case `rootfs_etc_hostname_content` that path-walks to `/etc/hostname`, opens the inode through `FileOps`, and asserts the read-back bytes match.
- The existing `rootfs_etc_is_directory` case is preserved unchanged.

Completes the end-to-end assertion CodeRabbit flagged as a gap on PR #295: the test now exercises `boot module → TarFs::mount → SuperBlock → path_walk → Inode (Reg) → FileOps::read → bytes`, not just path resolution to a directory.

## Test plan

- [x] `cargo check --target x86_64-unknown-none -Z build-std=core,alloc,compiler_builtins --test rootfs_module -p vibix` succeeds.
- [x] `cargo xtask initrd` rebuilds `target/rootfs.tar` to 5632 bytes (11 × 512: 5 dirs + 2 file headers + 2 data blocks + 2 end blocks).
- [x] `tar xOf target/rootfs.tar etc/hostname | od -c` prints exactly `v i b i x \n`.
- [ ] CI runs `rootfs_module` under QEMU and both test cases pass.