### PR TITLE
elf: detect PT_INTERP segment and load interpreter at INTERP_LOAD_BASE

### DIFF
--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -561,7 +561,12 @@ pub fn exec_atomic(elf_bytes: &[u8]) -> Result<core::convert::Infallible, i64> {
     // interpreter's entry point; otherwise jump directly to the binary's entry.
     let effective_entry = image.interp_entry.unwrap_or(image.entry);
     // Never returns.
-    unsafe { jump_to_ring3(effective_entry.as_u64(), crate::init_process::USER_STACK_TOP) }
+    unsafe {
+        jump_to_ring3(
+            effective_entry.as_u64(),
+            crate::init_process::USER_STACK_TOP,
+        )
+    }
 }
 
 /// Public wrapper around `copy_path_from_user` for use by the VFS

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -557,8 +557,11 @@ pub fn exec_atomic(elf_bytes: &[u8]) -> Result<core::convert::Infallible, i64> {
     // Now safe to release the old PML4 + its frames.
     drop(old_aspace);
 
+    // If the binary has a dynamic interpreter (PT_INTERP), jump to the
+    // interpreter's entry point; otherwise jump directly to the binary's entry.
+    let effective_entry = image.interp_entry.unwrap_or(image.entry);
     // Never returns.
-    unsafe { jump_to_ring3(image.entry.as_u64(), crate::init_process::USER_STACK_TOP) }
+    unsafe { jump_to_ring3(effective_entry.as_u64(), crate::init_process::USER_STACK_TOP) }
 }
 
 /// Public wrapper around `copy_path_from_user` for use by the VFS

--- a/kernel/src/init_process.rs
+++ b/kernel/src/init_process.rs
@@ -128,7 +128,20 @@ pub fn launch(bytes: &[u8]) -> usize {
     );
 
     // 4. Publish entry point and stash the address space.
-    INIT_ENTRY.store(image.entry.as_u64(), Ordering::Release);
+    // If the binary has a dynamic interpreter (PT_INTERP), jump to the
+    // interpreter's entry point — it will relocate itself and the main binary
+    // before transferring control to the main binary's entry. The main binary's
+    // original entry point goes into the auxv AT_ENTRY vector (issue #359).
+    let effective_entry = image.interp_entry.unwrap_or(image.entry);
+    if let Some(interp_base) = image.interp_base {
+        serial_println!(
+            "init: dynamic interpreter at base={:#x} entry={:#x} (main entry={:#x})",
+            interp_base,
+            effective_entry.as_u64(),
+            image.entry.as_u64(),
+        );
+    }
+    INIT_ENTRY.store(effective_entry.as_u64(), Ordering::Release);
     INIT_ADDRESS_SPACE.call_once(|| Arc::new(RwLock::new(aspace)));
 
     // 5. Spawn the kernel task that will drop to ring-3 and register it

--- a/kernel/src/mem/elf.rs
+++ b/kernel/src/mem/elf.rs
@@ -10,11 +10,14 @@ use x86_64::structures::paging::PageTableFlags;
 use x86_64::VirtAddr;
 
 const PT_LOAD: u32 = 1;
+const PT_INTERP: u32 = 3;
 const PF_X: u32 = 1 << 0;
 const PF_W: u32 = 1 << 1;
 
 const ELF_MAGIC: [u8; 4] = [0x7f, b'E', b'L', b'F'];
 const ELFCLASS64: u8 = 2;
+/// ELF type: shared object / position-independent executable (dynamic linker).
+const ET_DYN: u16 = 3;
 
 /// Path suffix the Limine config publishes for the PID 1 init ELF.
 /// Module lookup uses `ends_with` so an absolute-path prefix won't
@@ -71,6 +74,9 @@ pub(crate) struct LoadSegment {
 #[derive(Clone, Copy)]
 pub(crate) struct ParsedElf<'a> {
     ehdr: Elf64Ehdr,
+    /// The full source image bytes, needed to resolve segment content
+    /// (e.g. the PT_INTERP path string at `p_offset`).
+    bytes: &'a [u8],
     phdr_bytes: &'a [u8],
     phnum: usize,
 }
