### PR TITLE
fbcon: Shift+PgUp/PgDn paging through scrollback ring (#69)

### DIFF
--- a/kernel/src/fbview.rs
+++ b/kernel/src/fbview.rs
@@ -1,0 +1,82 @@
+//! Pure-logic helpers for the framebuffer viewport / scrollback paging.
+//!
+//! Lives outside `framebuffer.rs` so it compiles under host `cargo test`
+//! (the framebuffer module itself depends on raw-pointer pixel writes
+//! that are kernel-target only).
+
+/// Saturating clamp used by `Console::scroll_view_up`. Stepping past
+/// `scroll_filled` is silently capped so a held key doesn't wrap.
+pub fn clamp_offset_up(offset: usize, step: usize, filled: usize) -> usize {
+    offset.saturating_add(step).min(filled)
+}
+
+/// Saturating clamp used by `Console::scroll_view_down`. Returns 0 when
+/// the step would underflow.
+pub fn clamp_offset_down(offset: usize, step: usize) -> usize {
+    offset.saturating_sub(step)
+}
+
+/// Number of viewport rows that come from the scrollback ring vs. the
+/// live cell grid for a given offset/filled/rows configuration.
+/// Returns `(scrollback_rows, live_rows)`. The two always sum to `rows`.
+pub fn split_viewport(offset: usize, filled: usize, rows: usize) -> (usize, usize) {
+    let k = offset.min(filled).min(rows);
+    (k, rows - k)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_viewport_pinned_at_bottom_is_all_live() {
+        let (sb, live) = split_viewport(0, 200, 30);
+        assert_eq!((sb, live), (0, 30));
+    }
+
+    #[test]
+    fn split_viewport_partial_scrollback() {
+        let (sb, live) = split_viewport(5, 200, 30);
+        assert_eq!((sb, live), (5, 25));
+    }
+
+    #[test]
+    fn split_viewport_offset_clamped_by_filled() {
+        let (sb, live) = split_viewport(50, 8, 30);
+        assert_eq!((sb, live), (8, 22));
+    }
+
+    #[test]
+    fn split_viewport_offset_clamped_by_rows() {
+        let (sb, live) = split_viewport(100, 200, 30);
+        assert_eq!((sb, live), (30, 0));
+    }
+
+    #[test]
+    fn clamp_offset_up_saturates_at_filled() {
+        assert_eq!(clamp_offset_up(0, 29, 200), 29);
+        assert_eq!(clamp_offset_up(190, 29, 200), 200);
+        assert_eq!(clamp_offset_up(usize::MAX - 1, 29, 200), 200);
+    }
+
+    #[test]
+    fn clamp_offset_up_no_history_stays_zero() {
+        assert_eq!(clamp_offset_up(0, 29, 0), 0);
+    }
+
+    #[test]
+    fn clamp_offset_down_saturates_at_zero() {
+        assert_eq!(clamp_offset_down(29, 29), 0);
+        assert_eq!(clamp_offset_down(10, 29), 0);
+        assert_eq!(clamp_offset_down(50, 29), 21);
+    }
+
+    #[test]
+    fn page_paging_is_reversible() {
+        let filled = 200;
+        let page = 29;
+        let after_up = clamp_offset_up(0, page, filled);
+        let after_down = clamp_offset_down(after_up, page);
+        assert_eq!(after_down, 0);
+    }
+}

--- a/kernel/src/framebuffer.rs
+++ b/kernel/src/framebuffer.rs
@@ -64,6 +64,8 @@ const ANSI_BRIGHT: [u32; 8] = [
 /// Off-screen rows kept in the scrollback ring.
 pub const SCROLLBACK_ROWS: usize = 200;
 
+use crate::fbview::{clamp_offset_down, clamp_offset_up, split_viewport};
+
 // ─── character cell ────────────────────────────────────────────────────────
 
 #[derive(Clone, Copy)]
@@ -120,6 +122,12 @@ pub struct Console {
     scroll_head: usize,
     scroll_filled: usize,
 
+    // Viewport offset, in rows, from the live bottom. 0 = pinned to live
+    // output; positive values show that many rows of scrollback above the
+    // live top. Clamped to `scroll_filled`. Any new character output calls
+    // `pin_to_bottom()` first so live output always snaps the view back.
+    scroll_offset: usize,
+
     // SGR colour state.  We track base colour indices so that toggling
     // `bold` retroactively re-selects the bright palette entry.
     fg_base: Option<u8>, // 0-7 if an ANSI colour; None = default
@@ -172,6 +180,7 @@ impl Console {
             scrollback,
             scroll_head: 0,
             scroll_filled: 0,
+            scroll_offset: 0,
             fg_base: None,
             bg_base: None,
             bold: false,
@@ -207,6 +216,7 @@ impl Console {
     // ── screen clear ──────────────────────────────────────────────────────
 
     pub fn clear(&mut self) {
+        self.scroll_offset = 0;
         for cell in self.cells.iter_mut() {
             *cell = Cell::blank();
         }
@@ -273,6 +283,11 @@ impl Console {
     /// Called by the blink task.
     pub fn toggle_cursor(&mut self) {
         self.cursor_on = !self.cursor_on;
+        // When scrolled back, the live cursor isn't on screen. Flip the
+        // state so re-pinning restores the correct phase, but don't paint.
+        if self.scroll_offset != 0 {
+            return;
+        }
         let (cx, cy, on) = (self.cx, self.cy, self.cursor_on);
         self.draw_cursor(cx, cy, on);
     }
@@ -332,9 +347,172 @@ impl Console {
         }
     }
 
+    // ── scrollback viewport ───────────────────────────────────────────────
+
+    /// Maximum scroll-back offset the current viewport can reach.
+    fn max_scroll_offset(&self) -> usize {
+        self.scroll_filled
+    }
+
+    /// Step size for a page of scrollback — one screen minus one row of
+    /// overlap so readers don't lose their place.
+    fn page_step(&self) -> usize {
+        self.rows.saturating_sub(1).max(1)
+    }
+
+    /// Fetch the scrollback cell at `age` rows before the live top
+    /// (age 0 = most recently pushed). Returns `None` if `age` is out of
+    /// the filled range.
+    fn scrollback_row(&self, age: usize) -> Option<&[Cell]> {
+        if age >= self.scroll_filled {
+            return None;
+        }
+        let cols = self.cols;
+        let ring_row = (self.scroll_head + self.scroll_filled - 1 - age) % SCROLLBACK_ROWS;
+        let base = ring_row * cols;
+        Some(&self.scrollback[base..base + cols])
+    }
+
+    /// Repaint the entire pixel grid from the scroll-back ring + live
+    /// `cells`, honoring `scroll_offset`. Used whenever the viewport
+    /// shifts or returns to live.
+    fn repaint_viewport(&mut self) {
+        let cols = self.cols;
+        let rows = self.rows;
+        let (k, _live_rows) = split_viewport(self.scroll_offset, self.scroll_filled, rows);
+        // Rows [0..k): scrollback, with age decreasing as r grows.
+        for r in 0..k {
+            let age = k - 1 - r;
+            // Copy out the row so we don't hold an immutable borrow across
+            // render_cell_at, which needs &mut self.
+            let mut buf: [Cell; 256] = [Cell::blank(); 256];
+            if let Some(row) = self.scrollback_row(age) {
+                for (i, cell) in row.iter().enumerate().take(cols.min(buf.len())) {
+                    buf[i] = *cell;
+                }
+            }
+            for c in 0..cols.min(buf.len()) {
+                self.render_cell_at(c, r, buf[c]);
+            }
+        }
+        // Rows [k..rows): top `rows - k` rows of live cells.
+        for r in k..rows {
+            let live_row = r - k;
+            for c in 0..cols {
+                let cell = self.cells[live_row * cols + c];
+                self.render_cell_at(c, r, cell);
+            }
+        }
+    }
+
+    /// If the viewport is scrolled back, snap it to live and repaint.
+    /// Called at the top of every output-producing path so new writes
+    /// always show up.
+    fn pin_to_bottom(&mut self) {
+        if self.scroll_offset != 0 {
+            self.scroll_offset = 0;
+            self.repaint_viewport();
+        }
+    }
+
+    /// Scroll the viewport up by `lines` (toward older output). Saturates
+    /// at `scroll_filled` rows.
+    pub fn scroll_view_up(&mut self, lines: usize) {
+        let new = clamp_offset_up(self.scroll_offset, lines, self.max_scroll_offset());
+        if new != self.scroll_offset {
+            self.scroll_offset = new;
+            self.repaint_viewport();
+            self.draw_indicator();
+        }
+    }
+
+    /// Scroll the viewport down by `lines` (toward live output). Saturates
+    /// at 0; reaching 0 erases the indicator.
+    pub fn scroll_view_down(&mut self, lines: usize) {
+        let new = clamp_offset_down(self.scroll_offset, lines);
+        if new != self.scroll_offset {
+            self.scroll_offset = new;
+            self.repaint_viewport();
+            if self.scroll_offset == 0 {
+                // Restore cursor cell — indicator lived there only in pixels.
+                let (cx, cy, on) = (self.cx, self.cy, self.cursor_on);
+                self.draw_cursor(cx, cy, on);
+            } else {
+                self.draw_indicator();
+            }
+        }
+    }
+
+    /// Page one screen up.
+    pub fn scroll_view_up_page(&mut self) {
+        let step = self.page_step();
+        self.scroll_view_up(step);
+    }
+
+    /// Page one screen down.
+    pub fn scroll_view_down_page(&mut self) {
+        let step = self.page_step();
+        self.scroll_view_down(step);
+    }
+
+    /// Paint a small `[-offset/filled]` marker in the top row's right edge.
+    /// Written only to the pixel buffer (not the grid), so a pin-to-bottom
+    /// repaint from `cells` naturally erases it.
+    fn draw_indicator(&mut self) {
+        if self.scroll_offset == 0 || self.cols < 16 {
+            return;
+        }
+        // Build the ASCII marker, e.g. "[-12/200]".
+        let mut buf = [0u8; 24];
+        let mut w = 0;
+        let write_byte = |buf: &mut [u8; 24], w: &mut usize, b: u8| {
+            if *w < buf.len() {
+                buf[*w] = b;
+                *w += 1;
+            }
+        };
+        let write_num = |buf: &mut [u8; 24], w: &mut usize, mut n: usize| {
+            if n == 0 {
+                write_byte(buf, w, b'0');
+                return;
+            }
+            let mut digits = [0u8; 6];
+            let mut d = 0;
+            while n > 0 && d < digits.len() {
+                digits[d] = b'0' + (n % 10) as u8;
+                n /= 10;
+                d += 1;
+            }
+            while d > 0 {
+                d -= 1;
+                write_byte(buf, w, digits[d]);
+            }
+        };
+        write_byte(&mut buf, &mut w, b'[');
+        write_byte(&mut buf, &mut w, b'-');
+        write_num(&mut buf, &mut w, self.scroll_offset);
+        write_byte(&mut buf, &mut w, b'/');
+        write_num(&mut buf, &mut w, self.scroll_filled);
+        write_byte(&mut buf, &mut w, b']');
+        let len = w;
+        if len >= self.cols {
+            return;
+        }
+        let start_col = self.cols - len;
+        for (i, b) in buf.iter().enumerate().take(len) {
+            let cell = Cell {
+                ch: *b as char,
+                fg: ANSI_BRIGHT[3], // bright yellow — catches the eye
+                bg: DEFAULT_BG,
+            };
+            self.render_cell_at(start_col + i, 0, cell);
+        }
+    }
+
     // ── cursor-aware movement ─────────────────────────────────────────────
 
     fn move_to_newline(&mut self) {
+        self.pin_to_bottom();
         let (cx, cy) = (self.cx, self.cy);
         self.draw_cursor(cx, cy, false);
         self.cx = 0;
@@ -350,6 +528,10 @@ impl Console {
     // ── character output ──────────────────────────────────────────────────
 
     fn put_char(&mut self, c: char) {
+        // New output must snap the viewport back to live so the user sees
+        // what just got written.
+        self.pin_to_bottom();
+
         let fg = self.cur_fg();
         let bg = self.cur_bg();
 
@@ -425,6 +607,7 @@ impl Console {
                     self.move_to_newline();
                 }
                 '\r' => {
+                    self.pin_to_bottom();
                     let (cx, cy) = (self.cx, self.cy);
                     self.draw_cursor(cx, cy, false);
                     self.cx = 0;
@@ -432,6 +615,7 @@ impl Console {
                     self.draw_cursor(cx, cy, on);
                 }
                 '\t' => {
+                    self.pin_to_bottom();
                     let next_tab = ((self.cx / 8) + 1) * 8;
                     let (cx, cy) = (self.cx, self.cy);
                     self.draw_cursor(cx, cy, false);
@@ -522,6 +706,24 @@ pub fn toggle_cursor() {
     }
 }
 
+/// Scroll the viewport one page up toward older output. No-op when the
+/// scrollback ring is empty. Call from the input layer when the user
+/// presses Shift+PgUp.
+pub fn scroll_view_up_page() {
+    if let Some(c) = CONSOLE.lock().as_mut() {
+        c.scroll_view_up_page();
+    }
+}
+
+/// Scroll the viewport one page down toward live output. Reaching 0
+/// erases the scroll indicator. Call from the input layer when the user
+/// presses Shift+PgDn.
+pub fn scroll_view_down_page() {
+    if let Some(c) = CONSOLE.lock().as_mut() {
+        c.scroll_view_down_page();
+    }
+}
+
 #[doc(hidden)]
 pub fn _print(args: fmt::Arguments) {
     if let Some(c) = CONSOLE.lock().as_mut() {
@@ -539,3 +741,4 @@ macro_rules! println {
     () => ($crate::print!("\n"));
     ($($arg:tt)*) => ($crate::print!("{}\n", format_args!($($arg)*)));
 }
+

--- a/kernel/src/framebuffer.rs
+++ b/kernel/src/framebuffer.rs
@@ -741,4 +741,3 @@ macro_rules! println {
     () => ($crate::print!("\n"));
     ($($arg:tt)*) => ($crate::print!("{}\n", format_args!($($arg)*)));
 }
-

--- a/kernel/src/framebuffer.rs
+++ b/kernel/src/framebuffer.rs
@@ -377,8 +377,7 @@ impl Console {
             // correctly. Index arithmetic is duplicated here rather than
             // calling scrollback_row() to avoid holding an immutable borrow
             // across render_cell_at, which needs &mut self.
-            let ring_row =
-                (self.scroll_head + self.scroll_filled - 1 - age) % SCROLLBACK_ROWS;
+            let ring_row = (self.scroll_head + self.scroll_filled - 1 - age) % SCROLLBACK_ROWS;
             let base = ring_row * cols;
             for c in 0..cols {
                 let cell = self.scrollback[base + c];

--- a/kernel/src/framebuffer.rs
+++ b/kernel/src/framebuffer.rs
@@ -360,39 +360,29 @@ impl Console {
         self.rows.saturating_sub(1).max(1)
     }
 
-    /// Fetch the scrollback cell at `age` rows before the live top
-    /// (age 0 = most recently pushed). Returns `None` if `age` is out of
-    /// the filled range.
-    fn scrollback_row(&self, age: usize) -> Option<&[Cell]> {
-        if age >= self.scroll_filled {
-            return None;
-        }
-        let cols = self.cols;
-        let ring_row = (self.scroll_head + self.scroll_filled - 1 - age) % SCROLLBACK_ROWS;
-        let base = ring_row * cols;
-        Some(&self.scrollback[base..base + cols])
-    }
-
     /// Repaint the entire pixel grid from the scroll-back ring + live
     /// `cells`, honoring `scroll_offset`. Used whenever the viewport
     /// shifts or returns to live.
     fn repaint_viewport(&mut self) {
         let cols = self.cols;
         let rows = self.rows;
-        let (k, _live_rows) = split_viewport(self.scroll_offset, self.scroll_filled, rows);
-        // Rows [0..k): scrollback, with age decreasing as r grows.
+        let offset = self.scroll_offset.min(self.scroll_filled);
+        let (k, _live_rows) = split_viewport(offset, self.scroll_filled, rows);
+        // Rows [0..k): scrollback. The oldest visible row is age `offset-1`,
+        // and each successive row in the viewport is one step newer.
         for r in 0..k {
-            let age = k - 1 - r;
-            // Copy out the row so we don't hold an immutable borrow across
-            // render_cell_at, which needs &mut self.
-            let mut buf: [Cell; 256] = [Cell::blank(); 256];
-            if let Some(row) = self.scrollback_row(age) {
-                for (i, cell) in row.iter().enumerate().take(cols.min(buf.len())) {
-                    buf[i] = *cell;
-                }
-            }
-            for c in 0..cols.min(buf.len()) {
-                self.render_cell_at(c, r, buf[c]);
+            let age = offset - 1 - r;
+            // Copy cells from the scrollback ring directly without an
+            // intermediate buffer so rows wider than 256 columns render
+            // correctly. Index arithmetic is duplicated here rather than
+            // calling scrollback_row() to avoid holding an immutable borrow
+            // across render_cell_at, which needs &mut self.
+            let ring_row =
+                (self.scroll_head + self.scroll_filled - 1 - age) % SCROLLBACK_ROWS;
+            let base = ring_row * cols;
+            for c in 0..cols {
+                let cell = self.scrollback[base + c];
+                self.render_cell_at(c, r, cell);
             }
         }
         // Rows [k..rows): top `rows - k` rows of live cells.

--- a/kernel/src/input.rs
+++ b/kernel/src/input.rs
@@ -137,6 +137,14 @@ mod kernel_side {
         OVERFLOWS.load(Ordering::Relaxed)
     }
 
+    /// Whether either Shift key is currently held, per the pc-keyboard
+    /// decoder's internal modifier state. Reflects the state as of the
+    /// last decoded scancode — safe to call immediately after
+    /// [`try_read_key`] returns a key.
+    pub fn shift_held() -> bool {
+        KEYBOARD.lock().get_modifiers().is_shifted()
+    }
+
     /// Block (via `hlt`) until a decoded key is available.
     ///
     /// Disabling interrupts before the final empty-check plugs the race

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -35,6 +35,7 @@ pub mod bench;
 pub mod boot;
 #[cfg(target_os = "none")]
 pub mod framebuffer;
+pub mod fbview;
 #[cfg(any(test, target_os = "none"))]
 pub mod hpet;
 #[cfg(target_os = "none")]

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -33,9 +33,9 @@ pub mod arch;
 pub mod bench;
 #[cfg(target_os = "none")]
 pub mod boot;
+pub mod fbview;
 #[cfg(target_os = "none")]
 pub mod framebuffer;
-pub mod fbview;
 #[cfg(any(test, target_os = "none"))]
 pub mod hpet;
 #[cfg(target_os = "none")]

--- a/kernel/src/shell/mod.rs
+++ b/kernel/src/shell/mod.rs
@@ -22,7 +22,7 @@ mod kernel_side {
     use super::line_editor::{Effect, Input, LineEditor};
     use crate::mem::{frame, heap, FRAME_SIZE};
     use crate::task::TaskStateView;
-    use crate::{input, pci, serial, serial_print, serial_println, task, time};
+    use crate::{framebuffer, input, pci, serial, serial_print, serial_println, task, time};
 
     /// Flipped to `true` the first time the shell's `run` enters its main
     /// loop. Integration tests poll this to confirm the shell actually
@@ -63,6 +63,20 @@ mod kernel_side {
             return serial_byte(b, state);
         }
         let key = input::try_read_key()?;
+        // Shift+PgUp/PgDn pages the framebuffer scrollback. We capture the
+        // shift state immediately after decode (before any other scancode
+        // can advance the modifier state) and consume the key without
+        // forwarding it to the line editor.
+        if let DecodedKey::RawKey(kc @ (KeyCode::PageUp | KeyCode::PageDown)) = key {
+            if input::shift_held() {
+                match kc {
+                    KeyCode::PageUp => framebuffer::scroll_view_up_page(),
+                    KeyCode::PageDown => framebuffer::scroll_view_down_page(),
+                    _ => {}
+                }
+                return None;
+            }
+        }
         match key {
             DecodedKey::Unicode(c) => char_to_input(c),
             DecodedKey::RawKey(KeyCode::ArrowUp) => Some(Input::HistoryPrev),


### PR DESCRIPTION
Closes #69

## Summary

- Adds a viewport `scroll_offset` to the framebuffer console. When non-zero, the visible grid is composited from the existing `scrollback` ring (older rows toward the top of the screen) plus the top of the live cell grid.
- **Shift+PgUp** / **Shift+PgDn** page through the buffer (one screen at a time, leaving one row of overlap so readers don't lose their place).
- **Auto-snap to live**: every output-producing path (`put_char`, `move_to_newline`, `\r`, `\t`) calls `pin_to_bottom` first, so any new output snaps the viewport back to live and the user sees what just got written.
- **Visual indicator**: while scrolled back, a `[-N/M]` marker (bright yellow) is painted in the top-right of the screen. It lives only in the pixel buffer, so the cell-grid repaint that runs on pin-to-bottom naturally erases it.
- `toggle_cursor` early-returns while scrolled back so the blink timer doesn't paint over the historical view.
- Pure-logic helpers (`clamp_offset_up`/`_down`, `split_viewport`) split out into a new `kernel/src/fbview.rs` so they compile under host `cargo test` and get unit-test coverage. The framebuffer module remains kernel-target only.

## Test plan

- [x] `cargo xtask build` — kernel builds clean on `x86_64-unknown-none`.
- [x] `cargo xtask test` — full suite passes (the `blocking_sync` rwlock flake tracked by #385 surfaced once intermittently and cleared on retry; not introduced here).
- [x] `cargo xtask smoke` — all 30 markers present (the fork+exec+wait HARD_CAP flake tracked by #400 surfaced intermittently, also pre-existing; cleared on retry).
- [x] 8 new host unit tests in `fbview::tests`:
  - `split_viewport_pinned_at_bottom_is_all_live`
  - `split_viewport_partial_scrollback`
  - `split_viewport_offset_clamped_by_filled`
  - `split_viewport_offset_clamped_by_rows`
  - `clamp_offset_up_saturates_at_filled`
  - `clamp_offset_up_no_history_stays_zero`
  - `clamp_offset_down_saturates_at_zero`
  - `page_paging_is_reversible`