### PR TITLE
exec: write ELF auxv vector to initial user stack before ring-3 entry

### DIFF
--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -557,16 +557,27 @@ pub fn exec_atomic(elf_bytes: &[u8]) -> Result<core::convert::Infallible, i64> {
     // Now safe to release the old PML4 + its frames.
     drop(old_aspace);
 
+    // Write the System V AMD64 initial stack layout (argc/argv/envp/auxv) into
+    // the new stack frame via the HHDM window, matching what init_process does.
+    // TODO: replace with RDRAND once a CSPRNG is wired up.
+    let stack_phys = stack_frame.start_address().as_u64();
+    let random_seed = image.entry.as_u64() ^ stack_phys;
+    let mut random_bytes = [0u8; 16];
+    for (i, b) in random_bytes.iter_mut().enumerate() {
+        *b = ((random_seed >> (i % 8 * 8)) & 0xFF) as u8;
+    }
+    let initial_rsp = crate::mem::auxv::write_initial_stack(
+        stack_phys,
+        crate::init_process::USER_STACK_PAGE_VA,
+        &image,
+        &random_bytes,
+    );
+
     // If the binary has a dynamic interpreter (PT_INTERP), jump to the
     // interpreter's entry point; otherwise jump directly to the binary's entry.
     let effective_entry = image.interp_entry.unwrap_or(image.entry);
     // Never returns.
-    unsafe {
-        jump_to_ring3(
-            effective_entry.as_u64(),
-            crate::init_process::USER_STACK_TOP,
-        )
-    }
+    unsafe { jump_to_ring3(effective_entry.as_u64(), initial_rsp) }
 }
 
 /// Public wrapper around `copy_path_from_user` for use by the VFS

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -566,10 +566,17 @@ pub fn exec_atomic(elf_bytes: &[u8]) -> Result<core::convert::Infallible, i64> {
     for (i, b) in random_bytes.iter_mut().enumerate() {
         *b = ((random_seed >> (i % 8 * 8)) & 0xFF) as u8;
     }
+    let auxv_params = crate::mem::auxv::AuxvParams {
+        entry: image.entry.as_u64(),
+        interp_base: image.interp_base.unwrap_or(0),
+        phdr_vaddr: image.phdr_vaddr,
+        phdr_count: image.phdr_count as u64,
+        phdr_entsize: image.phdr_entsize as u64,
+    };
     let initial_rsp = crate::mem::auxv::write_initial_stack(
         stack_phys,
         crate::init_process::USER_STACK_PAGE_VA,
-        &image,
+        &auxv_params,
         &random_bytes,
     );
 

--- a/kernel/src/init_process.rs
+++ b/kernel/src/init_process.rs
@@ -27,6 +27,10 @@ use crate::serial_println;
 /// User-space entry point — set by `launch` before the task runs.
 static INIT_ENTRY: AtomicU64 = AtomicU64::new(0);
 
+/// Initial user RSP after the auxv/argv/argc layout has been written into
+/// the stack frame. Set by `launch`; read by `init_ring3_entry`.
+static INIT_STACK_PTR: AtomicU64 = AtomicU64::new(0);
+
 /// Pre-built init AddressSpace (with ELF VMAs and stack VMA).
 /// Consumed by `init_ring3_entry` on first and only use.
 static INIT_ADDRESS_SPACE: Once<Arc<RwLock<AddressSpace>>> = Once::new();
@@ -127,11 +131,29 @@ pub fn launch(bytes: &[u8]) -> usize {
         USER_STACK_TOP
     );
 
+    // 3b. Write the System V AMD64 initial stack layout (argc/argv/envp/auxv)
+    //     into the stack frame via the HHDM window before ring-3 entry.
+    //     The 16-byte AT_RANDOM seed is derived deterministically from the
+    //     entry address and stack physical address.
+    //     TODO: replace with RDRAND once a CSPRNG is wired up.
+    let random_seed = image.entry.as_u64() ^ stack_phys;
+    let mut random_bytes = [0u8; 16];
+    for (i, b) in random_bytes.iter_mut().enumerate() {
+        *b = ((random_seed >> (i % 8 * 8)) & 0xFF) as u8;
+    }
+    let initial_rsp = crate::mem::auxv::write_initial_stack(
+        stack_phys,
+        USER_STACK_PAGE_VA,
+        &image,
+        &random_bytes,
+    );
+    serial_println!("init: auxv written, initial rsp={:#x}", initial_rsp);
+
     // 4. Publish entry point and stash the address space.
     // If the binary has a dynamic interpreter (PT_INTERP), jump to the
     // interpreter's entry point — it will relocate itself and the main binary
     // before transferring control to the main binary's entry. The main binary's
-    // original entry point goes into the auxv AT_ENTRY vector (issue #359).
+    // original entry point is in the auxv AT_ENTRY vector.
     let effective_entry = image.interp_entry.unwrap_or(image.entry);
     if let Some(interp_base) = image.interp_base {
         serial_println!(
@@ -142,6 +164,7 @@ pub fn launch(bytes: &[u8]) -> usize {
         );
     }
     INIT_ENTRY.store(effective_entry.as_u64(), Ordering::Release);
+    INIT_STACK_PTR.store(initial_rsp, Ordering::Release);
     INIT_ADDRESS_SPACE.call_once(|| Arc::new(RwLock::new(aspace)));
 
     // 5. Spawn the kernel task that will drop to ring-3 and register it
@@ -163,6 +186,8 @@ pub fn launch(bytes: &[u8]) -> usize {
 fn init_ring3_entry() -> ! {
     let entry = INIT_ENTRY.load(Ordering::Acquire);
     assert!(entry != 0, "init_ring3_entry: INIT_ENTRY not set");
+    let initial_rsp = INIT_STACK_PTR.load(Ordering::Acquire);
+    assert!(initial_rsp != 0, "init_ring3_entry: INIT_STACK_PTR not set");
 
     // Replace this task's (empty) address space with the pre-built one.
     let init_aspace = INIT_ADDRESS_SPACE
@@ -195,11 +220,11 @@ fn init_ring3_entry() -> ! {
     crate::task::arm_ring3_syscall_stack();
 
     serial_println!(
-        "init: entering ring-3 entry={:#x} stack={:#x}",
+        "init: entering ring-3 entry={:#x} rsp={:#x}",
         entry,
-        USER_STACK_TOP
+        initial_rsp
     );
 
     // Drop to ring-3. Never returns.
-    unsafe { syscall::jump_to_ring3(entry, USER_STACK_TOP) }
+    unsafe { syscall::jump_to_ring3(entry, initial_rsp) }
 }

--- a/kernel/src/init_process.rs
+++ b/kernel/src/init_process.rs
@@ -141,10 +141,17 @@ pub fn launch(bytes: &[u8]) -> usize {
     for (i, b) in random_bytes.iter_mut().enumerate() {
         *b = ((random_seed >> (i % 8 * 8)) & 0xFF) as u8;
     }
+    let auxv_params = crate::mem::auxv::AuxvParams {
+        entry: image.entry.as_u64(),
+        interp_base: image.interp_base.unwrap_or(0),
+        phdr_vaddr: image.phdr_vaddr,
+        phdr_count: image.phdr_count as u64,
+        phdr_entsize: image.phdr_entsize as u64,
+    };
     let initial_rsp = crate::mem::auxv::write_initial_stack(
         stack_phys,
         USER_STACK_PAGE_VA,
-        &image,
+        &auxv_params,
         &random_bytes,
     );
     serial_println!("init: auxv written, initial rsp={:#x}", initial_rsp);

--- a/kernel/src/mem/auxv.rs
+++ b/kernel/src/mem/auxv.rs
@@ -1,0 +1,256 @@
+//! System V AMD64 initial stack layout writer.
+//!
+//! Before ring-3 entry the kernel must build the initial stack frame that
+//! the C runtime (or dynamic linker) expects to find at `[rsp]` on process
+//! start. The layout is defined in the System V AMD64 ABI §3.4:
+//!
+//! ```text
+//! HIGH ADDRESS (stack top)
+//!   [16-byte AT_RANDOM seed region]
+//!   AT_NULL    (0, 0)
+//!   AT_PAGESZ  (6, 4096)
+//!   AT_RANDOM  (25, va_of_16_bytes)
+//!   AT_ENTRY   (9,  main_entry)
+//!   AT_BASE    (7,  interp_base or 0)
+//!   AT_PHNUM   (5,  phdr_count)
+//!   AT_PHENT   (4,  phdr_entsize)
+//!   AT_PHDR    (3,  phdr_vaddr)
+//!   NULL       (envp terminator)
+//!   NULL       (argv terminator)
+//!   argc = 0
+//! LOW ADDRESS  ← initial RSP
+//! ```
+//!
+//! The stack frame is written into a physical page via the HHDM window
+//! because the page is mapped in the *user* PML4, not the kernel's. The
+//! HHDM window gives the kernel writable access to any physical frame
+//! without changing CR3.
+
+use super::loader::LoadedImage;
+use super::paging;
+
+/// Auxv tag constants (System V AMD64 ABI).
+const AT_NULL: u64 = 0;
+const AT_PHDR: u64 = 3;
+const AT_PHENT: u64 = 4;
+const AT_PHNUM: u64 = 5;
+const AT_PAGESZ: u64 = 6;
+const AT_BASE: u64 = 7;
+const AT_ENTRY: u64 = 9;
+const AT_RANDOM: u64 = 25;
+
+/// Page size reported to user space.
+const PAGE_SIZE: u64 = 4096;
+
+/// Write the System V AMD64 initial stack layout into the physical frame
+/// `stack_phys` via the HHDM window.
+///
+/// `image` provides the auxv values (`AT_PHDR`, `AT_PHENT`, `AT_PHNUM`,
+/// `AT_BASE`, `AT_ENTRY`). `stack_page_user_va` is the user-space VA of
+/// the base of the stack page (used to compute `AT_RANDOM`'s user-space
+/// address). `random_bytes` is the 16-byte seed placed at the top of the
+/// frame for `AT_RANDOM`.
+///
+/// Returns the new user RSP: the virtual address of the `argc` word at the
+/// bottom of the constructed layout.
+///
+/// # Panics
+///
+/// Panics if the layout would exceed 4096 bytes (the single-page stack frame).
+pub fn write_initial_stack(
+    stack_phys: u64,
+    stack_page_user_va: u64,
+    image: &LoadedImage,
+    random_bytes: &[u8; 16],
+) -> u64 {
+    // Map the physical frame into kernel VA space via HHDM.
+    let hhdm = paging::hhdm_offset();
+    let frame_base: *mut u8 = (hhdm.as_u64() + stack_phys) as *mut u8;
+
+    // We build the layout top-down within the 4096-byte page.
+    // `offset` counts bytes from the *top* of the frame.
+    let mut offset: usize = PAGE_SIZE as usize;
+
+    // Helper: write a u64 word top-down and return the new (lower) offset.
+    let push_u64 = |val: u64, offset: &mut usize| {
+        *offset -= 8;
+        // SAFETY: frame_base points to a writable HHDM-mapped frame;
+        // `offset` stays within [0, PAGE_SIZE).
+        unsafe {
+            core::ptr::write_unaligned(frame_base.add(*offset).cast::<u64>(), val);
+        }
+    };
+
+    // 1. Place the 16 AT_RANDOM bytes at the very top of the frame.
+    //    Their user-space VA is the top of the page minus 16.
+    let random_va = stack_page_user_va + PAGE_SIZE - 16;
+    // SAFETY: same frame, offset >= 0.
+    unsafe {
+        core::ptr::copy_nonoverlapping(
+            random_bytes.as_ptr(),
+            frame_base.add(PAGE_SIZE as usize - 16),
+            16,
+        );
+    }
+    offset -= 16;
+
+    // 2. Build auxv pairs (tag, value) — top-down, so write in reverse order.
+    //    AT_NULL must be the terminator (written first = highest in memory
+    //    before we push argc/argv/envp below it, but the iteration order
+    //    means we push the *last* entry first and work down to AT_NULL last).
+    //    We write in this order (which ends up high→low):
+    //      AT_NULL, AT_PAGESZ, AT_RANDOM, AT_ENTRY, AT_BASE,
+    //      AT_PHNUM, AT_PHENT, AT_PHDR
+    //    Reading bottom-up (low→high) the loader sees:
+    //      AT_PHDR, AT_PHENT, AT_PHNUM, AT_BASE, AT_ENTRY,
+    //      AT_RANDOM, AT_PAGESZ, AT_NULL
+    //    Both orderings are valid per the ABI (the auxv is a flat array
+    //    terminated by AT_NULL; order of other entries is implementation-defined).
+
+    // AT_NULL (terminator)
+    push_u64(0, &mut offset); // value
+    push_u64(AT_NULL, &mut offset); // tag
+
+    // AT_PAGESZ
+    push_u64(PAGE_SIZE, &mut offset);
+    push_u64(AT_PAGESZ, &mut offset);
+
+    // AT_RANDOM — pointer to the 16 bytes placed above
+    push_u64(random_va, &mut offset);
+    push_u64(AT_RANDOM, &mut offset);
+
+    // AT_ENTRY — main binary entry point (not the interpreter's)
+    push_u64(image.entry.as_u64(), &mut offset);
+    push_u64(AT_ENTRY, &mut offset);
+
+    // AT_BASE — interpreter load base (0 if statically linked)
+    push_u64(image.interp_base.unwrap_or(0), &mut offset);
+    push_u64(AT_BASE, &mut offset);
+
+    // AT_PHNUM
+    push_u64(image.phdr_count as u64, &mut offset);
+    push_u64(AT_PHNUM, &mut offset);
+
+    // AT_PHENT
+    push_u64(image.phdr_entsize as u64, &mut offset);
+    push_u64(AT_PHENT, &mut offset);
+
+    // AT_PHDR
+    push_u64(image.phdr_vaddr, &mut offset);
+    push_u64(AT_PHDR, &mut offset);
+
+    // 3. envp terminator (NULL pointer)
+    push_u64(0, &mut offset);
+
+    // 4. argv terminator (NULL pointer)
+    push_u64(0, &mut offset);
+
+    // 5. argc = 0
+    push_u64(0, &mut offset);
+
+    // Sanity: ensure we haven't overflowed into the random-seed region at the
+    // top of the frame. The random bytes occupy the top 16 bytes, and all
+    // auxv/envp/argv/argc words were written below them.
+    assert!(
+        offset + 16 <= PAGE_SIZE as usize,
+        "auxv: initial stack layout exceeds page boundary"
+    );
+
+    // The initial RSP is the user-space VA of the `argc` word we just wrote.
+    stack_page_user_va + offset as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mem::loader::LoadedImage;
+    use x86_64::VirtAddr;
+
+    fn sample_image() -> LoadedImage {
+        LoadedImage {
+            entry: VirtAddr::new(0x400080),
+            segments: 2,
+            image_end: 0x403000,
+            interp_entry: None,
+            interp_base: None,
+            phdr_vaddr: 0x400040,
+            phdr_count: 3,
+            phdr_entsize: 56,
+        }
+    }
+
+    // Simulate write_initial_stack without the HHDM dependency by writing
+    // into a local buffer and verifying the layout.
+    #[test]
+    fn initial_stack_layout_is_correct() {
+        let mut page = [0u8; 4096];
+        let random_bytes = [0xAAu8; 16];
+
+        // We manually replicate the layout logic here without the HHDM call.
+        let image = sample_image();
+        let stack_page_user_va: u64 = 0x7FFF_F000;
+        let mut offset: usize = 4096;
+
+        let push = |val: u64, page: &mut [u8; 4096], offset: &mut usize| {
+            *offset -= 8;
+            page[*offset..*offset + 8].copy_from_slice(&val.to_le_bytes());
+        };
+
+        // Place random bytes at top
+        let random_va = stack_page_user_va + 4096 - 16;
+        page[4096 - 16..4096].copy_from_slice(&random_bytes);
+        offset -= 16;
+
+        push(0, &mut page, &mut offset); // AT_NULL value
+        push(AT_NULL, &mut page, &mut offset);
+        push(PAGE_SIZE, &mut page, &mut offset);
+        push(AT_PAGESZ, &mut page, &mut offset);
+        push(random_va, &mut page, &mut offset);
+        push(AT_RANDOM, &mut page, &mut offset);
+        push(image.entry.as_u64(), &mut page, &mut offset);
+        push(AT_ENTRY, &mut page, &mut offset);
+        push(0u64, &mut page, &mut offset); // AT_BASE (no interp)
+        push(AT_BASE, &mut page, &mut offset);
+        push(image.phdr_count as u64, &mut page, &mut offset);
+        push(AT_PHNUM, &mut page, &mut offset);
+        push(image.phdr_entsize as u64, &mut page, &mut offset);
+        push(AT_PHENT, &mut page, &mut offset);
+        push(image.phdr_vaddr, &mut page, &mut offset);
+        push(AT_PHDR, &mut page, &mut offset);
+        push(0, &mut page, &mut offset); // envp NULL
+        push(0, &mut page, &mut offset); // argv NULL
+        push(0, &mut page, &mut offset); // argc
+
+        let rsp_offset = offset;
+
+        // argc == 0
+        let argc = u64::from_le_bytes(page[rsp_offset..rsp_offset + 8].try_into().unwrap());
+        assert_eq!(argc, 0, "argc must be 0");
+
+        // argv terminator follows
+        let argv_null =
+            u64::from_le_bytes(page[rsp_offset + 8..rsp_offset + 16].try_into().unwrap());
+        assert_eq!(argv_null, 0, "argv terminator must be NULL");
+
+        // Walk the auxv array from (rsp + 24: past argc, argv NULL, envp NULL)
+        let auxv_start = rsp_offset + 24;
+        let mut found_pagesz = false;
+        let mut found_null = false;
+        let mut i = auxv_start;
+        while i + 16 <= 4096 {
+            let tag = u64::from_le_bytes(page[i..i + 8].try_into().unwrap());
+            let val = u64::from_le_bytes(page[i + 8..i + 16].try_into().unwrap());
+            if tag == AT_NULL {
+                found_null = true;
+                break;
+            }
+            if tag == AT_PAGESZ {
+                assert_eq!(val, 4096, "AT_PAGESZ must be 4096");
+                found_pagesz = true;
+            }
+            i += 16;
+        }
+        assert!(found_pagesz, "AT_PAGESZ not found in auxv");
+        assert!(found_null, "AT_NULL terminator not found in auxv");
+    }
+}

--- a/kernel/src/mem/auxv.rs
+++ b/kernel/src/mem/auxv.rs
@@ -26,30 +26,43 @@
 //! HHDM window gives the kernel writable access to any physical frame
 //! without changing CR3.
 
-use super::loader::LoadedImage;
-use super::paging;
-
 /// Auxv tag constants (System V AMD64 ABI).
-const AT_NULL: u64 = 0;
-const AT_PHDR: u64 = 3;
-const AT_PHENT: u64 = 4;
-const AT_PHNUM: u64 = 5;
-const AT_PAGESZ: u64 = 6;
-const AT_BASE: u64 = 7;
-const AT_ENTRY: u64 = 9;
-const AT_RANDOM: u64 = 25;
+pub const AT_NULL: u64 = 0;
+pub const AT_PHDR: u64 = 3;
+pub const AT_PHENT: u64 = 4;
+pub const AT_PHNUM: u64 = 5;
+pub const AT_PAGESZ: u64 = 6;
+pub const AT_BASE: u64 = 7;
+pub const AT_ENTRY: u64 = 9;
+pub const AT_RANDOM: u64 = 25;
 
 /// Page size reported to user space.
-const PAGE_SIZE: u64 = 4096;
+pub const STACK_PAGE_SIZE: u64 = 4096;
+
+/// Parameters for the System V AMD64 initial stack layout.
+///
+/// Passed to [`write_initial_stack`] so the layout logic is decoupled from
+/// the `LoadedImage` type (which lives in `loader`, a kernel-only module).
+pub struct AuxvParams {
+    /// Main binary entry point (AT_ENTRY).
+    pub entry: u64,
+    /// Interpreter load base, or 0 if statically linked (AT_BASE).
+    pub interp_base: u64,
+    /// Virtual address of the main binary's program-header table (AT_PHDR).
+    pub phdr_vaddr: u64,
+    /// Number of program-header entries (AT_PHNUM).
+    pub phdr_count: u64,
+    /// Size of each program-header entry in bytes (AT_PHENT).
+    pub phdr_entsize: u64,
+}
 
 /// Write the System V AMD64 initial stack layout into the physical frame
 /// `stack_phys` via the HHDM window.
 ///
-/// `image` provides the auxv values (`AT_PHDR`, `AT_PHENT`, `AT_PHNUM`,
-/// `AT_BASE`, `AT_ENTRY`). `stack_page_user_va` is the user-space VA of
-/// the base of the stack page (used to compute `AT_RANDOM`'s user-space
-/// address). `random_bytes` is the 16-byte seed placed at the top of the
-/// frame for `AT_RANDOM`.
+/// `params` provides the auxv values. `stack_page_user_va` is the user-space
+/// VA of the base of the stack page (used to compute `AT_RANDOM`'s
+/// user-space address). `random_bytes` is the 16-byte seed placed at the top
+/// of the frame for `AT_RANDOM`.
 ///
 /// Returns the new user RSP: the virtual address of the `argc` word at the
 /// bottom of the constructed layout.
@@ -57,25 +70,28 @@ const PAGE_SIZE: u64 = 4096;
 /// # Panics
 ///
 /// Panics if the layout would exceed 4096 bytes (the single-page stack frame).
+#[cfg(target_os = "none")]
 pub fn write_initial_stack(
     stack_phys: u64,
     stack_page_user_va: u64,
-    image: &LoadedImage,
+    params: &AuxvParams,
     random_bytes: &[u8; 16],
 ) -> u64 {
+    use super::paging;
+
     // Map the physical frame into kernel VA space via HHDM.
     let hhdm = paging::hhdm_offset();
     let frame_base: *mut u8 = (hhdm.as_u64() + stack_phys) as *mut u8;
 
     // We build the layout top-down within the 4096-byte page.
     // `offset` counts bytes from the *top* of the frame.
-    let mut offset: usize = PAGE_SIZE as usize;
+    let mut offset: usize = STACK_PAGE_SIZE as usize;
 
-    // Helper: write a u64 word top-down and return the new (lower) offset.
+    // Helper: write a u64 word top-down.
     let push_u64 = |val: u64, offset: &mut usize| {
         *offset -= 8;
         // SAFETY: frame_base points to a writable HHDM-mapped frame;
-        // `offset` stays within [0, PAGE_SIZE).
+        // `offset` stays within [0, STACK_PAGE_SIZE).
         unsafe {
             core::ptr::write_unaligned(frame_base.add(*offset).cast::<u64>(), val);
         }
@@ -83,60 +99,45 @@ pub fn write_initial_stack(
 
     // 1. Place the 16 AT_RANDOM bytes at the very top of the frame.
     //    Their user-space VA is the top of the page minus 16.
-    let random_va = stack_page_user_va + PAGE_SIZE - 16;
-    // SAFETY: same frame, offset >= 0.
+    let random_va = stack_page_user_va + STACK_PAGE_SIZE - 16;
+    // SAFETY: frame_base + (PAGE_SIZE - 16) is within the same 4KiB frame.
     unsafe {
         core::ptr::copy_nonoverlapping(
             random_bytes.as_ptr(),
-            frame_base.add(PAGE_SIZE as usize - 16),
+            frame_base.add(STACK_PAGE_SIZE as usize - 16),
             16,
         );
     }
     offset -= 16;
 
-    // 2. Build auxv pairs (tag, value) — top-down, so write in reverse order.
-    //    AT_NULL must be the terminator (written first = highest in memory
-    //    before we push argc/argv/envp below it, but the iteration order
-    //    means we push the *last* entry first and work down to AT_NULL last).
-    //    We write in this order (which ends up high→low):
-    //      AT_NULL, AT_PAGESZ, AT_RANDOM, AT_ENTRY, AT_BASE,
-    //      AT_PHNUM, AT_PHENT, AT_PHDR
-    //    Reading bottom-up (low→high) the loader sees:
-    //      AT_PHDR, AT_PHENT, AT_PHNUM, AT_BASE, AT_ENTRY,
-    //      AT_RANDOM, AT_PAGESZ, AT_NULL
-    //    Both orderings are valid per the ABI (the auxv is a flat array
-    //    terminated by AT_NULL; order of other entries is implementation-defined).
+    // 2. Build auxv pairs (tag, value) top-down.
+    //    Written high→low: AT_NULL first (highest), then AT_PAGESZ, ..., AT_PHDR last.
+    //    The loader reads low→high: AT_PHDR, AT_PHENT, ..., AT_PAGESZ, AT_NULL.
+    //    Both orderings are valid per the ABI (auxv is an unordered array
+    //    terminated by AT_NULL).
 
-    // AT_NULL (terminator)
-    push_u64(0, &mut offset); // value
-    push_u64(AT_NULL, &mut offset); // tag
+    push_u64(0, &mut offset); // AT_NULL value
+    push_u64(AT_NULL, &mut offset);
 
-    // AT_PAGESZ
-    push_u64(PAGE_SIZE, &mut offset);
+    push_u64(STACK_PAGE_SIZE, &mut offset);
     push_u64(AT_PAGESZ, &mut offset);
 
-    // AT_RANDOM — pointer to the 16 bytes placed above
     push_u64(random_va, &mut offset);
     push_u64(AT_RANDOM, &mut offset);
 
-    // AT_ENTRY — main binary entry point (not the interpreter's)
-    push_u64(image.entry.as_u64(), &mut offset);
+    push_u64(params.entry, &mut offset);
     push_u64(AT_ENTRY, &mut offset);
 
-    // AT_BASE — interpreter load base (0 if statically linked)
-    push_u64(image.interp_base.unwrap_or(0), &mut offset);
+    push_u64(params.interp_base, &mut offset);
     push_u64(AT_BASE, &mut offset);
 
-    // AT_PHNUM
-    push_u64(image.phdr_count as u64, &mut offset);
+    push_u64(params.phdr_count, &mut offset);
     push_u64(AT_PHNUM, &mut offset);
 
-    // AT_PHENT
-    push_u64(image.phdr_entsize as u64, &mut offset);
+    push_u64(params.phdr_entsize, &mut offset);
     push_u64(AT_PHENT, &mut offset);
 
-    // AT_PHDR
-    push_u64(image.phdr_vaddr, &mut offset);
+    push_u64(params.phdr_vaddr, &mut offset);
     push_u64(AT_PHDR, &mut offset);
 
     // 3. envp terminator (NULL pointer)
@@ -152,7 +153,7 @@ pub fn write_initial_stack(
     // top of the frame. The random bytes occupy the top 16 bytes, and all
     // auxv/envp/argv/argc words were written below them.
     assert!(
-        offset + 16 <= PAGE_SIZE as usize,
+        offset + 16 <= STACK_PAGE_SIZE as usize,
         "auxv: initial stack layout exceeds page boundary"
     );
 
@@ -163,65 +164,66 @@ pub fn write_initial_stack(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mem::loader::LoadedImage;
-    use x86_64::VirtAddr;
 
-    fn sample_image() -> LoadedImage {
-        LoadedImage {
-            entry: VirtAddr::new(0x400080),
-            segments: 2,
-            image_end: 0x403000,
-            interp_entry: None,
-            interp_base: None,
-            phdr_vaddr: 0x400040,
-            phdr_count: 3,
-            phdr_entsize: 56,
-        }
+    // Build the SysV AMD64 initial stack layout into a caller-supplied buffer
+    // without any HHDM / kernel-paging dependency. Used by tests to verify
+    // the layout without booting a kernel.
+    fn build_layout_into_buf(
+        buf: &mut [u8; 4096],
+        stack_page_user_va: u64,
+        params: &AuxvParams,
+        random_bytes: &[u8; 16],
+    ) -> usize {
+        let mut offset: usize = 4096;
+
+        let push = |val: u64, buf: &mut [u8; 4096], offset: &mut usize| {
+            *offset -= 8;
+            buf[*offset..*offset + 8].copy_from_slice(&val.to_le_bytes());
+        };
+
+        // Random bytes at the top
+        let random_va = stack_page_user_va + STACK_PAGE_SIZE - 16;
+        buf[4096 - 16..4096].copy_from_slice(random_bytes);
+        offset -= 16;
+
+        push(0, buf, &mut offset); // AT_NULL value
+        push(AT_NULL, buf, &mut offset);
+        push(STACK_PAGE_SIZE, buf, &mut offset);
+        push(AT_PAGESZ, buf, &mut offset);
+        push(random_va, buf, &mut offset);
+        push(AT_RANDOM, buf, &mut offset);
+        push(params.entry, buf, &mut offset);
+        push(AT_ENTRY, buf, &mut offset);
+        push(params.interp_base, buf, &mut offset);
+        push(AT_BASE, buf, &mut offset);
+        push(params.phdr_count, buf, &mut offset);
+        push(AT_PHNUM, buf, &mut offset);
+        push(params.phdr_entsize, buf, &mut offset);
+        push(AT_PHENT, buf, &mut offset);
+        push(params.phdr_vaddr, buf, &mut offset);
+        push(AT_PHDR, buf, &mut offset);
+        push(0, buf, &mut offset); // envp NULL
+        push(0, buf, &mut offset); // argv NULL
+        push(0, buf, &mut offset); // argc
+
+        offset
     }
 
-    // Simulate write_initial_stack without the HHDM dependency by writing
-    // into a local buffer and verifying the layout.
     #[test]
     fn initial_stack_layout_is_correct() {
         let mut page = [0u8; 4096];
         let random_bytes = [0xAAu8; 16];
-
-        // We manually replicate the layout logic here without the HHDM call.
-        let image = sample_image();
         let stack_page_user_va: u64 = 0x7FFF_F000;
-        let mut offset: usize = 4096;
-
-        let push = |val: u64, page: &mut [u8; 4096], offset: &mut usize| {
-            *offset -= 8;
-            page[*offset..*offset + 8].copy_from_slice(&val.to_le_bytes());
+        let params = AuxvParams {
+            entry: 0x400080,
+            interp_base: 0,
+            phdr_vaddr: 0x400040,
+            phdr_count: 3,
+            phdr_entsize: 56,
         };
 
-        // Place random bytes at top
-        let random_va = stack_page_user_va + 4096 - 16;
-        page[4096 - 16..4096].copy_from_slice(&random_bytes);
-        offset -= 16;
-
-        push(0, &mut page, &mut offset); // AT_NULL value
-        push(AT_NULL, &mut page, &mut offset);
-        push(PAGE_SIZE, &mut page, &mut offset);
-        push(AT_PAGESZ, &mut page, &mut offset);
-        push(random_va, &mut page, &mut offset);
-        push(AT_RANDOM, &mut page, &mut offset);
-        push(image.entry.as_u64(), &mut page, &mut offset);
-        push(AT_ENTRY, &mut page, &mut offset);
-        push(0u64, &mut page, &mut offset); // AT_BASE (no interp)
-        push(AT_BASE, &mut page, &mut offset);
-        push(image.phdr_count as u64, &mut page, &mut offset);
-        push(AT_PHNUM, &mut page, &mut offset);
-        push(image.phdr_entsize as u64, &mut page, &mut offset);
-        push(AT_PHENT, &mut page, &mut offset);
-        push(image.phdr_vaddr, &mut page, &mut offset);
-        push(AT_PHDR, &mut page, &mut offset);
-        push(0, &mut page, &mut offset); // envp NULL
-        push(0, &mut page, &mut offset); // argv NULL
-        push(0, &mut page, &mut offset); // argc
-
-        let rsp_offset = offset;
+        let rsp_offset =
+            build_layout_into_buf(&mut page, stack_page_user_va, &params, &random_bytes);
 
         // argc == 0
         let argc = u64::from_le_bytes(page[rsp_offset..rsp_offset + 8].try_into().unwrap());

--- a/kernel/src/mem/elf.rs
+++ b/kernel/src/mem/elf.rs
@@ -172,6 +172,39 @@ impl<'a> ParsedElf<'a> {
         VirtAddr::new(self.ehdr.e_entry)
     }
 
+    /// Virtual address of the main binary's program-header table.
+    ///
+    /// Derived by finding the PT_LOAD segment whose file range covers
+    /// `e_phoff`, then computing `p_vaddr + (e_phoff - p_offset)`. Returns `0`
+    /// if no PT_LOAD covers the phdr table offset (unusual ELF layouts).
+    pub(crate) fn phdr_vaddr(&self) -> u64 {
+        let phoff = self.ehdr.e_phoff;
+        for i in 0..self.phnum {
+            let off = i * core::mem::size_of::<Elf64Phdr>();
+            // SAFETY: phdr_bytes was bounds-checked during parse.
+            let ph = unsafe {
+                core::ptr::read_unaligned(self.phdr_bytes.as_ptr().add(off).cast::<Elf64Phdr>())
+            };
+            if ph.p_type != PT_LOAD || ph.p_memsz == 0 {
+                continue;
+            }
+            if phoff >= ph.p_offset && phoff < ph.p_offset + ph.p_filesz {
+                return ph.p_vaddr + (phoff - ph.p_offset);
+            }
+        }
+        0
+    }
+
+    /// Number of program-header entries (`e_phnum`).
+    pub(crate) fn phdr_count(&self) -> u16 {
+        self.ehdr.e_phnum
+    }
+
+    /// Size of each program-header entry (`e_phentsize`).
+    pub(crate) fn phdr_entsize(&self) -> u16 {
+        self.ehdr.e_phentsize
+    }
+
     /// Return the interpreter path from the PT_INTERP segment, if present.
     ///
     /// The returned slice is the null-terminated path string *without* the

--- a/kernel/src/mem/loader.rs
+++ b/kernel/src/mem/loader.rs
@@ -90,6 +90,12 @@ pub struct LoadedImage {
     /// Virtual base address at which the interpreter was loaded.
     /// `None` if the binary has no PT_INTERP segment.
     pub interp_base: Option<u64>,
+    /// Virtual address of the main binary's program-header table (AT_PHDR).
+    pub phdr_vaddr: u64,
+    /// Number of program-header entries (AT_PHNUM).
+    pub phdr_count: u16,
+    /// Size of each program-header entry in bytes (AT_PHENT).
+    pub phdr_entsize: u16,
 }
 
 /// Parse `bytes` as an ELF64 image and install its `PT_LOAD` segments
@@ -135,6 +141,9 @@ pub fn load(bytes: &[u8]) -> Result<LoadedImage, LoadError> {
         image_end,
         interp_entry: None,
         interp_base: None,
+        phdr_vaddr: 0,
+        phdr_count: 0,
+        phdr_entsize: 0,
     })
 }
 
@@ -206,6 +215,9 @@ pub fn load_user_elf(bytes: &[u8], pml4: PhysFrame<Size4KiB>) -> Result<LoadedIm
         image_end,
         interp_entry: None,
         interp_base: None,
+        phdr_vaddr: parsed.phdr_vaddr(),
+        phdr_count: parsed.phdr_count(),
+        phdr_entsize: parsed.phdr_entsize(),
     })
 }
 

--- a/kernel/src/mem/mod.rs
+++ b/kernel/src/mem/mod.rs
@@ -15,6 +15,8 @@ pub mod refcount;
 pub mod tlb;
 
 #[cfg(any(target_os = "none", test))]
+pub(crate) mod auxv;
+#[cfg(any(target_os = "none", test))]
 pub(crate) mod elf;
 #[cfg(target_os = "none")]
 pub mod heap;


### PR DESCRIPTION
Closes #359

## Summary

- Add `phdr_vaddr()`, `phdr_count()`, and `phdr_entsize()` methods to `ParsedElf` in `elf.rs` so `LoadedImage` can carry AT_PHDR, AT_PHNUM, and AT_PHENT values
- Extend `LoadedImage` with `phdr_vaddr`, `phdr_count`, `phdr_entsize` fields; populate from parsed ELF in `load_user_elf`
- New `kernel/src/mem/auxv.rs`: `write_initial_stack()` builds the System V AMD64 initial stack layout into a physical frame via HHDM — argc=0, argv[], envp[], and auxv[] with AT_PHDR, AT_PHENT, AT_PHNUM, AT_BASE, AT_ENTRY, AT_RANDOM, AT_PAGESZ, AT_NULL
- `init_process::launch()` calls `write_initial_stack()` after mapping the user stack; `init_ring3_entry()` passes the returned RSP to `jump_to_ring3()` instead of the raw `USER_STACK_TOP`
- `exec_atomic()` mirrors the same call so exec'd children also receive a valid auxv

## Test plan

- [ ] `cargo xtask build` — kernel compiles without new warnings
- [ ] `cargo xtask test` — host unit test in `auxv.rs` verifies argc=0, argv/envp NULL terminators, AT_PAGESZ=4096, and AT_NULL terminator
- [ ] `cargo xtask smoke` — boot smoke markers still appear (static init binary unaffected by auxv layout)