@@ -165,6 +171,38 @@ impl<'a> ParsedElf<'a> {
     pub(crate) fn entry(&self) -> VirtAddr {
         VirtAddr::new(self.ehdr.e_entry)
     }
+
+    /// Return the interpreter path from the PT_INTERP segment, if present.
+    ///
+    /// The returned slice is the null-terminated path string *without* the
+    /// trailing `\0`. Returns `None` if there is no PT_INTERP segment, if the
+    /// segment's file range is out of bounds, or if the segment contains no
+    /// null byte (malformed).
+    pub(crate) fn interp_path(&self) -> Option<&'a [u8]> {
+        for i in 0..self.phnum {
+            let off = i * core::mem::size_of::<Elf64Phdr>();
+            // SAFETY: phdr_bytes was bounds-checked during parse to hold
+            // exactly `phnum` contiguous Elf64Phdr records.
+            let ph = unsafe {
+                core::ptr::read_unaligned(
+                    self.phdr_bytes.as_ptr().add(off).cast::<Elf64Phdr>(),
+                )
+            };
+            if ph.p_type != PT_INTERP {
+                continue;
+            }
+            let start = ph.p_offset as usize;
+            let end = (ph.p_offset as usize).checked_add(ph.p_filesz as usize)?;
+            if end > self.bytes.len() {
+                return None;
+            }
+            let content = &self.bytes[start..end];
+            // Find the null terminator within the segment content.
+            let nul = content.iter().position(|&b| b == 0)?;
+            return Some(&self.bytes[start..start + nul]);
+        }
+        None
+    }
 }
 
 /// Iterate `PT_LOAD` segments of the running kernel's ELF image,
@@ -196,17 +234,7 @@ pub(super) fn kernel_load_segments() -> impl Iterator<Item = LoadSegment> {
 
 #[cfg(target_os = "none")]
 pub(crate) fn first_loaded_module_bytes() -> Option<&'static [u8]> {
-    let resp = crate::boot::MODULE_REQUEST.get_response()?;
-    let file = resp
-        .modules()
-        .iter()
-        .find(|f| f.path().to_bytes().ends_with(USERSPACE_INIT_MODULE_SUFFIX))?;
-    let base = file.addr();
-    let size = file.size() as usize;
-    // SAFETY: Limine places module payloads in EXECUTABLE_AND_MODULES
-    // memory, which is preserved across `reclaim_bootloader_memory()`.
-    // The slice stays valid for the rest of the kernel's lifetime.
-    Some(unsafe { core::slice::from_raw_parts(base, size) })
+    module_bytes_for_path(USERSPACE_INIT_MODULE_SUFFIX)
 }
 
 /// Return the raw bytes of the `userspace_hello.elf` Limine module, or
@@ -214,14 +242,28 @@ pub(crate) fn first_loaded_module_bytes() -> Option<&'static [u8]> {
 /// replace the calling process's image with a fresh ELF payload.
 #[cfg(target_os = "none")]
 pub(crate) fn hello_module_bytes() -> Option<&'static [u8]> {
+    module_bytes_for_path(b"/boot/userspace_hello.elf")
+}
+
+/// Return the bytes of the Limine module whose path ends with `suffix`, or
+/// `None` if no such module was loaded.
+///
+/// Used to locate the dynamic interpreter (PT_INTERP) by path. The module
+/// path in the Limine config is typically the full absolute path (e.g.
+/// `/boot/ld-musl-x86_64.so.1`); callers pass the suffix (e.g.
+/// `b"ld-musl-x86_64.so.1"`) to avoid requiring an exact path match.
+#[cfg(target_os = "none")]
+pub(crate) fn module_bytes_for_path(suffix: &[u8]) -> Option<&'static [u8]> {
     let resp = crate::boot::MODULE_REQUEST.get_response()?;
     let file = resp
         .modules()
         .iter()
-        .find(|f| f.path().to_bytes().ends_with(b"/boot/userspace_hello.elf"))?;
+        .find(|f| f.path().to_bytes().ends_with(suffix))?;
     let base = file.addr();
     let size = file.size() as usize;
-    // SAFETY: same lifetime guarantee as first_loaded_module_bytes.
+    // SAFETY: Limine places module payloads in EXECUTABLE_AND_MODULES
+    // memory, preserved across reclaim_bootloader_memory(). The slice
+    // stays valid for the rest of the kernel's lifetime.
     Some(unsafe { core::slice::from_raw_parts(base, size) })
 }
 
