### PR TITLE
fix: resolve mmap_shared_anon_succeeds SMAP hang; remove from TEST_SKIPLIST

### DIFF
--- a/kernel/tests/syscall_mmap_family.rs
+++ b/kernel/tests/syscall_mmap_family.rs
@@ -112,6 +112,27 @@ fn run_tests() {
 
 // ── Helpers ─────────────────────────────────────────────────────────────
 
+/// Write a single byte to a user VA with interrupts disabled.
+///
+/// `copy_to_user` / `copy_from_user` bracket their work with STAC/CLAC
+/// (RFLAGS.AC). The AC bit is per-CPU: a context switch during the
+/// STAC/CLAC window would clobber it on the new CPU, defeating SMAP.
+/// Disabling interrupts for the duration keeps us on the same CPU.
+fn write_user_byte(uva: usize, byte: u8) {
+    x86_64::instructions::interrupts::without_interrupts(|| unsafe {
+        uaccess::copy_to_user(uva, &[byte]).expect("copy_to_user failed");
+    });
+}
+
+/// Read a single byte from a user VA with interrupts disabled.
+fn read_user_byte(uva: usize) -> u8 {
+    x86_64::instructions::interrupts::without_interrupts(|| unsafe {
+        let mut buf = [0u8; 1];
+        uaccess::copy_from_user(&mut buf, uva).expect("copy_from_user failed");
+        buf[0]
+    })
+}
+
 fn mmap(addr: u64, len: u64, prot: u32, flags: u32, fd: i64, off: u64) -> i64 {
     unsafe { syscall_dispatch(9, addr, len, prot as u64, flags as u64, fd as u64, off) }
 }
@@ -195,14 +216,10 @@ fn mmap_shared_anon_succeeds() {
     );
     assert!(r > 0, "anon-shared mmap failed: {}", r);
     // Touch the page; should demand-fault without panicking.
-    // copy_to/from_user bracket the access with STAC/CLAC so SMAP is
-    // satisfied when ring-0 test code writes to a USER_ACCESSIBLE page.
-    unsafe {
-        uaccess::copy_to_user(r as usize, &[0x7Fu8]).expect("copy_to_user failed");
-        let mut buf = [0u8; 1];
-        uaccess::copy_from_user(&mut buf, r as usize).expect("copy_from_user failed");
-        assert_eq!(buf[0], 0x7F);
-    }
+    // Helpers bracket with STAC/CLAC (SMAP) and disable interrupts so a
+    // context switch cannot clobber the per-CPU AC bit mid-copy.
+    write_user_byte(r as usize, 0x7F);
+    assert_eq!(read_user_byte(r as usize), 0x7F);
     let _ = munmap(r as u64, 4096);
 }
 
