### PR TITLE
xtask: ISR-reachable blocking-lock audit + lint

### DIFF
--- a/docs/isr-paging-audit.md
+++ b/docs/isr-paging-audit.md
@@ -1,0 +1,132 @@
+# ISR-reachable paging audit
+
+Tracks every function reachable from interrupt / exception context and
+classifies the synchronisation primitives it touches. The north star is
+that **no ISR-reachable path may acquire a `BlockingMutex` or a
+`BlockingRwLock`** — those primitives park the caller on a `WaitQueue`,
+and an ISR has nowhere safe to park (no task context, and it may have
+interrupted a thread that already holds the very lock it wants). An
+accidental blocking-lock acquisition on an ISR path produces a
+silent deadlock the first time the primitive is ever contended.
+
+Origin: issue #306 (follow-up to #147, whose item 1 was resolved by
+#305 moving the reaper off the timer ISR).
+
+## Entry points
+
+Every vector installed in `kernel/src/arch/x86_64/idt.rs` plus the three
+hardware IRQs wired in `kernel/src/arch/x86_64/interrupts.rs`:
+
+| Vector | Handler | File | Notes |
+|---|---|---|---|
+| #DE | `divide_error` | `arch/x86_64/idt.rs` | log + hang; no lock acquisitions |
+| #UD | `invalid_opcode` | `arch/x86_64/idt.rs` | log + hang |
+| #GP | `general_protection` | `arch/x86_64/idt.rs` | log + hang |
+| #DF | `double_fault` | `arch/x86_64/idt.rs` | runs on IST stack; log + hang |
+| #PF | `page_fault` | `arch/x86_64/idt.rs` | resolver — primary audit target |
+| IRQ 0 (timer) | `timer_interrupt` | `arch/x86_64/interrupts.rs` | EOI + `preempt_tick` |
+| IRQ 1 (keyboard) | `keyboard_interrupt` | `arch/x86_64/interrupts.rs` | `push_scancode_from_isr` + EOI |
+| IRQ 4 (serial) | `serial_interrupt` | `arch/x86_64/interrupts.rs` | `drain_rx_hardware` + EOI |
+
+The non-#PF CPU exceptions all terminate in `hang()` and touch no
+shared state; they are trivially safe and excluded from the lint.
+
+## #PF call chain
+
+The `page_fault` handler is the only exception that resolves rather
+than hangs, so it has the largest reachable surface:
+
+* `crate::test_hook::take_page_fault_expectation` — `AtomicU64::swap`; lock-free.
+* `crate::mem::pf::is_smap_violation` / `is_rsvd_fault` / `is_user_va` — pure predicates.
+* `crate::task::current_vma_lookup` — takes `SCHED.try_lock()` then `address_space.try_write()`, both `try_*`. Contention returns `None`; the handler falls through without touching further state.
+* `crate::task::current_growsdown_lookup` — same `try_*` discipline.
+* `crate::mem::paging::map_existing_in_pml4` — takes `MAPPER.lock()` (spin). May recurse into frame allocator (`frame::global()`, spin) if it needs a new page-table frame.
+* `crate::mem::paging::cow_copy_and_remap` — same set of spin locks, plus `refcount::dec_refcount` on the old frame and `VmObject::fault` for the new one.
+* `VmObject::fault` impls (`AnonObject`, etc.) — per-object state; no global locks.
+* `crate::task::find_stack_overflow` — reads atomics.
+* `crate::signal::deliver_fault_signal_iret` → `process::with_signal_state_for_task` → `process::mark_zombie` → `task::exit`. `task::exit` drops the current task's `Arc<RwLock<AddressSpace>>` reference; if this is the last reference the drop can call into `unmap_in_pml4` while still on the #PF frame, which in turn takes `MAPPER.lock()` (spin). See "Known gap 1" below.
+
+## Timer / keyboard / serial call chains
+
+* `timer_interrupt` → `time::on_tick` (atomics) → `notify_eoi` (PIC I/O) → `task::preempt_tick` → `SCHED.lock()` (spin) to pick the next task. Also wakes the reaper `WaitQueue` if there are victims; `WaitQueue::wake_one` takes `SCHED.lock()`.
+* `keyboard_interrupt` → `input::push_scancode_from_isr` (ring buffer behind a spin lock).
+* `serial_interrupt` → `serial::drain_rx_hardware` (port I/O + spin-locked ring buffer).
+
+## Lock inventory
+
+Every global lock reachable from ISR context today, with the primitive
+it uses:
+
+| Symbol | File | Primitive | ISR-safe? |
+|---|---|---|---|
+| `MAPPER` | `mem/paging.rs:53` | `spin::Mutex` | yes (doesn't park) |
+| `HHDM_OFFSET` | `mem/paging.rs:58` | `spin::Mutex` | yes |
+| `LIMINE_PML4_PHYS` | `mem/paging.rs:63` | `spin::Mutex` | yes |
+| `SCHED` | `task/mod.rs:65` | `spin::Mutex` | yes |
+| `REAPER_VICTIMS` | `task/mod.rs:76` | `spin::Mutex` | yes |
+| `frame::global()` | `mem/frame.rs` | `spin::Mutex` | yes |
+| Per-task `address_space` | `Arc<spin::RwLock<AddressSpace>>` | `spin::RwLock` | yes (accessed via `try_write` from #PF) |
+| `input` scancode ring | `input.rs` | `spin::Mutex` | yes |
+| `serial::rx_ring` | `serial.rs` | `spin::Mutex` | yes |
+
+No `BlockingMutex` or `BlockingRwLock` is reachable from any ISR
+today. Every `BlockingMutex` site we have lives under `fs/vfs` —
+inode state, open-file offsets, ramfs/tarfs bookkeeping — and the VFS
+is not reached from any interrupt handler.
+
+## Classification summary
+
+* **Safe today.** All ISR-reachable locks are `spin::Mutex` or
+  `spin::RwLock`. Spin locks never park, so no task can sleep holding
+  one, so an interrupted holder will resume and release within a bounded
+  time window.
+* **Safe-via-routing.** The reaper worker (#305) is the canonical escape
+  hatch for work that *would* need to block: enqueue on the spin-locked
+  `REAPER_VICTIMS`, wake the reaper task, return from the ISR.
+* **Dangerous.** None, as of this audit.
+
+## Known gaps and future work
+
+1. **`task::exit` from `#PF` drops the `AddressSpace` synchronously.**
+   The last `Arc` reference drop walks the VMA tree and calls into
+   `unmap_in_pml4`, which takes `MAPPER.lock()` (spin). That's fine
+   today — `MAPPER` is spin — but if `MAPPER` ever migrates to
+   `BlockingMutex` (see #314) this path will deadlock. Fix: route the
+   final drop through the reaper, the same way task stack freeing is
+   routed.
+2. **Planned `spin::Mutex` → `IrqLock` migrations** tracked in #314 and
+   #313. Those preserve ISR safety; the audit stays correct through
+   that migration.
+3. **Planned `spin::Mutex` → `BlockingMutex` migrations** would make
+   new paths dangerous. The lint in `xtask/src/isr_audit.rs` is the
+   guard rail: if anyone adds a blocking-lock acquisition to an
+   ISR-reachable file it fails `cargo xtask lint`.
+
+## Regression guard
+
+`xtask/src/isr_audit.rs` scans a curated set of ISR-reachable source
+files for:
+
+* Any bare `BlockingMutex::new(` or `BlockingRwLock::new(` construction.
+* Any `BlockingMutex<` or `BlockingRwLock<` type mention (field, return,
+  static).
+
+Either match fails the lint. The file allowlist lives in `isr_audit.rs`
+and must be refreshed when the reachable surface grows — if this audit
+doc and the lint disagree, the doc is authoritative; update both.
+
+The lint runs as part of `cargo xtask lint`, which is a CI gate, so new
+PRs that introduce blocking-lock acquisitions on ISR paths fail before
+merge.
+
+### Refreshing the allowlist
+
+When a new ISR entry point lands or an existing handler gains a new
+helper crate path:
+
+1. Trace the reachable call chain by hand (start at the vector handler,
+   follow every non-`try_*` function call).
+2. Add every new reachable file to `ISR_REACHABLE_FILES` in
+   `xtask/src/isr_audit.rs`.
+3. Update the "Entry points" and "#PF call chain" sections above.
+4. Re-run `cargo xtask lint` locally to confirm the lint still passes.

--- a/docs/isr-paging-audit.md
+++ b/docs/isr-paging-audit.md
@@ -9,8 +9,8 @@ interrupted a thread that already holds the very lock it wants). An
 accidental blocking-lock acquisition on an ISR path produces a
 silent deadlock the first time the primitive is ever contended.
 
-Origin: issue #306 (follow-up to #147, whose item 1 was resolved by
-#305 moving the reaper off the timer ISR).
+Origin: issue #306 (follow-up to #147, whose item 1 was resolved by #305
+moving the reaper off the timer ISR).
 
 ## Entry points
 
@@ -48,7 +48,7 @@ than hangs, so it has the largest reachable surface:
 
 ## Timer / keyboard / serial call chains
 
-* `timer_interrupt` → `time::on_tick` (atomics) → `notify_eoi` (PIC I/O) → `task::preempt_tick` → `SCHED.lock()` (spin) to pick the next task. Also wakes the reaper `WaitQueue` if there are victims; `WaitQueue::wake_one` takes `SCHED.lock()`.
+* `timer_interrupt` → `time::on_tick` (atomics) → `notify_eoi` (PIC I/O) → `task::preempt_tick` → `SCHED.try_lock()` (spin; bails on contention). Also wakes the reaper `WaitQueue` if there are victims; `WaitQueue::wake_one` takes `SCHED.lock()`.
 * `keyboard_interrupt` → `input::push_scancode_from_isr` (ring buffer behind a spin lock).
 * `serial_interrupt` → `serial::drain_rx_hardware` (port I/O + spin-locked ring buffer).
 

--- a/xtask/src/isr_audit.rs
+++ b/xtask/src/isr_audit.rs
@@ -1,0 +1,173 @@
+//! Regression guard for issue #306: no `BlockingMutex` / `BlockingRwLock`
+//! may appear on an ISR-reachable source path.
+//!
+//! Kept deliberately simple — a line-oriented string scan, no syn parsing.
+//! The goal is to catch new acquisitions added to files we already know
+//! the ISR handlers reach. Refreshing the file list is the maintainer's
+//! job when the reachable surface grows; `docs/isr-paging-audit.md`
+//! documents the procedure.
+
+use std::path::{Path, PathBuf};
+
+type R<T> = Result<T, Box<dyn std::error::Error>>;
+
+/// Files reachable from any ISR / exception handler. Paths are relative
+/// to the workspace root. See `docs/isr-paging-audit.md` for the
+/// per-file call-chain justification.
+const ISR_REACHABLE_FILES: &[&str] = &[
+    "kernel/src/arch/x86_64/idt.rs",
+    "kernel/src/arch/x86_64/interrupts.rs",
+    "kernel/src/mem/paging.rs",
+    "kernel/src/mem/frame.rs",
+    "kernel/src/mem/refcount.rs",
+    "kernel/src/mem/pf.rs",
+    "kernel/src/mem/addrspace.rs",
+    "kernel/src/mem/vmatree.rs",
+    "kernel/src/mem/vmobject.rs",
+    "kernel/src/time.rs",
+    "kernel/src/task/mod.rs",
+    "kernel/src/input.rs",
+    "kernel/src/serial.rs",
+    "kernel/src/signal/mod.rs",
+    "kernel/src/process/mod.rs",
+];
+
+/// Patterns that, if present on a line, indicate a blocking-primitive
+/// acquisition or construction reachable from an ISR. We look for type
+/// mentions (`BlockingMutex<`, `BlockingRwLock<`) and constructors
+/// (`BlockingMutex::new`, `BlockingRwLock::new`) — any of the four on
+/// an ISR-reachable file fails the lint.
+const FORBIDDEN_PATTERNS: &[&str] = &[
+    "BlockingMutex<",
+    "BlockingMutex::new",
+    "BlockingRwLock<",
+    "BlockingRwLock::new",
+];
+
+/// A single violation the lint found.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Finding {
+    pub file: String,
+    pub line_no: usize,
+    pub line: String,
+    pub pattern: &'static str,
+}
+
+/// Scan one file's contents for any forbidden pattern. Lines containing
+/// `// isr-audit: ok` are skipped (escape hatch for cases reviewed by
+/// hand — annotate the line with a rationale when using it).
+fn scan_contents(file: &str, contents: &str) -> Vec<Finding> {
+    let mut out = Vec::new();
+    for (idx, line) in contents.lines().enumerate() {
+        if line.contains("// isr-audit: ok") {
+            continue;
+        }
+        for pat in FORBIDDEN_PATTERNS {
+            if line.contains(pat) {
+                out.push(Finding {
+                    file: file.to_string(),
+                    line_no: idx + 1,
+                    line: line.trim_end().to_string(),
+                    pattern: pat,
+                });
+            }
+        }
+    }
+    out
+}
+
+fn scan_file(root: &Path, rel: &str) -> R<Vec<Finding>> {
+    let path: PathBuf = root.join(rel);
+    let contents = std::fs::read_to_string(&path)
+        .map_err(|e| format!("isr-audit: cannot read {}: {e}", path.display()))?;
+    Ok(scan_contents(rel, &contents))
+}
+
+/// Entry point used by `cargo xtask isr-audit` and by `cargo xtask lint`.
+pub fn run(workspace_root: &Path) -> R<()> {
+    let mut findings = Vec::new();
+    for rel in ISR_REACHABLE_FILES {
+        findings.extend(scan_file(workspace_root, rel)?);
+    }
+    if findings.is_empty() {
+        println!(
+            "→ isr-audit: OK ({} files scanned, no blocking-primitive acquisitions)",
+            ISR_REACHABLE_FILES.len()
+        );
+        return Ok(());
+    }
+    eprintln!(
+        "isr-audit: {} forbidden pattern(s) on ISR-reachable path(s):",
+        findings.len()
+    );
+    for f in &findings {
+        eprintln!("  {}:{}: [{}] {}", f.file, f.line_no, f.pattern, f.line);
+    }
+    eprintln!(
+        "See docs/isr-paging-audit.md. If the acquisition is provably safe, \
+         annotate the line with `// isr-audit: ok` and explain why."
+    );
+    Err(format!("isr-audit: {} finding(s)", findings.len()).into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clean_file_produces_no_findings() {
+        let src = "use spin::Mutex;\nstatic M: Mutex<u32> = Mutex::new(0);\n";
+        assert!(scan_contents("fake.rs", src).is_empty());
+    }
+
+    #[test]
+    fn blocking_mutex_type_flagged() {
+        let src = "use crate::sync::BlockingMutex;\n\
+                   static M: BlockingMutex<u32> = BlockingMutex::new(0);\n";
+        let findings = scan_contents("fake.rs", src);
+        // First line: `BlockingMutex;` — no `<` or `::new`, so no match.
+        // Second line: matches both `BlockingMutex<` and `BlockingMutex::new`.
+        assert_eq!(findings.len(), 2, "got: {findings:?}");
+        assert_eq!(findings[0].line_no, 2);
+        assert!(findings[0].pattern == "BlockingMutex<" || findings[0].pattern == "BlockingMutex::new");
+    }
+
+    #[test]
+    fn blocking_rwlock_constructor_flagged() {
+        let src = "let x = BlockingRwLock::new(0);\n";
+        let findings = scan_contents("fake.rs", src);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].pattern, "BlockingRwLock::new");
+    }
+
+    #[test]
+    fn escape_hatch_suppresses_finding() {
+        let src =
+            "let x = BlockingMutex::new(0); // isr-audit: ok — routed via reaper\n";
+        assert!(scan_contents("fake.rs", src).is_empty());
+    }
+
+    #[test]
+    fn line_numbers_are_one_indexed() {
+        let src = "\n\nBlockingMutex::new(0)\n";
+        let findings = scan_contents("fake.rs", src);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].line_no, 3);
+    }
+
+    #[test]
+    fn allowlisted_files_exist_on_disk() {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .to_path_buf();
+        for rel in ISR_REACHABLE_FILES {
+            let p = root.join(rel);
+            assert!(
+                p.is_file(),
+                "isr-audit allowlist references missing file: {}",
+                p.display()
+            );
+        }
+    }
+}