@@ -314,12 +356,16 @@ fn parse_elf64_inner(bytes: &[u8]) -> Result<ParsedElf<'_>, ElfParseError> {
             entry_covered = true;
         }
     }
-    if !entry_covered {
+    // ET_DYN (shared objects / dynamic linkers) may have e_entry == 0 and
+    // PT_LOAD segments starting at vaddr 0. The OS supplies the actual load
+    // base at runtime, so the entry-coverage check doesn't apply.
+    if !entry_covered && ehdr.e_type != ET_DYN {
         return Err(ElfParseError::EntryOutsideLoadSegment);
     }
 
     Ok(ParsedElf {
         ehdr,
+        bytes,
         phdr_bytes: &bytes[phoff..phdr_table_end],
         phnum,
     })
@@ -476,5 +522,85 @@ mod tests {
         let mut bytes = sample_elf_bytes();
         put64(&mut bytes, 24, 0x500000); // entry outside both PT_LOADs
         assert!(try_parse_elf64(&bytes).is_none());
+    }
+
+    /// Build a minimal ELF with a PT_INTERP segment and two PT_LOAD segments.
+    /// The interp path bytes are appended after the phdr table.
+    fn sample_elf_with_interp(path: &[u8]) -> Vec<u8> {
+        // Layout: EHDR | PHDR[0]=PT_INTERP | PHDR[1]=PT_LOAD(rx) | PHDR[2]=PT_LOAD(rw) | path bytes
+        let phdr_count = 3;
+        let phdr_table_size = phdr_count * PHDR_SIZE;
+        let path_offset = EHDR_SIZE + phdr_table_size;
+        // path bytes include null terminator
+        let total = path_offset + path.len() + 1;
+
+        let mut bytes = vec![0u8; total];
+        // ELF magic + class/data/version
+        bytes[0..4].copy_from_slice(&[0x7f, b'E', b'L', b'F']);
+        bytes[4] = 2; // ELFCLASS64
+        bytes[5] = 1; // little-endian
+        bytes[6] = 1; // ELF v1
+        put16(&mut bytes, 16, 2); // ET_EXEC
+        put16(&mut bytes, 18, 0x3e); // x86_64
+        put32(&mut bytes, 20, 1); // EV_CURRENT
+        put64(&mut bytes, 24, 0x400080); // entry (within PT_LOAD[0])
+        put64(&mut bytes, 32, EHDR_SIZE as u64); // e_phoff
+        put16(&mut bytes, 52, EHDR_SIZE as u16); // e_ehsize
+        put16(&mut bytes, 54, PHDR_SIZE as u16); // e_phentsize
+        put16(&mut bytes, 56, phdr_count as u16); // e_phnum
+
+        // phdr 0: PT_INTERP
+        let p0 = EHDR_SIZE;
+        put32(&mut bytes, p0, 3); // PT_INTERP
+        put64(&mut bytes, p0 + 8, path_offset as u64); // p_offset → appended path
+        put64(&mut bytes, p0 + 32, (path.len() + 1) as u64); // p_filesz (with nul)
+        put64(&mut bytes, p0 + 40, (path.len() + 1) as u64); // p_memsz
+
+        // phdr 1: PT_LOAD RX (covers entry 0x400080)
+        let p1 = EHDR_SIZE + PHDR_SIZE;
+        put32(&mut bytes, p1, 1); // PT_LOAD
+        put32(&mut bytes, p1 + 4, 1); // PF_X
+        put64(&mut bytes, p1 + 16, 0x400000); // p_vaddr
+        put64(&mut bytes, p1 + 40, 0x2000); // p_memsz
+
+        // phdr 2: PT_LOAD RW
+        let p2 = EHDR_SIZE + 2 * PHDR_SIZE;
+        put32(&mut bytes, p2, 1); // PT_LOAD
+        put32(&mut bytes, p2 + 4, 2); // PF_W
+        put64(&mut bytes, p2 + 16, 0x402000); // p_vaddr
+        put64(&mut bytes, p2 + 40, 0x1000); // p_memsz
+
+        // Write the path bytes (with null terminator) at `path_offset`.
+        bytes[path_offset..path_offset + path.len()].copy_from_slice(path);
+        bytes[path_offset + path.len()] = 0; // null terminator
+
+        bytes
+    }
+
+    #[test]
+    fn interp_path_returns_correct_string() {
+        let path = b"/lib/ld-musl-x86_64.so.1";
+        let bytes = sample_elf_with_interp(path);
+        let parsed = parse_elf64(&bytes);
+        assert_eq!(parsed.interp_path(), Some(path.as_slice()));
+    }
+
+    #[test]
+    fn interp_path_none_when_no_interp() {
+        let bytes = sample_elf_bytes();
+        let parsed = parse_elf64(&bytes);
+        assert!(parsed.interp_path().is_none());
+    }
+
+    #[test]
+    fn interp_path_none_when_no_null_terminator() {
+        let path = b"/lib/ld-musl-x86_64.so.1";
+        let mut bytes = sample_elf_with_interp(path);
+        // Overwrite the null terminator with a non-null byte so the segment
+        // contains no null byte.
+        let path_offset = EHDR_SIZE + 3 * PHDR_SIZE;
+        bytes[path_offset + path.len()] = b'!';
+        let parsed = parse_elf64(&bytes);
+        assert!(parsed.interp_path().is_none());
     }
 }

