### PR TITLE
docker: re-pin base image to linux/amd64 (Rosetta required)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-FROM ubuntu:24.04
+# Pinned to amd64: the kernel crate pulls in x86_64-only deps (pic8259,
+# uart_16550, x86_64), so the host rustc inside the container must be
+# x86_64-unknown-linux-gnu. On Apple Silicon, Docker Desktop must have
+# "Use Rosetta for x86_64/amd64 emulation" enabled (Settings → General);
+# QEMU-based emulation trips a Go regexp panic in `gh` on init.
+FROM --platform=linux/amd64 ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive \
     LANG=C.UTF-8 \


### PR DESCRIPTION
## Summary

- Re-applies the \`--platform=linux/amd64\` pin reverted in c0b496d.
- Adds a comment documenting why the pin is needed and the Apple Silicon prerequisite.

## Why the first attempt (#248) was reverted

The kernel crate pulls in x86_64-only deps (\`pic8259\`, \`uart_16550\`, \`x86_64\`), so the container's host rustc must resolve to \`x86_64-unknown-linux-gnu\` for \`cargo xtask test\`'s host-lib pre-pass to compile. On Apple Silicon without the pin, the toolchain resolves to aarch64 and the pre-pass fails.

With the pin, Docker Desktop emulates amd64 — but by default it uses **QEMU-user**, which trips a Go regexp init panic in \`gh\`:

\`\`\`
panic: regexp: Compile(\`...\`): error parsing regexp: expression too large
	at github.com/asaskevich/govalidator.init()
\`\`\`

That broke \`gh auth setup-git\` in the entrypoint and blocked every auto-engineer run on arm64.

## The fix

Docker Desktop has a \"Use Rosetta for x86_64/amd64 emulation on Apple Silicon\" setting (Settings → General). With Rosetta, the same amd64 image runs without the Go regexp panic — \`gh --version\` works, and the Rust host toolchain is still \`x86_64-unknown-linux-gnu\`.

The Dockerfile now documents this prerequisite inline.

## Test plan

- [x] \`docker run --platform=linux/amd64 vibix-auto-engineer gh --version\` succeeds under Rosetta (fails with regexp panic under QEMU).
- [ ] Full \`scripts/auto-engineer.sh\` run on Apple Silicon with Rosetta enabled completes \`cargo xtask test\` host-lib pre-pass.
- [x] CI (amd64 linux) unaffected — no platform change on Intel/CI hosts.