### PR TITLE
tests: use PATH_MAX constant in VFS path-copy tests (#328)

### DIFF
--- a/kernel/tests/syscall_open_mmap.rs
+++ b/kernel/tests/syscall_open_mmap.rs
@@ -17,6 +17,7 @@ use core::panic::PanicInfo;
 use core::ptr;
 
 use vibix::arch::x86_64::syscall::syscall_dispatch;
+use vibix::fs::vfs::path_walk::PATH_MAX;
 use vibix::fs::{EBADF, EINVAL, ENAMETOOLONG, ENODEV, ENOENT};
 use vibix::mem::pf::{MAP_ANONYMOUS, MAP_FIXED, MAP_PRIVATE, PROT_READ, PROT_WRITE};
 use vibix::mem::vmatree::{Share, Vma};
@@ -187,9 +188,9 @@ fn open_path_not_terminated() {
     install_user_staging_vma();
     // Fill enough of the staging page with non-NUL bytes that the
     // kernel's `PATH_MAX + 1`-sized copy-in buffer exhausts before
-    // hitting a terminator. `path_walk::PATH_MAX` is 4096, so the
-    // kernel reads up to 4097 bytes looking for a NUL.
-    const UNTERMINATED_BYTES: usize = 4097;
+    // hitting a terminator: the kernel reads up to PATH_MAX + 1 bytes
+    // looking for a NUL.
+    const UNTERMINATED_BYTES: usize = PATH_MAX + 1;
     unsafe {
         let dst = USER_PAGE_VA as *mut u8;
         let mut i = 0;

--- a/kernel/tests/syscall_vfs.rs
+++ b/kernel/tests/syscall_vfs.rs
@@ -16,6 +16,7 @@ use core::ptr;
 
 use vibix::arch::x86_64::syscall::syscall_dispatch;
 use vibix::fs::vfs::ops::Stat;
+use vibix::fs::vfs::path_walk::PATH_MAX;
 use vibix::fs::{EBADF, EINVAL, ENAMETOOLONG, ENOENT, ENOTDIR};
 use vibix::mem::vmatree::{Share, Vma};
 use vibix::mem::vmobject::AnonObject;
@@ -95,6 +96,10 @@ fn run_tests() {
         (
             "stat_enametoolong_on_overlong_path",
             &(stat_enametoolong_on_overlong_path as fn()),
+        ),
+        (
+            "stat_pathmax_boundary_is_accepted",
+            &(stat_pathmax_boundary_is_accepted as fn()),
         ),
     ];
     serial_println!("running {} tests", tests.len());
@@ -253,13 +258,13 @@ fn lstat_same_as_stat_on_dir() {
 }
 
 fn stat_enametoolong_on_overlong_path() {
-    // VFS PATH_MAX is 4096. A user path of 4097 non-NUL bytes means
-    // `copy_path_from_user` fills the whole kernel buffer (4096 + 1)
+    // A user path of PATH_MAX + 1 non-NUL bytes means
+    // `copy_path_from_user` fills the whole kernel buffer (PATH_MAX + 1)
     // without seeing a NUL and must return ENAMETOOLONG. Stage the path
     // at page 4 of USER_PAGE_VA so it doesn't collide with the stat
     // destination at page 1.
     install_user_staging_vma();
-    const OVERLONG: usize = 4097;
+    const OVERLONG: usize = PATH_MAX + 1;
     let path_uva = (USER_PAGE_VA + 4 * 4096) as u64;
     unsafe {
         let dst = path_uva as *mut u8;
@@ -274,6 +279,36 @@ fn stat_enametoolong_on_overlong_path() {
     }
     let r = unsafe { syscall_dispatch(SYS_STAT, path_uva, statbuf_uva(), 0, 0, 0, 0) };
     assert_eq!(r, ENAMETOOLONG, "expected ENAMETOOLONG, got {}", r);
+}
+
+fn stat_pathmax_boundary_is_accepted() {
+    // Boundary case for issue #328: a user path of exactly PATH_MAX
+    // non-NUL bytes plus a terminating NUL must pass the length check.
+    // Since the path doesn't exist, the expected error is ENOENT —
+    // crucially NOT ENAMETOOLONG (which would mean the accept side has
+    // an off-by-one). Stage at page 6 to avoid the overlong test's
+    // page 4 and the staging stat page.
+    install_user_staging_vma();
+    let path_uva = (USER_PAGE_VA + 6 * 4096) as u64;
+    unsafe {
+        let dst = path_uva as *mut u8;
+        // First byte is '/' so path_walk treats this as absolute; the
+        // remaining PATH_MAX - 1 bytes are a single component name that
+        // doesn't exist. Total non-NUL bytes = PATH_MAX.
+        ptr::write_volatile(dst, b'/');
+        let mut i = 1;
+        while i < PATH_MAX {
+            ptr::write_volatile(dst.add(i), b'a');
+            i += 1;
+        }
+        ptr::write_volatile(dst.add(PATH_MAX), 0);
+    }
+    let r = unsafe { syscall_dispatch(SYS_STAT, path_uva, statbuf_uva(), 0, 0, 0, 0) };
+    assert_eq!(
+        r, ENOENT,
+        "PATH_MAX-length non-existent path must be ENOENT (accept side), got {}",
+        r
+    );
 }
 
 fn open_o_directory_on_nondir_enotdir() {

--- a/kernel/tests/syscall_vfs.rs
+++ b/kernel/tests/syscall_vfs.rs
@@ -288,18 +288,22 @@ fn stat_pathmax_boundary_is_accepted() {
     // crucially NOT ENAMETOOLONG (which would mean the accept side has
     // an off-by-one). Stage at page 6 to avoid the overlong test's
     // page 4 and the staging stat page.
+    //
+    // path_walk enforces both PATH_MAX (total) and NAME_MAX (255) per
+    // component, so the PATH_MAX-byte string must be composed of short
+    // components: `/a/a/a...`. Each `/a` is 2 bytes, giving PATH_MAX/2
+    // one-character components after the leading slash-pair — well
+    // inside NAME_MAX.
     install_user_staging_vma();
     let path_uva = (USER_PAGE_VA + 6 * 4096) as u64;
+    const _: () = assert!(PATH_MAX % 2 == 0, "test assumes PATH_MAX even");
     unsafe {
         let dst = path_uva as *mut u8;
-        // First byte is '/' so path_walk treats this as absolute; the
-        // remaining PATH_MAX - 1 bytes are a single component name that
-        // doesn't exist. Total non-NUL bytes = PATH_MAX.
-        ptr::write_volatile(dst, b'/');
-        let mut i = 1;
+        let mut i = 0;
         while i < PATH_MAX {
-            ptr::write_volatile(dst.add(i), b'a');
-            i += 1;
+            ptr::write_volatile(dst.add(i), b'/');
+            ptr::write_volatile(dst.add(i + 1), b'a');
+            i += 2;
         }
         ptr::write_volatile(dst.add(PATH_MAX), 0);
     }


### PR DESCRIPTION
Closes #328

## Summary
- Replace hardcoded `4096` / `4097` literals in `kernel/tests/syscall_vfs.rs` (`stat_enametoolong_on_overlong_path`) and `kernel/tests/syscall_open_mmap.rs` (`open_path_not_terminated`) with `vibix::fs::vfs::path_walk::PATH_MAX` / `PATH_MAX + 1`, so the tests track the kernel constant rather than drift independently.
- Add `stat_pathmax_boundary_is_accepted` to `kernel/tests/syscall_vfs.rs`: stages exactly PATH_MAX non-NUL bytes followed by a terminating NUL at a fresh staging offset (page 6 of USER_PAGE_VA) and asserts ENOENT. A regression that tightened the check to `> PATH_MAX - 1` would surface here as a false ENAMETOOLONG.

## Test plan
- [x] `cargo test --target x86_64-unknown-none ... --test syscall_vfs --test syscall_open_mmap --no-run` — both binaries compile cleanly.
- [x] `cargo fmt --all -- --check` — clean.
- [ ] Full `cargo xtask test` under QEMU — sandbox cannot run QEMU (pre-existing `objcopy` environment issue on `main`); CI will run the complete integration suite.