--- a/kernel/src/mem/elf.rs
+++ b/kernel/src/mem/elf.rs
@@ -184,9 +184,7 @@ impl<'a> ParsedElf<'a> {
             // SAFETY: phdr_bytes was bounds-checked during parse to hold
             // exactly `phnum` contiguous Elf64Phdr records.
             let ph = unsafe {
-                core::ptr::read_unaligned(
-                    self.phdr_bytes.as_ptr().add(off).cast::<Elf64Phdr>(),
-                )
+                core::ptr::read_unaligned(self.phdr_bytes.as_ptr().add(off).cast::<Elf64Phdr>())
             };
             if ph.p_type != PT_INTERP {
                 continue;

--- a/kernel/src/mem/loader.rs
+++ b/kernel/src/mem/loader.rs
@@ -59,7 +59,19 @@ pub enum LoadError {
     /// first non-canonical lower-half address. Reject at load time so
     /// the panic can't be reached from a malformed user ELF.
     SegmentEndsAtUserVaEnd,
+    /// The main ELF has a PT_INTERP segment naming an interpreter, but no
+    /// Limine module with a matching path suffix was found.
+    InterpNotFound,
+    /// The interpreter ELF named by PT_INTERP failed to parse or map.
+    InterpLoadFailed,
 }
+
+/// Virtual base address where the dynamic interpreter (PT_INTERP) is loaded.
+///
+/// Chosen to be above the typical userspace binary load range (~0x400000) but
+/// well below the stack top (~0x7FFF_F000). This is a fixed address; a future
+/// ASLR implementation will randomize it.
+pub const INTERP_LOAD_BASE: u64 = 0x4000_0000;
 
 /// Result of a successful load: the entry point, segment count, and the
 /// page-aligned virtual address one byte past the last `PT_LOAD` segment.
@@ -72,6 +84,12 @@ pub struct LoadedImage {
     /// First page-aligned address after the last PT_LOAD segment.
     /// The `sys_brk` implementation uses this as the initial heap start.
     pub image_end: u64,
+    /// Entry point of the dynamic interpreter (PT_INTERP), adjusted by
+    /// `INTERP_LOAD_BASE`. `None` if the binary has no PT_INTERP segment.
+    pub interp_entry: Option<VirtAddr>,
+    /// Virtual base address at which the interpreter was loaded.
+    /// `None` if the binary has no PT_INTERP segment.
+    pub interp_base: Option<u64>,
 }
 
 /// Parse `bytes` as an ELF64 image and install its `PT_LOAD` segments
@@ -115,6 +133,8 @@ pub fn load(bytes: &[u8]) -> Result<LoadedImage, LoadError> {
         entry,
         segments,
         image_end,
+        interp_entry: None,
+        interp_base: None,
     })
 }
 
@@ -155,7 +175,7 @@ pub fn load_user_elf(bytes: &[u8], pml4: PhysFrame<Size4KiB>) -> Result<LoadedIm
             err = Some(LoadError::SegmentEndsAtUserVaEnd);
             break;
         }
-        if let Err((e, mapped)) = map_user_segment(bytes, seg, pml4) {
+        if let Err((e, mapped)) = map_user_segment(bytes, seg, pml4, 0) {
             err = Some(e);
             partial_pages = mapped;
             break;
@@ -184,6 +204,8 @@ pub fn load_user_elf(bytes: &[u8], pml4: PhysFrame<Size4KiB>) -> Result<LoadedIm
         entry,
         segments,
         image_end,
+        interp_entry: None,
+        interp_base: None,
     })
 }
 
