### PR TITLE
mem: refuse AnonObject faults on refcount-saturated frames (#255)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -207,3 +207,7 @@ harness = false
 [[test]]
 name = "rootfs_module"
 harness = false
+
+[[test]]
+name = "anon_fault_saturated"
+harness = false

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -526,7 +526,9 @@ pub fn exec_atomic(elf_bytes: &[u8]) -> Result<core::convert::Infallible, i64> {
         crate::mem::paging::map_in_pml4(new_pml4, stack_page, stack_flags).map_err(|_| -12i64)?;
 
     let stack_obj = AnonObject::new(Some(1));
-    stack_obj.insert_existing_frame(0, stack_frame.start_address().as_u64());
+    stack_obj
+        .insert_existing_frame(0, stack_frame.start_address().as_u64())
+        .expect("execve: freshly-mapped user stack frame cannot be saturated");
     let stack_start = crate::init_process::USER_STACK_PAGE_VA as usize;
     let stack_vma = Vma::new(
         stack_start,

--- a/kernel/src/init_process.rs
+++ b/kernel/src/init_process.rs
@@ -83,7 +83,9 @@ pub fn launch(bytes: &[u8]) -> usize {
     use crate::mem::vmatree::{VMA_GROWSDOWN, VMA_STACK_GUARD};
     let stack_obj = AnonObject::new(Some(1));
     let stack_phys = stack_frame.start_address().as_u64();
-    stack_obj.insert_existing_frame(0, stack_phys);
+    stack_obj
+        .insert_existing_frame(0, stack_phys)
+        .expect("init: freshly-mapped user stack frame cannot be saturated");
     let stack_start = USER_STACK_PAGE_VA as usize;
     let mut stack_vma = Vma::new(
         stack_start,

--- a/kernel/src/mem/loader.rs
+++ b/kernel/src/mem/loader.rs
@@ -263,8 +263,11 @@ pub fn load_user_elf_with_vmas(
             if let Some((frame, _)) = paging::translate_in_pml4(pml4, va) {
                 let phys = frame.start_address().as_u64();
                 // insert_existing_frame increments refcount by 1 for the
-                // cache reference. The PTE reference was set by load_user_elf.
-                obj.insert_existing_frame(i, phys);
+                // cache reference. The PTE reference was set by load_user_elf
+                // on a freshly-allocated frame (refcount 1), so saturation
+                // is statically impossible here.
+                obj.insert_existing_frame(i, phys)
+                    .expect("loader: freshly-mapped ELF frame cannot be saturated");
             }
         }
 

--- a/kernel/src/mem/vmobject.rs
+++ b/kernel/src/mem/vmobject.rs
@@ -43,6 +43,12 @@ pub enum VmFault {
     /// file mapping being written). Unused today but reserved so the
     /// resolver has one shape to match against.
     ProtectionViolation,
+    /// The target frame's refcount is pinned at `u16::MAX`; adding
+    /// another reference would violate RFC 0001's exact-or-over
+    /// invariant and risk a UAF on the matching drop. Produced by the
+    /// cache-hit path in [`AnonObject::fault`] when the shared frame is
+    /// already maximally-referenced.
+    RefcountSaturated,
 }
 
 /// Polymorphic "what backs this VMA" trait. Lives behind
@@ -163,16 +169,28 @@ impl VmObject for AnonObject {
             // one reference; the cache entry holds a separate reference.
             // Balanced by `frame::put` in `AddressSpace::drop` when the
             // PTE is removed (or `cow_copy_and_remap` when CoW resolves it).
+            //
+            // Checked increment: if the slot is pinned at `u16::MAX`
+            // another shared fault would violate RFC 0001's
+            // exact-or-over invariant and UAF on the matching drop.
+            // Refuse the fault instead of publishing the new reference.
             #[cfg(target_os = "none")]
-            crate::mem::refcount::inc_refcount(frame);
+            crate::mem::refcount::try_inc_refcount(frame)
+                .map_err(|_| VmFault::RefcountSaturated)?;
             return Ok(frame);
         }
         let phys = alloc_zeroed_page()?;
         inner.frames.insert(idx, phys);
         // `alloc_zeroed_page` sets refcount=1 (the cache's reference).
         // Increment once more for the PTE mapping being installed by caller.
+        //
+        // Saturation is impossible here: the frame was just allocated and
+        // its refcount is 1. Use the checked variant for consistency with
+        // the cache-hit path and panic on the invariant violation rather
+        // than silently saturating.
         #[cfg(target_os = "none")]
-        crate::mem::refcount::inc_refcount(phys);
+        crate::mem::refcount::try_inc_refcount(phys)
+            .expect("freshly-allocated frame cannot be at u16::MAX");
         Ok(phys)
     }
 
@@ -229,11 +247,25 @@ impl AnonObject {
     ///
     /// The caller must ensure that `phys` already has a PTE reference
     /// (refcount ≥ 1). This method adds the cache reference on top.
-    pub fn insert_existing_frame(&self, idx: usize, phys: u64) {
+    ///
+    /// Returns `Err(Saturated)` if `phys`'s refcount is already pinned
+    /// at `u16::MAX`. On error the frame is **not** inserted into the
+    /// cache, so no orphan reference is published. Today every caller
+    /// passes a freshly-allocated frame whose refcount is 1, so the
+    /// error is unreachable in practice — the fallible signature makes
+    /// the RFC 0001 exact-or-over invariant statically enforced should
+    /// that ever change.
+    pub fn insert_existing_frame(
+        &self,
+        idx: usize,
+        phys: u64,
+    ) -> Result<(), crate::mem::refcount::Saturated> {
+        // Bump the cache's reference first: if the slot is saturated we
+        // return before touching the BTreeMap, so no dangling cache
+        // entry references a frame whose refcount we failed to claim.
+        crate::mem::refcount::try_inc_refcount(phys)?;
         self.inner.lock().frames.insert(idx, phys);
-        // Add the cache's reference. The PTE reference was set by the
-        // original allocator/mapper; we are adding one more here.
-        crate::mem::refcount::inc_refcount(phys);
+        Ok(())
     }
 
     /// Remove cached frames whose page index is in `[first, last)` and

--- a/kernel/tests/anon_fault_saturated.rs
+++ b/kernel/tests/anon_fault_saturated.rs
@@ -1,0 +1,153 @@
+//! Integration test for #255: `AnonObject::fault` cache-hit and
+//! `insert_existing_frame` must refuse to bump a frame whose refcount is
+//! already pinned at `u16::MAX`, rather than silently saturating and
+//! publishing a reference the refcount cannot represent (UAF on the
+//! matching drop).
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use core::sync::atomic::Ordering;
+
+use vibix::mem::refcount;
+use vibix::mem::vmobject::{Access, AnonObject, VmFault, VmObject};
+use vibix::{
+    exit_qemu, serial_println, task,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "fault_cache_hit_refuses_saturated_frame",
+            &(fault_cache_hit_refuses_saturated_frame as fn()),
+        ),
+        (
+            "insert_existing_frame_refuses_saturated",
+            &(insert_existing_frame_refuses_saturated as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+/// Prime the given frame's refcount to `value` and return the amount we
+/// bumped it by, so the caller can restore it before drop. Uses the raw
+/// slot because `inc_refcount` saturates silently and `try_inc_refcount`
+/// would refuse past MAX.
+fn bump_refcount_to(phys: u64, value: u16) -> u16 {
+    let slot = refcount::page_refcount(phys);
+    let cur = slot.load(Ordering::Relaxed);
+    assert!(value >= cur, "bump_refcount_to can only raise the slot");
+    slot.store(value, Ordering::Relaxed);
+    value - cur
+}
+
+/// Restore a previously-bumped slot by subtracting `delta`. The object's
+/// `Drop` will still balance the natural refcount; we only need to undo
+/// the artificial inflation before that runs.
+fn unbump_refcount(phys: u64, delta: u16) {
+    let slot = refcount::page_refcount(phys);
+    let cur = slot.load(Ordering::Relaxed);
+    assert!(cur >= delta, "unbump underflow");
+    slot.store(cur - delta, Ordering::Relaxed);
+}
+
+/// Cache-hit fault with the frame's refcount already at `u16::MAX` must
+/// return `VmFault::RefcountSaturated` rather than publishing a new
+/// reference the refcount cannot track.
+fn fault_cache_hit_refuses_saturated_frame() {
+    // Fault once through a fresh object so the cache holds a real frame
+    // whose refcount we control. Write-access avoids any future CoW
+    // demotion that might add more references.
+    let obj = AnonObject::new(Some(1));
+    let phys = obj
+        .fault(0, Access::Write)
+        .expect("initial fault must succeed");
+
+    // Pin the slot at MAX; the next fault is a cache hit, which today
+    // does a checked increment and must refuse.
+    let delta = bump_refcount_to(phys, u16::MAX);
+
+    match obj.fault(0, Access::Read) {
+        Err(VmFault::RefcountSaturated) => {}
+        Err(other) => panic!("expected RefcountSaturated, got {other:?}"),
+        Ok(_) => panic!("fault must refuse to bump a saturated refcount"),
+    }
+
+    // Slot is still at MAX — the checked increment did not corrupt it.
+    assert_eq!(
+        refcount::page_refcount(phys).load(Ordering::Relaxed),
+        u16::MAX,
+        "refused fault must not move the refcount slot",
+    );
+
+    // Cache entry is still there: frame_at returns the same frame. The
+    // refused fault only blocks the increment, it does not evict.
+    assert_eq!(obj.frame_at(0), Some(phys));
+
+    // Undo the artificial inflation so the object's Drop balances.
+    unbump_refcount(phys, delta);
+    drop(obj);
+}
+
+/// `insert_existing_frame` on a frame whose refcount is already at
+/// `u16::MAX` must return `Err(Saturated)` and must not insert the frame
+/// into the cache (otherwise `Drop` would later decrement a reference
+/// the refcount never recorded).
+fn insert_existing_frame_refuses_saturated() {
+    // Allocate a frame via a throw-away object, then detach it: we keep
+    // the refcount slot alive but leave the target object with an empty
+    // cache so we are the only one trying to insert.
+    let scratch = AnonObject::new(Some(1));
+    let phys = scratch
+        .fault(0, Access::Write)
+        .expect("scratch fault must succeed");
+
+    // Pin the slot at MAX and drive the target through the
+    // public API. The bumped slot means `insert_existing_frame`
+    // must refuse.
+    let delta = bump_refcount_to(phys, u16::MAX);
+
+    let target = AnonObject::new(Some(1));
+    let result = target.insert_existing_frame(0, phys);
+    assert!(
+        matches!(result, Err(refcount::Saturated)),
+        "expected Err(Saturated), got {result:?}",
+    );
+
+    // Target cache is still empty: frame_at returns None, so no dangling
+    // reference will fire in Drop.
+    assert_eq!(target.frame_at(0), None);
+
+    // Slot still pinned at MAX; the refused call did not touch it.
+    assert_eq!(
+        refcount::page_refcount(phys).load(Ordering::Relaxed),
+        u16::MAX,
+    );
+
+    unbump_refcount(phys, delta);
+    drop(target);
+    drop(scratch);
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -826,6 +826,7 @@ fn test_all() -> R<()> {
         "vfs_backend",
         "vfs_hello",
         "rootfs_module",
+        "anon_fault_saturated",
     ] {
         cmd.arg("--test").arg(t);
     }


### PR DESCRIPTION
Closes #255

## Summary
- `AnonObject::fault` cache-hit arm now uses `try_inc_refcount` and returns a new `VmFault::RefcountSaturated` variant when the shared frame is already at `u16::MAX`, rather than silently saturating and handing back a reference the refcount cannot track.
- `AnonObject::insert_existing_frame` now returns `Result<(), refcount::Saturated>` and bumps the refcount **before** inserting into the cache, so a refusal leaves the BTreeMap unchanged (no orphan entry for `Drop` to later decrement).
- Fresh-allocation sites (new-page fault path, init stack setup, loader, execve) use `try_inc_refcount().expect(...)` since a just-allocated frame cannot be at MAX.

This closes the RFC 0001 "exact-or-over" gap on the demand-fault path: producing a reference that the refcount didn't record would have caused a UAF on the matching drop.

## Test plan
- [x] New integration test `kernel/tests/anon_fault_saturated.rs` with two cases:
  - `fault_cache_hit_refuses_saturated_frame` — pins the slot at `u16::MAX` via the raw refcount table, asserts the second fault returns `Err(VmFault::RefcountSaturated)`, and verifies the slot and cache entry are untouched.
  - `insert_existing_frame_refuses_saturated` — target object's `insert_existing_frame` returns `Err(Saturated)` on a pinned frame, with the cache left empty.
- [x] Test wired into `kernel/Cargo.toml` and `xtask/src/main.rs::test_all`.
- [x] `cargo build` clean (no_std kernel + new test binary both link).
- [ ] `cargo xtask test` / `cargo xtask smoke` — blocked in sandbox by a pre-existing `objcopy` environment issue (reproduces on `main`); CI is authoritative.