### PR TITLE
vfs: implement O_CREAT, O_EXCL, O_TRUNC, O_APPEND open flags

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -193,6 +193,10 @@ name = "syscall_lseek"
 harness = false
 
 [[test]]
+name = "syscall_open_flags"
+harness = false
+
+[[test]]
 name = "vm_integration"
 harness = false
 

--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -25,6 +25,7 @@ use super::super::syscall::copy_path_from_user_pub;
 use super::super::uaccess;
 use crate::fs::vfs::dentry::{DFlags, Dentry};
 use crate::fs::vfs::ops::{meta_into_stat, Stat};
+use crate::fs::vfs::ops::{SetAttr, SetAttrMask};
 use crate::fs::vfs::path_walk::{path_walk, LookupFlags, MountResolver, NameIdata, PATH_MAX};
 use crate::fs::vfs::super_block::SbActiveGuard;
 use crate::fs::vfs::Credential;
@@ -32,9 +33,12 @@ use crate::fs::vfs::{
     root as vfs_root, GlobalMountResolver, Inode, InodeKind, OpenFile, VfsBackend,
 };
 use crate::fs::{
-    flags as oflags, FileBackend, FileDescription, EBADF, EINVAL, ENAMETOOLONG, ENOENT, ENOMEM,
-    ENOTDIR,
+    flags as oflags, FileBackend, FileDescription, EBADF, EEXIST, EINVAL, ENAMETOOLONG, ENOENT,
+    ENOMEM, ENOTDIR,
 };
+
+/// EISDIR isn't in the top-level `crate::fs` errno set yet; inline the Linux value.
+const EISDIR: i64 = -21;
 
 /// Linux x86_64 value of the "use the current working directory"
 /// sentinel for `*at` syscalls. Sign-extended as an `i32`, negative,
@@ -151,6 +155,33 @@ fn install_fd(backend: Arc<dyn FileBackend>, flags: u32) -> i64 {
     }
 }
 