@@ -210,9 +227,7 @@ fn mmap_fixed_noreplace_overlap_eexist() {
     let a = anon_rw(4096);
     // Write a marker into the original page so we can prove it survives the
     // failed MAP_FIXED_NOREPLACE call.
-    unsafe {
-        uaccess::copy_to_user(a as usize, &[0xA5u8]).expect("copy_to_user failed");
-    }
+    write_user_byte(a as usize, 0xA5);
     // Re-requesting the same VA with MAP_FIXED_NOREPLACE must fail EEXIST.
     let r = mmap(
         a,
@@ -232,11 +247,7 @@ fn mmap_fixed_noreplace_overlap_eexist() {
         assert_eq!(vma.start, a as usize);
         assert_eq!(vma.end, (a as usize) + 4096);
     }
-    unsafe {
-        let mut buf = [0u8; 1];
-        uaccess::copy_from_user(&mut buf, a as usize).expect("copy_from_user failed");
-        assert_eq!(buf[0], 0xA5);
-    }
+    assert_eq!(read_user_byte(a as usize), 0xA5);
     // Bare MAP_FIXED at the same VA should succeed (silently evicts) and
     // return the requested address.
     let r = mmap(
@@ -281,12 +292,8 @@ fn mmap_fixed_noreplace_fresh_addr_succeeds() {
         r
     );
     // The mapping must be usable: demand-fault + read-back.
-    unsafe {
-        uaccess::copy_to_user(target as usize, &[0x5Au8]).expect("copy_to_user failed");
-        let mut buf = [0u8; 1];
-        uaccess::copy_from_user(&mut buf, target as usize).expect("copy_from_user failed");
-        assert_eq!(buf[0], 0x5A);
-    }
+    write_user_byte(target as usize, 0x5A);
+    assert_eq!(read_user_byte(target as usize), 0x5A);
     let _ = munmap(target, 4096);
     let _ = munmap(anchor, 4096);
 }
@@ -327,9 +334,7 @@ fn munmap_splits_middle_of_vma() {
 fn mprotect_partial_vma_succeeds() {
     // 4 pages RW — mprotect middle 2 to RO; both fragments must still exist.
     let a = anon_rw(4 * 4096);
-    unsafe {
-        uaccess::copy_to_user(a as usize, &[0xAAu8]).expect("copy_to_user failed");
-    }
+    write_user_byte(a as usize, 0xAA);
     let r = mprotect(a + 4096, 2 * 4096, PROT_READ);
     assert_eq!(r, 0, "mprotect partial VMA failed: {}", r);
 
@@ -385,20 +390,12 @@ fn mprotect_unknown_prot_bits_einval() {
 fn madvise_dontneed_rezeroes_page() {
     // Write a byte, MADV_DONTNEED the page, touch it again, verify zero.
     let a = anon_rw(4096);
-    unsafe {
-        uaccess::copy_to_user(a as usize, &[0x42u8]).expect("copy_to_user failed");
-        let mut buf = [0u8; 1];
-        uaccess::copy_from_user(&mut buf, a as usize).expect("copy_from_user failed");
-        assert_eq!(buf[0], 0x42);
-    }
+    write_user_byte(a as usize, 0x42);
+    assert_eq!(read_user_byte(a as usize), 0x42);
     let r = madvise(a, 4096, MADV_DONTNEED);
     assert_eq!(r, 0);
-    unsafe {
-        // The next read must see 0 — a fresh zero-filled frame.
-        let mut buf = [0u8; 1];
-        uaccess::copy_from_user(&mut buf, a as usize).expect("copy_from_user failed");
-        assert_eq!(buf[0], 0);
-    }
+    // The next read must see 0 — a fresh zero-filled frame.
+    assert_eq!(read_user_byte(a as usize), 0);
     let _ = munmap(a, 4096);
 }
 
@@ -418,32 +415,26 @@ fn malloc_workload_alloc_free_regrow() {
     const LEN: usize = PAGES * 4096;
 
     let a = anon_rw(LEN as u64);
-    unsafe {
-        for p in 0..PAGES {
-            let pattern = (p as u8).wrapping_mul(0x37).wrapping_add(0x11);
-            uaccess::copy_to_user((a as usize) + p * 4096, &[pattern])
-                .expect("copy_to_user failed");
-        }
-        for p in 0..PAGES {
-            let pattern = (p as u8).wrapping_mul(0x37).wrapping_add(0x11);
-            let mut buf = [0u8; 1];
-            uaccess::copy_from_user(&mut buf, (a as usize) + p * 4096)
-                .expect("copy_from_user failed");
-            assert_eq!(buf[0], pattern);
-        }
+    for p in 0..PAGES {
+        let pattern = (p as u8).wrapping_mul(0x37).wrapping_add(0x11);
+        write_user_byte((a as usize) + p * 4096, pattern);
+    }
+    for p in 0..PAGES {
+        let pattern = (p as u8).wrapping_mul(0x37).wrapping_add(0x11);
+        assert_eq!(read_user_byte((a as usize) + p * 4096), pattern);
     }
 
     assert_eq!(munmap(a, LEN as u64), 0);
 
     let b = anon_rw((LEN * 2) as u64);
-    unsafe {
-        // Entire arena must be zero-initialised on first touch.
-        for p in 0..(PAGES * 2) {
-            let mut buf = [0u8; 1];
-            uaccess::copy_from_user(&mut buf, (b as usize) + p * 4096)
-                .expect("copy_from_user failed");
-            assert_eq!(buf[0], 0, "fresh mmap page {} not zero", p);
-        }
+    // Entire arena must be zero-initialised on first touch.
+    for p in 0..(PAGES * 2) {
+        assert_eq!(
+            read_user_byte((b as usize) + p * 4096),
+            0,
+            "fresh mmap page {} not zero",
+            p
+        );
     }
     let _ = munmap(b, (LEN * 2) as u64);
 }

--- a/kernel/tests/syscall_mmap_family.rs
+++ b/kernel/tests/syscall_mmap_family.rs
@@ -19,9 +19,9 @@
 extern crate alloc;
 
 use core::panic::PanicInfo;
-use core::ptr;
 
 use vibix::arch::x86_64::syscall::syscall_dispatch;
+use vibix::arch::x86_64::uaccess;
 use vibix::fs::{EEXIST, EINVAL, ENODEV, ENOMEM};
 use vibix::mem::pf::{
     MADV_DONTNEED, MAP_ANONYMOUS, MAP_FIXED, MAP_FIXED_NOREPLACE, MAP_PRIVATE, MAP_SHARED,
@@ -195,9 +195,13 @@ fn mmap_shared_anon_succeeds() {
     );
     assert!(r > 0, "anon-shared mmap failed: {}", r);
     // Touch the page; should demand-fault without panicking.
+    // copy_to/from_user bracket the access with STAC/CLAC so SMAP is
+    // satisfied when ring-0 test code writes to a USER_ACCESSIBLE page.
     unsafe {
-        ptr::write_volatile(r as *mut u8, 0x7Fu8);
-        assert_eq!(ptr::read_volatile(r as *const u8), 0x7F);
+        uaccess::copy_to_user(r as usize, &[0x7Fu8]).expect("copy_to_user failed");
+        let mut buf = [0u8; 1];
+        uaccess::copy_from_user(&mut buf, r as usize).expect("copy_from_user failed");
+        assert_eq!(buf[0], 0x7F);
     }
     let _ = munmap(r as u64, 4096);
 }
@@ -207,7 +211,7 @@ fn mmap_fixed_noreplace_overlap_eexist() {
     // Write a marker into the original page so we can prove it survives the
     // failed MAP_FIXED_NOREPLACE call.
     unsafe {
-        ptr::write_volatile(a as *mut u8, 0xA5);
+        uaccess::copy_to_user(a as usize, &[0xA5u8]).expect("copy_to_user failed");
     }
     // Re-requesting the same VA with MAP_FIXED_NOREPLACE must fail EEXIST.
     let r = mmap(
@@ -229,7 +233,9 @@ fn mmap_fixed_noreplace_overlap_eexist() {
         assert_eq!(vma.end, (a as usize) + 4096);
     }
     unsafe {
-        assert_eq!(ptr::read_volatile(a as *const u8), 0xA5);
+        let mut buf = [0u8; 1];
+        uaccess::copy_from_user(&mut buf, a as usize).expect("copy_from_user failed");
+        assert_eq!(buf[0], 0xA5);
     }
     // Bare MAP_FIXED at the same VA should succeed (silently evicts) and
     // return the requested address.
@@ -276,8 +282,10 @@ fn mmap_fixed_noreplace_fresh_addr_succeeds() {
     );
     // The mapping must be usable: demand-fault + read-back.
     unsafe {
-        ptr::write_volatile(target as *mut u8, 0x5A);
-        assert_eq!(ptr::read_volatile(target as *const u8), 0x5A);
+        uaccess::copy_to_user(target as usize, &[0x5Au8]).expect("copy_to_user failed");
+        let mut buf = [0u8; 1];
+        uaccess::copy_from_user(&mut buf, target as usize).expect("copy_from_user failed");
+        assert_eq!(buf[0], 0x5A);
     }
     let _ = munmap(target, 4096);
     let _ = munmap(anchor, 4096);
@@ -320,7 +328,7 @@ fn mprotect_partial_vma_succeeds() {
     // 4 pages RW — mprotect middle 2 to RO; both fragments must still exist.
     let a = anon_rw(4 * 4096);
     unsafe {
-        ptr::write_volatile(a as *mut u8, 0xAA);
+        uaccess::copy_to_user(a as usize, &[0xAAu8]).expect("copy_to_user failed");
     }
     let r = mprotect(a + 4096, 2 * 4096, PROT_READ);
     assert_eq!(r, 0, "mprotect partial VMA failed: {}", r);
@@ -378,14 +386,18 @@ fn madvise_dontneed_rezeroes_page() {
     // Write a byte, MADV_DONTNEED the page, touch it again, verify zero.
     let a = anon_rw(4096);
     unsafe {
-        ptr::write_volatile(a as *mut u8, 0x42);
-        assert_eq!(ptr::read_volatile(a as *const u8), 0x42);
+        uaccess::copy_to_user(a as usize, &[0x42u8]).expect("copy_to_user failed");
+        let mut buf = [0u8; 1];
+        uaccess::copy_from_user(&mut buf, a as usize).expect("copy_from_user failed");
+        assert_eq!(buf[0], 0x42);
     }
     let r = madvise(a, 4096, MADV_DONTNEED);
     assert_eq!(r, 0);
     unsafe {
         // The next read must see 0 — a fresh zero-filled frame.
-        assert_eq!(ptr::read_volatile(a as *const u8), 0);
+        let mut buf = [0u8; 1];
+        uaccess::copy_from_user(&mut buf, a as usize).expect("copy_from_user failed");
+        assert_eq!(buf[0], 0);
     }
     let _ = munmap(a, 4096);
 }
@@ -409,11 +421,15 @@ fn malloc_workload_alloc_free_regrow() {
     unsafe {
         for p in 0..PAGES {
             let pattern = (p as u8).wrapping_mul(0x37).wrapping_add(0x11);
-            ptr::write_volatile((a as *mut u8).add(p * 4096), pattern);
+            uaccess::copy_to_user((a as usize) + p * 4096, &[pattern])
+                .expect("copy_to_user failed");
         }
         for p in 0..PAGES {
             let pattern = (p as u8).wrapping_mul(0x37).wrapping_add(0x11);
-            assert_eq!(ptr::read_volatile((a as *const u8).add(p * 4096)), pattern);
+            let mut buf = [0u8; 1];
+            uaccess::copy_from_user(&mut buf, (a as usize) + p * 4096)
+                .expect("copy_from_user failed");
+            assert_eq!(buf[0], pattern);
         }
     }
 
@@ -423,12 +439,10 @@ fn malloc_workload_alloc_free_regrow() {
     unsafe {
         // Entire arena must be zero-initialised on first touch.
         for p in 0..(PAGES * 2) {
-            assert_eq!(
-                ptr::read_volatile((b as *const u8).add(p * 4096)),
-                0,
-                "fresh mmap page {} not zero",
-                p
-            );
+            let mut buf = [0u8; 1];
+            uaccess::copy_from_user(&mut buf, (b as usize) + p * 4096)
+                .expect("copy_from_user failed");
+            assert_eq!(buf[0], 0, "fresh mmap page {} not zero", p);
         }
     }
     let _ = munmap(b, (LEN * 2) as u64);

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -795,12 +795,7 @@ fn parse_test_names(manifest: &str) -> R<Vec<String>> {
 /// Integration tests that parse from `kernel/Cargo.toml` but should
 /// NOT be run by `cargo xtask test`. Each entry must name the
 /// follow-up issue that tracks re-enabling it. Empty is the goal.
-///
-/// - `syscall_mmap_family`: `mmap_shared_anon_succeeds` hangs under
-///   QEMU (>30s timeout). Predates #292 and was silently skipped by
-///   the previous hardcoded allowlist; surfaced once the list became
-///   manifest-driven. Tracked in the follow-up opened alongside #292.
-const TEST_SKIPLIST: &[&str] = &["syscall_mmap_family"];
+const TEST_SKIPLIST: &[&str] = &[];
 
 /// Read `kernel/Cargo.toml` and return the declared integration-test
 /// target names, minus anything in [`TEST_SKIPLIST`]. Derived
@@ -1126,9 +1121,7 @@ harness = false
     #[test]
     fn parse_test_names_live_manifest_contains_new_entries() {
         // Guards against silent drift: these were previously absent
-        // from the hardcoded xtask array (issue #292). `syscall_mmap_family`
-        // is tracked in the manifest but currently in TEST_SKIPLIST,
-        // so assert it via the raw parser rather than the filtered list.
+        // from the hardcoded xtask array (issue #292).
         let raw = parse_test_names(
             &std::fs::read_to_string(workspace_root().join("kernel").join("Cargo.toml")).unwrap(),
         )
@@ -1140,7 +1133,7 @@ harness = false
             );
         }
         let filtered = integration_test_names().expect("parse live manifest");
-        for expected in &["execve_atomic", "fork_refcount"] {
+        for expected in &["execve_atomic", "fork_refcount", "syscall_mmap_family"] {
             assert!(
                 filtered.iter().any(|n| n == expected),
                 "expected {expected} in derived test list, got {filtered:?}"


### PR DESCRIPTION
## Summary

Closes #334

- **Root cause**: `mmap(MAP_ANONYMOUS)` creates VMAs with `USER_ACCESSIBLE` (U/S=1) PTEs. When ring-0 test code demand-faults such a page, the handler maps it and returns via IRET. The saved RFLAGS has AC=0, so the CPU retries the write with AC=0 against a now-present U/S=1 page — SMAP fires a second #PF that reaches `panic_smap_violation()` and hangs.
- **Fix**: Replace every direct `ptr::write/read_volatile` to mmap'd user pages with `copy_to_user` / `copy_from_user`, which bracket the access with STAC/CLAC. This is exactly the pattern documented in `smep_smap.rs` — the demand-fault resolves inside the STAC bracket, and the IRET retry completes with AC=1.
- **Skiplist**: Remove `syscall_mmap_family` from `TEST_SKIPLIST` and update the manifest assertion to verify the test runs.

## Test plan

- [x] `cargo check --target x86_64-unknown-none -Z build-std=core,alloc --test syscall_mmap_family` compiles clean
- [x] `cargo test -p xtask` passes (23/23, including the manifest-list assertion that now checks `syscall_mmap_family` appears in the filtered runner list)
- [x] `cargo xtask build` builds clean (pre-existing `is_guard_hit` dead_code warning only)
- [ ] `cargo xtask test` — CI will run `syscall_mmap_family` for the first time since it was skip-listed; all 14 subtests expected to pass