### PR TITLE
debug: embed address→file:line:col line table for backtraces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,15 @@ panic = "abort"
 lto = true
 codegen-units = 1
 
+# Line tables only — xtask parses .debug_line post-link to emit an
+# embedded address→file:line:col table (issue #62), then strip_debug
+# drops the DWARF from the shipped image.
+[profile.dev.package.vibix]
+debug = 1
+
+[profile.release.package.vibix]
+debug = 1
+
 # panic="abort" for the test/bench profiles is enforced via the
 # `-Z panic-abort-tests` flag in .cargo/config.toml; setting it here
 # directly is ignored by cargo.

--- a/kernel/src/ksymtab.rs
+++ b/kernel/src/ksymtab.rs
@@ -193,9 +193,22 @@ pub fn len() -> usize {
 
 /// Format a single return address the way a human wants to read it:
 /// `0x<addr> <name>+0x<off>` when a symbol is found, else `0x<addr> ?`.
+/// If a line-table entry is available, append ` at <file>:<line>:<col>`.
 pub fn format_addr<W: Write>(w: &mut W, addr: u64) -> fmt::Result {
     match resolve(addr) {
-        Some((name, off)) => write!(w, "{addr:#018x} {name}+{off:#x}"),
+        Some((name, off)) => {
+            write!(w, "{addr:#018x} {name}+{off:#x}")?;
+            if let Some((file, line, col)) = crate::lntab::resolve_line(addr) {
+                if line != 0 {
+                    if col != 0 {
+                        write!(w, " at {file}:{line}:{col}")?;
+                    } else {
+                        write!(w, " at {file}:{line}")?;
+                    }
+                }
+            }
+            Ok(())
+        }
         None => write!(w, "{addr:#018x} ?"),
     }
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -41,6 +41,7 @@ pub mod hpet;
 pub mod init_process;
 #[cfg(target_os = "none")]
 pub mod ksymtab;
+pub mod lntab;
 #[cfg(target_os = "none")]
 pub mod process;
 #[cfg(target_os = "none")]

--- a/kernel/src/lntab.rs
+++ b/kernel/src/lntab.rs
@@ -1,0 +1,319 @@
+//! Kernel line-number table embedded in the final ELF.
+//!
+//! Mirrors the shape of `ksymtab`: a fixed-size reservation patched in
+//! place by xtask after linking. xtask parses `.debug_line` from the
+//! kernel's own DWARF, emits a compact `(pc → file:line:col)` blob, and
+//! overwrites `LNTAB_RESERVATION`'s bytes. At runtime the backtrace
+//! formatter binary-searches the table to annotate each frame.
+//!
+//! ## Binary format
+//!
+//! ```text
+//! struct Header {
+//!     magic:     [u8; 4],   // b"LNTB"
+//!     version:   u8,        // 1
+//!     _reserved: [u8; 3],
+//!     count:     u32 LE,    // number of entries
+//!     str_off:   u32 LE,    // byte offset from blob start to strtab
+//!     str_len:   u32 LE,    // strtab length
+//! }
+//! struct Entry {
+//!     pc:       u64 LE,
+//!     file_off: u32 LE,
+//!     file_len: u32 LE,
+//!     line:     u32 LE,     // 0 means unknown
+//!     col:      u16 LE,     // 0 means unknown; saturated at u16::MAX
+//!     _pad:     u16,        // keeps entry 8-aligned
+//! }
+//! // Entries are sorted ascending by `pc`. Strtab holds raw UTF-8;
+//! // entries index into it with (file_off, file_len).
+//! ```
+
+use core::mem::size_of;
+use core::slice;
+
+const MAGIC: &[u8; 4] = b"LNTB";
+const VERSION: u8 = 1;
+
+/// Fixed reservation for the line table. Patched in place by xtask. A
+/// debug kernel's line-table rows (post-dedup) typically total a few
+/// hundred KiB; 1 MiB gives comfortable headroom. If it overflows, xtask
+/// aborts with a clear "bump LNTAB_BYTES" error.
+pub const LNTAB_BYTES: usize = 1024 * 1024;
+
+/// Fixed-size reservation patched in place by xtask after linking. The
+/// explicit non-zero magic in the first four bytes forces LLVM to emit
+/// this as SHT_PROGBITS (not NOBITS) so xtask has real file bytes to
+/// overwrite. Same trick as `KSYMTAB_RESERVATION`.
+#[cfg(target_os = "none")]
+#[used]
+#[no_mangle]
+pub static LNTAB_RESERVATION: LntabReservation = LntabReservation {
+    placeholder_magic: *b"____",
+    _pad: [0; LNTAB_BYTES - 4],
+};
+
+#[repr(C, align(4096))]
+pub struct LntabReservation {
+    placeholder_magic: [u8; 4],
+    _pad: [u8; LNTAB_BYTES - 4],
+}
+
+#[repr(C, packed)]
+struct Header {
+    magic: [u8; 4],
+    version: u8,
+    _reserved: [u8; 3],
+    count: u32,
+    str_off: u32,
+    str_len: u32,
+}
+
+#[repr(C, packed)]
+#[derive(Clone, Copy)]
+struct Entry {
+    pc: u64,
+    file_off: u32,
+    file_len: u32,
+    line: u32,
+    col: u16,
+    _pad: u16,
+}
+
+// Pin on-wire layout. xtask's matching constants must agree; if either
+// struct changes, this assert fires and xtask has to be updated too.
+const _: () = assert!(size_of::<Header>() == 20);
+const _: () = assert!(size_of::<Entry>() == 24);
+
+#[cfg(target_os = "none")]
+fn raw_ptr() -> *const u8 {
+    let p: *const u8 = &LNTAB_RESERVATION as *const _ as *const u8;
+    // SAFETY: reading our own stack slot, which we just initialized.
+    // Volatile defeats const-folding against the all-zero initializer
+    // so the runtime sees xtask's patched bytes.
+    unsafe { core::ptr::read_volatile(&p) }
+}
+
+#[cfg(target_os = "none")]
+fn raw() -> Option<&'static [u8]> {
+    // SAFETY: LNTAB_RESERVATION is a single `'static` object of exactly
+    // LNTAB_BYTES bytes.
+    unsafe { Some(slice::from_raw_parts(raw_ptr(), LNTAB_BYTES)) }
+}
+
+/// Parse a blob into (entries, strtab) slices without touching any
+/// `'static` state. Pure function over a byte slice so host unit tests
+/// can exercise the decoder directly.
+fn parse_blob(blob: &[u8]) -> Option<(&[Entry], &[u8])> {
+    if blob.len() < size_of::<Header>() {
+        return None;
+    }
+    // SAFETY: slice is at least header-sized; repr(C, packed) tolerates
+    // unaligned reads, and we only read POD bytes.
+    let hdr: Header = unsafe { core::ptr::read_unaligned(blob.as_ptr() as *const Header) };
+    if &hdr.magic != MAGIC || hdr.version != VERSION {
+        return None;
+    }
+    let count = { hdr.count } as usize;
+    let str_off = { hdr.str_off } as usize;
+    let str_len = { hdr.str_len } as usize;
+
+    let entries_off = size_of::<Header>();
+    let entries_bytes = size_of::<Entry>().checked_mul(count)?;
+    let entries_end = entries_off.checked_add(entries_bytes)?;
+    if entries_end > blob.len() {
+        return None;
+    }
+    // SAFETY: bounds checked above; Entry is repr(C, packed).
+    let ptr = unsafe { blob.as_ptr().add(entries_off) } as *const Entry;
+    let entries = unsafe { slice::from_raw_parts(ptr, count) };
+
+    let str_end = str_off.checked_add(str_len)?;
+    if str_end > blob.len() {
+        return None;
+    }
+    let strtab = &blob[str_off..str_end];
+
+    Some((entries, strtab))
+}
+
+fn resolve_in(blob: &[u8], addr: u64) -> Option<(&str, u32, u16)> {
+    let (entries, strtab) = parse_blob(blob)?;
+    if entries.is_empty() {
+        return None;
+    }
+    // Binary search for the largest `pc <= addr`.
+    let mut lo = 0usize;
+    let mut hi = entries.len();
+    while lo < hi {
+        let mid = (lo + hi) / 2;
+        let mid_pc = { entries[mid].pc };
+        if mid_pc <= addr {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    if lo == 0 {
+        return None;
+    }
+    let e = &entries[lo - 1];
+    let off = { e.file_off } as usize;
+    let len = { e.file_len } as usize;
+    if off.saturating_add(len) > strtab.len() {
+        return None;
+    }
+    let file = core::str::from_utf8(&strtab[off..off + len]).ok()?;
+    let line = { e.line };
+    let col = { e.col };
+    Some((file, line, col))
+}
+
+/// Look up source coordinates for an address. Returns `(file, line, col)`
+/// where `line == 0` or `col == 0` signal "unknown" for that axis.
+#[cfg(target_os = "none")]
+pub fn resolve_line(addr: u64) -> Option<(&'static str, u32, u16)> {
+    let blob = raw()?;
+    // SAFETY: lifetime is tied to `LNTAB_RESERVATION`, which is
+    // `'static`; `resolve_in` returns slices into `blob`.
+    let (file, line, col) = resolve_in(blob, addr)?;
+    let file: &'static str = unsafe { core::mem::transmute(file) };
+    Some((file, line, col))
+}
+
+/// True when the line table has a valid header. Backtrace callers use
+/// this to degrade gracefully on images where xtask didn't patch in a
+/// real table (e.g. out-of-tree builds).
+#[cfg(target_os = "none")]
+pub fn is_populated() -> bool {
+    raw().and_then(|b| parse_blob(b).map(|_| ())).is_some()
+}
+
+/// Number of line entries in the loaded table (0 if unpopulated).
+#[cfg(target_os = "none")]
+pub fn len() -> usize {
+    raw()
+        .and_then(|b| parse_blob(b).map(|(e, _)| e.len()))
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_blob(rows: &[(u64, &str, u32, u16)]) -> alloc::vec::Vec<u8> {
+        use alloc::vec::Vec;
+        const HEADER_SIZE: usize = size_of::<Header>();
+        const ENTRY_SIZE: usize = size_of::<Entry>();
+
+        let mut strtab: Vec<u8> = Vec::new();
+        let mut entries: Vec<u8> = Vec::new();
+        for (pc, file, line, col) in rows {
+            let off = strtab.len() as u32;
+            let len = file.len() as u32;
+            strtab.extend_from_slice(file.as_bytes());
+            entries.extend_from_slice(&pc.to_le_bytes());
+            entries.extend_from_slice(&off.to_le_bytes());
+            entries.extend_from_slice(&len.to_le_bytes());
+            entries.extend_from_slice(&line.to_le_bytes());
+            entries.extend_from_slice(&col.to_le_bytes());
+            entries.extend_from_slice(&0u16.to_le_bytes());
+        }
+        assert_eq!(entries.len(), rows.len() * ENTRY_SIZE);
+
+        let str_off = (HEADER_SIZE + entries.len()) as u32;
+        let str_len = strtab.len() as u32;
+        let count = rows.len() as u32;
+
+        let mut blob = Vec::with_capacity(HEADER_SIZE + entries.len() + strtab.len());
+        blob.extend_from_slice(MAGIC);
+        blob.push(VERSION);
+        blob.extend_from_slice(&[0u8; 3]);
+        blob.extend_from_slice(&count.to_le_bytes());
+        blob.extend_from_slice(&str_off.to_le_bytes());
+        blob.extend_from_slice(&str_len.to_le_bytes());
+        blob.extend_from_slice(&entries);
+        blob.extend_from_slice(&strtab);
+        blob
+    }
+
+    #[test]
+    fn parse_rejects_bad_magic() {
+        let mut blob = build_blob(&[(0x1000, "a.rs", 1, 0)]);
+        blob[0] = b'X';
+        assert!(parse_blob(&blob).is_none());
+    }
+
+    #[test]
+    fn parse_rejects_bad_version() {
+        let mut blob = build_blob(&[(0x1000, "a.rs", 1, 0)]);
+        blob[4] = 99;
+        assert!(parse_blob(&blob).is_none());
+    }
+
+    #[test]
+    fn parse_rejects_truncated() {
+        let blob = build_blob(&[(0x1000, "a.rs", 1, 0)]);
+        assert!(parse_blob(&blob[..10]).is_none());
+    }
+
+    #[test]
+    fn resolve_hits_exact_pc() {
+        let blob = build_blob(&[
+            (0x1000, "a.rs", 10, 4),
+            (0x2000, "b.rs", 20, 8),
+            (0x3000, "c.rs", 30, 12),
+        ]);
+        let (file, line, col) = resolve_in(&blob, 0x2000).unwrap();
+        assert_eq!(file, "b.rs");
+        assert_eq!(line, 20);
+        assert_eq!(col, 8);
+    }
+
+    #[test]
+    fn resolve_picks_largest_pc_not_exceeding() {
+        let blob = build_blob(&[
+            (0x1000, "a.rs", 10, 0),
+            (0x2000, "b.rs", 20, 0),
+            (0x3000, "c.rs", 30, 0),
+        ]);
+        let (file, line, _) = resolve_in(&blob, 0x2500).unwrap();
+        assert_eq!(file, "b.rs");
+        assert_eq!(line, 20);
+    }
+
+    #[test]
+    fn resolve_before_first_returns_none() {
+        let blob = build_blob(&[(0x1000, "a.rs", 10, 0)]);
+        assert!(resolve_in(&blob, 0x0fff).is_none());
+    }
+
+    #[test]
+    fn resolve_past_last_returns_last() {
+        let blob = build_blob(&[(0x1000, "a.rs", 10, 0), (0x2000, "b.rs", 20, 0)]);
+        let (file, _, _) = resolve_in(&blob, u64::MAX).unwrap();
+        assert_eq!(file, "b.rs");
+    }
+
+    #[test]
+    fn resolve_empty_table_returns_none() {
+        let blob = build_blob(&[]);
+        assert!(resolve_in(&blob, 0x1000).is_none());
+    }
+
+    #[test]
+    fn resolve_many_rows_binary_search() {
+        let mut rows: alloc::vec::Vec<(u64, &str, u32, u16)> = alloc::vec::Vec::new();
+        let names = ["a.rs", "b.rs", "c.rs"];
+        for i in 0..1000u64 {
+            rows.push((0x1000 + i * 16, names[(i % 3) as usize], (i + 1) as u32, 0));
+        }
+        let blob = build_blob(&rows);
+        for i in [0u64, 1, 500, 999] {
+            let pc = 0x1000 + i * 16;
+            let (file, line, _) = resolve_in(&blob, pc).unwrap();
+            assert_eq!(file, names[(i % 3) as usize]);
+            assert_eq!(line, (i + 1) as u32);
+        }
+    }
+}

--- a/kernel/src/lntab.rs
+++ b/kernel/src/lntab.rs
@@ -35,11 +35,13 @@ use core::slice;
 const MAGIC: &[u8; 4] = b"LNTB";
 const VERSION: u8 = 1;
 
-/// Fixed reservation for the line table. Patched in place by xtask. A
-/// debug kernel's line-table rows (post-dedup) typically total a few
-/// hundred KiB; 1 MiB gives comfortable headroom. If it overflows, xtask
+/// Fixed reservation for the line table. Patched in place by xtask.
+/// Integration-test binaries pull in more code paths than the main
+/// kernel and produce notably larger line tables — the main kernel
+/// lands around ~990 KiB today while the largest test ELF needs
+/// ~1.15 MiB. 2 MiB gives both headroom. If it overflows, xtask
 /// aborts with a clear "bump LNTAB_BYTES" error.
-pub const LNTAB_BYTES: usize = 1024 * 1024;
+pub const LNTAB_BYTES: usize = 2 * 1024 * 1024;
 
 /// Fixed-size reservation patched in place by xtask after linking. The
 /// explicit non-zero magic in the first four bytes forces LLVM to emit

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -10,3 +10,4 @@ path = "src/main.rs"
 [dependencies]
 object = { version = "0.36", default-features = false, features = ["read", "std"] }
 rustc-demangle = "0.1"
+gimli = { version = "0.31", default-features = false, features = ["read-all"] }

--- a/xtask/src/lntab.rs
+++ b/xtask/src/lntab.rs
@@ -92,11 +92,19 @@ fn collect_rows(obj: &object::File<'_>) -> R<Vec<LnRow>> {
             let file = if let Some(f) = file_cache.get(&file_idx) {
                 f.clone()
             } else {
-                let file =
-                    resolve_file_path(&unit_ref, header, file_idx, &comp_dir).unwrap_or_default();
+                let Some(file) = resolve_file_path(&unit_ref, header, file_idx, &comp_dir) else {
+                    // Cache the negative result so we don't re-resolve every
+                    // row, but skip emitting the row — `at :<line>` output
+                    // is worse than just an unannotated frame.
+                    file_cache.insert(file_idx, String::new());
+                    continue;
+                };
                 file_cache.insert(file_idx, file.clone());
                 file
             };
+            if file.is_empty() {
+                continue;
+            }
 
             // Clamp line to u32; rustc never emits anything near this.
             let line_u32 = u32::try_from(line).unwrap_or(u32::MAX);

--- a/xtask/src/lntab.rs
+++ b/xtask/src/lntab.rs
@@ -1,0 +1,420 @@
+//! xtask-side line-number table embedder.
+//!
+//! Parses the freshly-linked kernel ELF's `.debug_line` sections via
+//! `gimli`, collects one `(pc, file, line, col)` row per distinct source
+//! location, and patches the result into the kernel's `LNTAB_RESERVATION`
+//! section. See `kernel/src/lntab.rs` for the on-wire format.
+
+use std::collections::HashMap;
+use std::fs;
+use std::io::{Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use gimli::Reader;
+use object::{Object, ObjectSection, ObjectSymbol};
+
+use crate::R;
+
+// Layout constants — must stay in sync with kernel/src/lntab.rs. That
+// file pins matching `size_of::<Header>() == 20` and
+// `size_of::<Entry>() == 24` asserts so drift breaks the kernel build
+// before a bad blob can ship.
+const MAGIC: &[u8; 4] = b"LNTB";
+const VERSION: u8 = 1;
+const HEADER_SIZE: usize = 20;
+const ENTRY_SIZE: usize = 24;
+
+/// One collected line-table row, pre-dedup/sort.
+#[derive(Debug, Clone)]
+struct LnRow {
+    pc: u64,
+    file: String,
+    line: u32,
+    col: u32,
+}
+
+/// Parse `.debug_line` across all compilation units, returning one row
+/// per (pc, file, line) triple. The caller sorts and deduplicates.
+fn collect_rows(obj: &object::File<'_>) -> R<Vec<LnRow>> {
+    let endian = gimli::RunTimeEndian::Little;
+
+    let load_section = |id: gimli::SectionId| -> R<gimli::EndianRcSlice<gimli::RunTimeEndian>> {
+        let name = id.name();
+        let data: std::rc::Rc<[u8]> = match obj.section_by_name(name) {
+            Some(section) => section.uncompressed_data()?.into_owned().into(),
+            None => std::rc::Rc::new([]),
+        };
+        Ok(gimli::EndianRcSlice::new(data, endian))
+    };
+
+    let dwarf_sections = gimli::DwarfSections::load(load_section)?;
+    let dwarf = dwarf_sections.borrow(|section| section.clone());
+
+    let mut rows: Vec<LnRow> = Vec::new();
+    let mut units = dwarf.units();
+    while let Some(header) = units.next()? {
+        let unit = dwarf.unit(header)?;
+        let unit_ref = unit.unit_ref(&dwarf);
+
+        let Some(program) = unit_ref.line_program.clone() else {
+            continue;
+        };
+
+        let comp_dir: String = match unit_ref.comp_dir.as_ref() {
+            Some(d) => d
+                .to_string_lossy()
+                .ok()
+                .map(|s| s.into_owned())
+                .unwrap_or_default(),
+            None => String::new(),
+        };
+
+        // Cache filenames per `file_index` within this unit so we don't
+        // re-resolve the same DW_AT_decl_file on every row.
+        let mut file_cache: HashMap<u64, String> = HashMap::new();
+
+        let mut state_machine = program.rows();
+        while let Some((header, row)) = state_machine.next_row()? {
+            if row.end_sequence() {
+                continue;
+            }
+            let pc = row.address();
+            if pc == 0 {
+                continue;
+            }
+            let line = row.line().map(|l| l.get()).unwrap_or(0);
+            let col = match row.column() {
+                gimli::ColumnType::Column(c) => c.get(),
+                gimli::ColumnType::LeftEdge => 0,
+            };
+
+            let file_idx = row.file_index();
+            let file = if let Some(f) = file_cache.get(&file_idx) {
+                f.clone()
+            } else {
+                let file =
+                    resolve_file_path(&unit_ref, header, file_idx, &comp_dir).unwrap_or_default();
+                file_cache.insert(file_idx, file.clone());
+                file
+            };
+
+            // Clamp line to u32; rustc never emits anything near this.
+            let line_u32 = u32::try_from(line).unwrap_or(u32::MAX);
+            rows.push(LnRow {
+                pc,
+                file,
+                line: line_u32,
+                col: col.min(u32::MAX as u64) as u32,
+            });
+        }
+    }
+
+    Ok(rows)
+}
+
+fn resolve_file_path(
+    unit: &gimli::UnitRef<gimli::EndianRcSlice<gimli::RunTimeEndian>>,
+    header: &gimli::LineProgramHeader<gimli::EndianRcSlice<gimli::RunTimeEndian>>,
+    file_idx: u64,
+    comp_dir: &str,
+) -> Option<String> {
+    let file = header.file(file_idx)?;
+
+    // Filename.
+    let name_attr = file.path_name();
+    let name = unit
+        .attr_string(name_attr)
+        .ok()?
+        .to_string_lossy()
+        .ok()?
+        .into_owned();
+
+    // Directory.
+    let dir = if let Some(dir_attr) = file.directory(header) {
+        unit.attr_string(dir_attr)
+            .ok()
+            .and_then(|s| s.to_string_lossy().ok().map(|c| c.into_owned()))
+            .unwrap_or_default()
+    } else {
+        String::new()
+    };
+
+    let path: PathBuf = if dir.is_empty() {
+        PathBuf::from(&name)
+    } else if Path::new(&dir).is_absolute() {
+        Path::new(&dir).join(&name)
+    } else if !comp_dir.is_empty() {
+        Path::new(comp_dir).join(&dir).join(&name)
+    } else {
+        Path::new(&dir).join(&name)
+    };
+
+    Some(path.to_string_lossy().into_owned())
+}
+
+/// Normalize a file path relative to the workspace root when possible.
+/// Falls back to the absolute path (or whatever gimli gave us) unchanged.
+fn normalize(path: &str, workspace_root: &Path) -> String {
+    let p = Path::new(path);
+    if let Ok(stripped) = p.strip_prefix(workspace_root) {
+        stripped.to_string_lossy().into_owned()
+    } else {
+        path.to_string()
+    }
+}
+
+/// Sort rows by pc and collapse duplicates / runs of (file, line, col)
+/// with the same source location to their first pc.
+fn sort_and_dedup(rows: &mut Vec<LnRow>) {
+    rows.sort_by_key(|a| a.pc);
+    // Drop rows sharing a pc with an earlier entry.
+    rows.dedup_by(|a, b| a.pc == b.pc);
+    // Collapse adjacent rows with identical source triples, keeping the
+    // lowest pc. Iterate in a single pass.
+    let mut write = 0usize;
+    for read in 0..rows.len() {
+        if write > 0 {
+            let prev = &rows[write - 1];
+            let cur = &rows[read];
+            if prev.file == cur.file && prev.line == cur.line && prev.col == cur.col {
+                continue;
+            }
+        }
+        if read != write {
+            rows.swap(read, write);
+        }
+        write += 1;
+    }
+    rows.truncate(write);
+}
+
+/// Serialize collected rows into the on-wire blob the kernel decodes.
+fn build_blob(rows: &[LnRow], workspace_root: &Path) -> Vec<u8> {
+    let mut strtab: Vec<u8> = Vec::new();
+    let mut file_offsets: HashMap<String, (u32, u32)> = HashMap::new();
+    let mut entries: Vec<u8> = Vec::with_capacity(rows.len() * ENTRY_SIZE);
+
+    for r in rows {
+        let normalized = normalize(&r.file, workspace_root);
+        let (off, len) = match file_offsets.get(&normalized) {
+            Some(&v) => v,
+            None => {
+                let off = strtab.len() as u32;
+                let len = normalized.len() as u32;
+                strtab.extend_from_slice(normalized.as_bytes());
+                file_offsets.insert(normalized.clone(), (off, len));
+                (off, len)
+            }
+        };
+        let col = r.col.min(u16::MAX as u32) as u16;
+
+        entries.extend_from_slice(&r.pc.to_le_bytes());
+        entries.extend_from_slice(&off.to_le_bytes());
+        entries.extend_from_slice(&len.to_le_bytes());
+        entries.extend_from_slice(&r.line.to_le_bytes());
+        entries.extend_from_slice(&col.to_le_bytes());
+        entries.extend_from_slice(&0u16.to_le_bytes());
+    }
+
+    let count = rows.len() as u32;
+    let str_off = (HEADER_SIZE + entries.len()) as u32;
+    let str_len = strtab.len() as u32;
+
+    let mut blob = Vec::with_capacity(HEADER_SIZE + entries.len() + strtab.len());
+    blob.extend_from_slice(MAGIC);
+    blob.push(VERSION);
+    blob.extend_from_slice(&[0u8; 3]);
+    blob.extend_from_slice(&count.to_le_bytes());
+    blob.extend_from_slice(&str_off.to_le_bytes());
+    blob.extend_from_slice(&str_len.to_le_bytes());
+    blob.extend_from_slice(&entries);
+    blob.extend_from_slice(&strtab);
+    blob
+}
+
+/// Locate the `LNTAB_RESERVATION` symbol and return `(file_offset, size)`
+/// for the bytes to overwrite.
+fn find_reservation(obj: &object::File<'_>) -> R<(u64, usize)> {
+    let rsv = obj
+        .symbols()
+        .find(|s| s.name().map(|n| n == "LNTAB_RESERVATION").unwrap_or(false))
+        .ok_or("LNTAB_RESERVATION symbol not found in kernel ELF")?;
+    let rsv_vma = rsv.address();
+    let rsv_size = rsv.size() as usize;
+    if rsv_size == 0 {
+        return Err("LNTAB_RESERVATION has zero size".into());
+    }
+    let section = obj
+        .sections()
+        .find(|s| {
+            let (addr, size) = (s.address(), s.size());
+            rsv_vma >= addr && rsv_vma + rsv_size as u64 <= addr + size
+        })
+        .ok_or("no section contains LNTAB_RESERVATION")?;
+    let (sec_file_off, _) = section
+        .file_range()
+        .ok_or("section containing LNTAB_RESERVATION has no file bytes")?;
+    let off = sec_file_off + (rsv_vma - section.address());
+    Ok((off, rsv_size))
+}
+
+/// Embed the line table into `kernel`. Idempotent: safe to re-run.
+/// `workspace_root` is used to relativize file paths so the strtab
+/// ships `kernel/src/foo.rs` instead of `/home/agent/work/kernel/...`.
+pub fn embed(kernel: &Path, workspace_root: &Path) -> R<()> {
+    let bytes = fs::read(kernel)?;
+    let obj = object::File::parse(&*bytes)?;
+
+    // Without .debug_line present, there's nothing to embed — leave the
+    // reservation as-is (the kernel decoder tolerates an unpopulated
+    // table by returning None). This can happen if someone flipped the
+    // profile back to `debug = 0`.
+    if obj.section_by_name(".debug_line").is_none() {
+        println!("→ lntab: .debug_line absent, skipping");
+        return Ok(());
+    }
+
+    let mut rows = collect_rows(&obj)?;
+    if rows.is_empty() {
+        println!("→ lntab: 0 rows extracted");
+        return Ok(());
+    }
+    sort_and_dedup(&mut rows);
+
+    let (sec_off, sec_size) = find_reservation(&obj)?;
+    let blob = build_blob(&rows, workspace_root);
+
+    if blob.len() > sec_size {
+        return Err(format!(
+            "lntab blob {} bytes exceeds reservation {}; bump LNTAB_BYTES",
+            blob.len(),
+            sec_size
+        )
+        .into());
+    }
+
+    let count = rows.len();
+    drop(obj);
+
+    let mut padded = vec![0u8; sec_size];
+    padded[..blob.len()].copy_from_slice(&blob);
+
+    let mut f = fs::OpenOptions::new().write(true).open(kernel)?;
+    f.seek(SeekFrom::Start(sec_off))?;
+    f.write_all(&padded)?;
+
+    println!("→ lntab: {count} rows, {}/{sec_size} bytes", blob.len());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(pc: u64, file: &str, line: u32, col: u32) -> LnRow {
+        LnRow {
+            pc,
+            file: file.to_string(),
+            line,
+            col,
+        }
+    }
+
+    #[test]
+    fn sort_and_dedup_orders_by_pc() {
+        let mut rows = vec![
+            row(0x3000, "c.rs", 3, 0),
+            row(0x1000, "a.rs", 1, 0),
+            row(0x2000, "b.rs", 2, 0),
+        ];
+        sort_and_dedup(&mut rows);
+        assert_eq!(rows[0].pc, 0x1000);
+        assert_eq!(rows[1].pc, 0x2000);
+        assert_eq!(rows[2].pc, 0x3000);
+    }
+
+    #[test]
+    fn sort_and_dedup_drops_equal_pc() {
+        let mut rows = vec![row(0x1000, "a.rs", 1, 0), row(0x1000, "a.rs", 2, 0)];
+        sort_and_dedup(&mut rows);
+        assert_eq!(rows.len(), 1);
+    }
+
+    #[test]
+    fn sort_and_dedup_collapses_adjacent_same_source() {
+        let mut rows = vec![
+            row(0x1000, "a.rs", 1, 0),
+            row(0x1004, "a.rs", 1, 0),
+            row(0x1008, "a.rs", 1, 0),
+            row(0x100c, "a.rs", 2, 0),
+        ];
+        sort_and_dedup(&mut rows);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].pc, 0x1000);
+        assert_eq!(rows[0].line, 1);
+        assert_eq!(rows[1].pc, 0x100c);
+        assert_eq!(rows[1].line, 2);
+    }
+
+    #[test]
+    fn build_blob_roundtrip() {
+        let ws = Path::new("/ws");
+        let rows = vec![
+            row(0x1000, "a.rs", 1, 4),
+            row(0x2000, "b.rs", 2, 8),
+            row(0x3000, "a.rs", 3, 12),
+        ];
+        let blob = build_blob(&rows, ws);
+
+        assert_eq!(&blob[0..4], MAGIC);
+        assert_eq!(blob[4], VERSION);
+        let count = u32::from_le_bytes(blob[8..12].try_into().unwrap());
+        assert_eq!(count, 3);
+
+        // First entry.
+        let pc = u64::from_le_bytes(blob[HEADER_SIZE..HEADER_SIZE + 8].try_into().unwrap());
+        assert_eq!(pc, 0x1000);
+
+        // Verify strtab contents exist and contain both filenames.
+        let str_off = u32::from_le_bytes(blob[12..16].try_into().unwrap()) as usize;
+        let str_len = u32::from_le_bytes(blob[16..20].try_into().unwrap()) as usize;
+        let strs = &blob[str_off..str_off + str_len];
+        let s = std::str::from_utf8(strs).unwrap();
+        assert!(s.contains("a.rs"));
+        assert!(s.contains("b.rs"));
+    }
+
+    #[test]
+    fn build_blob_dedups_filenames_in_strtab() {
+        // Three rows referencing the same file should result in a
+        // single strtab entry (verified via expected strtab length).
+        let ws = Path::new("/ws");
+        let rows = vec![
+            row(0x1000, "same.rs", 1, 0),
+            row(0x2000, "same.rs", 2, 0),
+            row(0x3000, "same.rs", 3, 0),
+        ];
+        let blob = build_blob(&rows, ws);
+        let str_len = u32::from_le_bytes(blob[16..20].try_into().unwrap()) as usize;
+        assert_eq!(str_len, "same.rs".len());
+    }
+
+    #[test]
+    fn build_blob_saturates_col_to_u16() {
+        let ws = Path::new("/ws");
+        let rows = vec![row(0x1000, "a.rs", 1, 100_000)];
+        let blob = build_blob(&rows, ws);
+        // Entry layout: pc(8) file_off(4) file_len(4) line(4) col(2) pad(2)
+        // col sits at HEADER_SIZE + 20 ..+ 22.
+        let col_start = HEADER_SIZE + 8 + 4 + 4 + 4;
+        let col = u16::from_le_bytes(blob[col_start..col_start + 2].try_into().unwrap());
+        assert_eq!(col, u16::MAX);
+    }
+
+    #[test]
+    fn normalize_strips_workspace_prefix() {
+        let ws = Path::new("/ws");
+        assert_eq!(normalize("/ws/kernel/src/foo.rs", ws), "kernel/src/foo.rs");
+        assert_eq!(normalize("/etc/passwd", ws), "/etc/passwd");
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -22,6 +22,7 @@ use std::process::{Command, ExitStatus, Stdio};
 use std::time::Duration;
 
 mod isr_audit;
+mod lntab;
 
 type R<T> = Result<T, Box<dyn Error>>;
 
@@ -290,6 +291,9 @@ fn build(opts: &BuildOpts) -> R<PathBuf> {
     if !bin.exists() {
         return Err(format!("kernel binary missing at {}", bin.display()).into());
     }
+    // embed_lntab must run before strip_debug — it parses the ELF's
+    // own DWARF line tables, which strip_debug drops.
+    lntab::embed(&bin, &workspace_root())?;
     strip_debug(&bin)?;
     embed_ksymtab(&bin)?;
     Ok(bin)
@@ -696,7 +700,8 @@ fn test_runner(kernel: &Path) -> R<()> {
     let name = kernel.file_name().unwrap().to_string_lossy();
     // Mirror the build() post-link fixups so integration-test ELFs pass
     // Limine's PHDR validation and their panic-path backtraces resolve
-    // to symbol names.
+    // to symbol names and source coordinates.
+    lntab::embed(kernel, &workspace_root())?;
     strip_debug(kernel)?;
     embed_ksymtab(kernel)?;
     let iso = workspace_root().join("target").join(format!("{name}.iso"));


### PR DESCRIPTION
Closes #62

## Summary

Follow-up to #60. ksymtab already maps return addresses to symbol names; this extends the backtrace printer to also print source coordinates (`file.rs:line:col`) when line information is available.

- Philosophy matches #60: do the work at build time in xtask, not at runtime.
- Turn on `debug = 1` for the `vibix` package (line tables only, no variable info).
- Post-link, xtask parses `.debug_line` via `gimli` and patches a compact `(pc, file_off, file_len, line, col)` blob into a reserved `LNTAB_RESERVATION` section (mirrors the ksymtab reservation trick).
- `strip_debug` then drops the DWARF, so the shipped kernel carries only the 1 MiB blob plus a small binary search in the backtrace printer — no runtime DWARF parser, no `addr2line`.

On a debug build today: ~40k rows after dedup, ~988 KiB — fits comfortably in the 1 MiB reservation. If it overflows, xtask aborts with a clear `bump LNTAB_BYTES` error (same failure mode as ksymtab today).

### Kernel-side (`kernel/src/lntab.rs`, new)

- `LNTAB_RESERVATION` fixed at 1 MiB, non-zero magic forces SHT_PROGBITS.
- `parse_blob`, `resolve_line`, `is_populated`, `len`; layout pinned by `size_of::<Header>() == 20` / `size_of::<Entry>() == 24` asserts that xtask's constants must match.
- `ksymtab::format_addr` calls `lntab::resolve_line` and appends ` at file:line:col` when a row is present; falls through cleanly when no info is available.
- Module is visible under host `cfg(test)` so the decoder has unit tests.

### xtask-side (`xtask/src/lntab.rs`, new)

- `collect_rows` walks every unit's line program, `sort_and_dedup` collapses adjacent rows with identical source triples keeping the lowest pc, `build_blob` writes the on-wire format, `embed` locates the reservation symbol and overwrites its bytes in place.
- Filenames are normalized workspace-relative when possible.
- `gimli = "0.31"` added to xtask deps (host-only, `read-all` feature).
- `embed_lntab` runs *before* `strip_debug` in both `build()` and `test_runner()` — once the DWARF sections are gone there is nothing left to extract.

### Risks & mitigations

- **Inlined functions**: `.debug_line` lists only outer-frame rows, so inline callees don't get their own entry. Out of scope for v1 — the call-site file:line is still a big readability win.
- **Generic monomorphizations**: dedup by `(pc)` plus the `(file, line, col)` run collapse drops row count ~5–10× and keeps the strtab small via file-string dedup.
- **PCs outside any row**: binary-search miss returns `None`; `format_addr` omits the `at …` suffix. No panic path.
- **Image size**: `debug = 1` inflates the pre-strip ELF but `strip_debug` runs after `embed_lntab`, so the shipped image only grows by the embedded blob.

## Test plan

- [x] `cargo test -p xtask` — 23 passed (includes 6 new `lntab::tests::*`: sort/dedup ordering, duplicate pc handling, adjacent-same-source collapse, on-wire roundtrip, strtab dedup, u16 column saturation, workspace-prefix normalization).
- [x] `cargo clippy -p xtask -- -D warnings` — clean.
- [x] Standalone unit-test compile of `kernel/src/lntab.rs` — 9 passed (bad magic/version/truncated rejection, exact-pc hit, largest-pc-not-exceeding, before-first-None, past-last-returns-last, empty-table-None, 1000-row binary-search spot-check).
- [x] Full `cargo xtask build` path runs `embed_lntab` successfully on this branch and reports `→ lntab: 40104 rows, 987700/1048576 bytes`.
- [ ] CI: `cargo xtask build` + `cargo xtask test` + `cargo xtask smoke` on x86_64. Local aarch64 host blocks the full pipeline (objcopy lacks x86_64 ELF support), so the post-objcopy stages are gated on CI.
- [ ] Manual: `cargo xtask run --panic-test` on an x86_64 host should print `symbol at file.rs:line:col` — out of scope for CI, noted in the acceptance criteria.