### PR TITLE
tty: Termios (Linux termios2 layout) + sys_ioctl with TCGETS/TCSETS

### DIFF
--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -474,6 +474,11 @@ pub unsafe extern "C" fn syscall_dispatch(
         // kill(pid, sig) — send signal to process.
         KILL => crate::signal::sys_kill(a0, a1),
 
+        // ioctl(fd, cmd, arg) — device-specific control. Only the tty-like
+        // `SerialBackend` handles non-trivial `cmd`s today; all other
+        // backends inherit the `-ENOTTY` default.
+        IOCTL => super::syscalls::ioctl::sys_ioctl(a0, a1 as u32, a2 as usize),
+
         _ => -38i64, // ENOSYS
     }
 }
@@ -944,6 +949,7 @@ syscall_entry:
 pub mod syscall_nr {
     pub const READ: u64 = 0;
     pub const WRITE: u64 = 1;
+    pub const IOCTL: u64 = 16;
     pub const BRK: u64 = 12;
     pub const FORK: u64 = 57;
     pub const EXECVE: u64 = 59;
@@ -990,6 +996,7 @@ mod tests {
         // Basic I/O
         assert_eq!(syscall_nr::READ, 0, "SYS_read must be 0");
         assert_eq!(syscall_nr::WRITE, 1, "SYS_write must be 1");
+        assert_eq!(syscall_nr::IOCTL, 16, "SYS_ioctl must be 16");
         assert_eq!(syscall_nr::CLOSE, 3, "SYS_close must be 3");
         assert_eq!(syscall_nr::DUP, 32, "SYS_dup must be 32");
         assert_eq!(syscall_nr::DUP2, 33, "SYS_dup2 must be 33");

--- a/kernel/src/arch/x86_64/syscalls/ioctl.rs
+++ b/kernel/src/arch/x86_64/syscalls/ioctl.rs
@@ -1,0 +1,23 @@
+//! `sys_ioctl(fd, cmd, arg)` — device-specific control syscall.
+//!
+//! Looks up the backing fd in the current task's fd table, clones the
+//! `Arc<dyn FileBackend>`, and dispatches to `FileBackend::ioctl`. Most
+//! backends inherit the trait default and return `-ENOTTY`; the tty-like
+//! [`SerialBackend`](crate::fs::SerialBackend) handles the TC* family.
+
+/// Shared `ioctl` body. Called from the `IOCTL` arm of `syscall_dispatch`.
+pub unsafe fn sys_ioctl(fd: u64, cmd: u32, arg: usize) -> i64 {
+    let fd = fd as u32;
+    let backend = {
+        let tbl = crate::task::current_fd_table();
+        let b = match tbl.lock().get(fd) {
+            Ok(b) => b,
+            Err(e) => return e,
+        };
+        b
+    };
+    match backend.ioctl(cmd, arg) {
+        Ok(rc) => rc,
+        Err(e) => e,
+    }
+}

--- a/kernel/src/arch/x86_64/syscalls/mod.rs
+++ b/kernel/src/arch/x86_64/syscalls/mod.rs
@@ -4,4 +4,5 @@
 //! lives in its own file and syscall.rs can stay focused on the trampoline
 //! and register plumbing.
 
+pub mod ioctl;
 pub mod vfs;

--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -163,7 +163,7 @@ fn legacy_dev_backend(path: &[u8], flags: u64) -> Option<i64> {
     }
     let safe_flags =
         (flags as u32) & (oflags::O_RDONLY | oflags::O_WRONLY | oflags::O_RDWR | oflags::O_CLOEXEC);
-    let backend: Arc<dyn FileBackend> = Arc::new(crate::fs::SerialBackend);
+    let backend: Arc<dyn FileBackend> = Arc::new(crate::fs::SerialBackend::new());
     Some(install_fd(backend, safe_flags))
 }
 

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -418,10 +418,8 @@ impl FileBackend for SerialBackend {
                 // SAFETY: `arg` is a userspace VA. `copy_to_user` validates
                 // the range against USER_VA_END and brackets the write with
                 // STAC/CLAC so SMAP enforces the user mapping.
-                unsafe {
-                    crate::arch::x86_64::uaccess::copy_to_user(arg, snapshot.as_bytes())
-                }
-                .map_err(|e| e.as_errno())?;
+                unsafe { crate::arch::x86_64::uaccess::copy_to_user(arg, snapshot.as_bytes()) }
+                    .map_err(|e| e.as_errno())?;
                 Ok(0)
             }
             // Drain (TCSETSW) and flush (TCSETSF) reduce to "apply now" until

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -31,6 +31,14 @@ pub trait FileBackend: Send + Sync {
     fn read(&self, buf: &mut [u8]) -> Result<usize, i64>;
     fn write(&self, buf: &[u8]) -> Result<usize, i64>;
 
+    /// Device-specific control. `cmd` follows Linux's `_IOC` encoding; `arg`
+    /// is the third `ioctl(2)` argument, typically a userspace pointer. The
+    /// default returns `-ENOTTY`, which POSIX defines as "inappropriate ioctl
+    /// for device" — the correct error for fds that expose no `ioctl` surface.
+    fn ioctl(&self, _cmd: u32, _arg: usize) -> Result<i64, i64> {
+        Err(ENOTTY)
+    }
+
     /// Downcast to [`vfs::VfsBackend`] for fd-keyed syscalls that need the
     /// underlying `OpenFile` (e.g. `fstat`, `fstatat` with `AT_EMPTY_PATH`).
     /// Non-VFS backends (`SerialBackend`, test stubs) return `None` and
@@ -123,6 +131,8 @@ pub const ELOOP: i64 = -40;
 pub const EACCES: i64 = -13;
 pub const EBUSY: i64 = -16;
 pub const EOVERFLOW: i64 = -75;
+pub const ENOTTY: i64 = -25;
+pub const EFAULT: i64 = -14;
 
 /// Per-process file-descriptor array.
 ///
@@ -322,8 +332,33 @@ impl FileDescTable {
 /// Used as the backend for fds 0/1/2. Stdio bypasses the VFS on purpose:
 /// every task gets a direct [`SerialBackend`] so console I/O works even
 /// before `/dev/console` is wired up in `devfs`.
+///
+/// Holds a per-backend [`tty::termios::Termios`] so userspace
+/// `tcgetattr`/`tcsetattr` (via `TCGETS`/`TCSETS` ioctls) have something
+/// to read and write. Semantically the stored struct is a shim until the
+/// real `Tty` wrapper lands (issue #374): N_TTY is not yet consulting it
+/// for canonical-mode or echo processing, but the ABI is in place so
+/// userspace can start calling `tcgetattr` without `-ENOTTY`.
 #[cfg(target_os = "none")]
-pub struct SerialBackend;
+pub struct SerialBackend {
+    termios: spin::Mutex<crate::tty::termios::Termios>,
+}
+
+#[cfg(target_os = "none")]
+impl SerialBackend {
+    pub const fn new() -> Self {
+        Self {
+            termios: spin::Mutex::new(crate::tty::termios::Termios::sane()),
+        }
+    }
+}
+
+#[cfg(target_os = "none")]
+impl Default for SerialBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[cfg(target_os = "none")]
 impl FileBackend for SerialBackend {
@@ -351,6 +386,41 @@ impl FileBackend for SerialBackend {
         crate::serial::write_bytes(buf);
         Ok(buf.len())
     }
+
+    fn ioctl(&self, cmd: u32, arg: usize) -> Result<i64, i64> {
+        use crate::tty::termios::{Termios, TCGETS, TCSETS, TCSETSF, TCSETSW};
+        match cmd {
+            TCGETS => {
+                if arg == 0 {
+                    return Err(EFAULT);
+                }
+                let snapshot = *self.termios.lock();
+                // SAFETY: `arg` is a userspace VA. `copy_to_user` validates
+                // the range against USER_VA_END and brackets the write with
+                // STAC/CLAC so SMAP enforces the user mapping.
+                unsafe {
+                    crate::arch::x86_64::uaccess::copy_to_user(arg, snapshot.as_bytes())
+                }
+                .map_err(|e| e.as_errno())?;
+                Ok(0)
+            }
+            // Drain (TCSETSW) and flush (TCSETSF) reduce to "apply now" until
+            // the output ring and raw-input buffer introduced by #374 exist —
+            // at that point this arm splits and acquires the relevant queues.
+            TCSETS | TCSETSW | TCSETSF => {
+                if arg == 0 {
+                    return Err(EFAULT);
+                }
+                let mut bytes = [0u8; 44];
+                // SAFETY: see TCGETS.
+                unsafe { crate::arch::x86_64::uaccess::copy_from_user(&mut bytes, arg) }
+                    .map_err(|e| e.as_errno())?;
+                *self.termios.lock() = Termios::from_bytes(&bytes);
+                Ok(0)
+            }
+            _ => Err(ENOTTY),
+        }
+    }
 }
 
 #[cfg(target_os = "none")]
@@ -361,7 +431,7 @@ impl FileDescTable {
     /// and stderr all map to the same [`SerialBackend`], bypassing the VFS
     /// so console I/O works before any filesystem is mounted.
     pub fn new_with_stdio() -> Self {
-        let serial = Arc::new(SerialBackend) as Arc<dyn FileBackend>;
+        let serial = Arc::new(SerialBackend::new()) as Arc<dyn FileBackend>;
         Self::new_with_backends(serial.clone(), serial.clone(), serial.clone())
     }
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -60,6 +60,8 @@ pub mod test_harness;
 pub mod test_hook;
 #[cfg(any(test, target_os = "none"))]
 pub mod time;
+#[cfg(any(test, target_os = "none"))]
+pub mod tty;
 
 #[cfg(target_os = "none")]
 pub use test_harness::{exit_qemu, QemuExitCode, Testable};

--- a/kernel/src/tty/mod.rs
+++ b/kernel/src/tty/mod.rs
@@ -1,0 +1,9 @@
+//! TTY subsystem.
+//!
+//! Today this module is just the POSIX [`termios`] data type plus its
+//! ioctl command numbers — the minimum needed for userspace to call
+//! `tcgetattr`/`tcsetattr` on a tty-like fd. The `Tty` wrapper, line
+//! discipline, and wait-queue glue land in follow-up work (RFC 0003,
+//! issues #374–#376).
+
+pub mod termios;

--- a/kernel/src/tty/termios.rs
+++ b/kernel/src/tty/termios.rs
@@ -125,8 +125,14 @@ impl Termios {
 
     /// Reinterpret a 44-byte buffer as a termios for copy-from-user.
     pub fn from_bytes(bytes: &[u8; 44]) -> Self {
-        // SAFETY: Same as above — all-integer repr(C) layout.
-        unsafe { *(bytes.as_ptr() as *const Self) }
+        // `bytes` has alignment 1; Termios wants alignment 4. Read through
+        // `ptr::read_unaligned` so the reinterpret is defined even when the
+        // backing buffer is mis-aligned (common for SMAP bounce buffers on
+        // the kernel stack).
+        //
+        // SAFETY: All-integer `#[repr(C)]` layout — every 44-byte pattern
+        // is a valid inhabitant.
+        unsafe { core::ptr::read_unaligned(bytes.as_ptr() as *const Self) }
     }
 }
 

--- a/kernel/src/tty/termios.rs
+++ b/kernel/src/tty/termios.rs
@@ -1,0 +1,229 @@
+//! Linux `termios2` / `ktermios` layout and TC* ioctl command numbers.
+//!
+//! vibix ships Linux's kernel-side `struct termios2` as its canonical
+//! termios and exposes it through `TCGETS`/`TCSETS` directly. This is a
+//! documented deviation from strict glibc `<termios.h>` compatibility —
+//! see RFC 0003 §"Termios layout" for rationale. Userspace built against
+//! Linux kernel headers (musl, or glibc with `TCGETS2`/`TCSETS2`) reads
+//! the full 44-byte struct including `c_ispeed`/`c_ospeed`.
+//!
+//! Bit values and `c_cc` indices are pinned against Linux
+//! `<asm-generic/termbits.h>` and `<asm-generic/ioctls.h>`.
+
+/// Number of control characters in `c_cc`. Linux `NCCS` on asm-generic
+/// architectures is 19.
+pub const NCCS: usize = 19;
+
+/// Linux kernel-side `struct termios2` / `ktermios`.
+///
+/// Laid out so the on-wire representation matches Linux exactly:
+/// four `u32` flag words, a one-byte line-discipline selector, the
+/// `NCCS`-sized control-character array, then two `u32` baud rates.
+/// Total size is 44 bytes; `repr(C)` with `align_of == 4` gives no
+/// internal padding because the `[u8; 19]` lands at offset 17 and the
+/// next `u32` at offset 36 is 4-aligned.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Termios {
+    pub c_iflag: u32,
+    pub c_oflag: u32,
+    pub c_cflag: u32,
+    pub c_lflag: u32,
+    pub c_line: u8,
+    pub c_cc: [u8; NCCS],
+    pub c_ispeed: u32,
+    pub c_ospeed: u32,
+}
+
+// Size/alignment are load-bearing: the syscall ABI passes raw bytes,
+// so any drift would silently corrupt userspace termios reads.
+const _: () = assert!(core::mem::size_of::<Termios>() == 44);
+const _: () = assert!(core::mem::align_of::<Termios>() == 4);
+
+// --- c_iflag bits --------------------------------------------------------
+
+pub const IGNBRK: u32 = 0x0001;
+pub const BRKINT: u32 = 0x0002;
+pub const ISTRIP: u32 = 0x0020;
+pub const INLCR: u32 = 0x0040;
+pub const IGNCR: u32 = 0x0080;
+pub const ICRNL: u32 = 0x0100;
+pub const IXON: u32 = 0x0400;
+
+// --- c_oflag bits --------------------------------------------------------
+
+pub const OPOST: u32 = 0x0001;
+pub const ONLCR: u32 = 0x0004;
+pub const OCRNL: u32 = 0x0008;
+
+// --- c_lflag bits --------------------------------------------------------
+
+pub const ISIG: u32 = 0x0001;
+pub const ICANON: u32 = 0x0002;
+pub const ECHO: u32 = 0x0008;
+pub const ECHOE: u32 = 0x0010;
+pub const ECHOK: u32 = 0x0020;
+pub const ECHONL: u32 = 0x0040;
+pub const NOFLSH: u32 = 0x0080;
+pub const TOSTOP: u32 = 0x0100;
+pub const IEXTEN: u32 = 0x8000;
+
+// --- c_cc indices --------------------------------------------------------
+
+pub const VINTR: usize = 0;
+pub const VQUIT: usize = 1;
+pub const VERASE: usize = 2;
+pub const VKILL: usize = 3;
+pub const VEOF: usize = 4;
+pub const VTIME: usize = 5;
+pub const VMIN: usize = 6;
+pub const VSTART: usize = 8;
+pub const VSTOP: usize = 9;
+pub const VSUSP: usize = 10;
+pub const VEOL: usize = 11;
+
+// --- TC* ioctl command numbers (Linux <asm-generic/ioctls.h>) ------------
+
+pub const TCGETS: u32 = 0x5401;
+pub const TCSETS: u32 = 0x5402;
+pub const TCSETSW: u32 = 0x5403;
+pub const TCSETSF: u32 = 0x5404;
+
+impl Termios {
+    /// A "sane" default termios suitable for an interactive console:
+    /// canonical mode, echo on, input CR→NL, output NL→CRNL, signals
+    /// enabled, and the control-character table matching Linux `stty
+    /// sane`.
+    pub const fn sane() -> Self {
+        let mut c_cc = [0u8; NCCS];
+        c_cc[VINTR] = 0x03; // Ctrl-C
+        c_cc[VQUIT] = 0x1c; // Ctrl-\
+        c_cc[VERASE] = 0x7f; // DEL
+        c_cc[VKILL] = 0x15; // Ctrl-U
+        c_cc[VEOF] = 0x04; // Ctrl-D
+        c_cc[VSUSP] = 0x1a; // Ctrl-Z
+        c_cc[VSTART] = 0x11; // Ctrl-Q
+        c_cc[VSTOP] = 0x13; // Ctrl-S
+        Self {
+            c_iflag: ICRNL | IXON | BRKINT,
+            c_oflag: OPOST | ONLCR,
+            c_cflag: 0,
+            c_lflag: ISIG | ICANON | ECHO | ECHOE | ECHOK | IEXTEN,
+            c_line: 0,
+            c_cc,
+            c_ispeed: 0,
+            c_ospeed: 0,
+        }
+    }
+
+    /// View the struct as a 44-byte buffer for copy-to-user.
+    pub fn as_bytes(&self) -> &[u8; 44] {
+        // SAFETY: Termios is `#[repr(C)]`, size 44, contains only
+        // integer fields — every byte pattern is a valid inhabitant.
+        unsafe { &*(self as *const Self as *const [u8; 44]) }
+    }
+
+    /// Reinterpret a 44-byte buffer as a termios for copy-from-user.
+    pub fn from_bytes(bytes: &[u8; 44]) -> Self {
+        // SAFETY: Same as above — all-integer repr(C) layout.
+        unsafe { *(bytes.as_ptr() as *const Self) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::{align_of, offset_of, size_of};
+
+    #[test]
+    fn layout_matches_linux_termios2() {
+        assert_eq!(size_of::<Termios>(), 44);
+        assert_eq!(align_of::<Termios>(), 4);
+        assert_eq!(offset_of!(Termios, c_iflag), 0);
+        assert_eq!(offset_of!(Termios, c_oflag), 4);
+        assert_eq!(offset_of!(Termios, c_cflag), 8);
+        assert_eq!(offset_of!(Termios, c_lflag), 12);
+        assert_eq!(offset_of!(Termios, c_line), 16);
+        assert_eq!(offset_of!(Termios, c_cc), 17);
+        assert_eq!(offset_of!(Termios, c_ispeed), 36);
+        assert_eq!(offset_of!(Termios, c_ospeed), 40);
+    }
+
+    #[test]
+    fn iflag_bit_values_match_linux() {
+        assert_eq!(IGNBRK, 0x0001);
+        assert_eq!(BRKINT, 0x0002);
+        assert_eq!(ISTRIP, 0x0020);
+        assert_eq!(INLCR, 0x0040);
+        assert_eq!(IGNCR, 0x0080);
+        assert_eq!(ICRNL, 0x0100);
+        assert_eq!(IXON, 0x0400);
+    }
+
+    #[test]
+    fn oflag_bit_values_match_linux() {
+        assert_eq!(OPOST, 0x0001);
+        assert_eq!(ONLCR, 0x0004);
+        assert_eq!(OCRNL, 0x0008);
+    }
+
+    #[test]
+    fn lflag_bit_values_match_linux() {
+        assert_eq!(ISIG, 0x0001);
+        assert_eq!(ICANON, 0x0002);
+        assert_eq!(ECHO, 0x0008);
+        assert_eq!(ECHOE, 0x0010);
+        assert_eq!(ECHOK, 0x0020);
+        assert_eq!(ECHONL, 0x0040);
+        assert_eq!(NOFLSH, 0x0080);
+        assert_eq!(TOSTOP, 0x0100);
+        assert_eq!(IEXTEN, 0x8000);
+    }
+
+    #[test]
+    fn cc_indices_match_linux() {
+        assert_eq!(VINTR, 0);
+        assert_eq!(VQUIT, 1);
+        assert_eq!(VERASE, 2);
+        assert_eq!(VKILL, 3);
+        assert_eq!(VEOF, 4);
+        assert_eq!(VTIME, 5);
+        assert_eq!(VMIN, 6);
+        assert_eq!(VSTART, 8);
+        assert_eq!(VSTOP, 9);
+        assert_eq!(VSUSP, 10);
+        assert_eq!(VEOL, 11);
+    }
+
+    #[test]
+    fn ioctl_cmd_numbers_match_linux() {
+        assert_eq!(TCGETS, 0x5401);
+        assert_eq!(TCSETS, 0x5402);
+        assert_eq!(TCSETSW, 0x5403);
+        assert_eq!(TCSETSF, 0x5404);
+    }
+
+    #[test]
+    fn sane_defaults_match_stty_sane() {
+        let t = Termios::sane();
+        assert_eq!(t.c_iflag, ICRNL | IXON | BRKINT);
+        assert_eq!(t.c_oflag, OPOST | ONLCR);
+        assert_eq!(t.c_lflag, ISIG | ICANON | ECHO | ECHOE | ECHOK | IEXTEN);
+        assert_eq!(t.c_cc[VINTR], 0x03);
+        assert_eq!(t.c_cc[VQUIT], 0x1c);
+        assert_eq!(t.c_cc[VERASE], 0x7f);
+        assert_eq!(t.c_cc[VKILL], 0x15);
+        assert_eq!(t.c_cc[VEOF], 0x04);
+        assert_eq!(t.c_cc[VSUSP], 0x1a);
+        assert_eq!(t.c_cc[VSTART], 0x11);
+        assert_eq!(t.c_cc[VSTOP], 0x13);
+    }
+
+    #[test]
+    fn as_bytes_from_bytes_round_trip() {
+        let t = Termios::sane();
+        let bytes = *t.as_bytes();
+        let round = Termios::from_bytes(&bytes);
+        assert_eq!(t, round);
+    }
+}


### PR DESCRIPTION
Closes #373

## Summary
- New `kernel/src/tty/termios.rs` with Linux kernel-side `termios2`/`ktermios` layout (44 bytes, `c_ispeed`/`c_ospeed` inline) plus `c_iflag` / `c_oflag` / `c_lflag` bit constants, `c_cc` indices, and `TCGETS` / `TCSETS` / `TCSETSW` / `TCSETSF` command numbers pinned against `<asm-generic/termbits.h>` and `<asm-generic/ioctls.h>`. `Termios::sane()` returns the `stty sane` defaults.
- Adds `SYS_ioctl` at Linux nr 16 to `syscall_dispatch` and a defaulted `FileBackend::ioctl` method (default returns `-ENOTTY`, so existing backends stay source-compatible).
- `SerialBackend` (stdio) now carries a `spin::Mutex<Termios>` initialized to `Termios::sane()` and handles the four TC* ioctls with SMAP-bracketed `copy_from_user` / `copy_to_user`. Drain/flush semantics collapse to "apply now" until #374 lands the output ring and raw-input buffer; a module comment flags the shim status.
- Part of RFC 0003.

## Test plan
- [x] `cargo xtask build` — green (same pre-existing `dead_code` warning on `Task::is_guard_hit` as main).
- [x] `cargo test -p vibix --lib` — 200 tests pass, including 8 new `tty::termios` tests covering struct layout (size 44, align 4, field offsets), bit values, `c_cc` indices, ioctl command numbers, sane-defaults, and `as_bytes`/`from_bytes` round-trip.
- [x] `cargo test -p vibix --lib fs` — 20 tests pass, no regressions in fd-table behavior.
- [ ] `cargo xtask test` — pre-existing, unrelated flake in `blocking_sync::rwlock_writer_exclusion` times out on clean `main` at the same test (confirmed by running `cargo xtask test` on a freshly stashed checkout of `main`). Not introduced by this PR — also noted in PR #384.
- [ ] `cargo xtask smoke` — same two pre-existing markers missing on clean `main` (`hello: hello from execed child`, `init: fork+exec+wait ok`). Not introduced by this PR.