### PR TITLE
syscall: add DUP/DUP2 constants to syscall_nr and use in dispatch arms

### DIFF
--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -326,7 +326,7 @@ pub unsafe extern "C" fn syscall_dispatch(
         }
 
         // dup(oldfd)
-        32 => {
+        DUP => {
             let oldfd = a0 as u32;
             let tbl = crate::task::current_fd_table();
             let result = tbl.lock().dup(oldfd);
@@ -337,7 +337,7 @@ pub unsafe extern "C" fn syscall_dispatch(
         }
 
         // dup2(oldfd, newfd)
-        33 => {
+        DUP2 => {
             let oldfd = a0 as u32;
             let newfd = a1 as u32;
             let tbl = crate::task::current_fd_table();
@@ -936,6 +936,8 @@ pub mod syscall_nr {
     pub const OPENAT: u64 = 257;
     pub const LSEEK: u64 = 8;
     pub const CLOSE: u64 = 3;
+    pub const DUP: u64 = 32;
+    pub const DUP2: u64 = 33;
     pub const FSTAT: u64 = 5;
     pub const STAT: u64 = 4;
     pub const LSTAT: u64 = 6;
@@ -963,6 +965,8 @@ mod tests {
         assert_eq!(syscall_nr::READ, 0, "SYS_read must be 0");
         assert_eq!(syscall_nr::WRITE, 1, "SYS_write must be 1");
         assert_eq!(syscall_nr::CLOSE, 3, "SYS_close must be 3");
+        assert_eq!(syscall_nr::DUP, 32, "SYS_dup must be 32");
+        assert_eq!(syscall_nr::DUP2, 33, "SYS_dup2 must be 33");
         assert_eq!(syscall_nr::LSEEK, 8, "SYS_lseek must be 8");
 
         // Memory management


### PR DESCRIPTION
Closes #318

## Summary
- Add `DUP = 32` and `DUP2 = 33` to the `syscall_nr` module in `kernel/src/arch/x86_64/syscall.rs`.
- Replace the bare numeric match arms (`32 =>`, `33 =>`) in `syscall_dispatch` with the named constants so every arm uses the same style.
- Pin the new constants in `syscall_numbers_match_linux_x86_64_abi` alongside the existing ABI anchors.

## Test plan
- [x] `cargo check -p vibix --lib` (kernel target) — clean.
- [x] `cargo fmt -p vibix --check` — clean.
- [ ] CI runs the host unit tests, including `syscall_numbers_match_linux_x86_64_abi`, which now asserts `DUP = 32` and `DUP2 = 33`.
- [ ] CI runs the QEMU integration test lane to confirm no regression in the syscall dispatcher (fd_table test exercises dup/dup2).