### PR TITLE
shell: add uname, version, whoami, clear, date introspection builtins

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -211,3 +211,7 @@ harness = false
 [[test]]
 name = "anon_fault_saturated"
 harness = false
+
+[[test]]
+name = "shell_introspection"
+harness = false

--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -1,0 +1,108 @@
+//! Emits compile-time build metadata used by the `kernel::build_info`
+//! module: short git SHA, an ISO-8601 build timestamp, and the cargo
+//! profile name. Falls back to `"unknown"` for the SHA when the tree
+//! isn't a git checkout so tarball builds don't break.
+
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn main() {
+    let sha = git_short_sha().unwrap_or_else(|| "unknown".to_string());
+    let ts = build_timestamp();
+    let profile = std::env::var("PROFILE").unwrap_or_else(|_| "unknown".to_string());
+
+    println!("cargo:rustc-env=VIBIX_GIT_SHA={}", sha);
+    println!("cargo:rustc-env=VIBIX_BUILD_TIMESTAMP={}", ts);
+    println!("cargo:rustc-env=VIBIX_BUILD_PROFILE={}", profile);
+
+    // Only rebuild when the HEAD ref or the packed-refs file changes —
+    // not on every source edit. Paths are relative to the workspace
+    // root; `..` steps out of `kernel/`.
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed=../.git/refs/heads");
+    println!("cargo:rerun-if-changed=../.git/packed-refs");
+    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
+}
+
+fn git_short_sha() -> Option<String> {
+    let out = Command::new("git")
+        .args(["rev-parse", "--short=12", "HEAD"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8(out.stdout).ok()?.trim().to_string();
+    if sha.is_empty() {
+        None
+    } else {
+        Some(sha)
+    }
+}
+
+fn build_timestamp() -> String {
+    let epoch = std::env::var("SOURCE_DATE_EPOCH")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .or_else(|| {
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .ok()
+                .map(|d| d.as_secs())
+        })
+        .unwrap_or(0);
+    format_epoch(epoch)
+}
+
+/// Format seconds-since-epoch as `YYYY-MM-DD HH:MM:SS` UTC. No external
+/// dep — proleptic Gregorian calendar with a leap-year cycle that is
+/// correct for every year in the foreseeable future.
+fn format_epoch(epoch: u64) -> String {
+    let secs = epoch % 60;
+    let mins = (epoch / 60) % 60;
+    let hours = (epoch / 3600) % 24;
+    let mut days = epoch / 86_400;
+
+    let mut year: u64 = 1970;
+    loop {
+        let ydays = if is_leap(year) { 366 } else { 365 };
+        if days < ydays {
+            break;
+        }
+        days -= ydays;
+        year += 1;
+    }
+
+    let month_lens = [
+        31u64,
+        if is_leap(year) { 29 } else { 28 },
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+    ];
+    let mut month = 1u64;
+    for &len in &month_lens {
+        if days < len {
+            break;
+        }
+        days -= len;
+        month += 1;
+    }
+    let day = days + 1;
+
+    format!(
+        "{:04}-{:02}-{:02} {:02}:{:02}:{:02}",
+        year, month, day, hours, mins, secs
+    )
+}
+
+fn is_leap(year: u64) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
+}

--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -56,9 +56,9 @@ fn build_timestamp() -> String {
     format_epoch(epoch)
 }
 
-/// Format seconds-since-epoch as `YYYY-MM-DD HH:MM:SS` UTC. No external
-/// dep — proleptic Gregorian calendar with a leap-year cycle that is
-/// correct for every year in the foreseeable future.
+/// Format seconds-since-epoch as `YYYY-MM-DDTHH:MM:SSZ` (ISO-8601 UTC).
+/// No external dep — proleptic Gregorian calendar with a leap-year cycle
+/// that is correct for every year in the foreseeable future.
 fn format_epoch(epoch: u64) -> String {
     let secs = epoch % 60;
     let mins = (epoch / 60) % 60;
@@ -100,7 +100,7 @@ fn format_epoch(epoch: u64) -> String {
     let day = days + 1;
 
     format!(
-        "{:04}-{:02}-{:02} {:02}:{:02}:{:02}",
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
         year, month, day, hours, mins, secs
     )
 }

--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -10,10 +10,12 @@ fn main() {
     let sha = git_short_sha().unwrap_or_else(|| "unknown".to_string());
     let ts = build_timestamp();
     let profile = std::env::var("PROFILE").unwrap_or_else(|_| "unknown".to_string());
+    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "unknown".to_string());
 
     println!("cargo:rustc-env=VIBIX_GIT_SHA={}", sha);
     println!("cargo:rustc-env=VIBIX_BUILD_TIMESTAMP={}", ts);
     println!("cargo:rustc-env=VIBIX_BUILD_PROFILE={}", profile);
+    println!("cargo:rustc-env=VIBIX_TARGET_ARCH={}", arch);
 
     // Only rebuild when the HEAD ref or the packed-refs file changes —
     // not on every source edit. Paths are relative to the workspace

--- a/kernel/src/build_info.rs
+++ b/kernel/src/build_info.rs
@@ -5,7 +5,7 @@
 //! from host unit tests alike.
 
 pub const KERNEL_NAME: &str = "vibix";
-pub const ARCH: &str = "x86_64";
+pub const ARCH: &str = env!("VIBIX_TARGET_ARCH");
 
 /// Kernel "release" string — mirrors Linux's `uname -r` slot. We don't
 /// yet version the kernel independently of the workspace, so the crate

--- a/kernel/src/build_info.rs
+++ b/kernel/src/build_info.rs
@@ -1,0 +1,24 @@
+//! Compile-time build metadata baked in by `build.rs`.
+//!
+//! The values below are populated via `cargo:rustc-env=` directives, so
+//! they are plain string literals — usable from `no_std` contexts and
+//! from host unit tests alike.
+
+pub const KERNEL_NAME: &str = "vibix";
+pub const ARCH: &str = "x86_64";
+
+/// Kernel "release" string — mirrors Linux's `uname -r` slot. We don't
+/// yet version the kernel independently of the workspace, so the crate
+/// version is the most meaningful identifier a user can grep for.
+pub const RELEASE: &str = env!("CARGO_PKG_VERSION");
+
+/// Short git SHA of the tree the kernel was built from, or `"unknown"`
+/// when the tree wasn't a git checkout at build time.
+pub const GIT_SHA: &str = env!("VIBIX_GIT_SHA");
+
+/// ISO-8601 UTC timestamp captured at build time. Honors
+/// `SOURCE_DATE_EPOCH` for reproducible builds.
+pub const BUILD_TIMESTAMP: &str = env!("VIBIX_BUILD_TIMESTAMP");
+
+/// Cargo profile name (`"debug"`, `"release"`, …).
+pub const PROFILE: &str = env!("VIBIX_BUILD_PROFILE");

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -15,6 +15,7 @@ extern crate alloc;
 pub mod abi;
 #[cfg(any(test, target_os = "none"))]
 pub mod block;
+pub mod build_info;
 pub mod cpu;
 #[cfg(any(test, target_os = "none"))]
 pub mod fs;

--- a/kernel/src/shell/mod.rs
+++ b/kernel/src/shell/mod.rs
@@ -20,6 +20,7 @@ mod kernel_side {
 
     use super::ansi::{self, CsiFinal, Event};
     use super::line_editor::{Effect, Input, LineEditor};
+    use crate::build_info;
     use crate::mem::{frame, heap, FRAME_SIZE};
     use crate::task::TaskStateView;
     use crate::{input, pci, serial, serial_print, serial_println, task, time};
@@ -158,10 +159,22 @@ mod kernel_side {
             "mem" => cmd_mem(),
             "tasks" => cmd_tasks(),
             "pci" => cmd_pci(),
+            "uname" => cmd_uname(rest),
+            "version" => cmd_version(),
+            "whoami" => cmd_whoami(),
+            "clear" => cmd_clear(),
+            "date" => cmd_date(),
             "echo" => serial_println!("{}", rest),
             "panic" => panic!("shell: panic builtin invoked"),
             _ => serial_println!("unknown command: {} (try `help`)", cmd),
         }
+    }
+
+    /// Test-only entry point: run one line through the dispatch table
+    /// without touching the line editor or input rings. Integration
+    /// tests capture the serial output directly via UART loopback.
+    pub fn dispatch_for_test(line: &str) {
+        dispatch(line);
     }
 
     fn cmd_help() {
@@ -172,6 +185,11 @@ mod kernel_side {
         serial_println!("  mem             heap + free-frame counters");
         serial_println!("  tasks           live task ids and remaining slices");
         serial_println!("  pci             enumerated PCI devices on bus 0");
+        serial_println!("  uname [-asrvm]  print kernel name / release / arch");
+        serial_println!("  version         kernel version + build metadata");
+        serial_println!("  whoami          print effective user name");
+        serial_println!("  clear           clear the screen (Ctrl+L with no key)");
+        serial_println!("  date            wall-clock time from the RTC (UTC)");
         serial_println!("  echo <args>     echo the rest of the line");
         serial_println!("  panic           trigger a kernel panic (test aid)");
     }
@@ -250,6 +268,116 @@ mod kernel_side {
         }
     }
 
+    fn cmd_uname(args: &str) {
+        // Flag parsing: glued (`-am`) or split (`-a -m`) tokens are
+        // both accepted; bare `uname` → `-s`. `-a` wins over any other
+        // letters in the same invocation (Linux behavior).
+        let mut show_name = false;
+        let mut show_release = false;
+        let mut show_version = false;
+        let mut show_machine = false;
+        let mut show_all = false;
+        let mut any_flag = false;
+        let mut bad: Option<char> = None;
+
+        for tok in args.split_whitespace() {
+            if let Some(rest) = tok.strip_prefix('-') {
+                if rest.is_empty() {
+                    bad = Some('-');
+                    break;
+                }
+                for c in rest.chars() {
+                    any_flag = true;
+                    match c {
+                        'a' => show_all = true,
+                        's' => show_name = true,
+                        'r' => show_release = true,
+                        'v' => show_version = true,
+                        'm' => show_machine = true,
+                        other => {
+                            bad = Some(other);
+                            break;
+                        }
+                    }
+                }
+                if bad.is_some() {
+                    break;
+                }
+            } else {
+                bad = Some(tok.chars().next().unwrap_or('?'));
+                break;
+            }
+        }
+
+        if let Some(c) = bad {
+            serial_println!("uname: invalid option -- '{}'", c);
+            return;
+        }
+
+        if !any_flag {
+            show_name = true;
+        }
+
+        if show_all {
+            serial_println!(
+                "{} {} {} {}",
+                build_info::KERNEL_NAME,
+                build_info::RELEASE,
+                build_info::BUILD_TIMESTAMP,
+                build_info::ARCH,
+            );
+            return;
+        }
+
+        let mut first = true;
+        for (flag, value) in [
+            (show_name, build_info::KERNEL_NAME),
+            (show_release, build_info::RELEASE),
+            (show_version, build_info::BUILD_TIMESTAMP),
+            (show_machine, build_info::ARCH),
+        ] {
+            if flag {
+                if !first {
+                    serial_print!(" ");
+                }
+                serial_print!("{}", value);
+                first = false;
+            }
+        }
+        serial_println!();
+    }
+
+    fn cmd_version() {
+        serial_println!(
+            "{} {} {} {}",
+            build_info::KERNEL_NAME,
+            build_info::RELEASE,
+            build_info::BUILD_TIMESTAMP,
+            build_info::ARCH,
+        );
+        serial_println!(
+            "build: {} (git {})",
+            build_info::PROFILE,
+            build_info::GIT_SHA,
+        );
+    }
+
+    fn cmd_whoami() {
+        serial_println!("root");
+    }
+
+    fn cmd_clear() {
+        // Same VT100 sequence the line editor emits on Ctrl+L.
+        serial_print!("\x1b[2J\x1b[H");
+    }
+
+    fn cmd_date() {
+        match time::wall_clock() {
+            Some(now) => serial_println!("{} UTC", now),
+            None => serial_println!("date: unavailable (no RTC)"),
+        }
+    }
+
     fn cmd_tasks() {
         task::for_each_task(|t| {
             let tag = match t.state {
@@ -270,4 +398,4 @@ mod kernel_side {
 }
 
 #[cfg(target_os = "none")]
-pub use kernel_side::{run, SHELL_ONLINE};
+pub use kernel_side::{dispatch_for_test, run, SHELL_ONLINE};

--- a/kernel/tests/shell_introspection.rs
+++ b/kernel/tests/shell_introspection.rs
@@ -1,0 +1,153 @@
+//! Integration test: every introspection builtin dispatches without
+//! panicking, `build_info` constants are populated, and `whoami`'s
+//! serial output is captured end-to-end via UART loopback.
+//!
+//! Serial loopback is only used for the tiny `whoami` output (6 bytes)
+//! so the transmission fits inside the UART's 16-byte hardware FIFO
+//! during the `without_interrupts` window `serial_println!` takes.
+//! Larger outputs (`uname -a`, `version`) would race FIFO drain vs.
+//! IRQ4 re-enable, so they're verified only for "does not panic" +
+//! `build_info` value plumbing.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+
+use vibix::{
+    build_info, exit_qemu, serial, serial_println,
+    shell::dispatch_for_test,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+use x86_64::instructions::port::Port;
+
+const COM1_BASE: u16 = 0x3F8;
+const UART_REG_MCR: u16 = 4;
+const MCR_LOOPBACK_BITS: u8 = 0x1A;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "build_info_constants_populated",
+            &(build_info_constants_populated as fn()),
+        ),
+        (
+            "uname_default_does_not_panic",
+            &(uname_default_does_not_panic as fn()),
+        ),
+        (
+            "uname_flag_combos_do_not_panic",
+            &(uname_flag_combos_do_not_panic as fn()),
+        ),
+        ("version_does_not_panic", &(version_does_not_panic as fn())),
+        ("clear_does_not_panic", &(clear_does_not_panic as fn())),
+        ("date_does_not_panic", &(date_does_not_panic as fn())),
+        ("whoami_prints_root", &(whoami_prints_root as fn())),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+fn build_info_constants_populated() {
+    assert_eq!(build_info::KERNEL_NAME, "vibix");
+    assert_eq!(build_info::ARCH, "x86_64");
+    assert!(
+        !build_info::RELEASE.is_empty(),
+        "RELEASE should come from CARGO_PKG_VERSION"
+    );
+    assert!(
+        !build_info::GIT_SHA.is_empty(),
+        "GIT_SHA should be set (build.rs fallback is \"unknown\")"
+    );
+    assert!(
+        !build_info::BUILD_TIMESTAMP.is_empty(),
+        "BUILD_TIMESTAMP should be set by build.rs"
+    );
+    assert!(
+        !build_info::PROFILE.is_empty(),
+        "PROFILE should be set from cargo PROFILE env"
+    );
+}
+
+fn uname_default_does_not_panic() {
+    dispatch_for_test("uname");
+}
+
+fn uname_flag_combos_do_not_panic() {
+    dispatch_for_test("uname -a");
+    dispatch_for_test("uname -s");
+    dispatch_for_test("uname -r");
+    dispatch_for_test("uname -v");
+    dispatch_for_test("uname -m");
+    dispatch_for_test("uname -srm");
+    // Bad flag path: must print an error line, not panic.
+    dispatch_for_test("uname -Z");
+}
+
+fn version_does_not_panic() {
+    dispatch_for_test("version");
+}
+
+fn clear_does_not_panic() {
+    dispatch_for_test("clear");
+}
+
+fn date_does_not_panic() {
+    dispatch_for_test("date");
+}
+
+fn whoami_prints_root() {
+    // Drain any pre-existing bytes in the ring.
+    while serial::try_read_byte().is_some() {}
+
+    let mut mcr: Port<u8> = Port::new(COM1_BASE + UART_REG_MCR);
+    let saved_mcr = unsafe { mcr.read() };
+
+    // Enter loopback. "root\r\n" is 6 bytes → fits in the 16-byte
+    // 16550 RX FIFO during the single `without_interrupts` window
+    // `serial_println!` takes.
+    unsafe { mcr.write(MCR_LOOPBACK_BITS) };
+    dispatch_for_test("whoami");
+
+    // Give IRQ4 time to drain the FIFO into RX_RING.
+    let mut collected = alloc::vec::Vec::<u8>::new();
+    for _ in 0..200 {
+        while let Some(b) = serial::try_read_byte() {
+            collected.push(b);
+        }
+        if collected.len() >= 6 {
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+
+    // Restore MCR before emitting anything — otherwise pass/fail logs
+    // never leave the chip.
+    unsafe { mcr.write(saved_mcr) };
+
+    assert_eq!(
+        core::str::from_utf8(&collected).unwrap_or("<non-utf8>"),
+        "root\n",
+        "whoami should emit exactly \"root\\n\" (got {:?})",
+        collected
+    );
+}

--- a/kernel/tests/shell_introspection.rs
+++ b/kernel/tests/shell_introspection.rs
@@ -2,7 +2,7 @@
 //! panicking, `build_info` constants are populated, and `whoami`'s
 //! serial output is captured end-to-end via UART loopback.
 //!
-//! Serial loopback is only used for the tiny `whoami` output (6 bytes)
+//! Serial loopback is only used for the tiny `whoami` output (5 bytes)
 //! so the transmission fits inside the UART's 16-byte hardware FIFO
 //! during the `without_interrupts` window `serial_println!` takes.
 //! Larger outputs (`uname -a`, `version`) would race FIFO drain vs.
@@ -69,7 +69,10 @@ fn run_tests() {
 
 fn build_info_constants_populated() {
     assert_eq!(build_info::KERNEL_NAME, "vibix");
-    assert_eq!(build_info::ARCH, "x86_64");
+    assert!(
+        !build_info::ARCH.is_empty(),
+        "ARCH should be set from CARGO_CFG_TARGET_ARCH via build.rs"
+    );
     assert!(
         !build_info::RELEASE.is_empty(),
         "RELEASE should come from CARGO_PKG_VERSION"

--- a/kernel/tests/shell_introspection.rs
+++ b/kernel/tests/shell_introspection.rs
@@ -122,7 +122,7 @@ fn whoami_prints_root() {
     let mut mcr: Port<u8> = Port::new(COM1_BASE + UART_REG_MCR);
     let saved_mcr = unsafe { mcr.read() };
 
-    // Enter loopback. "root\r\n" is 6 bytes → fits in the 16-byte
+    // Enter loopback. "root\n" is 5 bytes → fits in the 16-byte
     // 16550 RX FIFO during the single `without_interrupts` window
     // `serial_println!` takes.
     unsafe { mcr.write(MCR_LOOPBACK_BITS) };
@@ -134,7 +134,7 @@ fn whoami_prints_root() {
         while let Some(b) = serial::try_read_byte() {
             collected.push(b);
         }
-        if collected.len() >= 6 {
+        if collected.len() >= 5 {
             break;
         }
         x86_64::instructions::hlt();


### PR DESCRIPTION
Closes #396

## Summary

- Adds five introspection builtins to the shell: `uname` (with Linux-style `-a|-s|-r|-v|-m` flags), `version`, `whoami`, `clear`, and `date`.
- Introduces a `kernel::build_info` module populated at compile time by a new `kernel/build.rs` (git short SHA, ISO-8601 UTC build timestamp, cargo profile). Honors `SOURCE_DATE_EPOCH` for reproducible builds; falls back to `"unknown"` for the SHA on non-git trees.
- Wires `build.rs`'s `rerun-if-changed` narrowly to `.git/HEAD`, `.git/refs/heads`, and `.git/packed-refs`, so source edits do not force the kernel to rebuild.
- Adds a `shell_introspection` integration test that exercises every new builtin via a new test-only `dispatch_for_test` entry point, and verifies `whoami`'s serial output end-to-end via UART loopback.

## Test plan

- [x] `cargo xtask build` — clean (only the pre-existing `is_guard_hit` warning).
- [x] `cargo test -p vibix --target x86_64-unknown-none --test shell_introspection …` — all 7 sub-tests pass.
- [x] `cargo xtask smoke` — all 30 markers present.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy -p xtask --all-targets -- -D warnings` — clean.

Notes:
- `blocking_sync` and `fpu_context_switch` occasionally hit the xtask runner's 30 s per-boot timeout under emulation. Both pass when run in isolation; this is a pre-existing flake tracked separately and unrelated to these changes.