### PR TITLE
syscall: expand VFS path buffer to PATH_MAX with ENAMETOOLONG

### DIFF
--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -19,11 +19,13 @@
 //! - `write_stat` for the userspace `struct stat` copy-out.
 
 use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
 
 use super::super::syscall::copy_path_from_user_pub;
 use super::super::uaccess;
 use crate::fs::vfs::ops::{meta_into_stat, Stat};
-use crate::fs::vfs::path_walk::{path_walk, LookupFlags, NameIdata};
+use crate::fs::vfs::path_walk::{path_walk, LookupFlags, NameIdata, PATH_MAX};
 use crate::fs::vfs::super_block::SbActiveGuard;
 use crate::fs::vfs::Credential;
 use crate::fs::vfs::{
@@ -44,9 +46,17 @@ pub const AT_SYMLINK_NOFOLLOW: u32 = 0x100;
 /// behind `dfd` (used by `fstatat(fd, "", &st, AT_EMPTY_PATH)`).
 pub const AT_EMPTY_PATH: u32 = 0x1000;
 
-/// Same bound as `sys_open`'s legacy buffer. Keeps a copy-in within a
-/// single kernel stack frame.
-const OPEN_PATH_MAX: usize = 128;
+/// Copy a user path into a heap buffer sized at `PATH_MAX + 1`. The
+/// `+1` lets `copy_path_from_user_pub` observe the terminating NUL
+/// within the buffer for paths of exactly `PATH_MAX` user bytes;
+/// anything longer returns `-ENAMETOOLONG`. A heap buffer avoids a
+/// 4 KiB stack frame on every VFS syscall.
+fn copy_user_path(path_uva: u64) -> Result<Vec<u8>, i64> {
+    let mut buf: Vec<u8> = vec![0u8; PATH_MAX + 1];
+    let n = unsafe { copy_path_from_user_pub(path_uva as usize, &mut buf) }?;
+    buf.truncate(n);
+    Ok(buf)
+}
 
 /// Resolve a user path to an `Arc<Inode>` via `path_walk`.
 ///
@@ -146,12 +156,11 @@ fn legacy_dev_backend(path: &[u8], flags: u64) -> Option<i64> {
 /// cwd / fd-rooted walks don't exist yet (#239).
 pub unsafe fn sys_openat_impl(dfd: i32, path_uva: u64, flags: u64, _mode: u64) -> i64 {
     // 1. Copy the user path.
-    let mut buf = [0u8; OPEN_PATH_MAX];
-    let n = match copy_path_from_user_pub(path_uva as usize, &mut buf) {
-        Ok(n) => n,
+    let buf = match copy_user_path(path_uva) {
+        Ok(b) => b,
         Err(e) => return e,
     };
-    let path = &buf[..n];
+    let path = buf.as_slice();
 
     // 2. Mutating create/truncate flags not supported in the read-path
     //    subset. Fail loudly so userspace gets a clear signal rather than
@@ -221,12 +230,11 @@ pub unsafe fn sys_openat_impl(dfd: i32, path_uva: u64, flags: u64, _mode: u64) -
 /// `stat(path, *statbuf)` (follow=true) / `lstat(path, *statbuf)`
 /// (follow=false — `nofollow=true` here flips the sense).
 pub unsafe fn sys_stat_impl(path_uva: u64, statbuf_uva: u64, nofollow: bool) -> i64 {
-    let mut buf = [0u8; OPEN_PATH_MAX];
-    let n = match copy_path_from_user_pub(path_uva as usize, &mut buf) {
-        Ok(n) => n,
+    let buf = match copy_user_path(path_uva) {
+        Ok(b) => b,
         Err(e) => return e,
     };
-    let path = &buf[..n];
+    let path = buf.as_slice();
 
     let (inode, _nd) = match resolve_inode(path, !nofollow) {
         Ok(v) => v,
@@ -270,12 +278,11 @@ pub unsafe fn sys_newfstatat_impl(dfd: i32, path_uva: u64, statbuf_uva: u64, fla
         return EINVAL;
     }
 
-    let mut buf = [0u8; OPEN_PATH_MAX];
-    let n = match copy_path_from_user_pub(path_uva as usize, &mut buf) {
-        Ok(n) => n,
+    let buf = match copy_user_path(path_uva) {
+        Ok(b) => b,
         Err(e) => return e,
     };
-    let path = &buf[..n];
+    let path = buf.as_slice();
 
     // AT_EMPTY_PATH + empty path + real fd: stat the file behind dfd.
     // AT_FDCWD (-100) is not a valid fd for this purpose — reject it

--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -19,7 +19,6 @@
 //! - `write_stat` for the userspace `struct stat` copy-out.
 
 use alloc::sync::Arc;
-use alloc::vec;
 use alloc::vec::Vec;
 
 use super::super::syscall::copy_path_from_user_pub;
@@ -31,7 +30,9 @@ use crate::fs::vfs::Credential;
 use crate::fs::vfs::{
     root as vfs_root, GlobalMountResolver, Inode, InodeKind, OpenFile, VfsBackend,
 };
-use crate::fs::{flags as oflags, FileBackend, FileDescription, EBADF, EINVAL, ENOENT, ENOTDIR};
+use crate::fs::{
+    flags as oflags, FileBackend, FileDescription, EBADF, EINVAL, ENOENT, ENOMEM, ENOTDIR,
+};
 
 /// Linux x86_64 value of the "use the current working directory"
 /// sentinel for `*at` syscalls. Sign-extended as an `i32`, negative,
@@ -51,8 +52,15 @@ pub const AT_EMPTY_PATH: u32 = 0x1000;
 /// within the buffer for paths of exactly `PATH_MAX` user bytes;
 /// anything longer returns `-ENAMETOOLONG`. A heap buffer avoids a
 /// 4 KiB stack frame on every VFS syscall.
+///
+/// Uses fallible allocation (`try_reserve_exact`) so a heap-pressure
+/// situation surfaces as `-ENOMEM` to userspace instead of tripping
+/// the kernel-wide `panic = "abort"` handler — a user syscall must
+/// never be a DoS vector against the kernel.
 fn copy_user_path(path_uva: u64) -> Result<Vec<u8>, i64> {
-    let mut buf: Vec<u8> = vec![0u8; PATH_MAX + 1];
+    let mut buf: Vec<u8> = Vec::new();
+    buf.try_reserve_exact(PATH_MAX + 1).map_err(|_| ENOMEM)?;
+    buf.resize(PATH_MAX + 1, 0u8);
     let n = unsafe { copy_path_from_user_pub(path_uva as usize, &mut buf) }?;
     buf.truncate(n);
     Ok(buf)

--- a/kernel/tests/syscall_open_mmap.rs
+++ b/kernel/tests/syscall_open_mmap.rs
@@ -185,12 +185,17 @@ fn open_bad_user_ptr_returns_efault() {
 
 fn open_path_not_terminated() {
     install_user_staging_vma();
-    // Fill the staging page with non-NUL bytes so the loop exhausts
-    // its 128-byte budget before hitting a terminator.
+    // Fill enough of the staging page with non-NUL bytes that the
+    // kernel's `PATH_MAX + 1`-sized copy-in buffer exhausts before
+    // hitting a terminator. `path_walk::PATH_MAX` is 4096, so the
+    // kernel reads up to 4097 bytes looking for a NUL.
+    const UNTERMINATED_BYTES: usize = 4097;
     unsafe {
         let dst = USER_PAGE_VA as *mut u8;
-        for i in 0..200 {
+        let mut i = 0;
+        while i < UNTERMINATED_BYTES {
             ptr::write_volatile(dst.add(i), b'A');
+            i += 1;
         }
     }
     let r = unsafe { syscall_dispatch(2, USER_PAGE_VA as u64, 0, 0, 0, 0, 0) };

--- a/kernel/tests/syscall_vfs.rs
+++ b/kernel/tests/syscall_vfs.rs
@@ -16,7 +16,7 @@ use core::ptr;
 
 use vibix::arch::x86_64::syscall::syscall_dispatch;
 use vibix::fs::vfs::ops::Stat;
-use vibix::fs::{EBADF, EINVAL, ENOENT, ENOTDIR};
+use vibix::fs::{EBADF, EINVAL, ENAMETOOLONG, ENOENT, ENOTDIR};
 use vibix::mem::vmatree::{Share, Vma};
 use vibix::mem::vmobject::AnonObject;
 use vibix::{
@@ -79,6 +79,10 @@ fn run_tests() {
             "open_o_directory_on_nondir_enotdir",
             &(open_o_directory_on_nondir_enotdir as fn()),
         ),
+        (
+            "stat_enametoolong_on_overlong_path",
+            &(stat_enametoolong_on_overlong_path as fn()),
+        ),
     ];
     serial_println!("running {} tests", tests.len());
     for (name, t) in tests {
@@ -123,7 +127,9 @@ fn install_user_staging_vma() {
 /// Copy a NUL-terminated path into the staging page at offset 0.
 fn stage_path(bytes: &[u8]) -> u64 {
     install_user_staging_vma();
-    assert!(bytes.len() < 128);
+    // Leave room for the staging page's `struct stat` half at +4096 so
+    // overlong-path tests (PATH_MAX = 4096) don't collide with it.
+    assert!(bytes.len() < 4096);
     unsafe {
         let dst = USER_PAGE_VA as *mut u8;
         for (i, b) in bytes.iter().enumerate() {
@@ -231,6 +237,30 @@ fn lstat_same_as_stat_on_dir() {
     let st2 = read_stat();
     assert_eq!(st1.st_ino, st2.st_ino);
     assert_eq!(st1.st_mode, st2.st_mode);
+}
+
+fn stat_enametoolong_on_overlong_path() {
+    // VFS PATH_MAX is 4096. A user path of 4097 non-NUL bytes means
+    // `copy_path_from_user` fills the whole kernel buffer (4096 + 1)
+    // without seeing a NUL and must return ENAMETOOLONG. Stage the path
+    // at page 4 of USER_PAGE_VA so it doesn't collide with the stat
+    // destination at page 1.
+    install_user_staging_vma();
+    const OVERLONG: usize = 4097;
+    let path_uva = (USER_PAGE_VA + 4 * 4096) as u64;
+    unsafe {
+        let dst = path_uva as *mut u8;
+        let mut i = 0;
+        while i < OVERLONG {
+            ptr::write_volatile(dst.add(i), b'a');
+            i += 1;
+        }
+        // Trailing NUL beyond PATH_MAX — the copy-in should stop with
+        // ENAMETOOLONG before ever reading this byte.
+        ptr::write_volatile(dst.add(OVERLONG), 0);
+    }
+    let r = unsafe { syscall_dispatch(SYS_STAT, path_uva, statbuf_uva(), 0, 0, 0, 0) };
+    assert_eq!(r, ENAMETOOLONG, "expected ENAMETOOLONG, got {}", r);
 }
 
 fn open_o_directory_on_nondir_enotdir() {


### PR DESCRIPTION
Closes #322

## Summary
- Replace the 128-byte stack buffer in `kernel/src/arch/x86_64/syscalls/vfs.rs` with a `PATH_MAX + 1` heap buffer shared across `sys_openat_impl`, `sys_stat_impl`, and `sys_newfstatat_impl`.
- Factor path copy-in into `copy_user_path`, aligning the syscall-layer limit with `path_walk::PATH_MAX` (4096). Paths longer than `PATH_MAX` return `-ENAMETOOLONG` via the existing `copy_path_from_user` NUL-search semantics.
- Add `stat_enametoolong_on_overlong_path` in `kernel/tests/syscall_vfs.rs` that stages a 4097-byte path on a fresh user page and asserts `sys_stat` returns `ENAMETOOLONG`.

## Test plan
- [x] `cargo xtask build` — kernel lib compiles cleanly (objcopy step is a known aarch64-host limitation; CI runs on x86_64).
- [x] `cargo check --target x86_64-unknown-none --test syscall_vfs -p vibix` passes.
- [ ] CI — full QEMU integration run of `tests/syscall_vfs.rs` including the new `stat_enametoolong_on_overlong_path` case.