### PR TITLE
vfs: split DString::try_from_bytes errno for empty vs overlength names

### DIFF
--- a/kernel/src/fs/vfs/mod.rs
+++ b/kernel/src/fs/vfs/mod.rs
@@ -167,11 +167,14 @@ pub struct DString {
 }
 
 impl DString {
-    /// Construct from a byte slice. Rejects empty names, names longer
-    /// than [`NAME_MAX`], and names containing `/` or NUL (both
-    /// illegal per POSIX §4.5).
+    /// Construct from a byte slice. Rejects empty names with `EINVAL`,
+    /// names longer than [`NAME_MAX`] with `ENAMETOOLONG`, and names
+    /// containing `/` or NUL with `EINVAL` (both illegal per POSIX §4.5).
     pub fn try_from_bytes(s: &[u8]) -> Result<Self, i64> {
-        if s.is_empty() || s.len() > NAME_MAX {
+        if s.is_empty() {
+            return Err(super::EINVAL);
+        }
+        if s.len() > NAME_MAX {
             return Err(super::ENAMETOOLONG);
         }
         if s.iter().any(|&b| b == b'/' || b == 0) {
@@ -221,13 +224,20 @@ mod tests {
 
     #[test]
     fn dstring_rejects_empty() {
-        assert!(DString::try_from_bytes(b"").is_err());
+        assert_eq!(
+            DString::try_from_bytes(b""),
+            Err(super::super::EINVAL),
+            "empty names must return EINVAL per POSIX, not ENAMETOOLONG"
+        );
     }
 
     #[test]
     fn dstring_rejects_too_long() {
         let long = [b'a'; NAME_MAX + 1];
-        assert!(DString::try_from_bytes(&long).is_err());
+        assert_eq!(
+            DString::try_from_bytes(&long),
+            Err(super::super::ENAMETOOLONG)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #256

## Summary
- Empty names now return `EINVAL` per POSIX §4.5 instead of sharing `ENAMETOOLONG` with the length-cap path.
- `dstring_rejects_empty` tightened to assert the exact errno; `dstring_rejects_too_long` mirrored for symmetry.
- All existing callers either `.unwrap()` static-known-valid names, `.map_err(|_| ENOENT)?`, or propagate via `?`. The sole propagator in ring-3 path resolution (`kernel/src/fs/vfs/path_walk.rs:272`) guards `NAME_MAX` on line 263 before reaching `try_from_bytes`, so the new `EINVAL` branch is only hit by empty components — the POSIX-correct behavior.

## Test plan
- [x] `cargo xtask build` compiles clean.
- [x] `cargo clippy --target x86_64-unknown-none -p vibix --lib` — no new warnings.
- [x] `cargo fmt --all -- --check` clean.
- [ ] CI runs `cargo xtask test` — covers the new errno assertions via the existing `dstring_rejects_empty` / `dstring_rejects_too_long` tests.