### PR TITLE
fs: centralize POSIX errno constants across VFS

### DIFF
--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -33,12 +33,9 @@ use crate::fs::vfs::{
     root as vfs_root, GlobalMountResolver, Inode, InodeKind, OpenFile, VfsBackend,
 };
 use crate::fs::{
-    flags as oflags, FileBackend, FileDescription, EBADF, EEXIST, EINVAL, ENAMETOOLONG, ENOENT,
-    ENOMEM, ENOTDIR,
+    flags as oflags, FileBackend, FileDescription, EBADF, EEXIST, EINVAL, EISDIR, ENAMETOOLONG,
+    ENOENT, ENOMEM, ENOTDIR,
 };
-
-/// EISDIR isn't in the top-level `crate::fs` errno set yet; inline the Linux value.
-const EISDIR: i64 = -21;
 
 /// Linux x86_64 value of the "use the current working directory"
 /// sentinel for `*at` syscalls. Sign-extended as an `i32`, negative,

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -149,25 +149,32 @@ pub struct FileDescription {
 const MAX_FD: usize = 1024;
 
 /// Linux errno constants (negated so they match syscall return values).
+pub const EPERM: i64 = -1;
 pub const ENOENT: i64 = -2;
+pub const EINTR: i64 = -4;
 pub const EBADF: i64 = -9;
-pub const ENOMEM: i64 = -12;
 pub const EAGAIN: i64 = -11;
-pub const EINVAL: i64 = -22;
-pub const EMFILE: i64 = -24;
-pub const ENAMETOOLONG: i64 = -36;
+pub const ENOMEM: i64 = -12;
+pub const EACCES: i64 = -13;
+pub const EFAULT: i64 = -14;
+pub const EBUSY: i64 = -16;
 pub const EEXIST: i64 = -17;
+pub const EXDEV: i64 = -18;
 pub const ENODEV: i64 = -19;
 pub const ENOTDIR: i64 = -20;
-pub const ELOOP: i64 = -40;
-pub const EACCES: i64 = -13;
-pub const EBUSY: i64 = -16;
-pub const EOVERFLOW: i64 = -75;
+pub const EISDIR: i64 = -21;
+pub const EINVAL: i64 = -22;
+pub const EMFILE: i64 = -24;
 pub const ENOTTY: i64 = -25;
-pub const EFAULT: i64 = -14;
-pub const EPIPE: i64 = -32;
-pub const EINTR: i64 = -4;
+pub const EFBIG: i64 = -27;
+pub const ENOSPC: i64 = -28;
 pub const ESPIPE: i64 = -29;
+pub const EROFS: i64 = -30;
+pub const EPIPE: i64 = -32;
+pub const ENAMETOOLONG: i64 = -36;
+pub const ENOTEMPTY: i64 = -39;
+pub const ELOOP: i64 = -40;
+pub const EOVERFLOW: i64 = -75;
 
 /// Per-process file-descriptor array.
 ///
@@ -676,5 +683,38 @@ mod tests {
         t.close_cloexec();
         assert_eq!(t.get(3).err(), Some(EBADF));
         assert!(t.get(4).is_ok());
+    }
+
+    /// Errno ABI matrix — pins each constant to its Linux x86_64 value
+    /// (negated). Any divergence from these numbers is an ABI break for
+    /// userspace and must fail here before shipping.
+    #[test]
+    fn errno_constants_match_linux_abi() {
+        assert_eq!(EPERM, -1);
+        assert_eq!(ENOENT, -2);
+        assert_eq!(EINTR, -4);
+        assert_eq!(EBADF, -9);
+        assert_eq!(EAGAIN, -11);
+        assert_eq!(ENOMEM, -12);
+        assert_eq!(EACCES, -13);
+        assert_eq!(EFAULT, -14);
+        assert_eq!(EBUSY, -16);
+        assert_eq!(EEXIST, -17);
+        assert_eq!(EXDEV, -18);
+        assert_eq!(ENODEV, -19);
+        assert_eq!(ENOTDIR, -20);
+        assert_eq!(EISDIR, -21);
+        assert_eq!(EINVAL, -22);
+        assert_eq!(EMFILE, -24);
+        assert_eq!(ENOTTY, -25);
+        assert_eq!(EFBIG, -27);
+        assert_eq!(ENOSPC, -28);
+        assert_eq!(ESPIPE, -29);
+        assert_eq!(EROFS, -30);
+        assert_eq!(EPIPE, -32);
+        assert_eq!(ENAMETOOLONG, -36);
+        assert_eq!(ENOTEMPTY, -39);
+        assert_eq!(ELOOP, -40);
+        assert_eq!(EOVERFLOW, -75);
     }
 }

