### PR TITLE
signal: deliver SIGSEGV from #PF handler on ring-3 access violations

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -267,6 +267,22 @@ extern "x86-interrupt" fn page_fault(frame: InterruptStackFrame, code: PageFault
         hang();
     }
 
+    // Ring-3 access violation fall-through: every path above that *could*
+    // legitimately resolve a user fault has either returned or fallen
+    // through with a diagnostic. A user-mode fault reaching here is an
+    // unrecoverable access violation (bad deref, write to a read-only
+    // page that isn't CoW-eligible, exec on NX, etc.) — deliver SIGSEGV
+    // with DefaultAction::Terminate. The helper calls `task::exit()`, so
+    // IRETQ never runs; the scheduler context-switches to the next task.
+    if cpl != 0 {
+        serial_println!(
+            "#PF ring-3 access violation addr={:#x} code={:?}",
+            addr_u64,
+            code,
+        );
+        unsafe { crate::signal::deliver_fault_signal_iret(crate::signal::SIGSEGV) };
+    }
+
     serial_println!(
         "EXCEPTION: #PF addr={:#x} code={:?}\n{:#?}",
         addr_u64,

--- a/kernel/src/signal/mod.rs
+++ b/kernel/src/signal/mod.rs
@@ -376,19 +376,18 @@ pub fn sys_kill(pid: u64, sig: u64) -> i64 {
 /// Must be called from an exception handler on behalf of the currently
 /// running task. Does not return.
 pub unsafe fn deliver_fault_signal_iret(sig: u8) -> ! {
-    let task_id = crate::task::current_id();
-    // Raise the signal on the current task so the disposition lookup below
-    // sees it pending (and any future handler-dispatch path can treat it
-    // the same as a sigqueue from another task).
-    let _ = crate::process::with_signal_state_for_task(task_id, |state| {
-        state.raise(sig);
-    });
+    // Precondition: `sig` is a valid signal number. `sig == 0` would underflow
+    // the `dispositions[sig - 1]` index below; guard it in debug builds so a
+    // future caller that forgets fails loudly instead of corrupting memory.
+    debug_assert!(sig > 0 && sig <= NSIG, "invalid signal number");
 
-    // Look up the disposition; SIGSEGV/SIGBUS/SIGILL/SIGFPE are all
-    // default-Terminate, but a future syscall may have registered a handler.
+    let task_id = crate::task::current_id();
+    // Raise, immediately clear the pending bit (we service synchronously),
+    // and read the disposition under a single lock acquisition. Doing this in
+    // one critical section avoids a window where another path could observe
+    // the signal pending while we're already about to service it.
     let disp = crate::process::with_signal_state_for_task(task_id, |state| {
-        // Clear the pending bit we just set — we're about to service it
-        // synchronously below, either as Terminate or (TODO) handler-redirect.
+        state.raise(sig);
         state.pending &= !sig_bit(sig);
         state.dispositions[(sig - 1) as usize]
     })

--- a/kernel/src/signal/mod.rs
+++ b/kernel/src/signal/mod.rs
@@ -353,6 +353,63 @@ pub fn sys_kill(pid: u64, sig: u64) -> i64 {
     raise_signal_on_pid(pid as u32, sig)
 }
 
+// ── Delivery from exception handlers (IRETQ path) ─────────────────────────
+
+/// Deliver a synchronous fault signal raised from an exception handler (e.g.
+/// `#PF` on a ring-3 access violation) to the currently running task.
+///
+/// Unlike [`check_and_deliver_signals`] (syscall-return path), this is called
+/// from an interrupt handler with no saved `SyscallReturnContext` — the user
+/// RIP/RSP/RFLAGS are captured in the hardware-pushed `InterruptStackFrame`.
+///
+/// Current scope: only the `SIG_DFL` / `DefaultAction::Terminate` case is
+/// implemented. The signal is raised on the current task, then the terminate
+/// path runs directly: `reparent_children → mark_zombie(-sig) → task::exit()`.
+/// `task::exit()` is `!`, so the exception handler never returns — the
+/// scheduler context-switches to the next task instead of executing `IRETQ`.
+///
+/// Handler-dispatch (`Disposition::Handler`) for fault signals is not yet
+/// implemented; installing a SIGSEGV handler and triggering a #PF will fall
+/// through to terminate semantics. Tracked in the follow-up to #337.
+///
+/// # Safety
+/// Must be called from an exception handler on behalf of the currently
+/// running task. Does not return.
+pub unsafe fn deliver_fault_signal_iret(sig: u8) -> ! {
+    let task_id = crate::task::current_id();
+    // Raise the signal on the current task so the disposition lookup below
+    // sees it pending (and any future handler-dispatch path can treat it
+    // the same as a sigqueue from another task).
+    let _ = crate::process::with_signal_state_for_task(task_id, |state| {
+        state.raise(sig);
+    });
+
+    // Look up the disposition; SIGSEGV/SIGBUS/SIGILL/SIGFPE are all
+    // default-Terminate, but a future syscall may have registered a handler.
+    let disp = crate::process::with_signal_state_for_task(task_id, |state| {
+        // Clear the pending bit we just set — we're about to service it
+        // synchronously below, either as Terminate or (TODO) handler-redirect.
+        state.pending &= !sig_bit(sig);
+        state.dispositions[(sig - 1) as usize]
+    })
+    .unwrap_or(Disposition::Default);
+
+    match disp {
+        Disposition::Handler(_) | Disposition::Ignore | Disposition::Default => {
+            // Handler + Ignore paths aren't meaningful for a synchronous fault
+            // (the faulting instruction would re-fault immediately on IRETQ).
+            // Fall through to Terminate for all cases until the follow-up lands.
+            let pid = crate::process::current_pid();
+            crate::serial_println!("signal: terminate pid={} sig={} (fault)", pid, sig);
+            if pid != 0 {
+                crate::process::reparent_children(pid);
+                crate::process::mark_zombie(pid, -(sig as i32));
+            }
+        }
+    }
+    crate::task::exit();
+}
+
 // ── Delivery at syscall return ────────────────────────────────────────────
 
 /// Kernel-stack layout pushed by the `syscall_entry` asm trampoline
@@ -450,6 +507,7 @@ unsafe fn deliver_signal(sig: u8, ctx: &mut SyscallReturnContext) {
             match default_action(sig) {
                 DefaultAction::Terminate => {
                     let pid = crate::process::current_pid();
+                    crate::serial_println!("signal: terminate pid={} sig={}", pid, sig);
                     if pid != 0 {
                         crate::process::reparent_children(pid);
                         crate::process::mark_zombie(pid, -(sig as i32));


### PR DESCRIPTION
Closes #337.

## Summary
- `kernel/src/arch/x86_64/idt.rs`: replace the terminal `hang()` on the ring-3 `#PF` fall-through with a call to a new `signal::deliver_fault_signal_iret(SIGSEGV)`. All paths above (SMAP panic, RSVD panic, user-VA-end MAPERR, VMA-backed demand/CoW, growsdown, stack-overflow guard) still handle or panic as before; only the previously-fatal ring-3 access-violation arm is affected.
- `kernel/src/signal/mod.rs`: add `deliver_fault_signal_iret(sig)` for synchronous fault signals from exception handlers. Runs the Terminate path (`reparent_children` → `mark_zombie(-sig)` → `task::exit()`), so IRETQ never executes — the scheduler context-switches to the next task instead of halting the CPU.
- Add a `signal: terminate pid=<p> sig=<n>` trace line in the existing Terminate arm of `deliver_signal` (per the issue work items) and a matching `(fault)` variant in the new IRET-path helper.

## Scope notes
- Handler-dispatch (`Disposition::Handler`) from exception context requires pushing a `SigFrame` onto the user stack from the `#PF` handler, which needs more plumbing than this PR. That case currently falls through to Terminate and is called out in the helper docstring as a follow-up to #337 — a handler-registered SIGSEGV still terminates rather than looping the fault.
- Unblocks #225 (mprotect downgrade + write should SIGSEGV via ring-3 driver), which was the original discovery motivation.

## Test plan
- [x] \`cargo xtask build\` — kernel compiles (pre-existing aarch64/pic8259 host-toolchain issue blocks the objcopy step on this machine; CI x86_64 builds the kernel cleanly).
- [ ] \`cargo xtask test\` — host unit test phase is blocked on this host by the same pre-existing aarch64/pic8259 issue; relying on CI to exercise the kernel-target integration tests.
- [ ] \`cargo xtask smoke\` — relying on CI; the smoke boot does not exercise a ring-3 access violation so no markers change.
- [ ] End-to-end ring-3 fault → `mark_zombie(-11)` integration test — deferred as a follow-up (needs a bundled userspace program that deliberately dereferences a bad pointer); will land with the PR that closes #225.