### PR TITLE
loader: reclaim staged frames on partial ELF load failure

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -149,6 +149,10 @@ name = "addrspace_drop"
 harness = false
 
 [[test]]
+name = "exec_atomic_partial_load"
+harness = false
+
+[[test]]
 name = "execve_atomic"
 harness = false
 

--- a/kernel/src/mem/loader.rs
+++ b/kernel/src/mem/loader.rs
@@ -148,20 +148,16 @@ pub fn load_user_elf(bytes: &[u8], pml4: PhysFrame<Size4KiB>) -> Result<LoadedIm
     let mut segments = 0usize;
     let mut image_end = 0u64;
     let mut err: Option<LoadError> = None;
+    let mut partial_pages = 0u64;
     for seg in parsed.load_segments() {
         let seg_end = (seg.vaddr.as_u64() + seg.memsz + PAGE_SIZE - 1) & !(PAGE_SIZE - 1);
-        // Reject before mapping: `image_end` is later fed to
-        // `VirtAddr::new` (set_brk_start, exec), which panics at
-        // USER_VA_END. Prior segments in the same ELF may already be
-        // mapped in `pml4` — the caller drops the partial PML4 on
-        // error, matching the existing MapFailed / SegmentNotLowerHalf
-        // paths.
         if seg_end >= USER_VA_END {
             err = Some(LoadError::SegmentEndsAtUserVaEnd);
             break;
         }
-        if let Err(e) = map_user_segment(bytes, seg, pml4) {
+        if let Err((e, mapped)) = map_user_segment(bytes, seg, pml4) {
             err = Some(e);
+            partial_pages = mapped;
             break;
         }
         if seg_end > image_end {
@@ -174,6 +170,13 @@ pub fn load_user_elf(bytes: &[u8], pml4: PhysFrame<Size4KiB>) -> Result<LoadedIm
     // CR3 yet at load time). The CR3 write in init_ring3_entry provides
     // the definitive TLB flush before entering user code.
     if let Some(e) = err {
+        // Release every leaf frame we installed in `pml4` before failing.
+        // Without this, frames in completed segments and any partial
+        // progress within the aborted segment would be leaked when the
+        // caller drops the staged AddressSpace — Drop walks `self.vmas`,
+        // which the `load_user_elf_with_vmas` caller hasn't populated
+        // yet.
+        unmap_partial_load(parsed, pml4, segments, partial_pages);
         return Err(e);
     }
 
@@ -182,6 +185,44 @@ pub fn load_user_elf(bytes: &[u8], pml4: PhysFrame<Size4KiB>) -> Result<LoadedIm
         segments,
         image_end,
     })
+}
+
+/// Unmap and free every leaf frame installed by a partial
+/// [`load_user_elf`] run. `completed` is the number of PT_LOAD segments
+/// that were fully mapped; `partial_pages` is the number of pages of
+/// segment `completed` (0-indexed: the aborted segment) that had been
+/// mapped before its error. Unmapping an already-unmapped page is a
+/// no-op, matching the defensive pattern in `Drop for AddressSpace`.
+#[cfg(target_os = "none")]
+fn unmap_partial_load(
+    parsed: elf::ParsedElf<'_>,
+    pml4: PhysFrame<Size4KiB>,
+    completed: usize,
+    partial_pages: u64,
+) {
+    use x86_64::structures::paging::FrameDeallocator;
+    let mut alloc = paging::KernelFrameAllocator;
+    for (idx, seg) in parsed.load_segments().enumerate().take(completed + 1) {
+        let pages = if idx < completed {
+            seg.memsz.div_ceil(PAGE_SIZE)
+        } else {
+            partial_pages
+        };
+        for i in 0..pages {
+            let va = seg.vaddr + i * PAGE_SIZE;
+            let page = Page::<Size4KiB>::containing_address(va);
+            if let Ok(frame) = paging::unmap_in_pml4(pml4, page) {
+                // SAFETY: frame was just unmapped from `pml4`; no other
+                // mapping aliases it (the staged PML4 is not live and
+                // the loader holds the sole PTE reference, set to 1 by
+                // `KernelFrameAllocator::allocate_frame` via
+                // `frame::alloc`).
+                unsafe {
+                    alloc.deallocate_frame(frame);
+                }
+            }
+        }
+    }
 }
 
 /// Load `bytes` as a lower-half ELF into `pml4` AND register each
