### PR TITLE
vfs: implement lseek / file offsets on open file descriptions

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -189,6 +189,10 @@ name = "syscall_vfs"
 harness = false
 
 [[test]]
+name = "syscall_lseek"
+harness = false
+
+[[test]]
 name = "vm_integration"
 harness = false
 

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -336,6 +336,28 @@ pub unsafe extern "C" fn syscall_dispatch(
             }
         }
 
+        // lseek(fd, offset, whence) — reposition the shared open-file offset.
+        //   whence: SEEK_SET=0, SEEK_CUR=1, SEEK_END=2.
+        // Returns the new absolute offset on success, or a negated errno
+        // (EBADF, EINVAL, ESPIPE, EOVERFLOW).
+        LSEEK => {
+            let fd = a0 as u32;
+            let off = a1 as i64;
+            let whence = a2 as i32;
+            let backend = {
+                let tbl = crate::task::current_fd_table();
+                let x = match tbl.lock().get(fd) {
+                    Ok(b) => b,
+                    Err(e) => return e,
+                };
+                x
+            };
+            match backend.lseek(off, whence) {
+                Ok(n) => n,
+                Err(e) => e,
+            }
+        }
+
         // dup2(oldfd, newfd)
         DUP2 => {
             let oldfd = a0 as u32;

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -59,6 +59,18 @@ pub trait FileBackend: Send + Sync {
         DEFAULT_POLLMASK
     }
 
+    /// Reposition the shared file offset per POSIX `lseek(2)`.
+    ///
+    /// `whence` follows the Linux ABI (`SEEK_SET`=0, `SEEK_CUR`=1,
+    /// `SEEK_END`=2). The default returns `ESPIPE`, which is the correct
+    /// answer for pipes, FIFOs, sockets, and any other backend that has
+    /// no random-access offset — matching the Linux behaviour for drivers
+    /// without a `.llseek` file-op. Backends over seekable objects
+    /// (VFS-backed regular files) override this.
+    fn lseek(&self, _off: i64, _whence: i32) -> Result<i64, i64> {
+        Err(ESPIPE)
+    }
+
     /// Downcast to [`vfs::VfsBackend`] for fd-keyed syscalls that need the
     /// underlying `OpenFile` (e.g. `fstat`, `fstatat` with `AT_EMPTY_PATH`).
     /// Non-VFS backends (`SerialBackend`, test stubs) return `None` and
@@ -155,6 +167,7 @@ pub const ENOTTY: i64 = -25;
 pub const EFAULT: i64 = -14;
 pub const EPIPE: i64 = -32;
 pub const EINTR: i64 = -4;
+pub const ESPIPE: i64 = -29;
 
 /// Per-process file-descriptor array.
 ///
@@ -631,6 +644,16 @@ mod tests {
         assert!(t.get(0).is_ok());
         assert!(t.get(1).is_ok());
         assert!(t.get(2).is_ok());
+    }
+
+    #[test]
+    fn default_lseek_returns_espipe() {
+        // Backends that do not override lseek (pipes, sockets, synthetic
+        // stdio) must surface ESPIPE — matching Linux's behaviour for
+        // drivers without a .llseek file-op.
+        let backend = NullBackend;
+        assert_eq!(backend.lseek(0, 0), Err(ESPIPE));
+        assert_eq!(backend.lseek(42, 1), Err(ESPIPE));
     }
 
     #[test]

--- a/kernel/src/fs/vfs/backend.rs
+++ b/kernel/src/fs/vfs/backend.rs
@@ -22,9 +22,15 @@
 
 use alloc::sync::Arc;
 
-use crate::fs::{FileBackend, EOVERFLOW};
+use crate::fs::{FileBackend, EINVAL, EOVERFLOW};
 
 use super::open_file::OpenFile;
+use super::ops::Whence;
+
+/// Linux `lseek(2)` whence constants. Values pinned to the x86_64 ABI.
+pub const SEEK_SET: i32 = 0;
+pub const SEEK_CUR: i32 = 1;
+pub const SEEK_END: i32 = 2;
 
 /// Wraps an [`OpenFile`] as a [`FileBackend`] for the fd-table.
 ///
@@ -64,6 +70,27 @@ impl FileBackend for VfsBackend {
         *off = off.checked_add(n as u64).ok_or(EOVERFLOW)?;
         Ok(n)
     }
+
+    /// Reposition the shared file offset.
+    ///
+    /// Maps the Linux `whence` integer to [`Whence`] (rejecting unknown
+    /// values with `EINVAL`) and delegates to [`FileOps::seek`], which is
+    /// responsible for acquiring `OpenFile.offset` and applying the
+    /// filesystem's notion of file size for `SEEK_END`. Returns the new
+    /// absolute offset as an `i64`, or `EOVERFLOW` if it does not fit.
+    fn lseek(&self, off: i64, whence: i32) -> Result<i64, i64> {
+        let w = match whence {
+            SEEK_SET => Whence::Set,
+            SEEK_CUR => Whence::Cur,
+            SEEK_END => Whence::End,
+            _ => return Err(EINVAL),
+        };
+        let new_off = self.open_file.ops.seek(&self.open_file, w, off)?;
+        if new_off > i64::MAX as u64 {
+            return Err(EOVERFLOW);
+        }
+        Ok(new_off as i64)
+    }
 }
 
 #[cfg(test)]