--- a/kernel/src/fs/vfs/devfs.rs
+++ b/kernel/src/fs/vfs/devfs.rs
@@ -45,14 +45,7 @@ use super::ops::{
 use super::super_block::{SbFlags, SuperBlock};
 use super::MountFlags;
 
-// ---------------------------------------------------------------------------
-// errno constants
-// ---------------------------------------------------------------------------
-
-const ENOENT: i64 = -2;
-const EAGAIN: i64 = -11;
-const EISDIR: i64 = -21;
-const ENOTDIR: i64 = -20;
+use crate::fs::{EAGAIN, EISDIR, ENOENT};
 
 // DEVFS_MAGIC — not in the Linux set but chosen to be distinct.
 const DEVFS_MAGIC: u64 = 0x1373;

--- a/kernel/src/fs/vfs/ops.rs
+++ b/kernel/src/fs/vfs/ops.rs
@@ -15,6 +15,7 @@ use super::inode::{Inode, InodeMeta};
 use super::open_file::OpenFile;
 use super::super_block::SuperBlock;
 use super::{Access, Credential, InodeKind, Timespec};
+use crate::fs::{EACCES, EINVAL, ENOENT, ENOTDIR, ENOTTY, EPERM, ESPIPE};
 
 /// Source of a mount operation. Separated from the target path so
 /// future sources (block device, ramdisk module, network URL) can be
@@ -189,7 +190,7 @@ pub trait SuperOps: Send + Sync {
 /// FS doesn't have to stub them.
 pub trait InodeOps: Send + Sync {
     fn lookup(&self, _dir: &Inode, _name: &[u8]) -> Result<Arc<Inode>, i64> {
-        Err(super::super::ENOENT)
+        Err(ENOENT)
     }
     fn create(&self, _dir: &Inode, _name: &[u8], _mode: u16) -> Result<Arc<Inode>, i64> {
         Err(EPERM)
@@ -220,7 +221,7 @@ pub trait InodeOps: Send + Sync {
     }
 
     fn readlink(&self, _inode: &Inode, _buf: &mut [u8]) -> Result<usize, i64> {
-        Err(EINVAL_OP)
+        Err(EINVAL)
     }
 
     fn getattr(&self, inode: &Inode, out: &mut Stat) -> Result<(), i64>;
@@ -237,7 +238,7 @@ pub trait InodeOps: Send + Sync {
 /// control channel.
 pub trait FileOps: Send + Sync {
     fn read(&self, _f: &OpenFile, _buf: &mut [u8], _off: u64) -> Result<usize, i64> {
-        Err(EINVAL_OP)
+        Err(EINVAL)
     }
     fn write(&self, _f: &OpenFile, _buf: &[u8], _off: u64) -> Result<usize, i64> {
         // Read-only filesystems keep this default; signal "write not
@@ -260,15 +261,6 @@ pub trait FileOps: Send + Sync {
         Ok(())
     }
 }
-
-// errno values used by default trait bodies. The broadly-used ones
-// already live in `kernel::fs`; re-exported here for readability.
-const EPERM: i64 = -1;
-const EINVAL_OP: i64 = super::super::EINVAL;
-const ENOTTY: i64 = -25;
-const ENOTDIR: i64 = -20;
-const ESPIPE: i64 = -29;
-const EACCES: i64 = -13;
 
 /// Default POSIX permission check: owner / group / other bits in
 /// `InodeMeta.mode`. uid 0 (root) bypasses all checks. The `execute`

--- a/kernel/src/fs/vfs/ramfs.rs
+++ b/kernel/src/fs/vfs/ramfs.rs
@@ -54,17 +54,7 @@ use super::ops::{
 use super::super_block::{SbFlags, SuperBlock};
 use super::DString;
 
-// ---------------------------------------------------------------------------
-// Local errno values
-// ---------------------------------------------------------------------------
-
-const EPERM: i64 = -1;
-const ENOENT: i64 = -2;
-const EISDIR: i64 = -21;
-const ENOTDIR: i64 = -20;
-const ENOTEMPTY: i64 = -39;
-const EINVAL: i64 = -22;
-const EXDEV: i64 = -18;
+use crate::fs::{EINVAL, EISDIR, ENOENT, ENOTDIR, ENOTEMPTY, EPERM, EXDEV};
 
 // RAMFS_MAGIC matches Linux's value.
 const RAMFS_MAGIC: u64 = 0x858458f6;

--- a/kernel/src/fs/vfs/ramfs.rs
+++ b/kernel/src/fs/vfs/ramfs.rs
@@ -694,7 +694,7 @@ impl FileOps for RamfsInode {
                 children,
                 parent_ino,
             } => (children, *parent_ino),
-            _ => return Err(-20i64), // ENOTDIR
+            _ => return Err(ENOTDIR),
         };
 
         let dir_ino = inode.ino;

--- a/kernel/src/fs/vfs/tarfs.rs
+++ b/kernel/src/fs/vfs/tarfs.rs
@@ -26,7 +26,7 @@ use super::ops::{
 };
 use super::super_block::{SbFlags, SuperBlock};
 use super::MountFlags;
-use crate::fs::{EINVAL, ENOENT, ENOTDIR};
+use crate::fs::{EINVAL, EISDIR, ENOENT, ENOTDIR, EROFS};
 
 const BLOCK: usize = 512;
 
@@ -149,7 +149,7 @@ impl InodeOps for TarInodeOps {
 
     fn setattr(&self, _inode: &Inode, _attr: &SetAttr) -> Result<(), i64> {
         // Read-only.
-        Err(-30) // EROFS
+        Err(EROFS)
     }
 
     fn readlink(&self, inode: &Inode, buf: &mut [u8]) -> Result<usize, i64> {
@@ -183,7 +183,7 @@ impl FileOps for TarFileOps {
         let node = sup.node(f.inode.ino)?;
         let (offset, len) = match &node.data {
             NodeData::Reg { offset, len } => (*offset, *len),
-            NodeData::Dir { .. } => return Err(-21), // EISDIR
+            NodeData::Dir { .. } => return Err(EISDIR),
             NodeData::Link { .. } => return Err(EINVAL),
         };
         if off as usize >= len {
@@ -201,7 +201,7 @@ impl FileOps for TarFileOps {
         let node = sup.node(f.inode.ino)?;
         let size = match &node.data {
             NodeData::Reg { len, .. } => *len as i64,
-            NodeData::Dir { .. } => return Err(-21), // EISDIR
+            NodeData::Dir { .. } => return Err(EISDIR),
             NodeData::Link { .. } => return Err(EINVAL),
         };
         let mut cur = f.offset.lock();


### PR DESCRIPTION
Closes #413.

## Summary

- Add the missing POSIX errnos (EPERM, EISDIR, EXDEV, ENOTEMPTY, EROFS, ENOSPC, EFBIG) to `kernel/src/fs/mod.rs` and sort the full set by numeric value for grep-friendliness.
- Remove duplicate local errno const blocks that had drifted across ramfs, devfs, ops, and the x86_64 syscall dispatcher — everything now imports from `crate::fs`.
- Replace three bare numeric literals in `tarfs.rs` (`-30` EROFS, two `-21` EISDIR) with their named constants.
- Add a host-unit ABI matrix test (`fs::tests::errno_constants_match_linux_abi`) that pins every errno to its Linux x86_64 value — any future ABI drift fails the build before it reaches userspace.

Numeric values are unchanged; this is pure renaming + centralization. Existing `syscall_vfs` / `syscall_open_flags` / `vfs_backend` integration tests already exercise the primary `ENOENT` / `EEXIST` / `EBADF` / `EINVAL` / `EISDIR` / `ENOTDIR` / `ENAMETOOLONG` paths at the syscall boundary.

## Test plan
- [x] `cargo xtask build` clean (only pre-existing `is_guard_hit` dead_code warning).
- [x] `cargo test --package vibix --lib` — 248/248 pass including the new `errno_constants_match_linux_abi` matrix.
- [x] `cargo xtask smoke` — 30/30 markers ✓.
- [x] VFS integration tests (`syscall_vfs`, `syscall_open_flags`, `syscall_lseek`, `vfs_backend`, `vfs_hello`) all pass individually under QEMU.
- [ ] `blocking_sync::rwlock_writer_exclusion` is a known pre-existing environmental flake on this host (timed out at 30 s), unrelated to these errno changes.