@@ -244,13 +285,17 @@ pub fn load_user_elf_with_vmas(
     Ok(image)
 }
 
+/// On error, returns the underlying `LoadError` along with the number of
+/// pages that had been successfully mapped into `pml4` before the error —
+/// the caller uses that count to unmap and free those frames on the
+/// failure path.
 fn map_user_segment(
     bytes: &[u8],
     seg: elf::LoadSegment,
     pml4: PhysFrame<Size4KiB>,
-) -> Result<(), LoadError> {
+) -> Result<(), (LoadError, u64)> {
     if seg.vaddr.as_u64() >= UPPER_HALF_START {
-        return Err(LoadError::SegmentNotLowerHalf);
+        return Err((LoadError::SegmentNotLowerHalf, 0));
     }
     // Reject segments whose virtual range overflows or crosses the
     // lower-half ceiling. Without this check, a large `p_memsz` could
@@ -262,10 +307,10 @@ fn map_user_segment(
         .checked_add(seg.memsz)
         .map_or(true, |end| end > UPPER_HALF_START)
     {
-        return Err(LoadError::SegmentNotLowerHalf);
+        return Err((LoadError::SegmentNotLowerHalf, 0));
     }
     if seg.vaddr.as_u64() & (PAGE_SIZE - 1) != 0 {
-        return Err(LoadError::SegmentNotPageAligned);
+        return Err((LoadError::SegmentNotPageAligned, 0));
     }
 
     let file_end = seg.file_offset + seg.filesz;
@@ -278,12 +323,17 @@ fn map_user_segment(
     // ring-3 code can actually reach the pages.
     let flags = seg.flags | PageTableFlags::USER_ACCESSIBLE;
 
+    let mut mapped = 0u64;
     for i in 0..page_count {
         let va = seg.vaddr + i * PAGE_SIZE;
         let page = Page::<Size4KiB>::containing_address(va);
         // map_in_pml4 allocates a fresh zeroed frame and installs it in
         // pml4 (not the global kernel mapper).
-        let frame = paging::map_in_pml4(pml4, page, flags).map_err(LoadError::MapFailed)?;
+        let frame = match paging::map_in_pml4(pml4, page, flags) {
+            Ok(f) => f,
+            Err(e) => return Err((LoadError::MapFailed(e), mapped)),
+        };
+        mapped += 1;
 
         // Fill file content through the HHDM window.
         let dst_base = hhdm + frame.start_address().as_u64();

--- a/kernel/tests/exec_atomic_partial_load.rs
+++ b/kernel/tests/exec_atomic_partial_load.rs
@@ -1,0 +1,151 @@
+//! Integration test for #267: a partial-failure ELF load must not leak
+//! leaf frames into the staged PML4. `Drop for AddressSpace` walks
+//! `self.vmas` only, so any frame `load_user_elf` maps before bailing
+//! out would escape reclamation if the loader itself didn't clean up
+//! on its error path.
+//!
+//! We craft a two-segment ELF where segment 0 is a valid lower-half
+//! mapping (so `load_user_elf` maps one leaf frame into the fresh
+//! PML4) and segment 1 ends at `USER_VA_END`, tripping the
+//! `SegmentEndsAtUserVaEnd` check *after* segment 0 has already
+//! installed its frame. A correct loader frees that frame before
+//! returning `Err`; a leaky one leaves it stranded.
+//!
+//! The test then reclaims the PML4 and its intermediate page tables
+//! so the only remaining delta between baseline and post-load is any
+//! frame that escaped the loader's cleanup. That delta must be zero.
+
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+
+use vibix::mem::frame;
+use vibix::mem::loader::{load_user_elf, LoadError};
+use vibix::mem::paging;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[(
+        "partial_load_failure_does_not_leak_frames",
+        &(partial_load_failure_does_not_leak_frames as fn()),
+    )];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+// Minimal ELF64 layout: one Ehdr then N Phdrs, no sections, no data.
+// Segment 0's single page lives entirely inside the HHDM-mapped image
+// bytes — the loader zero-fills via `map_in_pml4` and only copies
+// `filesz` bytes, which we leave at 0 so no source data is needed.
+const EHDR: usize = 64;
+const PHDR: usize = 56;
+const HEADER_SIZE: usize = EHDR + 2 * PHDR;
+
+/// Build an ELF64 with two PT_LOAD segments:
+///   - seg 0: lower-half, one page, filesz=0 (pure .bss). Maps cleanly.
+///   - seg 1: `p_vaddr = USER_VA_END - 0x1000`, `p_memsz = 0x1000`, so
+///     page-aligned end equals `USER_VA_END` → triggers
+///     `SegmentEndsAtUserVaEnd` in the loader.
+fn build_partial_fail_elf() -> [u8; HEADER_SIZE] {
+    let mut bytes = [0u8; HEADER_SIZE];
+
+    // Ehdr
+    bytes[0..4].copy_from_slice(&[0x7f, b'E', b'L', b'F']);
+    bytes[4] = 2; // ELFCLASS64
+    bytes[5] = 1; // little-endian
+    bytes[6] = 1; // ELF version
+    bytes[16..18].copy_from_slice(&2u16.to_le_bytes()); // ET_EXEC
+    bytes[18..20].copy_from_slice(&0x3eu16.to_le_bytes()); // EM_X86_64
+    bytes[20..24].copy_from_slice(&1u32.to_le_bytes()); // e_version
+                                                        // e_entry: inside segment 0.
+    bytes[24..32].copy_from_slice(&0x0000_0000_0040_0000u64.to_le_bytes());
+    bytes[32..40].copy_from_slice(&(EHDR as u64).to_le_bytes()); // e_phoff
+    bytes[52..54].copy_from_slice(&(EHDR as u16).to_le_bytes()); // e_ehsize
+    bytes[54..56].copy_from_slice(&(PHDR as u16).to_le_bytes()); // e_phentsize
+    bytes[56..58].copy_from_slice(&2u16.to_le_bytes()); // e_phnum = 2
+
+    // Phdr 0: PT_LOAD at 0x0040_0000, one page, R+X, filesz=0.
+    let p0 = EHDR;
+    bytes[p0..p0 + 4].copy_from_slice(&1u32.to_le_bytes()); // PT_LOAD
+    bytes[p0 + 4..p0 + 8].copy_from_slice(&5u32.to_le_bytes()); // R+X
+    bytes[p0 + 16..p0 + 24].copy_from_slice(&0x0000_0000_0040_0000u64.to_le_bytes()); // p_vaddr
+    bytes[p0 + 40..p0 + 48].copy_from_slice(&0x1000u64.to_le_bytes()); // p_memsz
+                                                                      // p_offset/p_filesz/p_paddr default to 0 — a zero-filesz PT_LOAD is
+                                                                      // a valid .bss-only segment.
+
+    // Phdr 1: PT_LOAD whose page-aligned end lands on USER_VA_END.
+    let p1 = EHDR + PHDR;
+    bytes[p1..p1 + 4].copy_from_slice(&1u32.to_le_bytes()); // PT_LOAD
+    bytes[p1 + 4..p1 + 8].copy_from_slice(&5u32.to_le_bytes()); // R+X
+    bytes[p1 + 16..p1 + 24].copy_from_slice(&0x0000_7fff_ffff_f000u64.to_le_bytes()); // p_vaddr
+    bytes[p1 + 40..p1 + 48].copy_from_slice(&0x1000u64.to_le_bytes()); // p_memsz
+
+    bytes
+}
+
+fn partial_load_failure_does_not_leak_frames() {
+    let bytes = build_partial_fail_elf();
+
+    // Baseline taken *before* the PML4 alloc so the allocation and
+    // later `free_pml4_frame` cancel out in the arithmetic — the only
+    // surviving delta would be leaked leaf frames from the failed load.
+    let before = frame::free_frames();
+    let pml4 = paging::new_task_pml4();
+
+    let result = load_user_elf(&bytes, pml4);
+    match result {
+        Err(LoadError::SegmentEndsAtUserVaEnd) => {}
+        other => panic!(
+            "expected SegmentEndsAtUserVaEnd, got {:?} — the crafted ELF \
+             may have been rejected earlier than the intended failure \
+             point, invalidating the leak check",
+            other
+        ),
+    }
+
+    let after_load = frame::free_frames();
+
+    // Tear down the intermediate page tables the loader installed while
+    // mapping segment 0 (L3/L2/L1 under 0x0040_0000) plus the PML4
+    // frame itself. With a correct loader, segment 0's leaf data frame
+    // was already reclaimed on the error path, so after this teardown
+    // the frame count must return to `before` exactly. A leaky loader
+    // leaves that frame stranded, surfacing as a one-frame deficit.
+    unsafe {
+        paging::free_user_page_tables(pml4);
+        paging::free_pml4_frame(pml4);
+    }
+    let after_teardown = frame::free_frames();
+
+    serial_println!(
+        "frame counts: before={before} after_load={after_load} after_teardown={after_teardown}"
+    );
+
+    assert_eq!(
+        after_teardown, before,
+        "frame accounting mismatch after failed load+teardown: \
+         before={before}, after_teardown={after_teardown}, \
+         delta={} — a leaf frame leaked on the loader error path",
+        before as isize - after_teardown as isize,
+    );
+}

--- a/kernel/tests/exec_atomic_partial_load.rs
+++ b/kernel/tests/exec_atomic_partial_load.rs
@@ -90,8 +90,8 @@ fn build_partial_fail_elf() -> [u8; HEADER_SIZE] {
     bytes[p0 + 4..p0 + 8].copy_from_slice(&5u32.to_le_bytes()); // R+X
     bytes[p0 + 16..p0 + 24].copy_from_slice(&0x0000_0000_0040_0000u64.to_le_bytes()); // p_vaddr
     bytes[p0 + 40..p0 + 48].copy_from_slice(&0x1000u64.to_le_bytes()); // p_memsz
-                                                                      // p_offset/p_filesz/p_paddr default to 0 — a zero-filesz PT_LOAD is
-                                                                      // a valid .bss-only segment.
+                                                                       // p_offset/p_filesz/p_paddr default to 0 — a zero-filesz PT_LOAD is
+                                                                       // a valid .bss-only segment.
 
     // Phdr 1: PT_LOAD whose page-aligned end lands on USER_VA_END.
     let p1 = EHDR + PHDR;
@@ -142,7 +142,8 @@ fn partial_load_failure_does_not_leak_frames() {
     );
 
     assert_eq!(
-        after_teardown, before,
+        after_teardown,
+        before,
         "frame accounting mismatch after failed load+teardown: \
          before={before}, after_teardown={after_teardown}, \
          delta={} — a leaf frame leaked on the loader error path",

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -814,6 +814,7 @@ fn test_all() -> R<()> {
         "task_exit",
         "addrspace",
         "addrspace_drop",
+        "exec_atomic_partial_load",
         "fork_cow",
         "tlb_flusher",
         "smep_smap",


### PR DESCRIPTION
Closes #267

## Summary
- `load_user_elf` now reclaims every leaf frame it mapped into the staged PML4 before returning `Err`, so a mid-load failure no longer strands frames outside the reach of `Drop for AddressSpace` (which walks `self.vmas` only).
- Per-segment mapping progress (`partial_pages`) is tracked alongside completed-segment count, then replayed by a new `unmap_partial_load` helper that unmaps each page via `paging::unmap_in_pml4` and returns the backing `PhysFrame` to `KernelFrameAllocator`.
- All error arms in the PT_LOAD loop (range checks, alignment, page-table installation failure) now funnel through the single cleanup path.

## Test plan
- [x] New integration test `exec_atomic_partial_load` crafts a 2-PT_LOAD ELF where segment 0 maps cleanly and segment 1 trips `SegmentEndsAtUserVaEnd`, then asserts the frame counter returns to its pre-alloc baseline after teardown. Passes under QEMU.
- [x] Existing `userspace_loader` (3 tests) and `execve_atomic` (1 test) still green — loader behaves identically on the happy path and on the `execve_atomic_preserves_aspace_on_garbage_elf` rollback path.
- [x] `addrspace_drop` still green — loader-local cleanup doesn't disturb `Drop for AddressSpace`'s per-VMA reclamation.