+/// Split `path` into its parent directory and final component for
+/// `O_CREAT`-style dispatch. Rejects inputs with no nameable leaf — an
+/// empty path, a bare `/`, or anything whose final component is `.` /
+/// `..` / empty (trailing slash) — since `create(parent, leaf)` cannot
+/// act on them.
+fn split_parent(path: &[u8]) -> Result<(&[u8], &[u8]), i64> {
+    if path.is_empty() {
+        return Err(ENOENT);
+    }
+    // Strip a trailing slash for "/foo/" but keep bare "/" as-is so the
+    // rejection below triggers.
+    let trimmed = if path.len() > 1 && *path.last().unwrap() == b'/' {
+        &path[..path.len() - 1]
+    } else {
+        path
+    };
+    let (parent, leaf) = match trimmed.iter().rposition(|&b| b == b'/') {
+        Some(0) => (&b"/"[..], &trimmed[1..]),
+        Some(i) => (&trimmed[..i], &trimmed[i + 1..]),
+        None => (&b"."[..], trimmed),
+    };
+    if leaf.is_empty() || leaf == b"." || leaf == b".." {
+        return Err(ENOENT);
+    }
+    Ok((parent, leaf))
+}
+
 /// `/dev/{stdin,stdout,stderr,serial}` legacy compat: returns a
 /// `SerialBackend`-backed description when path matches. None otherwise.
 fn legacy_dev_backend(path: &[u8], flags: u64) -> Option<i64> {
@@ -173,49 +204,89 @@ fn legacy_dev_backend(path: &[u8], flags: u64) -> Option<i64> {
 /// `dfd` is accepted but only `AT_FDCWD` is honored today — passing a
 /// real fd for a relative path returns `-EINVAL` because per-process
 /// cwd / fd-rooted walks don't exist yet (#239).
-pub unsafe fn sys_openat_impl(dfd: i32, path_uva: u64, flags: u64, _mode: u64) -> i64 {
+pub unsafe fn sys_openat_impl(dfd: i32, path_uva: u64, flags: u64, mode: u64) -> i64 {
     // 1. Copy the user path.
     let buf = match copy_user_path(path_uva) {
         Ok(b) => b,
         Err(e) => return e,
     };
     let path = buf.as_slice();
-
-    // 2. Mutating create/truncate flags not supported in the read-path
-    //    subset. Fail loudly so userspace gets a clear signal rather than
-    //    a silent no-op.
     let flags32 = flags as u32;
-    if flags32 & oflags::O_CREAT != 0 {
-        return crate::fs::EACCES;
-    }
-    if flags32 & oflags::O_TRUNC != 0 {
-        return crate::fs::EACCES;
-    }
 
-    // 3. Legacy /dev/{stdin,stdout,stderr,serial} fast path. Bypasses
+    // 2. Legacy /dev/{stdin,stdout,stderr,serial} fast path. Bypasses
     //    the VFS so a smoke boot that opens these before the devfs
     //    character devices exist keeps working.
     if let Some(r) = legacy_dev_backend(path, flags) {
         return r;
     }
 
-    // 4. `*at` preconditions. Non-AT_FDCWD dfd is out of scope for the
+    // 3. `*at` preconditions. Non-AT_FDCWD dfd is out of scope for the
     //    read-path subset; absolute paths ignore dfd entirely.
     let is_absolute = path.first() == Some(&b'/');
     if dfd != AT_FDCWD && !is_absolute {
         return EINVAL;
     }
 
-    // 5. Walk.
-    let follow = (flags as u32) & oflags::O_NOFOLLOW == 0;
+    // 4. Walk. If O_CREAT is set and the leaf does not exist, try to
+    //    create it in the parent directory, then re-walk.
+    let follow = flags32 & oflags::O_NOFOLLOW == 0;
     let (inode, nd) = match resolve_inode(path, follow) {
-        Ok(v) => v,
+        Ok(v) => {
+            // File exists. With O_CREAT|O_EXCL this is an error.
+            if flags32 & oflags::O_CREAT != 0 && flags32 & oflags::O_EXCL != 0 {
+                return EEXIST;
+            }
+            v
+        }
+        Err(e) if e == ENOENT && flags32 & oflags::O_CREAT != 0 => {
+            let (parent_path, leaf) = match split_parent(path) {
+                Ok(v) => v,
+                Err(e) => return e,
+            };
+            let (parent_inode, _pnd) = match resolve_inode(parent_path, /* follow */ true) {
+                Ok(v) => v,
+                Err(e) => return e,
+            };
+            if parent_inode.kind != InodeKind::Dir {
+                return ENOTDIR;
+            }
+            let create_mode = (mode as u16) & 0o7777;
+            if let Err(e) = parent_inode.ops.create(&parent_inode, leaf, create_mode) {
+                return e;
+            }
+            // Re-resolve to pick up the freshly created dentry+inode.
+            match resolve_inode(path, follow) {
+                Ok(v) => v,
+                Err(e) => return e,
+            }
+        }
         Err(e) => return e,
     };
 
-    // 6. O_DIRECTORY check.
-    if (flags as u32) & oflags::O_DIRECTORY != 0 && inode.kind != InodeKind::Dir {
+    // 5. O_DIRECTORY check.
+    if flags32 & oflags::O_DIRECTORY != 0 && inode.kind != InodeKind::Dir {
         return ENOTDIR;
+    }
+
+    // 6. O_TRUNC: zero the file length for a writable open on a regular
+    //    file. Silently ignored on a read-only open (Linux semantics);
+    //    rejected with EISDIR on a directory.
+    if flags32 & oflags::O_TRUNC != 0 {
+        if inode.kind == InodeKind::Dir {
+            return EISDIR;
+        }
+        let access = flags32 & oflags::O_ACCMODE;
+        if inode.kind == InodeKind::Reg && (access == oflags::O_WRONLY || access == oflags::O_RDWR)
+        {
+            let attr = SetAttr {
+                mask: SetAttrMask::SIZE,
+                size: 0,
+                ..SetAttr::default()
+            };
+            if let Err(e) = inode.ops.setattr(&inode, &attr) {
+                return e;
+            }
+        }
     }
 
     // 7. Build the OpenFile. The edge list in `nd` keeps the SB alive

--- a/kernel/src/fs/vfs/backend.rs
+++ b/kernel/src/fs/vfs/backend.rs
@@ -22,7 +22,7 @@
 
 use alloc::sync::Arc;
 
-use crate::fs::{FileBackend, EINVAL, EOVERFLOW};
+use crate::fs::{flags as oflags, FileBackend, EINVAL, EOVERFLOW};
 
 use super::open_file::OpenFile;
 use super::ops::Whence;
@@ -66,8 +66,16 @@ impl FileBackend for VfsBackend {
     /// read-only filesystem).
     fn write(&self, buf: &[u8]) -> Result<usize, i64> {
         let mut off = self.open_file.offset.lock();
-        let n = self.open_file.ops.write(&self.open_file, buf, *off)?;
-        *off = off.checked_add(n as u64).ok_or(EOVERFLOW)?;
+        // POSIX O_APPEND: under the offset mutex (which also serialises
+        // writes through dup'd fds that share this open-file description),
+        // snap the write position to end-of-file before dispatching.
+        let write_off = if self.open_file.flags & oflags::O_APPEND != 0 {
+            self.open_file.inode.meta.read().size
+        } else {
+            *off
+        };
+        let n = self.open_file.ops.write(&self.open_file, buf, write_off)?;
+        *off = write_off.checked_add(n as u64).ok_or(EOVERFLOW)?;
         Ok(n)
     }
 
@@ -105,6 +113,7 @@ mod tests {
     use crate::fs::vfs::FsId;
     use crate::fs::{flags, FileDescTable, FileDescription, EINVAL, EOVERFLOW, ESPIPE};
     use alloc::sync::Arc;
+    use core::sync::atomic::{AtomicU64, Ordering};
 
     // -----------------------------------------------------------------------
     // Stubs
@@ -183,6 +192,18 @@ mod tests {
     }
 
     fn make_open_file_with_ops(ops: Arc<dyn FileOps>) -> Arc<OpenFile> {
+        make_open_file_with_ops_flags(ops, 0)
+    }
+
+    fn make_open_file_with_ops_flags(ops: Arc<dyn FileOps>, flags: u32) -> Arc<OpenFile> {
+        make_open_file_with_ops_flags_meta(ops, flags, InodeMeta::default())
+    }
+
+    fn make_open_file_with_ops_flags_meta(
+        ops: Arc<dyn FileOps>,
+        flags: u32,
+        meta: InodeMeta,
+    ) -> Arc<OpenFile> {
         let sb = Arc::new(SuperBlock::new(
             FsId(42),
             Arc::new(StubSuperOps),
@@ -196,11 +217,11 @@ mod tests {
             Arc::new(StubInodeOps),
             ops.clone(),
             InodeKind::Reg,
-            InodeMeta::default(),
+            meta,
         ));
         let dentry = Dentry::new_root(inode.clone());
         let guard = SbActiveGuard::try_acquire(&sb).expect("guard");
-        OpenFile::new(dentry, inode, ops, sb.clone(), 0, guard)
+        OpenFile::new(dentry, inode, ops, sb.clone(), flags, guard)
     }
 
     fn make_open_file(fill_byte: u8) -> Arc<OpenFile> {
@@ -337,6 +358,67 @@ mod tests {
         let of = make_open_file(0);
         let backend = VfsBackend { open_file: of };
         assert_eq!(backend.lseek(0, SEEK_SET), Err(ESPIPE));
+    }
+
+    /// A `FileOps` stub that records the offset its `write` was called at.
+    struct RecordingWriteOps {
+        last_off: AtomicU64,
+    }
+    impl FileOps for RecordingWriteOps {
+        fn write(&self, _f: &OpenFile, buf: &[u8], off: u64) -> Result<usize, i64> {
+            self.last_off.store(off, Ordering::SeqCst);
+            Ok(buf.len())
+        }
+    }
+
+    #[test]
+    fn write_without_o_append_uses_tracked_offset() {
+        let ops = Arc::new(RecordingWriteOps {
+            last_off: AtomicU64::new(0),
+        });
+        let of = make_open_file_with_ops_flags_meta(
+            ops.clone(),
+            0,
+            InodeMeta {
+                size: 100,
+                ..Default::default()
+            },
+        );
+        *of.offset.lock() = 7;
+        let backend = VfsBackend {
+            open_file: of.clone(),
+        };
+        backend.write(b"xyz").expect("write");
+        assert_eq!(ops.last_off.load(Ordering::SeqCst), 7);
+        assert_eq!(*of.offset.lock(), 10);
+    }
+
+    #[test]
+    fn write_with_o_append_snaps_to_eof() {
+        let ops = Arc::new(RecordingWriteOps {
+            last_off: AtomicU64::new(0),
+        });
+        let of = make_open_file_with_ops_flags_meta(
+            ops.clone(),
+            flags::O_APPEND,
+            InodeMeta {
+                size: 100,
+                ..Default::default()
+            },
+        );
+        // Even if the tracked offset points elsewhere, O_APPEND must
+        // dispatch the write at the current EOF.
+        *of.offset.lock() = 0;
+        let backend = VfsBackend {
+            open_file: of.clone(),
+        };
+        backend.write(b"abcd").expect("write");
+        assert_eq!(
+            ops.last_off.load(Ordering::SeqCst),
+            100,
+            "O_APPEND must use inode size as write offset"
+        );
+        assert_eq!(*of.offset.lock(), 104, "offset advances from EOF by n");
     }
 
     #[test]

--- a/kernel/src/fs/vfs/ramfs.rs
+++ b/kernel/src/fs/vfs/ramfs.rs
@@ -605,11 +605,18 @@ impl InodeOps for RamfsInode {
     fn setattr(&self, inode: &Inode, attr: &SetAttr) -> Result<(), i64> {
         if attr.mask.contains(SetAttrMask::SIZE) {
             let mut body = self.body.lock();
-            if let RamfsBody::Reg { data } = &mut *body {
-                data.resize(attr.size as usize, 0);
+            match &mut *body {
+                RamfsBody::Reg { data } => {
+                    data.resize(attr.size as usize, 0);
+                }
+                RamfsBody::Dir { .. } => return Err(EISDIR),
+                RamfsBody::Sym { .. } => return Err(EINVAL),
             }
         }
         let mut meta = inode.meta.write();
+        if attr.mask.contains(SetAttrMask::SIZE) {
+            meta.size = attr.size;
+        }
         if attr.mask.contains(SetAttrMask::MODE) {
             meta.mode = attr.mode;
         }
@@ -1103,6 +1110,48 @@ mod tests {
         assert_eq!(a.meta.read().nlink, 3);
         a.ops.rmdir(&a, b"b").expect("rmdir b");
         assert_eq!(a.meta.read().nlink, 2);
+    }
+
+    #[test]
+    fn setattr_size_updates_meta_and_data() {
+        let sb = make_ramfs();
+        let root = root_of(&sb);
+        let child = root.ops.create(&root, b"f", 0o644).expect("create");
+        let file = open_inode(&sb, child.clone());
+        child
+            .file_ops
+            .write(&file, b"hello world", 0)
+            .expect("write");
+        assert_eq!(child.meta.read().size, 11);
+
+        let attr = SetAttr {
+            mask: SetAttrMask::SIZE,
+            size: 0,
+            ..SetAttr::default()
+        };
+        child.ops.setattr(&child, &attr).expect("truncate to 0");
+        assert_eq!(
+            child.meta.read().size,
+            0,
+            "setattr(SIZE=0) must update meta.size"
+        );
+        let mut buf = [0u8; 4];
+        let n = child.file_ops.read(&file, &mut buf, 0).expect("read");
+        assert_eq!(n, 0, "read after truncate sees empty file");
+    }
+
+    #[test]
+    fn setattr_size_on_dir_is_eisdir() {
+        let sb = make_ramfs();
+        let root = root_of(&sb);
+        root.ops.mkdir(&root, b"d", 0o755).expect("mkdir");
+        let d = root.ops.lookup(&root, b"d").expect("lookup");
+        let attr = SetAttr {
+            mask: SetAttrMask::SIZE,
+            size: 0,
+            ..SetAttr::default()
+        };
+        assert_eq!(d.ops.setattr(&d, &attr), Err(EISDIR));
     }
 
     #[test]

--- a/kernel/tests/syscall_open_flags.rs
+++ b/kernel/tests/syscall_open_flags.rs
@@ -1,0 +1,261 @@
+//! Integration test for issue #412: O_CREAT / O_EXCL / O_TRUNC / O_APPEND
+//! semantics in `sys_openat`.
+//!
+//! Runs against the booted kernel's ramfs mount at `/tmp` so that the
+//! write paths (create / truncate / append) exercise a real read-write
+//! filesystem driver through the syscall dispatcher.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use core::ptr;
+
+use vibix::arch::x86_64::syscall::syscall_dispatch;
+use vibix::fs::{EEXIST, ENOENT};
+use vibix::mem::vmatree::{Share, Vma};
+use vibix::mem::vmobject::AnonObject;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+use x86_64::structures::paging::PageTableFlags;
+
+const SYS_READ: u64 = 0;
+const SYS_WRITE: u64 = 1;
+const SYS_OPEN: u64 = 2;
+const SYS_CLOSE: u64 = 3;
+const SYS_LSEEK: u64 = 8;
+
+const O_RDONLY: u64 = 0o0;
+const O_WRONLY: u64 = 0o1;
+const O_RDWR: u64 = 0o2;
+const O_CREAT: u64 = 0o100;
+const O_EXCL: u64 = 0o200;
+const O_TRUNC: u64 = 0o1000;
+const O_APPEND: u64 = 0o2000;
+
+const SEEK_END: u64 = 2;
+
+const USER_PAGE_VA: usize = 0x0000_2002_0000_0000;
+const USER_PAGE_LEN: usize = 4 * 4096;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    vibix::task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("create_new_file", &(create_new_file as fn())),
+        ("create_without_excl_ok", &(create_without_excl_ok as fn())),
+        ("excl_collision_eexist", &(excl_collision_eexist as fn())),
+        (
+            "open_missing_without_creat_enoent",
+            &(open_missing_without_creat_enoent as fn()),
+        ),
+        ("trunc_zeroes_writable", &(trunc_zeroes_writable as fn())),
+        ("append_writes_at_eof", &(append_writes_at_eof as fn())),
+    ];
+    for (name, t) in tests {
+        serial_println!("syscall_open_flags: {}", name);
+        t.run();
+    }
+}
+
+fn install_user_staging_vma() {
+    static INSTALLED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+    if INSTALLED.swap(true, core::sync::atomic::Ordering::SeqCst) {
+        return;
+    }
+    let prot_pte =
+        (PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE).bits();
+    vibix::task::install_vma_on_current(Vma::new(
+        USER_PAGE_VA,
+        USER_PAGE_VA + USER_PAGE_LEN,
+        0x3,
+        prot_pte,
+        Share::Private,
+        AnonObject::new(Some(USER_PAGE_LEN / 4096)),
+        0,
+    ));
+    unsafe {
+        // Touch every page to force-fault before any syscall.
+        let dst = USER_PAGE_VA as *mut u8;
+        let mut i = 0;
+        while i < USER_PAGE_LEN {
+            ptr::write_volatile(dst.add(i), 0);
+            i += 4096;
+        }
+    }
+}
+
+/// Stage `bytes` at USER_PAGE_VA (+ NUL terminator) and return the VA.
+fn stage(bytes: &[u8]) -> u64 {
+    install_user_staging_vma();
+    assert!(bytes.len() < 4096);
+    unsafe {
+        let dst = USER_PAGE_VA as *mut u8;
+        for (i, b) in bytes.iter().enumerate() {
+            ptr::write_volatile(dst.add(i), *b);
+        }
+        ptr::write_volatile(dst.add(bytes.len()), 0);
+    }
+    USER_PAGE_VA as u64
+}
+
+/// Copy `bytes` to a scratch region within the staging page, returning
+/// that region's VA. The staged path must not overlap; callers are
+/// expected to stage the path first.
+fn stage_payload(bytes: &[u8]) -> u64 {
+    assert!(bytes.len() <= USER_PAGE_LEN - 4096);
+    let va = USER_PAGE_VA as u64 + 4096;
+    unsafe {
+        let dst = va as *mut u8;
+        for (i, b) in bytes.iter().enumerate() {
+            ptr::write_volatile(dst.add(i), *b);
+        }
+    }
+    va
+}
+
+fn open(path: &[u8], flags: u64, mode: u64) -> i64 {
+    let uva = stage(path);
+    unsafe { syscall_dispatch(SYS_OPEN, uva, flags, mode, 0, 0, 0) }
+}
+
+fn close(fd: i64) -> i64 {
+    unsafe { syscall_dispatch(SYS_CLOSE, fd as u64, 0, 0, 0, 0, 0) }
+}
+
+fn write_bytes(fd: i64, bytes: &[u8]) -> i64 {
+    let uva = stage_payload(bytes);
+    unsafe { syscall_dispatch(SYS_WRITE, fd as u64, uva, bytes.len() as u64, 0, 0, 0) }
+}
+
+fn read_bytes(fd: i64, out: &mut [u8]) -> i64 {
+    let buf_va = USER_PAGE_VA as u64 + 2 * 4096;
+    let n = unsafe { syscall_dispatch(SYS_READ, fd as u64, buf_va, out.len() as u64, 0, 0, 0) };
+    if n > 0 {
+        unsafe {
+            let src = buf_va as *const u8;
+            for i in 0..n as usize {
+                out[i] = ptr::read_volatile(src.add(i));
+            }
+        }
+    }
+    n
+}
+
+fn lseek_end(fd: i64) -> i64 {
+    unsafe { syscall_dispatch(SYS_LSEEK, fd as u64, 0, SEEK_END, 0, 0, 0) }
+}
+
+// --- Tests ---------------------------------------------------------------
+
+fn create_new_file() {
+    let fd = open(b"/tmp/creat-new\0", O_WRONLY | O_CREAT, 0o644);
+    assert!(fd >= 3, "O_CREAT on new path must succeed, got {}", fd);
+    assert_eq!(close(fd), 0);
+
+    // Reopen RDONLY — the file must exist now.
+    let fd2 = open(b"/tmp/creat-new\0", O_RDONLY, 0);
+    assert!(fd2 >= 3, "reopen after O_CREAT failed: {}", fd2);
+    assert_eq!(close(fd2), 0);
+}
+
+fn create_without_excl_ok() {
+    // O_CREAT without O_EXCL on an existing file opens it, doesn't error.
+    let fd = open(b"/tmp/creat-idem\0", O_WRONLY | O_CREAT, 0o644);
+    assert!(fd >= 3);
+    assert_eq!(close(fd), 0);
+    let fd2 = open(b"/tmp/creat-idem\0", O_WRONLY | O_CREAT, 0o644);
+    assert!(
+        fd2 >= 3,
+        "second O_CREAT w/o O_EXCL must succeed, got {}",
+        fd2
+    );
+    assert_eq!(close(fd2), 0);
+}
+
+fn excl_collision_eexist() {
+    let fd = open(b"/tmp/creat-excl\0", O_WRONLY | O_CREAT, 0o644);
+    assert!(fd >= 3);
+    assert_eq!(close(fd), 0);
+    let r = open(b"/tmp/creat-excl\0", O_WRONLY | O_CREAT | O_EXCL, 0o644);
+    assert_eq!(
+        r, EEXIST,
+        "O_CREAT|O_EXCL on existing must be EEXIST, got {}",
+        r
+    );
+}
+
+fn open_missing_without_creat_enoent() {
+    let r = open(b"/tmp/no-such-file-ever\0", O_RDONLY, 0);
+    assert_eq!(
+        r, ENOENT,
+        "open missing without O_CREAT must be ENOENT, got {}",
+        r
+    );
+}
+
+fn trunc_zeroes_writable() {
+    // Create + write some payload.
+    let fd = open(b"/tmp/trunc\0", O_WRONLY | O_CREAT, 0o644);
+    assert!(fd >= 3);
+    let n = write_bytes(fd, b"hello world");
+    assert_eq!(n, 11);
+    assert_eq!(close(fd), 0);
+
+    // Re-open with O_TRUNC — content must be gone.
+    let fd2 = open(b"/tmp/trunc\0", O_WRONLY | O_TRUNC, 0);
+    assert!(fd2 >= 3, "O_TRUNC open failed: {}", fd2);
+    assert_eq!(close(fd2), 0);
+
+    let fd3 = open(b"/tmp/trunc\0", O_RDONLY, 0);
+    assert!(fd3 >= 3);
+    let mut buf = [0u8; 16];
+    let r = read_bytes(fd3, &mut buf);
+    assert_eq!(r, 0, "read after O_TRUNC must see empty file, got n={}", r);
+    assert_eq!(close(fd3), 0);
+}
+
+fn append_writes_at_eof() {
+    // Seed with some content via two separate writes using O_APPEND.
+    let fd = open(b"/tmp/append\0", O_RDWR | O_CREAT, 0o644);
+    assert!(fd >= 3);
+    let n = write_bytes(fd, b"AAAA");
+    assert_eq!(n, 4);
+    assert_eq!(close(fd), 0);
+
+    // Open O_APPEND and write — must land at EOF regardless of offset.
+    let fd2 = open(b"/tmp/append\0", O_WRONLY | O_APPEND, 0);
+    assert!(fd2 >= 3, "O_APPEND open failed: {}", fd2);
+    let n = write_bytes(fd2, b"BBBB");
+    assert_eq!(n, 4);
+    // Sanity: lseek to end reports 8.
+    let eof = lseek_end(fd2);
+    assert_eq!(eof, 8, "EOF after append must be 8, got {}", eof);
+    assert_eq!(close(fd2), 0);
+
+    // Read back and confirm the append landed after the initial content.
+    let fd3 = open(b"/tmp/append\0", O_RDONLY, 0);
+    assert!(fd3 >= 3);
+    let mut buf = [0u8; 16];
+    let r = read_bytes(fd3, &mut buf);
+    assert_eq!(r, 8);
+    assert_eq!(&buf[..8], b"AAAABBBB");
+    assert_eq!(close(fd3), 0);
+}


### PR DESCRIPTION
Closes #412.

## Summary

- `sys_openat` now honors `O_CREAT`, `O_EXCL`, and `O_TRUNC` instead of rejecting them with `EACCES`.
- `O_CREAT` splits off the parent directory, walks it, and calls `InodeOps::create`, then re-resolves to pick up the freshly materialized dentry/inode. `O_CREAT|O_EXCL` on an existing path returns `EEXIST`.
- `O_TRUNC` applies `setattr(SIZE=0)` on a writable regular file; `EISDIR` on a directory; silently ignored for read-only opens (matches Linux).
- `O_APPEND` is handled in `VfsBackend::write`: under the `OpenFile` offset mutex, the write offset is snapped to `inode.meta.size` so every write lands at EOF regardless of where the tracked offset points — dup'd fds and forked children that share the description serialize through the same mutex.
- Fixed an adjacent `ramfs::setattr` bug where the data vec was resized for `SetAttrMask::SIZE` but `inode.meta.size` was never updated, so `stat` / `fstat` continued to report the pre-truncate length after a truncate. `setattr(SIZE)` on a directory now returns `EISDIR`.

## Test plan

- [x] `cargo xtask build`
- [x] `cargo xtask test-unit` — 239 host unit tests pass.
- [x] `cargo test --test syscall_open_flags` (QEMU) — all 6 new tests pass: `create_new_file`, `create_without_excl_ok`, `excl_collision_eexist`, `open_missing_without_creat_enoent`, `trunc_zeroes_writable`, `append_writes_at_eof`.
- [x] `cargo xtask smoke` — 30/30 markers.
- [x] Pre-existing `blocking_sync::rwlock_writer_exclusion` flake reproduces on `main`; unrelated to this change.