### PR TITLE
process: add session/pgrp/controlling-tty to PCB + session syscalls

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -219,3 +219,7 @@ harness = false
 [[test]]
 name = "shell_introspection"
 harness = false
+
+[[test]]
+name = "session_syscalls"
+harness = false

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -519,6 +519,20 @@ pub unsafe extern "C" fn syscall_dispatch(
         // pselect6(nfds, readfds, writefds, exceptfds, ts, sigmask).
         PSELECT6 => crate::poll::syscalls::sys_pselect6(a0, a1, a2, a3, a4, a5),
 
+        // setsid() — create a new session with the caller as leader.
+        SETSID => crate::process::sys_setsid(),
+
+        // getsid(pid) — return the session id of `pid`, or the caller's
+        // session when pid==0.
+        GETSID => crate::process::sys_getsid(a0 as u32),
+
+        // setpgid(pid, pgid) — move `pid` into process group `pgid`.
+        SETPGID => crate::process::sys_setpgid(a0 as u32, a1 as u32),
+
+        // getpgid(pid) — return the pgrp id of `pid`, or the caller's
+        // pgrp when pid==0.
+        GETPGID => crate::process::sys_getpgid(a0 as u32),
+
         _ => -38i64, // ENOSYS
     }
 }
@@ -1022,6 +1036,10 @@ pub mod syscall_nr {
     pub const SELECT: u64 = 23;
     pub const PSELECT6: u64 = 270;
     pub const PPOLL: u64 = 271;
+    pub const SETPGID: u64 = 109;
+    pub const SETSID: u64 = 112;
+    pub const GETPGID: u64 = 121;
+    pub const GETSID: u64 = 124;
 }
 
 #[cfg(test)]
@@ -1077,5 +1095,11 @@ mod tests {
         assert_eq!(syscall_nr::SELECT, 23, "SYS_select must be 23");
         assert_eq!(syscall_nr::PSELECT6, 270, "SYS_pselect6 must be 270");
         assert_eq!(syscall_nr::PPOLL, 271, "SYS_ppoll must be 271");
+
+        // Session / process group
+        assert_eq!(syscall_nr::SETPGID, 109, "SYS_setpgid must be 109");
+        assert_eq!(syscall_nr::SETSID, 112, "SYS_setsid must be 112");
+        assert_eq!(syscall_nr::GETPGID, 121, "SYS_getpgid must be 121");
+        assert_eq!(syscall_nr::GETSID, 124, "SYS_getsid must be 124");
     }
 }

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -18,6 +18,7 @@ use spin::{Lazy, Mutex};
 
 use crate::signal::SignalState;
 use crate::sync::WaitQueue;
+use crate::tty::{ProcessGroupId, SessionId, Tty};
 
 /// Scheduling / lifecycle state of a process entry.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -41,6 +42,16 @@ pub struct ProcessEntry {
     pub state: ProcessState,
     /// Per-process signal state — pending mask, blocked mask, dispositions.
     pub signals: Arc<Mutex<SignalState>>,
+    /// POSIX session id. `setsid` creates a new session with `session_id
+    /// == pgrp_id == pid`; children inherit across `fork` and `execve`.
+    pub session_id: SessionId,
+    /// POSIX process-group id. Always equal to the pgrp leader's pid.
+    pub pgrp_id: ProcessGroupId,
+    /// Controlling terminal, if any. Cleared by `setsid`; `TIOCSCTTY`
+    /// (#376) acquires one; shared by every member of a session via
+    /// `Arc` so the tty outlives the session leader until every
+    /// referring process has dropped it.
+    pub controlling_tty: Option<Arc<Tty>>,
 }
 
 struct Table {
@@ -86,16 +97,29 @@ pub fn register_init(task_id: usize) {
             exit_status: None,
             state: ProcessState::Alive,
             signals: Arc::new(Mutex::new(SignalState::new())),
+            session_id: 1,
+            pgrp_id: 1,
+            controlling_tty: None,
         },
     );
     t.pid_of.insert(task_id, 1);
 }
 
 /// Allocate a new PID and insert a live entry for `task_id` with
