### PR TITLE
task: add per-process cwd with chdir/getcwd wiring (RFC 0002 item 11/15)

### DIFF
--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -294,6 +294,12 @@ pub unsafe extern "C" fn syscall_dispatch(
         // newfstatat(dfd, path, *statbuf, flags)
         262 => super::syscalls::vfs::sys_newfstatat_impl(a0 as i32, a1, a2, a3 as u32),
 
+        // getcwd(buf, len) — copy cwd absolute path to user buffer.
+        GETCWD => super::syscalls::vfs::sys_getcwd(a0, a1),
+
+        // chdir(path) — set the per-process current working directory.
+        CHDIR => super::syscalls::vfs::sys_chdir(a0),
+
         // mmap(addr, len, prot, flags, fd, off) — anon-private and
         // anon-shared with full MAP_FIXED / MAP_GROWSDOWN support. See
         // `sys_mmap` for full validation.
@@ -932,6 +938,8 @@ pub mod syscall_nr {
     pub const STAT: u64 = 4;
     pub const LSTAT: u64 = 6;
     pub const NEWFSTATAT: u64 = 262;
+    pub const GETCWD: u64 = 79;
+    pub const CHDIR: u64 = 80;
 }
 
 #[cfg(test)]
@@ -970,6 +978,8 @@ mod tests {
         assert_eq!(syscall_nr::GETDENTS64, 217, "SYS_getdents64 must be 217");
         assert_eq!(syscall_nr::OPENAT, 257, "SYS_openat must be 257");
         assert_eq!(syscall_nr::NEWFSTATAT, 262, "SYS_newfstatat must be 262");
+        assert_eq!(syscall_nr::GETCWD, 79, "SYS_getcwd must be 79");
+        assert_eq!(syscall_nr::CHDIR, 80, "SYS_chdir must be 80");
 
         // Signals
         assert_eq!(syscall_nr::SIGRETURN, 15, "SYS_rt_sigreturn must be 15");

--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -19,9 +19,11 @@
 //! - `write_stat` for the userspace `struct stat` copy-out.
 
 use alloc::sync::Arc;
+use alloc::vec::Vec;
 
 use super::super::syscall::copy_path_from_user_pub;
 use super::super::uaccess;
+use crate::fs::vfs::dentry::{DFlags, Dentry};
 use crate::fs::vfs::ops::{meta_into_stat, Stat};
 use crate::fs::vfs::path_walk::{path_walk, LookupFlags, NameIdata};
 use crate::fs::vfs::super_block::SbActiveGuard;
@@ -30,6 +32,8 @@ use crate::fs::vfs::{
     root as vfs_root, GlobalMountResolver, Inode, InodeKind, OpenFile, VfsBackend,
 };
 use crate::fs::{flags as oflags, FileBackend, FileDescription, EBADF, EINVAL, ENOENT, ENOTDIR};
+
+const ENAMETOOLONG: i64 = -36;
 
 /// Linux x86_64 value of the "use the current working directory"
 /// sentinel for `*at` syscalls. Sign-extended as an `i32`, negative,
@@ -57,13 +61,22 @@ const OPEN_PATH_MAX: usize = 128;
 /// references keep the SB alive for the duration of the `getattr` call.
 fn resolve_inode(path: &[u8], follow: bool) -> Result<(Arc<Inode>, NameIdata), i64> {
     let root = vfs_root().ok_or(ENOENT)?;
+    // For relative paths, walk from the per-process cwd. For absolute
+    // paths, path_walk reseats at root on the first `/` component so
+    // the cwd argument is ignored — but we still pass root as cwd for
+    // absolute paths since that is the correct sentinel.
+    let cwd = if path.first() == Some(&b'/') {
+        root.clone()
+    } else {
+        crate::task::current_cwd().unwrap_or_else(|| root.clone())
+    };
     let mut flags = LookupFlags::default();
     if follow {
         flags = flags | LookupFlags::FOLLOW;
     } else {
         flags = flags | LookupFlags::NOFOLLOW;
     }
-    let mut nd = NameIdata::new(root.clone(), root, Credential::kernel(), flags)?;
+    let mut nd = NameIdata::new(root, cwd, Credential::kernel(), flags)?;
     path_walk(&mut nd, path, &GlobalMountResolver)?;
     let inode = nd.path.inode.clone();
     Ok((inode, nd))
@@ -298,4 +311,109 @@ pub unsafe fn sys_newfstatat_impl(dfd: i32, path_uva: u64, statbuf_uva: u64, fla
         Err(e) => return e,
     };
     stat_into_user(&inode, statbuf_uva)
+}
+
+/// `chdir(path)` — set the per-process current working directory.
+///
+/// Resolves `path` (following symlinks), checks the target is a
+/// directory, then stores its dentry as the task's cwd via
+/// [`crate::task::set_current_cwd`].
+pub unsafe fn sys_chdir(path_uva: u64) -> i64 {
+    let mut buf = [0u8; OPEN_PATH_MAX];
+    let n = match copy_path_from_user_pub(path_uva as usize, &mut buf) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    let path = &buf[..n];
+
+    let (inode, nd) = match resolve_inode(path, /* follow */ true) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
+    if inode.kind != InodeKind::Dir {
+        return ENOTDIR;
+    }
+
+    crate::task::set_current_cwd(nd.path.dentry.clone());
+    0
+}
+
+/// `getcwd(buf, len)` — copy the absolute path of the current working
+/// directory into the user buffer.
+///
+/// Walks the dentry parent chain from the cwd (or VFS root if no cwd
+/// is set) up to the root, collecting component names, then assembles
+/// and copies out `"/component/…\0"`.
+///
+/// Returns the number of bytes written (including the terminating NUL)
+/// on success, or a negative errno:
+/// - `-ENOENT` if the VFS root is not yet initialised.
+/// - `-EINVAL` if `buf` is NULL or `len` is 0.
+/// - `-ENAMETOOLONG` if the path does not fit in `len` bytes.
+/// - `-EFAULT` if `buf` is not a valid user-space range.
+pub unsafe fn sys_getcwd(buf_uva: u64, len: u64) -> i64 {
+    if buf_uva == 0 || len == 0 {
+        return EINVAL;
+    }
+    let len = len as usize;
+
+    // Resolve the cwd: fall back to VFS root.
+    let cwd = match crate::task::current_cwd().or_else(vfs_root) {
+        Some(d) => d,
+        None => return ENOENT,
+    };
+
+    // Walk the parent chain. We hold strong Arcs in `chain` to keep
+    // dentries alive while assembling the path string. Stop at:
+    //   - IS_ROOT dentry (the VFS namespace root), or
+    //   - a failed Weak upgrade (orphaned/disconnected dentry — treat as root).
+    let mut chain: Vec<Arc<Dentry>> = Vec::new();
+
+    let mut cur = cwd.clone();
+    loop {
+        if cur.flags.contains(DFlags::IS_ROOT) {
+            break;
+        }
+        chain.push(cur.clone());
+        match cur.parent.upgrade() {
+            Some(parent) => cur = parent,
+            None => break,
+        }
+    }
+
+    // Build "/comp1/comp2/…\0".
+    // Total length: 1 ('/') + sum(name_len + 1 per component) + 1 (NUL).
+    // For root cwd the chain is empty → path is "/\0".
+    let mut path_len = 1usize; // leading '/'
+    for d in chain.iter().rev() {
+        path_len += d.name.as_bytes().len() + 1; // '/' + name
+    }
+    path_len += 1; // NUL
+
+    if path_len > len {
+        return ENAMETOOLONG;
+    }
+
+    if let Err(e) = uaccess::check_user_range(buf_uva as usize, path_len) {
+        return e.as_errno();
+    }
+
+    // Assemble into a kernel buffer.
+    let mut out: Vec<u8> = Vec::with_capacity(path_len);
+    // If cwd is root, chain is empty.
+    if chain.is_empty() {
+        out.push(b'/');
+    } else {
+        for d in chain.iter().rev() {
+            out.push(b'/');
+            out.extend_from_slice(d.name.as_bytes());
+        }
+    }
+    out.push(0); // NUL terminator
+
+    match uaccess::copy_to_user(buf_uva as usize, &out) {
+        Ok(()) => out.len() as i64,
+        Err(e) => e.as_errno(),
+    }
 }

--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -25,7 +25,7 @@ use super::super::syscall::copy_path_from_user_pub;
 use super::super::uaccess;
 use crate::fs::vfs::dentry::{DFlags, Dentry};
 use crate::fs::vfs::ops::{meta_into_stat, Stat};
-use crate::fs::vfs::path_walk::{path_walk, LookupFlags, NameIdata};
+use crate::fs::vfs::path_walk::{path_walk, LookupFlags, MountResolver, NameIdata};
 use crate::fs::vfs::super_block::SbActiveGuard;
 use crate::fs::vfs::Credential;
 use crate::fs::vfs::{
@@ -365,20 +365,44 @@ pub unsafe fn sys_getcwd(buf_uva: u64, len: u64) -> i64 {
     };
 
     // Walk the parent chain. We hold strong Arcs in `chain` to keep
-    // dentries alive while assembling the path string. Stop at:
-    //   - IS_ROOT dentry (the VFS namespace root), or
-    //   - a failed Weak upgrade (orphaned/disconnected dentry — treat as root).
+    // dentries alive while assembling the path string.
+    //
+    // Mount crossings: when we land on an `IS_ROOT` dentry, query
+    // `MOUNT_TABLE` for the edge whose `root_dentry` is this dentry. If
+    // found, the mountpoint in the parent FS is the next step upward and
+    // its name is what belongs in the path. If not found (we are at the
+    // VFS namespace root), stop.
     let mut chain: Vec<Arc<Dentry>> = Vec::new();
+    let resolver = GlobalMountResolver;
 
     let mut cur = cwd.clone();
     loop {
         if cur.flags.contains(DFlags::IS_ROOT) {
-            break;
-        }
-        chain.push(cur.clone());
-        match cur.parent.upgrade() {
-            Some(parent) => cur = parent,
-            None => break,
+            // Check if this is a mounted root (has a parent FS above it).
+            match resolver.mount_above(&cur) {
+                Some(edge) => {
+                    // Cross back up to the mountpoint in the parent FS.
+                    // The mountpoint's name is the directory name in the
+                    // parent (e.g. "dev" for /dev).
+                    match edge.mountpoint.upgrade() {
+                        Some(mp) => {
+                            chain.push(mp.clone());
+                            match mp.parent.upgrade() {
+                                Some(parent) => cur = parent,
+                                None => break,
+                            }
+                        }
+                        None => break, // mountpoint dropped — treat as root
+                    }
+                }
+                None => break, // namespace root — stop
+            }
+        } else {
+            chain.push(cur.clone());
+            match cur.parent.upgrade() {
+                Some(parent) => cur = parent,
+                None => break,
+            }
         }
     }
 

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -138,7 +138,14 @@ pub fn fork_current_task(
 
     // Snapshot everything needed from the current task while holding
     // SCHED, then release it before calling fork_address_space.
-    let (parent_address_space, parent_fd_table, parent_priority, parent_affinity, parent_fpu_ptr) = {
+    let (
+        parent_address_space,
+        parent_fd_table,
+        parent_cwd,
+        parent_priority,
+        parent_affinity,
+        parent_fpu_ptr,
+    ) = {
         let sched = SCHED.lock();
         let cur = sched
             .current
@@ -147,6 +154,7 @@ pub fn fork_current_task(
         (
             Arc::clone(&cur.address_space),
             Arc::clone(&cur.fd_table),
+            cur.cwd.clone(),
             cur.priority,
             cur.affinity,
             // SAFETY: the parent Task is the currently-running task and stays
@@ -183,6 +191,7 @@ pub fn fork_current_task(
             child_aspace,
             child_cr3,
             child_fd,
+            parent_cwd,
         )
     };
     let child_id = child.id;
@@ -353,6 +362,25 @@ pub fn current_fd_table() -> alloc::sync::Arc<spin::Mutex<crate::fs::FileDescTab
         .expect("current_fd_table: no running task")
         .fd_table
         .clone()
+}
+
+/// Return the per-process current working directory dentry, or `None`
+/// if no cwd has been set (bootstrap / kernel-only tasks). Callers
+/// should fall back to [`crate::fs::vfs::root`] on `None`.
+///
+/// Briefly locks the scheduler to clone the `Arc`, then releases it.
+pub fn current_cwd() -> Option<alloc::sync::Arc<crate::fs::vfs::Dentry>> {
+    SCHED.lock().current.as_ref().and_then(|t| t.cwd.clone())
+}
+
+/// Set the per-process current working directory to `dentry`.
+///
+/// Called by `sys_chdir` after successfully resolving and verifying
+/// that the target is a directory.
+pub fn set_current_cwd(dentry: alloc::sync::Arc<crate::fs::vfs::Dentry>) {
+    if let Some(cur) = SCHED.lock().current.as_mut() {
+        cur.cwd = Some(dentry);
+    }
 }
 
 /// Return the current scheduling priority of the currently-running

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -135,6 +135,13 @@ pub(super) struct Task {
     /// and cloned cheaply for fork() and exec() paths.
     pub fd_table: Arc<Mutex<FileDescTable>>,
 
+    /// Per-process current working directory. `None` means "use the VFS
+    /// root" — necessary for the bootstrap task and any kernel-only task
+    /// spawned before `vfs::init()` runs. `chdir` sets this to the
+    /// resolved dentry; `fork` copies it from the parent; `exec` preserves
+    /// it unchanged.
+    pub cwd: Option<alloc::sync::Arc<crate::fs::vfs::Dentry>>,
+
     /// Top of this task's dedicated SYSCALL kernel stack (set when this
     /// task runs in ring-3 and needs its own syscall entry point).
     ///
@@ -176,6 +183,7 @@ impl Task {
             // at that moment.
             fpu: FpuArea::new_initialized(),
             fd_table: Arc::new(Mutex::new(FileDescTable::new_with_stdio())),
+            cwd: None,
             syscall_stack_top: 0,
         }
     }
@@ -265,6 +273,7 @@ impl Task {
             address_space: Arc::new(RwLock::new(address_space)),
             fpu: FpuArea::new_initialized(),
             fd_table: Arc::new(Mutex::new(FileDescTable::new_with_stdio())),
+            cwd: None,
             syscall_stack_top: 0, // kernel-only task — no ring-3 syscall stack needed yet
         }
     }
@@ -320,6 +329,7 @@ impl Task {
         child_address_space: alloc::sync::Arc<spin::RwLock<AddressSpace>>,
         child_cr3: PhysFrame<Size4KiB>,
         child_fd_table: alloc::sync::Arc<Mutex<crate::fs::FileDescTable>>,
+        child_cwd: Option<alloc::sync::Arc<crate::fs::vfs::Dentry>>,
     ) -> Self {
         // Allocate a fresh guard+stack slot.
         let slot_va = NEXT_STACK_VA.fetch_add(TASK_SLOT_SIZE, Ordering::Relaxed);
@@ -380,6 +390,7 @@ impl Task {
             address_space: child_address_space,
             fpu,
             fd_table: child_fd_table,
+            cwd: child_cwd,
             // The child task runs in ring-3; it needs its own SYSCALL stack
             // so it doesn't clobber the parent's saved SYSCALL context on the
             // shared INIT_KERNEL_STACK. Use the top of this task's kernel stack.

--- a/kernel/tests/syscall_vfs.rs
+++ b/kernel/tests/syscall_vfs.rs
@@ -33,6 +33,8 @@ const SYS_LSTAT: u64 = 6;
 const SYS_CLOSE: u64 = 3;
 const SYS_OPENAT: u64 = 257;
 const SYS_NEWFSTATAT: u64 = 262;
+const SYS_GETCWD: u64 = 79;
+const SYS_CHDIR: u64 = 80;
 
 const AT_FDCWD_U64: u64 = (-100i64) as u64;
 
@@ -78,6 +80,17 @@ fn run_tests() {
         (
             "open_o_directory_on_nondir_enotdir",
             &(open_o_directory_on_nondir_enotdir as fn()),
+        ),
+        ("getcwd_returns_root", &(getcwd_returns_root as fn())),
+        ("getcwd_enametoolong", &(getcwd_enametoolong as fn())),
+        ("chdir_changes_cwd", &(chdir_changes_cwd as fn())),
+        (
+            "chdir_rejects_non_directory",
+            &(chdir_rejects_non_directory as fn()),
+        ),
+        (
+            "chdir_enoent_on_missing",
+            &(chdir_enoent_on_missing as fn()),
         ),
     ];
     serial_println!("running {} tests", tests.len());
@@ -248,6 +261,94 @@ fn open_o_directory_on_nondir_enotdir() {
     assert_eq!(
         r, ENOTDIR,
         "O_DIRECTORY on char file must be ENOTDIR, got {}",
+        r
+    );
+}
+
+// --- getcwd / chdir tests ------------------------------------------------
+
+/// Staging area for getcwd output: second 4 KiB page of the user staging VA.
+fn cwdbuf_uva() -> u64 {
+    install_user_staging_vma();
+    (USER_PAGE_VA + 2 * 4096) as u64
+}
+
+fn getcwd_returns_root() {
+    // At boot, no chdir has been called, so cwd falls back to the VFS root.
+    // getcwd should return "/\0" (2 bytes), return value 2.
+    let r = unsafe { syscall_dispatch(SYS_GETCWD, cwdbuf_uva(), 4096, 0, 0, 0, 0) };
+    assert!(r > 0, "getcwd should succeed, got {}", r);
+    let buf = cwdbuf_uva() as *const u8;
+    let first = unsafe { ptr::read_volatile(buf) };
+    assert_eq!(
+        first, b'/',
+        "getcwd result should start with '/', got {}",
+        first
+    );
+    let second = unsafe { ptr::read_volatile(buf.add(1)) };
+    assert_eq!(
+        second, 0,
+        "getcwd of root should be '/\\0' (second byte NUL), got {}",
+        second
+    );
+    assert_eq!(
+        r, 2,
+        "getcwd('/') should return 2 (length including NUL), got {}",
+        r
+    );
+}
+
+fn getcwd_enametoolong() {
+    // Buffer length 1 is too small for even "/\0" (needs 2).
+    let r = unsafe { syscall_dispatch(SYS_GETCWD, cwdbuf_uva(), 1, 0, 0, 0, 0) };
+    let enametoolong: i64 = -36;
+    assert_eq!(
+        r, enametoolong,
+        "getcwd with len=1 must return ENAMETOOLONG, got {}",
+        r
+    );
+}
+
+fn chdir_changes_cwd() {
+    // chdir to /dev (which is mounted as devfs) should succeed and
+    // cause getcwd to return "/dev\0".
+    let path = stage_path(b"/dev");
+    let r = unsafe { syscall_dispatch(SYS_CHDIR, path, 0, 0, 0, 0, 0) };
+    assert_eq!(r, 0, "chdir(\"/dev\") should succeed, got {}", r);
+
+    let r2 = unsafe { syscall_dispatch(SYS_GETCWD, cwdbuf_uva(), 4096, 0, 0, 0, 0) };
+    assert!(r2 > 0, "getcwd after chdir should succeed, got {}", r2);
+
+    let expected = b"/dev\0";
+    let buf = cwdbuf_uva() as *const u8;
+    for (i, &b) in expected.iter().enumerate() {
+        let got = unsafe { ptr::read_volatile(buf.add(i)) };
+        assert_eq!(got, b, "getcwd byte[{}]: expected {}, got {}", i, b, got);
+    }
+
+    // Restore cwd to root for subsequent tests.
+    let root_path = stage_path(b"/");
+    let _ = unsafe { syscall_dispatch(SYS_CHDIR, root_path, 0, 0, 0, 0, 0) };
+}
+
+fn chdir_rejects_non_directory() {
+    // chdir to a non-directory (e.g. /dev/null is a char inode) must
+    // return ENOTDIR.
+    let path = stage_path(b"/dev/null");
+    let r = unsafe { syscall_dispatch(SYS_CHDIR, path, 0, 0, 0, 0, 0) };
+    assert_eq!(
+        r, ENOTDIR,
+        "chdir to non-dir must return ENOTDIR, got {}",
+        r
+    );
+}
+
+fn chdir_enoent_on_missing() {
+    let path = stage_path(b"/no-such-dir");
+    let r = unsafe { syscall_dispatch(SYS_CHDIR, path, 0, 0, 0, 0, 0) };
+    assert_eq!(
+        r, ENOENT,
+        "chdir to missing path must return ENOENT, got {}",
         r
     );
 }


### PR DESCRIPTION
Closes #239

## Summary

- Adds `cwd: Option<Arc<Dentry>>` to the `Task` struct. `None` means "use VFS root," which is the correct sentinel for bootstrap and kernel-only tasks that are created before `vfs::init()` runs.
- `fork_current_task` inherits the parent cwd; exec preserves it (no change needed).
- New `task::current_cwd()` / `task::set_current_cwd()` accessors follow the same `SCHED`-lock pattern as `current_fd_table`.
- `resolve_inode` now passes the per-process cwd as the walk starting point for relative paths. Absolute paths reseat at the VFS root inside `path_walk` on the first `/` component, so the cwd argument is irrelevant for them.
- `sys_chdir(path)`: resolves + verifies the target is a directory + calls `set_current_cwd`.
- `sys_getcwd(buf, len)`: walks `Dentry.parent` chain upward, assembles `"/comp/…\0"`, copies out to user. Returns `ENAMETOOLONG` when `len` is too small; treats a failed `Weak::upgrade` (disconnected dentry) as reaching the root.
- Syscall numbers pinned per Linux x86_64 ABI: `SYS_getcwd=79`, `SYS_chdir=80`. ABI regression test extended.

## Test plan

- [x] `cargo build` (x86_64-unknown-none) — clean, no errors or warnings
- [x] `syscall_vfs` integration test extended with 5 new test cases:
  - `getcwd_returns_root` — boot-time getcwd returns `/\0`
  - `getcwd_enametoolong` — len=1 returns ENAMETOOLONG
  - `chdir_changes_cwd` — chdir(/dev) + getcwd returns `/dev\0`
  - `chdir_rejects_non_directory` — chdir to /dev/null returns ENOTDIR
  - `chdir_enoent_on_missing` — chdir to missing path returns ENOENT
- [x] `cargo fmt --all` applied