@@ -243,27 +265,31 @@ pub fn load_user_elf_with_vmas(
 ) -> Result<LoadedImage, LoadError> {
     use super::vmatree::{Share, Vma};
     use super::vmobject::{AnonObject, VmObject};
-    use x86_64::VirtAddr;
 
-    let image = load_user_elf(bytes, pml4)?;
+    let mut image = load_user_elf(bytes, pml4)?;
 
     let parsed = elf::try_parse_elf64(bytes).ok_or(LoadError::NotElf64)?;
-    for seg in parsed.load_segments() {
-        if seg.vaddr.as_u64() >= UPPER_HALF_START {
-            continue;
+
+    // Helper closure: register one ELF segment as a VMA, pre-populating the
+    // AnonObject cache with the frames the loader just installed at
+    // `effective_vaddr = seg.vaddr + base_offset`.
+    let mut register_vma = |seg: elf::LoadSegment, base_offset: u64| {
+        let effective_vaddr = seg.vaddr.as_u64().wrapping_add(base_offset);
+        if effective_vaddr >= UPPER_HALF_START {
+            return;
         }
         let page_count = seg.memsz.div_ceil(PAGE_SIZE) as usize;
-        let start = seg.vaddr.as_u64() as usize;
+        let start = effective_vaddr as usize;
         let end = start + page_count * PAGE_SIZE as usize;
         let obj = AnonObject::new(Some(page_count));
 
         // Pre-populate the cache with the frames the loader just mapped.
         for i in 0..page_count {
-            let va = VirtAddr::new(seg.vaddr.as_u64() + i as u64 * PAGE_SIZE);
+            let va = VirtAddr::new(effective_vaddr + i as u64 * PAGE_SIZE);
             if let Some((frame, _)) = paging::translate_in_pml4(pml4, va) {
                 let phys = frame.start_address().as_u64();
                 // insert_existing_frame increments refcount by 1 for the
-                // cache reference. The PTE reference was set by load_user_elf
+                // cache reference. The PTE reference was set by the loader
                 // on a freshly-allocated frame (refcount 1), so saturation
                 // is statically impossible here.
                 obj.insert_existing_frame(i, phys)
@@ -283,6 +309,51 @@ pub fn load_user_elf_with_vmas(
             0,
         );
         address_space.insert(vma);
+    };
+
+    for seg in parsed.load_segments() {
+        register_vma(seg, 0);
+    }
+
+    // Check for a dynamic interpreter (PT_INTERP). If present, look it up
+    // in the Limine modules by path suffix, load its segments at
+    // INTERP_LOAD_BASE, and record its adjusted entry point.
+    if let Some(interp_path) = parsed.interp_path() {
+        let interp_bytes =
+            elf::module_bytes_for_path(interp_path).ok_or(LoadError::InterpNotFound)?;
+
+        let interp_parsed =
+            elf::try_parse_elf64(interp_bytes).ok_or(LoadError::InterpLoadFailed)?;
+
+        // Load interpreter PT_LOAD segments at INTERP_LOAD_BASE.
+        let mut interp_err: Option<LoadError> = None;
+        for seg in interp_parsed.load_segments() {
+            let seg_end = seg
+                .vaddr
+                .as_u64()
+                .wrapping_add(INTERP_LOAD_BASE)
+                .wrapping_add(seg.memsz);
+            if seg_end >= USER_VA_END {
+                interp_err = Some(LoadError::InterpLoadFailed);
+                break;
+            }
+            if let Err((e, _)) = map_user_segment(interp_bytes, seg, pml4, INTERP_LOAD_BASE) {
+                interp_err = Some(e);
+                break;
+            }
+        }
+        if let Some(e) = interp_err {
+            return Err(e);
+        }
+
+        // Register interpreter segments as VMAs so fork copies them.
+        for seg in interp_parsed.load_segments() {
+            register_vma(seg, INTERP_LOAD_BASE);
+        }
+
+        let interp_entry_vaddr = interp_parsed.entry().as_u64() + INTERP_LOAD_BASE;
+        image.interp_entry = Some(VirtAddr::new(interp_entry_vaddr));
+        image.interp_base = Some(INTERP_LOAD_BASE);
     }
 
     Ok(image)
@@ -292,27 +363,36 @@ pub fn load_user_elf_with_vmas(
 /// pages that had been successfully mapped into `pml4` before the error —
 /// the caller uses that count to unmap and free those frames on the
 /// failure path.
+///
+/// `base_offset` is added to each segment's `p_vaddr` before mapping. Pass
+/// `0` for the main binary (which is linked at its final load address) and
+/// `INTERP_LOAD_BASE` for a position-independent interpreter whose segment
+/// vaddrs start near 0.
 fn map_user_segment(
     bytes: &[u8],
     seg: elf::LoadSegment,
     pml4: PhysFrame<Size4KiB>,
+    base_offset: u64,
 ) -> Result<(), (LoadError, u64)> {
-    if seg.vaddr.as_u64() >= UPPER_HALF_START {
+    let effective_vaddr = seg
+        .vaddr
+        .as_u64()
+        .checked_add(base_offset)
+        .ok_or((LoadError::SegmentNotLowerHalf, 0))?;
+    if effective_vaddr >= UPPER_HALF_START {
         return Err((LoadError::SegmentNotLowerHalf, 0));
     }
     // Reject segments whose virtual range overflows or crosses the
     // lower-half ceiling. Without this check, a large `p_memsz` could
     // push later pages into non-canonical space, panicking in
     // `VirtAddr::new()` during the mapping loop.
-    if seg
-        .vaddr
-        .as_u64()
+    if effective_vaddr
         .checked_add(seg.memsz)
         .map_or(true, |end| end > UPPER_HALF_START)
     {
         return Err((LoadError::SegmentNotLowerHalf, 0));
     }
-    if seg.vaddr.as_u64() & (PAGE_SIZE - 1) != 0 {
+    if effective_vaddr & (PAGE_SIZE - 1) != 0 {
         return Err((LoadError::SegmentNotPageAligned, 0));
     }
 
@@ -328,7 +408,7 @@ fn map_user_segment(
 
     let mut mapped = 0u64;
     for i in 0..page_count {
-        let va = seg.vaddr + i * PAGE_SIZE;
+        let va = VirtAddr::new(effective_vaddr + i * PAGE_SIZE);
         let page = Page::<Size4KiB>::containing_address(va);
         // map_in_pml4 allocates a fresh zeroed frame and installs it in
         // pml4 (not the global kernel mapper).

--- a/kernel/src/mem/loader.rs
+++ b/kernel/src/mem/loader.rs
@@ -222,6 +222,21 @@ fn unmap_partial_load(
     completed: usize,
     partial_pages: u64,
 ) {
+    unmap_partial_load_at_base(parsed, pml4, 0, completed, partial_pages);
+}
+
+/// Like [`unmap_partial_load`] but with an explicit `base_offset` added to
+/// each segment's `p_vaddr` before computing the virtual address to unmap.
+/// Used to clean up a partially-mapped interpreter whose segments were loaded
+/// at `INTERP_LOAD_BASE` rather than at their literal `p_vaddr` values.
+#[cfg(target_os = "none")]
+fn unmap_partial_load_at_base(
+    parsed: elf::ParsedElf<'_>,
+    pml4: PhysFrame<Size4KiB>,
+    base_offset: u64,
+    completed: usize,
+    partial_pages: u64,
+) {
     use x86_64::structures::paging::FrameDeallocator;
     let mut alloc = paging::KernelFrameAllocator;
     for (idx, seg) in parsed.load_segments().enumerate().take(completed + 1) {
@@ -231,7 +246,7 @@ fn unmap_partial_load(
             partial_pages
         };
         for i in 0..pages {
-            let va = seg.vaddr + i * PAGE_SIZE;
+            let va = VirtAddr::new(seg.vaddr.as_u64().wrapping_add(base_offset) + i * PAGE_SIZE);
             let page = Page::<Size4KiB>::containing_address(va);
             if let Ok(frame) = paging::unmap_in_pml4(pml4, page) {
                 // SAFETY: frame was just unmapped from `pml4`; no other
@@ -319,13 +334,23 @@ pub fn load_user_elf_with_vmas(
     // in the Limine modules by path suffix, load its segments at
     // INTERP_LOAD_BASE, and record its adjusted entry point.
     if let Some(interp_path) = parsed.interp_path() {
+        // PT_INTERP stores the full path (e.g. `/lib/ld-musl-x86_64.so.1`)
+        // but the Limine module is usually published under `/boot/...`. Match
+        // on the basename only so the path prefix difference doesn't matter.
+        let interp_basename = interp_path
+            .iter()
+            .rposition(|&b| b == b'/')
+            .map(|slash| &interp_path[slash + 1..])
+            .unwrap_or(interp_path);
         let interp_bytes =
-            elf::module_bytes_for_path(interp_path).ok_or(LoadError::InterpNotFound)?;
+            elf::module_bytes_for_path(interp_basename).ok_or(LoadError::InterpNotFound)?;
 
         let interp_parsed =
             elf::try_parse_elf64(interp_bytes).ok_or(LoadError::InterpLoadFailed)?;
 
         // Load interpreter PT_LOAD segments at INTERP_LOAD_BASE.
+        let mut interp_completed = 0usize;
+        let mut interp_partial_pages = 0u64;
         let mut interp_err: Option<LoadError> = None;
         for seg in interp_parsed.load_segments() {
             let seg_end = seg
@@ -337,12 +362,24 @@ pub fn load_user_elf_with_vmas(
                 interp_err = Some(LoadError::InterpLoadFailed);
                 break;
             }
-            if let Err((e, _)) = map_user_segment(interp_bytes, seg, pml4, INTERP_LOAD_BASE) {
+            if let Err((e, mapped)) = map_user_segment(interp_bytes, seg, pml4, INTERP_LOAD_BASE) {
+                interp_partial_pages = mapped;
                 interp_err = Some(e);
                 break;
             }
+            interp_completed += 1;
         }
         if let Some(e) = interp_err {
+            // Free any interpreter frames we already mapped so the staged
+            // AddressSpace doesn't leak them on drop (VMAs haven't been
+            // registered yet at this point).
+            unmap_partial_load_at_base(
+                interp_parsed,
+                pml4,
+                INTERP_LOAD_BASE,
+                interp_completed,
+                interp_partial_pages,
+            );
             return Err(e);
         }
 


### PR DESCRIPTION
Closes #358

## Summary

- Add `PT_INTERP` and `ET_DYN` constants to `elf.rs`; store full image `bytes` in `ParsedElf` so the new `interp_path()` method can extract the null-terminated interpreter path string from the PT_INTERP segment's file content. Returns `None` if no PT_INTERP is present or the segment is malformed (no null terminator, out-of-bounds).
- Relax the `EntryOutsideLoadSegment` validation for `ET_DYN` binaries — a dynamic linker may have `e_entry == 0` because the OS supplies the load base at runtime.
- Add `module_bytes_for_path(suffix)` in `elf.rs` to look up any Limine module by path suffix; simplify the two existing per-module helpers to delegate to it.
- Extend `LoadedImage` with `interp_entry: Option<VirtAddr>` and `interp_base: Option<u64>` (both `None` for static binaries).
- Add `INTERP_LOAD_BASE = 0x4000_0000`, `LoadError::InterpNotFound`, and `LoadError::InterpLoadFailed`.
- Refactor `map_user_segment` to accept a `base_offset` parameter so ET_DYN segments (vaddr near 0) can be mapped at `INTERP_LOAD_BASE` without code duplication.
- Extend `load_user_elf_with_vmas`: after loading the main binary, check for PT_INTERP, look up the interpreter in Limine modules, load its PT_LOAD segments at `INTERP_LOAD_BASE` with VMA tracking, and record the adjusted interpreter entry and base in `LoadedImage`.
- Update `init_process.rs` and `syscall.rs` to use `interp_entry.unwrap_or(entry)` so the OS jumps to the dynamic linker rather than the main binary when a PT_INTERP is present.

## Test plan

- [x] `cargo xtask build` — kernel compiles cleanly for `x86_64-unknown-none`, no errors or new warnings
- [x] `cargo test --package xtask` — 23 xtask tests pass
- [x] `cargo clippy -p xtask --all-targets -- -D warnings` — clean
- New unit tests in `elf.rs`: `interp_path_returns_correct_string`, `interp_path_none_when_no_interp`, `interp_path_none_when_no_null_terminator` — verified compile; will run in CI on x86_64