-/// `parent_pid` as parent. Returns the new PID.
+/// `parent_pid` as parent, inheriting session / pgrp / controlling tty
+/// from the parent entry. Returns the new PID.
+///
+/// If `parent_pid` is not in the table (kernel-origin process, test
+/// harness), the new entry starts with `session_id == pgrp_id == pid`
+/// and no controlling tty — i.e. its own session.
 pub fn register(task_id: usize, parent_pid: u32) -> u32 {
     let pid = NEXT_PID.fetch_add(1, Ordering::Relaxed);
     let mut t = TABLE.lock();
+    let (session_id, pgrp_id, controlling_tty) = t
+        .by_pid
+        .get(&parent_pid)
+        .map(|p| (p.session_id, p.pgrp_id, p.controlling_tty.clone()))
+        .unwrap_or((pid, pid, None));
     t.by_pid.insert(
         pid,
         ProcessEntry {
@@ -105,6 +129,9 @@ pub fn register(task_id: usize, parent_pid: u32) -> u32 {
             exit_status: None,
             state: ProcessState::Alive,
             signals: Arc::new(Mutex::new(SignalState::new())),
+            session_id,
+            pgrp_id,
+            controlling_tty,
         },
     );
     t.pid_of.insert(task_id, pid);
@@ -233,4 +260,215 @@ pub fn with_signal_state_for_task<R>(
 pub fn task_id_for_pid(pid: u32) -> Option<usize> {
     let t = TABLE.lock();
     t.by_pid.get(&pid).map(|e| e.task_id)
+}
+
+// ── Session / process-group syscalls ──────────────────────────────────────
+//
+// POSIX errno values returned by these helpers. Centralised so the syscall
+// dispatch arms stay readable.
+const EPERM: i64 = -1;
+const ESRCH: i64 = -3;
+const EINVAL: i64 = -22;
+
+/// Pure helper behind `setsid()` — see [`sys_setsid`]. Accepts the caller
+/// pid explicitly so host unit tests can drive it without going through
+/// the scheduler's `current_id()`.
+pub fn setsid_for(caller_pid: u32) -> i64 {
+    if caller_pid == 0 {
+        return EPERM;
+    }
+    let mut t = TABLE.lock();
+    let Some(entry) = t.by_pid.get_mut(&caller_pid) else {
+        return EPERM;
+    };
+    if entry.pgrp_id == caller_pid {
+        return EPERM;
+    }
+    entry.session_id = caller_pid;
+    entry.pgrp_id = caller_pid;
+    entry.controlling_tty = None;
+    caller_pid as i64
+}
+
+/// `setsid()` — create a new session with the caller as leader.
+///
+/// POSIX requires EPERM if the caller is already a process-group leader,
+/// to prevent a pgrp being split across two sessions.  On success sets
+/// `session_id == pgrp_id == pid` and drops any existing controlling tty,
+/// then returns the new session id.
+pub fn sys_setsid() -> i64 {
+    setsid_for(current_pid())
+}
+
+/// `getsid(pid)` — return the session id of `pid`, or of the caller if
+/// `pid == 0`. Returns ESRCH for unknown pids.
+pub fn sys_getsid(pid: u32) -> i64 {
+    let t = TABLE.lock();
+    let target = if pid == 0 {
+        let self_pid = *t.pid_of.get(&crate::task::current_id()).unwrap_or(&0);
+        if self_pid == 0 {
+            return ESRCH;
+        }
+        self_pid
+    } else {
+        pid
+    };
+    match t.by_pid.get(&target) {
+        Some(e) => e.session_id as i64,
+        None => ESRCH,
+    }
+}
+
+/// `getpgid(pid)` — return the pgrp id of `pid`, or of the caller if
+/// `pid == 0`. Returns ESRCH for unknown pids.
+pub fn sys_getpgid(pid: u32) -> i64 {
+    let t = TABLE.lock();
+    let target = if pid == 0 {
+        let self_pid = *t.pid_of.get(&crate::task::current_id()).unwrap_or(&0);
+        if self_pid == 0 {
+            return ESRCH;
+        }
+        self_pid
+    } else {
+        pid
+    };
+    match t.by_pid.get(&target) {
+        Some(e) => e.pgrp_id as i64,
+        None => ESRCH,
+    }
+}
+
+/// Pure helper behind `setpgid()` — see [`sys_setpgid`]. Accepts the
+/// caller pid explicitly for testability.
+pub fn setpgid_for(caller_pid: u32, pid: u32, pgid: u32) -> i64 {
+    if caller_pid == 0 {
+        return EPERM;
+    }
+    let mut t = TABLE.lock();
+
+    let target_pid = if pid == 0 { caller_pid } else { pid };
+    let pgid = if pgid == 0 { target_pid } else { pgid };
+
+    let caller_session = match t.by_pid.get(&caller_pid) {
+        Some(e) => e.session_id,
+        None => return EPERM,
+    };
+
+    let (target_session, target_is_leader) = match t.by_pid.get(&target_pid) {
+        Some(e) => (e.session_id, e.session_id == e.pid),
+        None => return ESRCH,
+    };
+
+    if target_pid != caller_pid {
+        let parent_is_caller = t
+            .by_pid
+            .get(&target_pid)
+            .map(|e| e.parent_pid == caller_pid)
+            .unwrap_or(false);
+        if !parent_is_caller {
+            return ESRCH;
+        }
+    }
+
+    if target_session != caller_session {
+        return EPERM;
+    }
+
+    if target_is_leader {
+        return EPERM;
+    }
+
+    if pgid != target_pid {
+        match t.by_pid.values().find(|e| e.pgrp_id == pgid) {
+            Some(e) if e.session_id == caller_session => {}
+            Some(_) => return EPERM,
+            None => return EINVAL,
+        }
+    }
+
+    if let Some(entry) = t.by_pid.get_mut(&target_pid) {
+        entry.pgrp_id = pgid;
+    }
+    0
+}
+
+/// `setpgid(pid, pgid)` — move `pid` into process group `pgid`.
+///
+/// Per POSIX:
+/// - `pid == 0` means the caller; `pgid == 0` means "same as `pid`".
+/// - The target must be the caller or one of the caller's children.
+/// - Target and `pgid`'s session must match the caller's session.
+/// - `pgid` must either equal `pid` (creating a new pgrp) or name an
+///   existing pgrp in the same session.
+/// - A session leader may not change its own pgrp (EPERM).
+pub fn sys_setpgid(pid: u32, pgid: u32) -> i64 {
+    setpgid_for(current_pid(), pid, pgid)
+}
+
+/// Session/pgrp test helpers, exposed so the `session_syscalls` kernel
+/// integration test can drive the table without the scheduler. Not
+/// gated on `cfg(test)` because the integration test is a separate
+/// crate that imports `vibix` as a normal dependency.
+#[doc(hidden)]
+pub mod test_helpers {
+    use super::*;
+
+    /// Drop every entry in TABLE so tests don't leak state into each
+    /// other.  Also resets `NEXT_PID` so pid allocation is deterministic.
+    pub fn reset_table() {
+        let mut t = TABLE.lock();
+        t.by_pid.clear();
+        t.pid_of.clear();
+        NEXT_PID.store(2, Ordering::Relaxed);
+    }
+
+    /// Insert a synthetic entry with an explicit pid so tests can drive
+    /// the session syscalls without going through the real scheduler.
+    pub fn insert(pid: u32, parent_pid: u32, session_id: u32, pgrp_id: u32) {
+        let mut t = TABLE.lock();
+        t.by_pid.insert(
+            pid,
+            ProcessEntry {
+                pid,
+                task_id: pid as usize,
+                parent_pid,
+                exit_status: None,
+                state: ProcessState::Alive,
+                signals: Arc::new(Mutex::new(SignalState::new())),
+                session_id,
+                pgrp_id,
+                controlling_tty: None,
+            },
+        );
+        t.pid_of.insert(pid as usize, pid);
+    }
+
+    /// Overwrite fields on an existing entry from a test — used to set
+    /// up edge cases like "child is itself a session leader".
+    pub fn patch(pid: u32, mut f: impl FnMut(&mut ProcessEntry)) {
+        let mut t = TABLE.lock();
+        if let Some(e) = t.by_pid.get_mut(&pid) {
+            f(e);
+        }
+    }
+
+    /// Borrow a snapshot of the entry for assertions.
+    pub fn snapshot(pid: u32) -> Option<(u32, u32, bool)> {
+        let t = TABLE.lock();
+        t.by_pid
+            .get(&pid)
+            .map(|e| (e.session_id, e.pgrp_id, e.controlling_tty.is_some()))
+    }
+
+    /// Attach a fresh controlling TTY (used by setsid-clears-ctty test).
+    pub fn attach_ctty(pid: u32) {
+        let mut t = TABLE.lock();
+        if let Some(e) = t.by_pid.get_mut(&pid) {
+            e.controlling_tty = Some(Arc::new(Tty::new()));
+        }
+    }
+
+    pub const EPERM_I64: i64 = EPERM;
+    pub const ESRCH_I64: i64 = ESRCH;
+    pub const EINVAL_I64: i64 = EINVAL;
 }

--- a/kernel/src/tty/mod.rs
+++ b/kernel/src/tty/mod.rs
@@ -1,9 +1,139 @@
 //! TTY subsystem.
 //!
-//! Today this module is just the POSIX [`termios`] data type plus its
-//! ioctl command numbers — the minimum needed for userspace to call
-//! `tcgetattr`/`tcsetattr` on a tty-like fd. The `Tty` wrapper, line
-//! discipline, and wait-queue glue land in follow-up work (RFC 0003,
-//! issues #374–#376).
+//! Today this module is [`termios`] plus a minimal [`Tty`] stub with the
+//! job-control fields the PCB needs for `setsid`/`setpgid` (#372). The
+//! `LineDiscipline`, `TtyDriver`, and `DeferredByteRing` arrive with
+//! #374–#376.
 
 pub mod termios;
+
+use core::sync::atomic::{AtomicU32, Ordering};
+
+use spin::Mutex;
+
+/// POSIX session identifier. `0` is reserved for "no session" (bootstrap
+/// kernel tasks before the process table is populated).
+pub type SessionId = u32;
+
+/// POSIX process-group identifier. `0` is reserved for "no foreground pgrp".
+pub type ProcessGroupId = u32;
+
+/// Lock-free pgrp snapshot.
+///
+/// Used by the N_TTY ISIG fast path (#375) so a character arriving on the
+/// serial ISR can read the foreground pgrp without acquiring
+/// `tty.ctrl.lock()` — see RFC 0003 §Lock order.
+pub struct AtomicPid(AtomicU32);
+
+impl AtomicPid {
+    pub const fn new(v: u32) -> Self {
+        Self(AtomicU32::new(v))
+    }
+
+    pub fn load(&self) -> u32 {
+        self.0.load(Ordering::Acquire)
+    }
+
+    pub fn store(&self, v: u32) {
+        self.0.store(v, Ordering::Release);
+    }
+}
+
+/// Controlling-terminal job-control state.
+///
+/// Stored under `Tty.ctrl`. The `pgrp_snapshot` field mirrors `pgrp` so
+/// ISR-context code can read it without taking `ctrl.lock()`. Mutators
+/// (`TIOCSPGRP`, ctty acquisition) must update both fields under the lock
+/// to keep them in sync.
+pub struct JobControl {
+    pub session: Option<SessionId>,
+    pub pgrp: Option<ProcessGroupId>,
+    pub pgrp_snapshot: AtomicPid,
+}
+
+impl JobControl {
+    pub const fn new() -> Self {
+        Self {
+            session: None,
+            pgrp: None,
+            pgrp_snapshot: AtomicPid::new(0),
+        }
+    }
+
+    /// Set the foreground pgrp and update the lock-free snapshot atomically
+    /// from the writer's perspective. Caller must hold `Tty.ctrl.lock()`.
+    pub fn set_pgrp(&mut self, pgrp: Option<ProcessGroupId>) {
+        self.pgrp = pgrp;
+        self.pgrp_snapshot.store(pgrp.unwrap_or(0));
+    }
+}
+
+impl Default for JobControl {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Minimal TTY stub.
+///
+/// #372 needs `Option<Arc<Tty>>` in the PCB to hold the controlling
+/// terminal, and the N_TTY ISIG path needs a place to publish the pgrp
+/// snapshot. #374 extends this with `driver`, `ldisc`, `termios`, and
+/// `read_wait`/`write_wait` wait-queues — additive changes that don't
+/// touch the PCB wiring landed here.
+pub struct Tty {
+    pub ctrl: Mutex<JobControl>,
+}
+
+impl Tty {
+    pub fn new() -> Self {
+        Self {
+            ctrl: Mutex::new(JobControl::new()),
+        }
+    }
+}
+
+impl Default for Tty {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn atomic_pid_round_trip() {
+        let p = AtomicPid::new(0);
+        assert_eq!(p.load(), 0);
+        p.store(42);
+        assert_eq!(p.load(), 42);
+        p.store(0);
+        assert_eq!(p.load(), 0);
+    }
+
+    #[test]
+    fn set_pgrp_updates_snapshot() {
+        let mut jc = JobControl::new();
+        assert_eq!(jc.pgrp, None);
+        assert_eq!(jc.pgrp_snapshot.load(), 0);
+
+        jc.set_pgrp(Some(7));
+        assert_eq!(jc.pgrp, Some(7));
+        assert_eq!(jc.pgrp_snapshot.load(), 7);
+
+        jc.set_pgrp(None);
+        assert_eq!(jc.pgrp, None);
+        assert_eq!(jc.pgrp_snapshot.load(), 0);
+    }
+
+    #[test]
+    fn tty_default_has_no_session_or_pgrp() {
+        let tty = Tty::new();
+        let ctrl = tty.ctrl.lock();
+        assert!(ctrl.session.is_none());
+        assert!(ctrl.pgrp.is_none());
+        assert_eq!(ctrl.pgrp_snapshot.load(), 0);
+    }
+}

--- a/kernel/tests/session_syscalls.rs
+++ b/kernel/tests/session_syscalls.rs
@@ -1,0 +1,202 @@
+//! Integration test: session / process-group PCB fields and the
+//! `setsid` / `setpgid` / `getsid` / `getpgid` syscall helpers (#372).
+//!
+//! Drives `process::test_helpers` to set up synthetic `ProcessEntry`
+//! rows and exercise the pure branches of `setsid_for` / `setpgid_for`.
+//! End-to-end ring-3 syscall dispatch is covered by userspace work in
+//! #376.
+
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+use vibix::process::{self, test_helpers as h};
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    serial_println!("session_syscalls: init ok");
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "register_inherits_session_and_pgrp_from_parent",
+            &(register_inherits_session_and_pgrp_from_parent as fn()),
+        ),
+        (
+            "register_without_parent_opens_own_session",
+            &(register_without_parent_opens_own_session as fn()),
+        ),
+        (
+            "getsid_and_getpgid_lookup",
+            &(getsid_and_getpgid_lookup as fn()),
+        ),
+        (
+            "setsid_rejects_process_group_leader",
+            &(setsid_rejects_process_group_leader as fn()),
+        ),
+        (
+            "setsid_rejects_unknown_caller",
+            &(setsid_rejects_unknown_caller as fn()),
+        ),
+        (
+            "setsid_creates_new_session_and_clears_ctty",
+            &(setsid_creates_new_session_and_clears_ctty as fn()),
+        ),
+        (
+            "setpgid_rejects_cross_session_target",
+            &(setpgid_rejects_cross_session_target as fn()),
+        ),
+        (
+            "setpgid_rejects_non_child_target",
+            &(setpgid_rejects_non_child_target as fn()),
+        ),
+        (
+            "setpgid_rejects_session_leader_target",
+            &(setpgid_rejects_session_leader_target as fn()),
+        ),
+        (
+            "setpgid_moves_child_into_existing_pgrp",
+            &(setpgid_moves_child_into_existing_pgrp as fn()),
+        ),
+        (
+            "setpgid_creates_new_pgrp_when_pgid_equals_target",
+            &(setpgid_creates_new_pgrp_when_pgid_equals_target as fn()),
+        ),
+        (
+            "setpgid_rejects_nonexistent_pgid_in_session",
+            &(setpgid_rejects_nonexistent_pgid_in_session as fn()),
+        ),
+        (
+            "setpgid_pgid_zero_means_target",
+            &(setpgid_pgid_zero_means_target as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+fn register_inherits_session_and_pgrp_from_parent() {
+    h::reset_table();
+    h::insert(100, 0, 42, 77);
+    let child = process::register(200, 100);
+    let (session, pgrp, has_tty) = h::snapshot(child).unwrap();
+    assert_eq!(session, 42);
+    assert_eq!(pgrp, 77);
+    assert!(!has_tty);
+}
+
+fn register_without_parent_opens_own_session() {
+    h::reset_table();
+    let child = process::register(300, 999);
+    let (session, pgrp, _) = h::snapshot(child).unwrap();
+    assert_eq!(session, child);
+    assert_eq!(pgrp, child);
+}
+
+fn getsid_and_getpgid_lookup() {
+    h::reset_table();
+    h::insert(10, 0, 5, 7);
+    assert_eq!(process::sys_getsid(10), 5);
+    assert_eq!(process::sys_getpgid(10), 7);
+    assert_eq!(process::sys_getsid(9999), h::ESRCH_I64);
+    assert_eq!(process::sys_getpgid(9999), h::ESRCH_I64);
+}
+
+fn setsid_rejects_process_group_leader() {
+    h::reset_table();
+    h::insert(10, 0, 10, 10);
+    assert_eq!(process::setsid_for(10), h::EPERM_I64);
+}
+
+fn setsid_rejects_unknown_caller() {
+    h::reset_table();
+    assert_eq!(process::setsid_for(0), h::EPERM_I64);
+    assert_eq!(process::setsid_for(9999), h::EPERM_I64);
+}
+
+fn setsid_creates_new_session_and_clears_ctty() {
+    h::reset_table();
+    h::insert(50, 0, 5, 7);
+    h::attach_ctty(50);
+    assert_eq!(process::setsid_for(50), 50);
+    let (session, pgrp, has_tty) = h::snapshot(50).unwrap();
+    assert_eq!(session, 50);
+    assert_eq!(pgrp, 50);
+    assert!(!has_tty);
+}
+
+fn setpgid_rejects_cross_session_target() {
+    h::reset_table();
+    h::insert(10, 0, 5, 10);
+    h::insert(30, 10, 9, 30);
+    assert_eq!(process::setpgid_for(10, 30, 30), h::EPERM_I64);
+}
+
+fn setpgid_rejects_non_child_target() {
+    h::reset_table();
+    h::insert(10, 0, 5, 10);
+    h::insert(20, 99, 5, 20);
+    assert_eq!(process::setpgid_for(10, 20, 20), h::ESRCH_I64);
+}
+
+fn setpgid_rejects_session_leader_target() {
+    h::reset_table();
+    h::insert(10, 0, 5, 10);
+    // pid=5 is a session leader (session_id == pid). Re-parent under 10
+    // so the caller-authority check passes and the leader guard fires.
+    h::insert(5, 10, 5, 5);
+    assert_eq!(process::setpgid_for(10, 5, 5), h::EPERM_I64);
+}
+
+fn setpgid_moves_child_into_existing_pgrp() {
+    h::reset_table();
+    h::insert(10, 0, 5, 10);
+    h::insert(20, 10, 5, 20); // pgrp leader of pgrp 20
+    h::insert(21, 10, 5, 21); // own pgrp, will join 20
+    assert_eq!(process::setpgid_for(10, 21, 20), 0);
+    let (_, pgrp, _) = h::snapshot(21).unwrap();
+    assert_eq!(pgrp, 20);
+}
+
+fn setpgid_creates_new_pgrp_when_pgid_equals_target() {
+    h::reset_table();
+    h::insert(10, 0, 5, 10);
+    h::insert(20, 10, 5, 10); // child inherited parent's pgrp
+    assert_eq!(process::setpgid_for(10, 20, 20), 0);
+    let (_, pgrp, _) = h::snapshot(20).unwrap();
+    assert_eq!(pgrp, 20);
+}
+
+fn setpgid_rejects_nonexistent_pgid_in_session() {
+    h::reset_table();
+    h::insert(10, 0, 5, 10);
+    h::insert(20, 10, 5, 10);
+    assert_eq!(process::setpgid_for(10, 20, 99), h::EINVAL_I64);
+}
+
+fn setpgid_pgid_zero_means_target() {
+    h::reset_table();
+    h::insert(10, 0, 5, 10);
+    h::insert(20, 10, 5, 10);
+    // pgid == 0 should resolve to target_pid (20), creating a new pgrp.
+    assert_eq!(process::setpgid_for(10, 20, 0), 0);
+    let (_, pgrp, _) = h::snapshot(20).unwrap();
+    assert_eq!(pgrp, 20);
+}


### PR DESCRIPTION
Closes #372

## Summary

- Extends `ProcessEntry` with `session_id`, `pgrp_id`, and `controlling_tty: Option<Arc<Tty>>` (RFC 0003 §Lock order / §Job control).
- `register` inherits session/pgrp/ctty from the parent entry so `fork` children join the parent's session and pgrp automatically; kernel-origin processes open their own session.
- Implements `sys_setsid`/`sys_getsid`/`sys_setpgid`/`sys_getpgid` with Linux x86_64 ABI numbers (112/124/109/121) and pure `setsid_for`/`setpgid_for` helpers so the logic is driveable from tests without the scheduler.
- Adds a minimal `tty::Tty` stub with `JobControl { session, pgrp, pgrp_snapshot: AtomicPid }`. The lock-free `AtomicPid` satisfies the RFC's ISIG fast-path requirement that N_TTY read the foreground pgrp without acquiring `tty.ctrl.lock()`. #374/#375 extend `Tty` additively with driver/ldisc/termios/wait-queues — the wiring landed here stays untouched.
- `execve` preserves session/pgrp/ctty for free: `exec_atomic` keeps the same PID and therefore the same `ProcessEntry`.

## Test plan

- [x] `cargo xtask build` — clean build on `x86_64-unknown-none`
- [x] `cargo xtask test` — 206 host unit tests pass (including 3 new `tty::tests::*`); 13-case `session_syscalls` QEMU integration test passes
- [x] `cargo xtask smoke` — all 30 markers present
- [x] `cargo fmt --all --check` — clean
- [x] New test coverage:
  - `tty::tests::atomic_pid_round_trip`, `set_pgrp_updates_snapshot`, `tty_default_has_no_session_or_pgrp`
  - `session_syscalls::{register_inherits_session_and_pgrp_from_parent, register_without_parent_opens_own_session, getsid_and_getpgid_lookup, setsid_rejects_process_group_leader, setsid_rejects_unknown_caller, setsid_creates_new_session_and_clears_ctty, setpgid_rejects_cross_session_target, setpgid_rejects_non_child_target, setpgid_rejects_session_leader_target, setpgid_moves_child_into_existing_pgrp, setpgid_creates_new_pgrp_when_pgid_equals_target, setpgid_rejects_nonexistent_pgid_in_session, setpgid_pgid_zero_means_target}`
  - Syscall ABI regression anchor extended in `arch::x86_64::syscall::tests::syscall_numbers_match_linux_x86_64_abi`

## Follow-ups (out of scope for #372)

- TIOCSCTTY acquisition and `open(tty, !O_NOCTTY)` → ctty — #376.
- SIGTTIN/SIGTTOU on background-pgrp I/O — #376.
- Orphaned-pgrp checks — #375.