--- a/xtask/src/isr_audit.rs
+++ b/xtask/src/isr_audit.rs
@@ -129,7 +129,9 @@ mod tests {
         // Second line: matches both `BlockingMutex<` and `BlockingMutex::new`.
         assert_eq!(findings.len(), 2, "got: {findings:?}");
         assert_eq!(findings[0].line_no, 2);
-        assert!(findings[0].pattern == "BlockingMutex<" || findings[0].pattern == "BlockingMutex::new");
+        assert!(
+            findings[0].pattern == "BlockingMutex<" || findings[0].pattern == "BlockingMutex::new"
+        );
     }
 
     #[test]
@@ -142,8 +144,7 @@ mod tests {
 
     #[test]
     fn escape_hatch_suppresses_finding() {
-        let src =
-            "let x = BlockingMutex::new(0); // isr-audit: ok — routed via reaper\n";
+        let src = "let x = BlockingMutex::new(0); // isr-audit: ok — routed via reaper\n";
         assert!(scan_contents("fake.rs", src).is_empty());
     }
 

--- a/xtask/src/isr_audit.rs
+++ b/xtask/src/isr_audit.rs
@@ -39,8 +39,10 @@ const ISR_REACHABLE_FILES: &[&str] = &[
 /// an ISR-reachable file fails the lint.
 const FORBIDDEN_PATTERNS: &[&str] = &[
     "BlockingMutex<",
+    "BlockingMutex::<",
     "BlockingMutex::new",
     "BlockingRwLock<",
+    "BlockingRwLock::<",
     "BlockingRwLock::new",
 ];
 
@@ -140,6 +142,25 @@ mod tests {
         let findings = scan_contents("fake.rs", src);
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].pattern, "BlockingRwLock::new");
+    }
+
+    #[test]
+    fn turbofish_form_flagged() {
+        // `BlockingMutex::<u32>::new(0)` must not bypass the lint. Without the
+        // `BlockingMutex::<` pattern the bare `BlockingMutex<` and
+        // `BlockingMutex::new` patterns both miss because `::<u32>::` sits
+        // between the name and `new`.
+        let src = "let x = BlockingMutex::<u32>::new(0);\n\
+                   let y = BlockingRwLock::<u32>::new(0);\n";
+        let findings = scan_contents("fake.rs", src);
+        assert!(
+            findings.iter().any(|f| f.pattern == "BlockingMutex::<"),
+            "turbofish BlockingMutex not flagged: {findings:?}"
+        );
+        assert!(
+            findings.iter().any(|f| f.pattern == "BlockingRwLock::<"),
+            "turbofish BlockingRwLock not flagged: {findings:?}"
+        );
     }
 
     #[test]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -9,6 +9,7 @@
 //!   test-runner   — (internal) boot a pre-built test kernel ELF in QEMU
 //!   smoke         — boot the kernel and assert on expected serial markers
 //!   lint          — run clippy on xtask (host) and vibix (kernel, no_std)
