### PR TITLE
ci: split CI into fmt-build / unit / integration / smoke jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,90 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  # Fast lane: formatting, clippy (host-only), and release build sanity.
+  # Does not need QEMU, so it finishes well ahead of the kernel test jobs.
+  fmt-build:
+    name: fmt + build (release)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y --no-install-recommends \
+            xorriso build-essential
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: nightly
+          components: rust-src, llvm-tools, rustfmt, clippy
+          targets: x86_64-unknown-none
+
+      - name: Cache cargo + limine
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+            build/limine
+          key: ${{ runner.os }}-cargo-fmt-build-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-fmt-build-
+            ${{ runner.os }}-cargo-
+
+      - name: cargo fmt --check
+        run: cargo fmt --all -- --check
+
+      # Kernel clippy requires --target x86_64-unknown-none + -Z build-std,
+      # which isn't wired through xtask yet. Scope clippy to the host-crate
+      # (xtask) for now; kernel clippy is a follow-up.
+      - name: cargo clippy (xtask)
+        run: cargo clippy -p xtask --all-targets -- -D warnings
+
+      - name: cargo xtask build --release
+        run: cargo xtask build --release
+
+  unit-tests:
+    name: host unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y --no-install-recommends \
+            build-essential
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: nightly
+          components: rust-src, llvm-tools, rustfmt, clippy
+          targets: x86_64-unknown-none
+
+      - name: Cache cargo
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-unit-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-unit-
+            ${{ runner.os }}-cargo-
+
+      - name: cargo xtask test-unit
+        run: cargo xtask test-unit
+
+  integration-tests:
+    name: integration tests (QEMU)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -40,24 +123,46 @@ jobs:
             ~/.cargo/git
             target
             build/limine
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+          key: ${{ runner.os }}-cargo-integration-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-integration-
+            ${{ runner.os }}-cargo-
 
-      - name: cargo fmt --check
-        run: cargo fmt --all -- --check
+      - name: cargo xtask test-integration
+        run: cargo xtask test-integration
 
-      # Kernel clippy requires --target x86_64-unknown-none + -Z build-std,
-      # which isn't wired through xtask yet. Scope clippy to the host-crate
-      # (xtask) for now; kernel clippy is a follow-up.
-      - name: cargo clippy (xtask)
-        run: cargo clippy -p xtask --all-targets -- -D warnings
+  smoke:
+    name: smoke test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: cargo xtask test
-        run: cargo xtask test
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y --no-install-recommends \
+            qemu-system-x86 xorriso build-essential
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: nightly
+          components: rust-src, llvm-tools, rustfmt, clippy
+          targets: x86_64-unknown-none
+
+      - name: Cache cargo + limine
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+            build/limine
+          key: ${{ runner.os }}-cargo-smoke-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-smoke-
+            ${{ runner.os }}-cargo-
 
       - name: cargo xtask smoke
         run: cargo xtask smoke
-
-      - name: cargo xtask build --release
-        run: cargo xtask build --release
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
             ~/.cargo/git
             target
             build/limine
-          key: ${{ runner.os }}-cargo-fmt-build-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-fmt-build-${{ hashFiles('**/Cargo.lock', 'xtask/src/main.rs') }}
           restore-keys: |
             ${{ runner.os }}-cargo-fmt-build-
             ${{ runner.os }}-cargo-
@@ -123,7 +123,7 @@ jobs:
             ~/.cargo/git
             target
             build/limine
-          key: ${{ runner.os }}-cargo-integration-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-integration-${{ hashFiles('**/Cargo.lock', 'xtask/src/main.rs') }}
           restore-keys: |
             ${{ runner.os }}-cargo-integration-
             ${{ runner.os }}-cargo-
@@ -159,7 +159,7 @@ jobs:
             ~/.cargo/git
             target
             build/limine
-          key: ${{ runner.os }}-cargo-smoke-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-smoke-${{ hashFiles('**/Cargo.lock', 'xtask/src/main.rs') }}
           restore-keys: |
             ${{ runner.os }}-cargo-smoke-
             ${{ runner.os }}-cargo-

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -118,6 +118,8 @@ fn main() -> R<()> {
             run(&opts)?;
         }
         "test" => test_all()?,
+        "test-unit" => test_unit()?,
+        "test-integration" => test_integration()?,
         "test-runner" => {
             let kernel = rest.first().ok_or("test-runner: missing kernel ELF path")?;
             test_runner(Path::new(kernel))?;
@@ -133,7 +135,7 @@ fn main() -> R<()> {
         other => {
             eprintln!("unknown subcommand: {other}");
             eprintln!(
-                "usage: cargo xtask [build|initrd|iso|run|test|smoke|lint|isr-audit|clean] [--release] [--fault-test] [--panic-test] [--bench]"
+                "usage: cargo xtask [build|initrd|iso|run|test|test-unit|test-integration|smoke|lint|isr-audit|clean] [--release] [--fault-test] [--panic-test] [--bench]"
             );
             std::process::exit(2);
         }
@@ -897,7 +899,7 @@ fn integration_test_names() -> R<Vec<String>> {
     Ok(filtered)
 }
 
-fn test_all() -> R<()> {
+fn test_unit() -> R<()> {
     // Host unit tests (--lib only; pure-logic modules).
     println!("→ host unit tests");
     check(
@@ -906,7 +908,10 @@ fn test_all() -> R<()> {
             .args(["test", "--package", "vibix", "--lib"])
             .status()?,
     )?;
+    Ok(())
+}
 
+fn test_integration() -> R<()> {
     // QEMU integration tests. Each is invoked by name so cargo doesn't
     // also try to build the lib's no_std test harness (which would
     // require std). Cargo's runner config invokes us back as
@@ -925,7 +930,12 @@ fn test_all() -> R<()> {
         cmd.arg("--test").arg(t);
     }
     check(cmd.status()?)?;
+    Ok(())
+}
 
+fn test_all() -> R<()> {
+    test_unit()?;
+    test_integration()?;
     Ok(())
 }
 


### PR DESCRIPTION
Closes #421

## Summary

Previously a single CI job ran fmt, clippy, host tests, QEMU integration tests, smoke, and the release build serially — a ~6+ minute pipeline where the slow QEMU legs gated quick signals like fmt/clippy/build that usually fail fast.

Split the workflow into four parallel jobs so each track surfaces independently:

- `fmt-build` — `cargo fmt --check`, xtask clippy, `cargo xtask build --release` (no QEMU)
- `unit-tests` — `cargo xtask test-unit` (host `--lib` only, no QEMU)
- `integration-tests` — `cargo xtask test-integration` (QEMU kernel tests)
- `smoke` — `cargo xtask smoke`

Also split the xtask `test` subcommand into `test-unit` / `test-integration` so the matrix jobs can each run their half standalone. Local `cargo xtask test` still runs both.

Each job has its own cache key with a shared `${{ runner.os }}-cargo-` restore-key prefix, so concurrent writes from separate jobs don't clobber one another while still benefiting from cross-job cache warm-up.

## Test plan
- [x] `cargo xtask build` — green
- [x] `cargo xtask test-unit` — 227 passed
- [x] `cargo xtask smoke` — all 30 markers present
- [x] `cargo fmt --all -- --check` + `cargo clippy -p xtask --all-targets -- -D warnings` — clean
- [ ] CI exercises the new matrix on this PR