@@ -75,7 +102,8 @@ mod tests {
     use crate::fs::vfs::ops::{FileOps, InodeOps, SetAttr, Stat, StatFs, SuperOps};
     use crate::fs::vfs::super_block::{SbActiveGuard, SbFlags, SuperBlock};
     use crate::fs::vfs::FsId;
-    use crate::fs::{flags, FileDescTable, FileDescription};
+    use crate::fs::{flags, FileDescTable, FileDescription, EINVAL, EOVERFLOW, ESPIPE};
+    use crate::fs::vfs::ops::Whence;
     use alloc::sync::Arc;
 
     // -----------------------------------------------------------------------
@@ -109,6 +137,38 @@ mod tests {
         fill_byte: u8,
     }
 
+    /// A `FileOps` stub whose `seek` mirrors ramfs (SEEK_SET absolute,
+    /// SEEK_CUR relative, SEEK_END from a fixed `size`). Used to exercise
+    /// `VfsBackend::lseek` end-to-end without pulling in ramfs.
+    struct SeekableOps {
+        size: u64,
+    }
+
+    impl FileOps for SeekableOps {
+        fn seek(&self, f: &OpenFile, whence: Whence, off: i64) -> Result<u64, i64> {
+            let mut cur = f.offset.lock();
+            let new_off = match whence {
+                Whence::Set => off,
+                Whence::Cur => (*cur as i64).saturating_add(off),
+                Whence::End => (self.size as i64).saturating_add(off),
+            };
+            if new_off < 0 {
+                return Err(EINVAL);
+            }
+            *cur = new_off as u64;
+            Ok(*cur)
+        }
+    }
+
+    /// A `FileOps` stub whose `seek` returns an offset larger than
+    /// `i64::MAX`, to exercise the `EOVERFLOW` path in `VfsBackend::lseek`.
+    struct HugeSeekOps;
+    impl FileOps for HugeSeekOps {
+        fn seek(&self, _f: &OpenFile, _whence: Whence, _off: i64) -> Result<u64, i64> {
+            Ok(u64::MAX)
+        }
+    }
+
     impl FileOps for CountingOps {
         fn read(&self, _f: &OpenFile, buf: &mut [u8], _off: u64) -> Result<usize, i64> {
             for b in buf.iter_mut() {
@@ -120,6 +180,27 @@ mod tests {
         fn write(&self, _f: &OpenFile, buf: &[u8], _off: u64) -> Result<usize, i64> {
             Ok(buf.len())
         }
+    }
+
+    fn make_open_file_with_ops(ops: Arc<dyn FileOps>) -> Arc<OpenFile> {
+        let sb = Arc::new(SuperBlock::new(
+            FsId(42),
+            Arc::new(StubSuperOps),
+            "stub",
+            512,
+            SbFlags::default(),
+        ));
+        let inode = Arc::new(Inode::new(
+            1,
+            Arc::downgrade(&sb),
+            Arc::new(StubInodeOps),
+            ops.clone(),
+            InodeKind::Reg,
+            InodeMeta::default(),
+        ));
+        let dentry = Dentry::new_root(inode.clone());
+        let guard = SbActiveGuard::try_acquire(&sb).expect("guard");
+        OpenFile::new(dentry, inode, ops, sb.clone(), 0, guard)
     }
 
     fn make_open_file(fill_byte: u8) -> Arc<OpenFile> {
@@ -201,6 +282,91 @@ mod tests {
         let mut buf2 = [0u8; 2];
         child_backend.read(&mut buf2).unwrap();
         assert_eq!(*of.offset.lock(), 5, "offset advances further via child");
+    }
+
+    #[test]
+    fn lseek_set_absolute_offset() {
+        let of = make_open_file_with_ops(Arc::new(SeekableOps { size: 100 }));
+        let backend = VfsBackend {
+            open_file: of.clone(),
+        };
+        assert_eq!(backend.lseek(42, SEEK_SET), Ok(42));
+        assert_eq!(*of.offset.lock(), 42);
+    }
+
+    #[test]
+    fn lseek_cur_advances_from_current() {
+        let of = make_open_file_with_ops(Arc::new(SeekableOps { size: 100 }));
+        *of.offset.lock() = 10;
+        let backend = VfsBackend {
+            open_file: of.clone(),
+        };
+        assert_eq!(backend.lseek(5, SEEK_CUR), Ok(15));
+        assert_eq!(*of.offset.lock(), 15);
+    }
+
+    #[test]
+    fn lseek_end_from_file_size() {
+        let of = make_open_file_with_ops(Arc::new(SeekableOps { size: 100 }));
+        let backend = VfsBackend {
+            open_file: of.clone(),
+        };
+        assert_eq!(backend.lseek(-10, SEEK_END), Ok(90));
+        assert_eq!(*of.offset.lock(), 90);
+    }
+
+    #[test]
+    fn lseek_negative_result_returns_einval() {
+        let of = make_open_file_with_ops(Arc::new(SeekableOps { size: 100 }));
+        let backend = VfsBackend { open_file: of };
+        assert_eq!(backend.lseek(-1, SEEK_SET), Err(EINVAL));
+    }
+
+    #[test]
+    fn lseek_unknown_whence_returns_einval() {
+        let of = make_open_file_with_ops(Arc::new(SeekableOps { size: 100 }));
+        let backend = VfsBackend { open_file: of };
+        assert_eq!(backend.lseek(0, 99), Err(EINVAL));
+    }
+
+    #[test]
+    fn lseek_default_ops_seek_returns_espipe() {
+        // CountingOps does not override `FileOps::seek`, so it inherits
+        // the default ESPIPE — confirming that a FileOps lacking seek
+        // surfaces ESPIPE end-to-end.
+        let of = make_open_file(0);
+        let backend = VfsBackend { open_file: of };
+        assert_eq!(backend.lseek(0, SEEK_SET), Err(ESPIPE));
+    }
+
+    #[test]
+    fn lseek_overflow_returns_eoverflow() {
+        let of = make_open_file_with_ops(Arc::new(HugeSeekOps));
+        let backend = VfsBackend { open_file: of };
+        assert_eq!(backend.lseek(0, SEEK_SET), Err(EOVERFLOW));
+    }
+
+    #[test]
+    fn lseek_across_fork_shares_offset() {
+        // Same offset mutex across parent/child → lseek on one side is
+        // visible to the other, matching POSIX open-file-description sharing.
+        let of = make_open_file_with_ops(Arc::new(SeekableOps { size: 100 }));
+        let parent_backend = Arc::new(VfsBackend {
+            open_file: of.clone(),
+        }) as Arc<dyn FileBackend>;
+        let mut parent = FileDescTable::new();
+        let desc = Arc::new(FileDescription {
+            backend: parent_backend,
+            flags: 0,
+        });
+        let fd = parent.alloc_fd(desc).expect("alloc_fd");
+        let child = parent.clone_for_fork();
+
+        parent.get(fd).unwrap().lseek(42, SEEK_SET).unwrap();
+        assert_eq!(*of.offset.lock(), 42);
+        // Child sees the same offset via its own fd — via the shared OpenFile.
+        assert!(child.get(fd).is_ok());
+        assert_eq!(*of.offset.lock(), 42);
     }
 
     #[test]

--- a/kernel/src/fs/vfs/backend.rs
+++ b/kernel/src/fs/vfs/backend.rs
@@ -99,11 +99,11 @@ mod tests {
     use crate::fs::vfs::dentry::Dentry;
     use crate::fs::vfs::inode::{Inode, InodeKind, InodeMeta};
     use crate::fs::vfs::open_file::OpenFile;
+    use crate::fs::vfs::ops::Whence;
     use crate::fs::vfs::ops::{FileOps, InodeOps, SetAttr, Stat, StatFs, SuperOps};
     use crate::fs::vfs::super_block::{SbActiveGuard, SbFlags, SuperBlock};
     use crate::fs::vfs::FsId;
     use crate::fs::{flags, FileDescTable, FileDescription, EINVAL, EOVERFLOW, ESPIPE};
-    use crate::fs::vfs::ops::Whence;
     use alloc::sync::Arc;
 
     // -----------------------------------------------------------------------

--- a/kernel/src/fs/vfs/tarfs.rs
+++ b/kernel/src/fs/vfs/tarfs.rs
@@ -196,14 +196,25 @@ impl FileOps for TarFileOps {
         Ok(n)
     }
 
-    fn seek(&self, _f: &OpenFile, whence: Whence, off: i64) -> Result<u64, i64> {
-        // Only SEEK_SET is meaningful without an internal offset
-        // here; lseek's real work happens in `OpenFile.offset`, so
-        // we just validate and echo.
-        match whence {
-            Whence::Set if off >= 0 => Ok(off as u64),
-            _ => Err(EINVAL),
+    fn seek(&self, f: &OpenFile, whence: Whence, off: i64) -> Result<u64, i64> {
+        let sup = self.super_()?;
+        let node = sup.node(f.inode.ino)?;
+        let size = match &node.data {
+            NodeData::Reg { len, .. } => *len as i64,
+            NodeData::Dir { .. } => return Err(-21), // EISDIR
+            NodeData::Link { .. } => return Err(EINVAL),
+        };
+        let mut cur = f.offset.lock();
+        let new_off = match whence {
+            Whence::Set => off,
+            Whence::Cur => (*cur as i64).saturating_add(off),
+            Whence::End => size.saturating_add(off),
+        };
+        if new_off < 0 {
+            return Err(EINVAL);
         }
+        *cur = new_off as u64;
+        Ok(*cur)
     }
 
     fn getdents(&self, f: &OpenFile, buf: &mut [u8], cookie: &mut u64) -> Result<usize, i64> {

--- a/kernel/tests/syscall_lseek.rs
+++ b/kernel/tests/syscall_lseek.rs
@@ -1,0 +1,228 @@
+//! Integration test for issue #410: `lseek` syscall.
+//!
+//! Exercises the `SYS_LSEEK` dispatcher arm end-to-end:
+//! - `SEEK_SET` repositions the shared offset on a rootfs regular file
+//!   and a subsequent `SYS_READ` reads from the new position.
+//! - `SEEK_CUR` advances the offset relative to the current position.
+//! - `SEEK_END` positions relative to file size (tested via negative
+//!   offset reaching into the payload).
+//! - A negative resulting offset returns `EINVAL`.
+//! - An unknown `whence` returns `EINVAL`.
+//! - `lseek` on `/dev/stdin` (a `SerialBackend`) returns `ESPIPE`, per
+//!   POSIX "lseek on a non-seekable backend".
+//! - `lseek` on a closed / never-opened fd returns `EBADF`.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use core::ptr;
+
+use vibix::arch::x86_64::syscall::syscall_dispatch;
+use vibix::fs::{EBADF, EINVAL, ESPIPE};
+use vibix::mem::vmatree::{Share, Vma};
+use vibix::mem::vmobject::AnonObject;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+use x86_64::structures::paging::PageTableFlags;
+
+const SYS_READ: u64 = 0;
+const SYS_OPEN: u64 = 2;
+const SYS_CLOSE: u64 = 3;
+const SYS_LSEEK: u64 = 8;
+
+const SEEK_SET: u64 = 0;
+const SEEK_CUR: u64 = 1;
+const SEEK_END: u64 = 2;
+
+/// Rootfs file populated by `xtask::ensure_initrd`. Content is the
+/// 6-byte UTF-8 string `b"vibix\n"`; any drift here and the test fails
+/// noisily, which is the point.
+const HOSTNAME_PATH: &[u8] = b"/etc/hostname\0";
+const HOSTNAME_CONTENT: &[u8] = b"vibix\n";
+
+const USER_PAGE_VA: usize = 0x0000_2001_0000_0000;
+const USER_PAGE_LEN: usize = 4 * 4096;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    vibix::task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("lseek_set_rewinds", &(lseek_set_rewinds as fn())),
+        ("lseek_cur_advances", &(lseek_cur_advances as fn())),
+        ("lseek_end_negative", &(lseek_end_negative as fn())),
+        (
+            "lseek_negative_result_einval",
+            &(lseek_negative_result_einval as fn()),
+        ),
+        (
+            "lseek_unknown_whence_einval",
+            &(lseek_unknown_whence_einval as fn()),
+        ),
+        ("lseek_on_stdio_espipe", &(lseek_on_stdio_espipe as fn())),
+        ("lseek_on_closed_fd_ebadf", &(lseek_on_closed_fd_ebadf as fn())),
+    ];
+    for (name, t) in tests {
+        serial_println!("syscall_lseek: {}", name);
+        t.run();
+    }
+}
+
+/// Install a single demand-paged anonymous VMA at `USER_PAGE_VA` so
+/// tests can stage user-visible bytes there. Mirrors the pattern used
+/// by `syscall_open_mmap.rs`.
+fn install_user_staging_vma() {
+    static INSTALLED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+    if INSTALLED.swap(true, core::sync::atomic::Ordering::SeqCst) {
+        return;
+    }
+    let prot_pte =
+        (PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE).bits();
+    vibix::task::install_vma_on_current(Vma::new(
+        USER_PAGE_VA,
+        USER_PAGE_VA + USER_PAGE_LEN,
+        0x3, // PROT_READ | PROT_WRITE
+        prot_pte,
+        Share::Private,
+        AnonObject::new(Some(USER_PAGE_LEN / 4096)),
+        0,
+    ));
+    unsafe {
+        ptr::write_volatile(USER_PAGE_VA as *mut u8, 0);
+    }
+}
+
+/// Copy `bytes` to the user page at offset 0 and return the VA.
+fn stage(bytes: &[u8]) -> u64 {
+    install_user_staging_vma();
+    assert!(bytes.len() < USER_PAGE_LEN);
+    unsafe {
+        let dst = USER_PAGE_VA as *mut u8;
+        for (i, b) in bytes.iter().enumerate() {
+            ptr::write_volatile(dst.add(i), *b);
+        }
+    }
+    USER_PAGE_VA as u64
+}
+
+fn open_ro(path: &[u8]) -> i64 {
+    let uva = stage(path);
+    unsafe { syscall_dispatch(SYS_OPEN, uva, 0, 0, 0, 0, 0) }
+}
+
+fn close(fd: i64) -> i64 {
+    unsafe { syscall_dispatch(SYS_CLOSE, fd as u64, 0, 0, 0, 0, 0) }
+}
+
+fn lseek(fd: i64, off: i64, whence: u64) -> i64 {
+    unsafe { syscall_dispatch(SYS_LSEEK, fd as u64, off as u64, whence, 0, 0, 0) }
+}
+
+/// Read up to `len` bytes into a scratch region of the user page, then
+/// copy them back into a kernel-side buffer for assertion.
+fn read_bytes(fd: i64, out: &mut [u8]) -> i64 {
+    // Stash the read at USER_PAGE_VA + 256 so it doesn't clobber the
+    // path we just used for open.
+    let buf_va = USER_PAGE_VA as u64 + 256;
+    let n = unsafe { syscall_dispatch(SYS_READ, fd as u64, buf_va, out.len() as u64, 0, 0, 0) };
+    if n > 0 {
+        unsafe {
+            let src = buf_va as *const u8;
+            for i in 0..n as usize {
+                out[i] = ptr::read_volatile(src.add(i));
+            }
+        }
+    }
+    n
+}
+
+fn lseek_set_rewinds() {
+    let fd = open_ro(HOSTNAME_PATH);
+    assert!(fd >= 3, "open /etc/hostname failed: {}", fd);
+    let mut buf = [0u8; 6];
+    let n = read_bytes(fd, &mut buf);
+    assert_eq!(n, HOSTNAME_CONTENT.len() as i64);
+    assert_eq!(&buf, HOSTNAME_CONTENT);
+
+    // Rewind and re-read — offset must actually be reset.
+    let new_off = lseek(fd, 0, SEEK_SET);
+    assert_eq!(new_off, 0, "SEEK_SET to 0 must return 0, got {}", new_off);
+
+    let mut buf2 = [0u8; 6];
+    let n2 = read_bytes(fd, &mut buf2);
+    assert_eq!(n2, HOSTNAME_CONTENT.len() as i64);
+    assert_eq!(&buf2, HOSTNAME_CONTENT);
+
+    assert_eq!(close(fd), 0);
+}
+
+fn lseek_cur_advances() {
+    let fd = open_ro(HOSTNAME_PATH);
+    assert!(fd >= 3);
+    // Read 2 bytes.
+    let mut buf = [0u8; 2];
+    assert_eq!(read_bytes(fd, &mut buf), 2);
+    assert_eq!(&buf, b"vi");
+    // SEEK_CUR +1 → position 3.
+    assert_eq!(lseek(fd, 1, SEEK_CUR), 3);
+    // Read next byte → 'i' (index 3 of b"vibix\n").
+    let mut b = [0u8; 1];
+    assert_eq!(read_bytes(fd, &mut b), 1);
+    assert_eq!(b[0], b'i');
+    close(fd);
+}
+
+fn lseek_end_negative() {
+    let fd = open_ro(HOSTNAME_PATH);
+    assert!(fd >= 3);
+    // Seek to 1 byte before EOF; should point at '\n'.
+    assert_eq!(lseek(fd, -1, SEEK_END), (HOSTNAME_CONTENT.len() - 1) as i64);
+    let mut b = [0u8; 1];
+    assert_eq!(read_bytes(fd, &mut b), 1);
+    assert_eq!(b[0], b'\n');
+    close(fd);
+}
+
+fn lseek_negative_result_einval() {
+    let fd = open_ro(HOSTNAME_PATH);
+    assert!(fd >= 3);
+    // Try to seek before the start of the file.
+    assert_eq!(lseek(fd, -1, SEEK_SET), EINVAL);
+    close(fd);
+}
+
+fn lseek_unknown_whence_einval() {
+    let fd = open_ro(HOSTNAME_PATH);
+    assert!(fd >= 3);
+    assert_eq!(lseek(fd, 0, 99), EINVAL);
+    close(fd);
+}
+
+fn lseek_on_stdio_espipe() {
+    // fd 0 (stdin) is backed by SerialBackend, which has no seek offset.
+    // The default FileBackend::lseek returns ESPIPE.
+    assert_eq!(lseek(0, 0, SEEK_SET), ESPIPE);
+    assert_eq!(lseek(1, 0, SEEK_CUR), ESPIPE);
+}
+
+fn lseek_on_closed_fd_ebadf() {
+    // Very large fd — unambiguously never opened in any test flow.
+    assert_eq!(lseek(9999, 0, SEEK_SET), EBADF);
+}

--- a/kernel/tests/syscall_lseek.rs
+++ b/kernel/tests/syscall_lseek.rs
@@ -77,7 +77,10 @@ fn run_tests() {
             &(lseek_unknown_whence_einval as fn()),
         ),
         ("lseek_on_stdio_espipe", &(lseek_on_stdio_espipe as fn())),
-        ("lseek_on_closed_fd_ebadf", &(lseek_on_closed_fd_ebadf as fn())),
+        (
+            "lseek_on_closed_fd_ebadf",
+            &(lseek_on_closed_fd_ebadf as fn()),
+        ),
     ];
     for (name, t) in tests {
         serial_println!("syscall_lseek: {}", name);


### PR DESCRIPTION
Closes #410

## Summary

- Adds `FileBackend::lseek(off, whence)` with a POSIX-correct `ESPIPE` default so pipes, FIFOs, sockets, and `SerialBackend`-backed stdio report "not seekable" out of the box; overridden by `VfsBackend` to delegate to `FileOps::seek`.
- Wires `SYS_lseek` (nr 8) through the syscall dispatcher — `SEEK_SET`/`SEEK_CUR`/`SEEK_END` values pinned to the Linux ABI; unknown whence → `EINVAL`, u64→i64 overflow → `EOVERFLOW`.
- Fixes `tarfs::seek`, which until now echoed its argument without ever mutating `OpenFile.offset`, so post-`lseek` reads silently continued from the old position. Now mirrors ramfs: locks the offset, resolves the new position against the tar node's length, rejects negative results with `EINVAL`, and writes back.

## Test plan

- [x] `cargo xtask build` — clean
- [x] `cargo xtask smoke` — all 30 markers present
- [x] Host unit tests — `fs::tests::default_lseek_returns_espipe` passes; full lib suite 228/228 green
- [x] New `syscall_lseek` integration test runs under QEMU with 7/7 passing:
  - `lseek_set_rewinds`, `lseek_cur_advances`, `lseek_end_negative`
  - `lseek_negative_result_einval`, `lseek_unknown_whence_einval`
  - `lseek_on_stdio_espipe`, `lseek_on_closed_fd_ebadf`
- [x] `vfs_backend` and `syscall_vfs` integration tests re-run cleanly — no regression on adjacent paths
- [ ] Note: `blocking_sync::rwlock_writer_exclusion` times out under `cargo xtask test`; verified to reproduce on clean `main` without this branch, so it is a pre-existing flake unrelated to lseek wiring

## Notes

- The private `ESPIPE` alias in `fs/vfs/ops.rs` is retained — it's still used by the `FileOps::seek` default body. A follow-up could dedupe to the now-public `fs::ESPIPE`.
- This is one of six sub-issues decomposed from #87 (VFS POSIX semantics tracking). Siblings: #411 getdents, #412 O_CREAT/TRUNC/APPEND, #413 errno cleanup, #414 dup/dup2/dup3, #415 fcntl.