### PR TITLE
docs: point fs/mod.rs and README at the VFS layer

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ sequence, and public API for its subsystem.
 | [input.md](input.md) | PS/2 keyboard and ring buffer | `kernel/src/input.rs` |
 | [tasks.md](tasks.md) | Preemptive scheduler + blocking primitives | `kernel/src/task/`, `kernel/src/sync/` |
 | [diagnostics.md](diagnostics.md) | klog ring, ksymtab, backtrace unwinder | `kernel/src/klog.rs`, `kernel/src/ksymtab.rs`, `kernel/src/arch/x86_64/backtrace.rs` |
+| *(see below)* | Virtual filesystem + per-process fd table | `kernel/src/fs/vfs/`, `kernel/src/fs/mod.rs` |
 
 ## Initialization Order
 
@@ -44,3 +45,23 @@ task::init()            — bootstrap task, scheduler online
 
 The framebuffer console is optional and initialized separately in `main.rs`
 immediately after `serial::init()`, before the shared `vibix::init()` call.
+
+## Filesystem
+
+The filesystem layer follows the classic vnode model (Kleiman, USENIX 1986),
+split across two directories:
+
+- `kernel/src/fs/vfs/` — the virtual filesystem core. Three refcounted
+  in-kernel objects (`SuperBlock`, `Inode`, `Dentry`) driven by four
+  dyn-dispatch traits (`FileSystem`, `SuperOps`, `InodeOps`, `FileOps`). A
+  mount table attaches superblocks at dentries; path resolution walks the
+  dentry tree across mount points and terminates at an `Arc<Inode>`.
+  Concrete filesystems (`ramfs`, `tarfs`, `devfs`) live beside `mod.rs` in
+  that directory and plug in by implementing the operation traits.
+- `kernel/src/fs/mod.rs` — the per-process fd table (`FileDescTable`) and
+  the `FileBackend` trait. This is a thin adapter: path-opened files flow
+  through `vfs::VfsBackend`; `SerialBackend` provides stdio on fds 0/1/2
+  without going through the VFS so console I/O works before any mount.
+
+See [RFC 0002](RFC/0002-virtual-filesystem.md) for the design rationale,
+object lifetimes, locking order, and roadmap.

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -1,10 +1,21 @@
 //! Per-process file-descriptor table and file-backend abstraction.
 //!
+//! This module is a thin adapter between syscalls and the filesystem layer
+//! that lives in [`vfs`]. The real name→inode lookup, mount table, dentry
+//! cache, and concrete filesystems (`ramfs`, `tarfs`, `devfs`) are implemented
+//! there; everything in this file is just the per-process fd array plus the
+//! small [`FileBackend`] trait that hides whether a given fd is path-opened
+//! (VFS-backed via [`vfs::VfsBackend`]) or synthetic (`SerialBackend` for
+//! stdio, test stubs in unit tests).
+//!
+//! See [`docs/RFC/0002-virtual-filesystem.md`] for the overall design.
+//!
 //! The module is split into:
 //! - Core types (`FileBackend`, `FileDescription`, `FileDescTable`) — compiled
 //!   for both `target_os = "none"` and host unit tests.
 //! - `SerialBackend` + `FileDescTable::new_with_stdio()` — compiled for
 //!   `target_os = "none"` only (require port I/O and the serial subsystem).
+//! - [`vfs`] — the real filesystem layer, compiled for `target_os = "none"`.
 
 use alloc::sync::Arc;
 use alloc::vec::Vec;
@@ -308,8 +319,9 @@ impl FileDescTable {
 
 /// Serial (COM1) backend.
 ///
-/// Used as the backend for fds 0/1/2 in early userspace before a real VFS
-/// is available.
+/// Used as the backend for fds 0/1/2. Stdio bypasses the VFS on purpose:
+/// every task gets a direct [`SerialBackend`] so console I/O works even
+/// before `/dev/console` is wired up in `devfs`.
 #[cfg(target_os = "none")]
 pub struct SerialBackend;
 
@@ -346,8 +358,8 @@ impl FileDescTable {
     /// Create a table with fds 0/1/2 wired to the COM1 serial port.
     ///
     /// This is the standard starting point for every new task: stdin, stdout,
-    /// and stderr all map to the same `SerialBackend` until the VFS is
-    /// available.
+    /// and stderr all map to the same [`SerialBackend`], bypassing the VFS
+    /// so console I/O works before any filesystem is mounted.
     pub fn new_with_stdio() -> Self {
         let serial = Arc::new(SerialBackend) as Arc<dyn FileBackend>;
         Self::new_with_backends(serial.clone(), serial.clone(), serial.clone())


### PR DESCRIPTION
Closes #242

## Summary

- Reframe the `kernel/src/fs/mod.rs` module docstring as the thin fd-table adapter it now is, explicitly pointing at `kernel/src/fs/vfs/` as the real filesystem layer and linking to RFC 0002.
- Remove the two stale comments on `SerialBackend` / `FileDescTable::new_with_stdio` that described the VFS as future work; rephrase them to explain why stdio deliberately bypasses the VFS.
- Add a **Filesystem** section to `docs/README.md` describing the VFS architecture, the per-process fd table adapter, and linking to RFC 0002. Also add a subsystem row pointing at the section.

RFC 0002 Implementation Roadmap item 14/15. Docs-only cleanup once the VFS landed.

## Test plan

- [x] `cargo xtask build` — compiles cleanly (pre-existing `objcopy` environment issue reproduces on `main` unchanged; no logic changed by this PR).