### PR TITLE
auto-engineer: emulation-aware xtask timeouts via host-hints file

### DIFF
--- a/.claude/skills/auto-engineer/SKILL.md
+++ b/.claude/skills/auto-engineer/SKILL.md
@@ -13,6 +13,8 @@ Read these shared playbooks first:
 - `docs/agent-playbooks/pr-review.md`
 - `docs/agent-playbooks/prioritization.md`
 
+If `/etc/vibix-host-hints.md` exists, read it too — it carries host-specific guidance (e.g. larger Bash-tool timeouts when the container is running under emulation) that overrides the default assumptions in these playbooks. On native amd64 hosts the file is absent and there's nothing to read.
+
 Closes the full SDLC loop without prompting the user between steps. Each invocation runs **one cycle** (pick → plan → implement → PR → wait → merge), then reschedules itself via `ScheduleWakeup` with prompt `/auto-engineer` for the next cycle. Stops cleanly when it runs out of work or hits something it can't safely resolve.
 
 This skill is a deliberate override of the project's default "don't merge your own PRs" rule — merging is the whole point of closing the loop. It only applies while auto-engineer is driving.
@@ -212,6 +214,8 @@ cargo xtask build
 cargo xtask test
 cargo xtask smoke
 ```
+
+When invoking these through the Bash tool, pick the `timeout` parameter from `/etc/vibix-host-hints.md` if present — emulated hosts need the full 600000 ms cap for `cargo xtask test`. If the hints file is absent, native amd64 timings apply and the tool's 120000 ms default is usually fine for `build`/`smoke` but still too tight for `test` (budget ~180000 ms).
 
 On failure: diagnose and fix in place. **Maximum 3 fix attempts per cycle.** If the 3rd attempt still fails → **stop** with a summary of the failure and what was tried.
 

--- a/scripts/auto-engineer.sh
+++ b/scripts/auto-engineer.sh
@@ -84,6 +84,56 @@ tmux_pane_vol_opts=()
 slug_file=""
 poller_pid=""
 restore_tmux_rename=""
+hints_vol_opts=()
+
+# The image is pinned to linux/amd64 (Rosetta required on Apple Silicon,
+# qemu-user elsewhere). When the host is not amd64, the container runs
+# under emulation and cargo xtask wall-clock times balloon. Write a hints
+# file that the auto-engineer skill will read to pick generous Bash-tool
+# timeouts. On native amd64 hosts the file is absent and no guidance leaks
+# into the agent's context.
+hints_file=""
+host_arch="$(uname -m)"
+case "$host_arch" in
+    x86_64|amd64) : ;;
+    *)
+        hints_file="$(mktemp -t vibix-host-hints.XXXXXX.md)"
+        cat > "$hints_file" <<'EOF'
+# Host hints
+
+This container is pinned to `linux/amd64` but the host is not amd64, so
+every instruction runs under emulation (Rosetta on Apple Silicon, qemu-user
+elsewhere). Wall-clock for `cargo xtask` is ~5-10x native.
+
+When invoking these commands through the Bash tool, set `timeout` at least
+as high as the value below. Do not use the tool's 120000 ms default — it
+will kill the command mid-run and force rework.
+
+| Command             | Observed (emulated) | Use timeout |
+|---------------------|---------------------|-------------|
+| `cargo xtask build` | ~65 s warm, 3-5 min cold | `300000` (5 min) |
+| `cargo xtask test`  | ~330 s (~5.5 min)        | `600000` (10 min, tool max) |
+| `cargo xtask smoke` | ~34 s warm, ~100 s cold  | `200000` (~3.3 min) |
+
+The Bash tool caps `timeout` at 600000 ms. For `cargo xtask test` use the
+cap. If a command legitimately needs longer, run it in the background
+(`run_in_background: true`) and poll instead of extending the timeout.
+EOF
+        hints_vol_opts+=(-v "$hints_file:/etc/vibix-host-hints.md:ro")
+        ;;
+esac
+
+tmux_window_id=""
+cleanup() {
+    [ -n "$poller_pid" ] && kill "$poller_pid" 2>/dev/null || true
+    [ -n "$slug_file" ] && rm -f "$slug_file" 2>/dev/null || true
+    [ -n "$hints_file" ] && rm -f "$hints_file" 2>/dev/null || true
+    if [ -n "$restore_tmux_rename" ] && command -v tmux >/dev/null 2>&1; then
+        tmux set-window-option ${tmux_window_id:+-t "$tmux_window_id"} automatic-rename "$restore_tmux_rename" >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup EXIT
+
 if [ -n "${TMUX:-}" ] && command -v tmux >/dev/null 2>&1; then
     # Capture the window ID of the pane this script is running in, so the
     # poller renames *this* window rather than whatever window happens to be
@@ -116,18 +166,13 @@ if [ -n "${TMUX:-}" ] && command -v tmux >/dev/null 2>&1; then
         done
     ) &
     poller_pid=$!
-
-    trap '
-        [ -n "$poller_pid" ] && kill "$poller_pid" 2>/dev/null || true
-        [ -n "$slug_file" ] && rm -f "$slug_file" 2>/dev/null || true
-        tmux set-window-option ${tmux_window_id:+-t "$tmux_window_id"} automatic-rename "$restore_tmux_rename" >/dev/null 2>&1 || true
-    ' EXIT
 fi
 
 docker run --rm -it \
     ${docker_sec_opts[@]+"${docker_sec_opts[@]}"} \
     "${claude_vol_opts[@]}" \
     ${tmux_pane_vol_opts[@]+"${tmux_pane_vol_opts[@]}"} \
+    ${hints_vol_opts[@]+"${hints_vol_opts[@]}"} \
     -e GITHUB_TOKEN \
     -e ANTHROPIC_API_KEY \
     -e GIT_AUTHOR_NAME \


### PR DESCRIPTION
## Summary
- Claude's Bash tool defaults to a 120000 ms timeout. Under Rosetta/qemu-user on a non-amd64 host, `cargo xtask test` takes ~330s and cold `cargo xtask build` 3–5 min, so the default kills commands mid-run and forces wasted rework.
- `scripts/auto-engineer.sh` now checks `uname -m`; on non-amd64 hosts it writes a short markdown file with observed wall-clock budgets and recommended `timeout` values, bind-mounted read-only at `/etc/vibix-host-hints.md`. Native amd64 hosts get no file — zero context pollution.
- Auto-engineer skill gets two pointers: a top-of-file "read it if it exists" and a step-4 reminder where `cargo xtask build/test/smoke` actually run.
- Unified the EXIT trap — the tmux poller's trap used to clobber any outer cleanup; now one `cleanup` function covers poller PID, slug file, hints file, and automatic-rename restoration.

Measured on an arm64 Mac mini under Rosetta:

| Command             | Observed             | Recommended timeout |
|---------------------|----------------------|---------------------|
| `cargo xtask build` | ~65 s warm, 3–5 min cold | `300000` (5 min)    |
| `cargo xtask test`  | ~330 s (~5.5 min)    | `600000` (tool max) |
| `cargo xtask smoke` | ~34 s warm, ~100 s cold  | `200000` (~3.3 min) |

## Test plan
- [ ] On arm64 macOS: run `scripts/auto-engineer.sh`, confirm `/etc/vibix-host-hints.md` exists in the container and contains the table; confirm host-side tempfile is deleted on exit.
- [ ] On native amd64 Linux: run the same script, confirm `/etc/vibix-host-hints.md` is absent in the container.
- [ ] Under tmux on both hosts: confirm tmux `automatic-rename` is still correctly disabled and restored on the launching window (no regression from the consolidated EXIT trap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)