+//!   isr-audit     — scan ISR-reachable files for blocking-lock regressions
 //!   clean         — remove build artifacts
 //!
 //! Flags (apply where sensible): --release, --fault-test, --panic-test
@@ -19,6 +20,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus, Stdio};
 use std::time::Duration;
+
+mod isr_audit;
 
 type R<T> = Result<T, Box<dyn Error>>;
 
@@ -116,6 +119,7 @@ fn main() -> R<()> {
         }
         "smoke" => smoke(&opts)?,
         "lint" => lint()?,
+        "isr-audit" => isr_audit::run(&workspace_root())?,
         "initrd" => {
             let path = ensure_initrd()?;
             println!("→ initrd: {}", path.display());
@@ -124,7 +128,7 @@ fn main() -> R<()> {
         other => {
             eprintln!("unknown subcommand: {other}");
             eprintln!(
-                "usage: cargo xtask [build|initrd|iso|run|test|smoke|lint|clean] [--release] [--fault-test] [--panic-test] [--bench]"
+                "usage: cargo xtask [build|initrd|iso|run|test|smoke|lint|isr-audit|clean] [--release] [--fault-test] [--panic-test] [--bench]"
             );
             std::process::exit(2);
         }
@@ -966,6 +970,9 @@ fn lint() -> R<()> {
             .args(["--all-targets", "--", "-D", "warnings"])
             .status()?,
     )?;
+
+    println!("→ isr-audit: scanning ISR-reachable files");
+    isr_audit::run(&workspace_root())?;
 
     Ok(())
 }


### PR DESCRIPTION
Closes #306

## Summary
- Adds `docs/isr-paging-audit.md` enumerating every source file reachable from an interrupt/exception handler (#PF plus timer/keyboard/serial IRQs plus the hang-only CPU exceptions), with call chains, a full lock inventory, and classifications (safe / safe-via-routing / dangerous).
- Adds `xtask/src/isr_audit.rs`, a line-oriented scanner that fails if `BlockingMutex::new`, `BlockingMutex<`, `BlockingRwLock::new`, or `BlockingRwLock<` appears on any ISR-reachable file. Curated allowlist of 15 files (traced from the four vector classes). Escape hatch: `// isr-audit: ok` on a reviewed line.
- Wires `cargo xtask isr-audit` as a standalone subcommand and invokes it from `lint()` so the existing CI lint gate picks up regressions.

## Findings
**No dangerous chains today.** Every ISR-reachable lock in the kernel is a `spin::Mutex` or `spin::RwLock`, which don't park. The VFS owns every current `BlockingMutex` site and is never reached from an ISR. The lint is purely a forward-looking regression guard.

One known-gap worth tracking, captured in the doc but intentionally not fixed in this PR: the `#PF` handler's ring-3 SIGSEGV path (#344) calls `task::exit`, which drops the `AddressSpace` and can call `unmap_in_pml4` -> `MAPPER.lock()`. Safe today because `MAPPER` is spin; will need to route the final drop through the reaper if/when `MAPPER` migrates to `BlockingMutex` (per #314).

## Out of scope (explicit deferrals)
- Fixing dangerous chains — none exist today, and the migrations that would create them (#313 `SCHED` -> IrqLock, #314 remaining spin::Mutex statics) are already tracked.
- syn-based parsing of the lint. The regex-string approach catches every real case; if it starts producing false positives the `// isr-audit: ok` hatch and the file allowlist are the two adjustment knobs.

## Test plan
- [x] `cargo test -p xtask` — 5 new unit tests pass (clean file, type flagged, constructor flagged, escape hatch, line numbers, allowlist-files-exist-on-disk). All 15 xtask tests green.
- [x] `cargo run -p xtask -- isr-audit` — scanner reports `OK (15 files scanned, no blocking-primitive acquisitions)`.
- [x] `cargo clippy -p xtask --all-targets -- -D warnings` — clean.
- [ ] `cargo xtask lint` — runs the full clippy+audit chain on CI (local host is aarch64; kernel clippy for `x86_64-unknown-none` only runs on CI).
- [ ] `cargo xtask build` / `test` / `smoke` — no kernel code changed, so these lanes should be unaffected; CI validates.