### PR TITLE
shell: handle CSI parameter and intermediate bytes

### DIFF
--- a/kernel/src/shell/ansi.rs
+++ b/kernel/src/shell/ansi.rs
@@ -1,0 +1,266 @@
+//! ANSI CSI state machine for the shell's serial input path.
+//!
+//! Serial keyboards send arrow keys and other editing keys as escape
+//! sequences: plain arrows arrive as three bytes (`ESC [ A`..`D`, or
+//! `ESC O A`..`D` from some xterm modes), and modified arrows like
+//! Ctrl+Up arrive as longer sequences with parameter bytes — xterm's
+//! Ctrl+Up is `ESC [ 1 ; 5 A`. The state machine here walks those
+//! sequences byte-by-byte so the shell can route each completed CSI to
+//! an editor event without the caller having to buffer escape bytes.
+//!
+//! Kept as a pure submodule (no kernel imports, no I/O) so it compiles
+//! and tests on the host like `line_editor`.
+//!
+//! Byte-range vocabulary (per ECMA-48 / VT100):
+//! - `0x20..=0x2F` — intermediate bytes (e.g. `!`, space).
+//! - `0x30..=0x3F` — parameter bytes (digits, `;`, `?`, etc.).
+//! - `0x40..=0x7E` — final byte that terminates the CSI.
+
+/// Current position in the escape-sequence grammar. Stored outside the
+/// state machine because serial bytes are consumed across many calls
+/// (each one is a fresh [`step`]).
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum State {
+    /// No escape in progress.
+    #[default]
+    Ground,
+    /// Saw `ESC`, waiting for `[` or `O`.
+    Esc,
+    /// In a CSI body, no parameter / intermediate bytes seen yet.
+    Csi,
+    /// In a CSI body, at least one parameter or intermediate byte
+    /// accumulated. Treated identically to [`State::Csi`] for
+    /// dispatch — we only care about the final byte today — but kept
+    /// distinct so a future richer decoder can attach a small param
+    /// buffer without touching callers.
+    CsiParam,
+}
+
+/// Final byte of a CSI sequence, classified for the caller.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CsiFinal {
+    /// `A` — up arrow (with or without modifiers).
+    Up,
+    /// `B` — down arrow.
+    Down,
+    /// `C` — right arrow.
+    Right,
+    /// `D` — left arrow.
+    Left,
+    /// Any other final byte in `0x40..=0x7E`. Surfaced so callers can
+    /// extend routing later without another state-machine revision.
+    Other(u8),
+}
+
+/// Result of feeding one byte to the state machine.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Event {
+    /// A ground-state byte the caller should interpret as literal
+    /// input. Not emitted for bytes consumed inside an escape.
+    Byte(u8),
+    /// A CSI sequence terminated on this byte.
+    Csi(CsiFinal),
+}
+
+/// Feed one serial byte into the state machine. Returns `Some(event)`
+/// when the byte completes a dispatchable input; returns `None` when
+/// the byte was consumed mid-sequence (or a malformed sequence was
+/// dropped) and the caller should wait for more bytes.
+pub fn step(state: &mut State, b: u8) -> Option<Event> {
+    match (*state, b) {
+        (State::Ground, 0x1b) => {
+            *state = State::Esc;
+            None
+        }
+        (State::Ground, _) => Some(Event::Byte(b)),
+
+        (State::Esc, b'[') | (State::Esc, b'O') => {
+            *state = State::Csi;
+            None
+        }
+        (State::Esc, _) => {
+            // Bare ESC followed by something that isn't the CSI
+            // introducer: drop and resync.
+            *state = State::Ground;
+            None
+        }
+
+        (State::Csi, _) | (State::CsiParam, _) => csi_byte(state, b),
+    }
+}
+
+/// Inner CSI handler. Split out so the two in-CSI states share the
+/// param / intermediate / final classification in one place.
+fn csi_byte(state: &mut State, b: u8) -> Option<Event> {
+    match b {
+        // Parameter or intermediate byte: keep accumulating. Upgrades
+        // the state to `CsiParam` so future callers can tell a "plain"
+        // CSI from a parameterised one without re-scanning.
+        0x20..=0x3F => {
+            *state = State::CsiParam;
+            None
+        }
+        // Final byte: dispatch and reset.
+        0x40..=0x7E => {
+            *state = State::Ground;
+            Some(Event::Csi(classify_final(b)))
+        }
+        // Anything else (C0 control char mid-sequence, 8-bit byte):
+        // malformed, drop and resync to Ground.
+        _ => {
+            *state = State::Ground;
+            None
+        }
+    }
+}
+
+fn classify_final(b: u8) -> CsiFinal {
+    match b {
+        b'A' => CsiFinal::Up,
+        b'B' => CsiFinal::Down,
+        b'C' => CsiFinal::Right,
+        b'D' => CsiFinal::Left,
+        _ => CsiFinal::Other(b),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn feed(state: &mut State, bytes: &[u8]) -> Vec<Event> {
+        let mut out = Vec::new();
+        for &b in bytes {
+            if let Some(ev) = step(state, b) {
+                out.push(ev);
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn printable_ascii_passthrough() {
+        let mut s = State::default();
+        assert_eq!(feed(&mut s, b"hi!"), vec![
+            Event::Byte(b'h'),
+            Event::Byte(b'i'),
+            Event::Byte(b'!'),
+        ]);
+        assert_eq!(s, State::Ground);
+    }
+
+    #[test]
+    fn plain_up_arrow_dispatches_up() {
+        let mut s = State::default();
+        assert_eq!(
+            feed(&mut s, b"\x1b[A"),
+            vec![Event::Csi(CsiFinal::Up)],
+        );
+        assert_eq!(s, State::Ground);
+    }
+
+    #[test]
+    fn plain_down_arrow_dispatches_down() {
+        let mut s = State::default();
+        assert_eq!(
+            feed(&mut s, b"\x1b[B"),
+            vec![Event::Csi(CsiFinal::Down)],
+        );
+    }
+
+    #[test]
+    fn xterm_o_introducer_accepted() {
+        // Some xterm modes use `ESC O A` for arrows.
+        let mut s = State::default();
+        assert_eq!(
+            feed(&mut s, b"\x1bOA"),
+            vec![Event::Csi(CsiFinal::Up)],
+        );
+    }
+
+    #[test]
+    fn ctrl_up_with_params_dispatches_up() {
+        // xterm Ctrl+Up: ESC [ 1 ; 5 A. Issue #310 policy is to map
+        // modified arrows onto the same final-byte classification as
+        // plain arrows for now.
+        let mut s = State::default();
+        assert_eq!(
+            feed(&mut s, b"\x1b[1;5A"),
+            vec![Event::Csi(CsiFinal::Up)],
+        );
+        assert_eq!(s, State::Ground);
+    }
+
+    #[test]
+    fn intermediate_byte_does_not_drop_sequence() {
+        // `ESC [ ! p` is a valid DECSTR soft reset; we don't act on
+        // it, but the state machine must consume it without stranding
+        // the next arrow.
+        let mut s = State::default();
+        assert_eq!(
+            feed(&mut s, b"\x1b[!p"),
+            vec![Event::Csi(CsiFinal::Other(b'p'))],
+        );
+        assert_eq!(
+            feed(&mut s, b"\x1b[A"),
+            vec![Event::Csi(CsiFinal::Up)],
+        );
+    }
+
+    #[test]
+    fn csi_with_control_byte_mid_sequence_resyncs() {
+        // A stray control byte inside a CSI body is malformed; drop
+        // the in-progress sequence and resync. The following plain
+        // arrow must still dispatch.
+        let mut s = State::default();
+        assert_eq!(feed(&mut s, b"\x1b[1\x07"), Vec::<Event>::new());
+        assert_eq!(s, State::Ground);
+        assert_eq!(
+            feed(&mut s, b"\x1b[B"),
+            vec![Event::Csi(CsiFinal::Down)],
+        );
+    }
+
+    #[test]
+    fn bare_esc_followed_by_letter_resets() {
+        // ESC followed by a non-CSI-introducer byte: drop and resync;
+        // the trailing letter is not delivered as a ground byte
+        // (matches the pre-existing Esc/_ behaviour).
+        let mut s = State::default();
+        assert_eq!(feed(&mut s, b"\x1bX"), Vec::<Event>::new());
+        assert_eq!(s, State::Ground);
+        // Next printable byte passes through normally.
+        assert_eq!(feed(&mut s, b"y"), vec![Event::Byte(b'y')]);
+    }
+
+    #[test]
+    fn high_bit_byte_in_ground_surfaces_as_byte() {
+        // The state machine itself passes 8-bit bytes through; it's
+        // the shell's caller that guards against `b as char`
+        // producing replacement chars.
+        let mut s = State::default();
+        assert_eq!(feed(&mut s, &[0xC3]), vec![Event::Byte(0xC3)]);
+    }
+
+    #[test]
+    fn left_right_finals_classified() {
+        let mut s = State::default();
+        assert_eq!(
+            feed(&mut s, b"\x1b[C"),
+            vec![Event::Csi(CsiFinal::Right)],
+        );
+        assert_eq!(
+            feed(&mut s, b"\x1b[D"),
+            vec![Event::Csi(CsiFinal::Left)],
+        );
+    }
+
+    #[test]
+    fn unknown_final_reported_as_other() {
+        let mut s = State::default();
+        assert_eq!(
+            feed(&mut s, b"\x1b[H"),
+            vec![Event::Csi(CsiFinal::Other(b'H'))],
+        );
+    }
+}

--- a/kernel/src/shell/ansi.rs
+++ b/kernel/src/shell/ansi.rs
@@ -78,6 +78,9 @@ pub fn step(state: &mut State, b: u8) -> Option<Event> {
             *state = State::Csi;
             None
         }
+        // A fresh ESC mid-recovery restarts parsing rather than
+        // dropping the new introducer along with the stale one.
+        (State::Esc, 0x1b) => None,
         (State::Esc, _) => {
             // Bare ESC followed by something that isn't the CSI
             // introducer: drop and resync.
@@ -93,6 +96,13 @@ pub fn step(state: &mut State, b: u8) -> Option<Event> {
 /// param / intermediate / final classification in one place.
 fn csi_byte(state: &mut State, b: u8) -> Option<Event> {
     match b {
+        // A fresh ESC inside a CSI body abandons the in-progress
+        // sequence and starts a new one — the next byte is treated as
+        // the introducer.
+        0x1b => {
+            *state = State::Esc;
+            None
+        }
         // Parameter or intermediate byte: keep accumulating. Upgrades
         // the state to `CsiParam` so future callers can tell a "plain"
         // CSI from a parameterised one without re-scanning.
@@ -200,6 +210,27 @@ mod tests {
         assert_eq!(feed(&mut s, b"\x1b[1\x07"), Vec::<Event>::new());
         assert_eq!(s, State::Ground);
         assert_eq!(feed(&mut s, b"\x1b[B"), vec![Event::Csi(CsiFinal::Down)],);
+    }
+
+    #[test]
+    fn fresh_esc_after_bare_esc_starts_new_sequence() {
+        // `ESC ESC [ A` should dispatch Up, not lose the second ESC
+        // along with the first as "bare ESC + non-introducer".
+        let mut s = State::default();
+        assert_eq!(feed(&mut s, b"\x1b\x1b[A"), vec![Event::Csi(CsiFinal::Up)],);
+        assert_eq!(s, State::Ground);
+    }
+
+    #[test]
+    fn fresh_esc_inside_csi_starts_new_sequence() {
+        // `ESC [ 1 ESC [ A` should dispatch Up: the new ESC abandons
+        // the in-progress CSI and re-enters Esc so `[ A` completes.
+        let mut s = State::default();
+        assert_eq!(
+            feed(&mut s, b"\x1b[1\x1b[A"),
+            vec![Event::Csi(CsiFinal::Up)],
+        );
+        assert_eq!(s, State::Ground);
     }
 
     #[test]

--- a/kernel/src/shell/ansi.rs
+++ b/kernel/src/shell/ansi.rs
@@ -141,41 +141,31 @@ mod tests {
     #[test]
     fn printable_ascii_passthrough() {
         let mut s = State::default();
-        assert_eq!(feed(&mut s, b"hi!"), vec![
-            Event::Byte(b'h'),
-            Event::Byte(b'i'),
-            Event::Byte(b'!'),
-        ]);
+        assert_eq!(
+            feed(&mut s, b"hi!"),
+            vec![Event::Byte(b'h'), Event::Byte(b'i'), Event::Byte(b'!'),]
+        );
         assert_eq!(s, State::Ground);
     }
 
     #[test]
     fn plain_up_arrow_dispatches_up() {
         let mut s = State::default();
-        assert_eq!(
-            feed(&mut s, b"\x1b[A"),
-            vec![Event::Csi(CsiFinal::Up)],
-        );
+        assert_eq!(feed(&mut s, b"\x1b[A"), vec![Event::Csi(CsiFinal::Up)],);
         assert_eq!(s, State::Ground);
     }
 
     #[test]
     fn plain_down_arrow_dispatches_down() {
         let mut s = State::default();
-        assert_eq!(
-            feed(&mut s, b"\x1b[B"),
-            vec![Event::Csi(CsiFinal::Down)],
-        );
+        assert_eq!(feed(&mut s, b"\x1b[B"), vec![Event::Csi(CsiFinal::Down)],);
     }
 
     #[test]
     fn xterm_o_introducer_accepted() {
         // Some xterm modes use `ESC O A` for arrows.
         let mut s = State::default();
-        assert_eq!(
-            feed(&mut s, b"\x1bOA"),
-            vec![Event::Csi(CsiFinal::Up)],
-        );
+        assert_eq!(feed(&mut s, b"\x1bOA"), vec![Event::Csi(CsiFinal::Up)],);
     }
 
     #[test]
@@ -184,10 +174,7 @@ mod tests {
         // modified arrows onto the same final-byte classification as
         // plain arrows for now.
         let mut s = State::default();
-        assert_eq!(
-            feed(&mut s, b"\x1b[1;5A"),
-            vec![Event::Csi(CsiFinal::Up)],
-        );
+        assert_eq!(feed(&mut s, b"\x1b[1;5A"), vec![Event::Csi(CsiFinal::Up)],);
         assert_eq!(s, State::Ground);
     }
 
@@ -201,10 +188,7 @@ mod tests {
             feed(&mut s, b"\x1b[!p"),
             vec![Event::Csi(CsiFinal::Other(b'p'))],
         );
-        assert_eq!(
-            feed(&mut s, b"\x1b[A"),
-            vec![Event::Csi(CsiFinal::Up)],
-        );
+        assert_eq!(feed(&mut s, b"\x1b[A"), vec![Event::Csi(CsiFinal::Up)],);
     }
 
     #[test]
@@ -215,10 +199,7 @@ mod tests {
         let mut s = State::default();
         assert_eq!(feed(&mut s, b"\x1b[1\x07"), Vec::<Event>::new());
         assert_eq!(s, State::Ground);
-        assert_eq!(
-            feed(&mut s, b"\x1b[B"),
-            vec![Event::Csi(CsiFinal::Down)],
-        );
+        assert_eq!(feed(&mut s, b"\x1b[B"), vec![Event::Csi(CsiFinal::Down)],);
     }
 
     #[test]
@@ -245,14 +226,8 @@ mod tests {
     #[test]
     fn left_right_finals_classified() {
         let mut s = State::default();
-        assert_eq!(
-            feed(&mut s, b"\x1b[C"),
-            vec![Event::Csi(CsiFinal::Right)],
-        );
-        assert_eq!(
-            feed(&mut s, b"\x1b[D"),
-            vec![Event::Csi(CsiFinal::Left)],
-        );
+        assert_eq!(feed(&mut s, b"\x1b[C"), vec![Event::Csi(CsiFinal::Right)],);
+        assert_eq!(feed(&mut s, b"\x1b[D"), vec![Event::Csi(CsiFinal::Left)],);
     }
 
     #[test]

--- a/kernel/src/shell/mod.rs
+++ b/kernel/src/shell/mod.rs
@@ -9,6 +9,7 @@
 //! Line-editing state (history ring, current line) lives in the
 //! [`line_editor`] submodule as pure logic so it's host-unit-testable.
 
+pub mod ansi;
 pub mod line_editor;
 
 #[cfg(target_os = "none")]
@@ -17,6 +18,7 @@ mod kernel_side {
 
     use pc_keyboard::{DecodedKey, KeyCode};
 
+    use super::ansi::{self, CsiFinal, Event};
     use super::line_editor::{Effect, Input, LineEditor};
     use crate::mem::{frame, heap, FRAME_SIZE};
     use crate::task::TaskStateView;
@@ -29,16 +31,6 @@ mod kernel_side {
 
     const PROMPT: &str = "vibix> ";
 
-    /// Serial-side ANSI CSI state. Serial arrow keys arrive as three
-    /// bytes `ESC [ A..D`; xterm sometimes prefixes with `O` instead of
-    /// `[`, so we accept both.
-    #[derive(Clone, Copy, Eq, PartialEq)]
-    enum Ansi {
-        Ground,
-        Esc,
-        Csi,
-    }
-
     /// Task entry point. Spawn as `task::spawn(shell::run)`.
     pub fn run() -> ! {
         serial_println!("shell: prompt online");
@@ -46,7 +38,7 @@ mod kernel_side {
         prompt();
 
         let mut editor = LineEditor::new();
-        let mut ansi = Ansi::Ground;
+        let mut ansi = ansi::State::default();
         loop {
             if let Some(ev) = next_input(&mut ansi) {
                 for eff in editor.on_input(ev) {
@@ -66,9 +58,9 @@ mod kernel_side {
     /// responsive even when both rings accumulate simultaneously. The
     /// `ansi` state machine is threaded across calls so multi-byte
     /// escape sequences on serial survive across `hlt` gaps.
-    fn next_input(ansi: &mut Ansi) -> Option<Input> {
+    fn next_input(state: &mut ansi::State) -> Option<Input> {
         if let Some(b) = serial::try_read_byte() {
-            return serial_byte(b, ansi);
+            return serial_byte(b, state);
         }
         let key = input::try_read_key()?;
         match key {
@@ -81,42 +73,27 @@ mod kernel_side {
 
     /// Translate a serial byte through the CSI state machine. On
     /// completion of an arrow escape, return the corresponding `Input`.
-    /// Unrecognised finals drop the sequence silently.
-    fn serial_byte(b: u8, ansi: &mut Ansi) -> Option<Input> {
-        match (*ansi, b) {
-            (Ansi::Ground, 0x1b) => {
-                *ansi = Ansi::Esc;
-                None
-            }
-            (Ansi::Esc, b'[') | (Ansi::Esc, b'O') => {
-                *ansi = Ansi::Csi;
-                None
-            }
-            (Ansi::Esc, _) => {
-                // Bare ESC followed by non-CSI: drop, reset.
-                *ansi = Ansi::Ground;
-                None
-            }
-            (Ansi::Csi, b'A') => {
-                *ansi = Ansi::Ground;
-                Some(Input::HistoryPrev)
-            }
-            (Ansi::Csi, b'B') => {
-                *ansi = Ansi::Ground;
-                Some(Input::HistoryNext)
-            }
-            (Ansi::Csi, b'C') | (Ansi::Csi, b'D') => {
-                // Left/right — deferred per issue #112.
-                *ansi = Ansi::Ground;
-                None
-            }
-            (Ansi::Csi, _) => {
-                // Unrecognised CSI final — drop and resync.
-                *ansi = Ansi::Ground;
-                None
-            }
-            (Ansi::Ground, _) => char_to_input(b as char),
+    /// Unrecognised finals and parameterised sequences with non-arrow
+    /// finals drop silently.
+    fn serial_byte(b: u8, state: &mut ansi::State) -> Option<Input> {
+        match ansi::step(state, b)? {
+            Event::Byte(b) => byte_to_input(b),
+            Event::Csi(CsiFinal::Up) => Some(Input::HistoryPrev),
+            Event::Csi(CsiFinal::Down) => Some(Input::HistoryNext),
+            // Left/right and other finals: deferred per issue #112.
+            Event::Csi(_) => None,
         }
+    }
+
+    /// Ground-state byte from the ANSI state machine. Bytes above
+    /// 0x7F (UTF-8 continuation bytes, 8-bit terminals) are ignored
+    /// rather than cast blindly to `char`, which would coerce them
+    /// into unrelated Latin-1 code points.
+    fn byte_to_input(b: u8) -> Option<Input> {
+        if b > 0x7F {
+            return None;
+        }
+        char_to_input(b as char)
     }
 
     /// Map a single decoded character to an editor event. Ctrl+C/L


### PR DESCRIPTION
Closes #310

## Summary
- Extract the serial CSI state machine out of `kernel/src/shell/mod.rs` into a new pure-logic `shell::ansi` submodule (mirrors the `line_editor` pattern so it compiles and host-tests under `cargo xtask test`'s first phase).
- Add a `CsiParam` state that consumes parameter (`0x30..=0x3F`) and intermediate (`0x20..=0x2F`) bytes, dispatching on the final byte (`0x40..=0x7E`). Modified arrows like xterm's Ctrl+Up (`ESC [ 1 ; 5 A`) now route to `HistoryPrev`/`HistoryNext` instead of being silently dropped. Full modifier decoding stays deferred per the issue — we only route on the final byte today.
- Guard the ground-state `b as char` path so bytes above `0x7F` are ignored rather than coerced through Latin-1.

## Test plan
- [x] Host unit tests colocated in `shell::ansi` cover: plain Up/Down/Left/Right, xterm `ESC O` introducer, Ctrl+Up with parameters, intermediate-byte survival (`ESC [ ! p`), mid-sequence control-byte resync, bare-ESC reset, high-bit byte passthrough, unknown final classified as `Other(u8)`.
- [x] `cargo xtask build` compiles the kernel clean (one pre-existing `is_guard_hit` dead-code warning unchanged).
- [ ] CI to run `cargo xtask test` + `cargo xtask smoke` on x86_64 (local host is aarch64, so the host-test build of x86_64-only crates can't run here).