### PR TITLE
fs: implement fcntl F_GETFL/F_SETFL, F_GETFD/F_SETFD, F_DUPFD

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -197,6 +197,10 @@ name = "syscall_getdents"
 harness = false
 
 [[test]]
+name = "syscall_fcntl"
+harness = false
+
+[[test]]
 name = "syscall_open_flags"
 harness = false
 

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -395,6 +395,43 @@ pub unsafe extern "C" fn syscall_dispatch(
             }
         }
 
+        // fcntl(fd, cmd, arg) — per-fd status / close-on-exec / dup-above.
+        // Returns cmd-specific value on success, negated errno on error.
+        FCNTL => {
+            let fd = a0 as u32;
+            let cmd = a1 as u32;
+            let arg = a2;
+            let tbl = crate::task::current_fd_table();
+            let mut guard = tbl.lock();
+            match cmd {
+                crate::fs::F_GETFD => match guard.get_fd_flags(fd) {
+                    Ok(v) => v as i64,
+                    Err(e) => e,
+                },
+                crate::fs::F_SETFD => match guard.set_fd_flags(fd, arg as u32) {
+                    Ok(()) => 0,
+                    Err(e) => e,
+                },
+                crate::fs::F_GETFL => match guard.get_status_flags(fd) {
+                    Ok(v) => v as i64,
+                    Err(e) => e,
+                },
+                crate::fs::F_SETFL => match guard.set_status_flags(fd, arg as u32) {
+                    Ok(()) => 0,
+                    Err(e) => e,
+                },
+                crate::fs::F_DUPFD => match guard.dupfd_from(fd, arg as u32, false) {
+                    Ok(new_fd) => new_fd as i64,
+                    Err(e) => e,
+                },
+                crate::fs::F_DUPFD_CLOEXEC => match guard.dupfd_from(fd, arg as u32, true) {
+                    Ok(new_fd) => new_fd as i64,
+                    Err(e) => e,
+                },
+                _ => crate::fs::EINVAL,
+            }
+        }
+
         // dup2(oldfd, newfd)
         DUP2 => {
             let oldfd = a0 as u32;
@@ -1047,6 +1084,7 @@ pub mod syscall_nr {
     pub const CLOSE: u64 = 3;
     pub const DUP: u64 = 32;
     pub const DUP2: u64 = 33;
+    pub const FCNTL: u64 = 72;
     pub const FSTAT: u64 = 5;
     pub const STAT: u64 = 4;
     pub const LSTAT: u64 = 6;
@@ -1083,6 +1121,7 @@ mod tests {
         assert_eq!(syscall_nr::CLOSE, 3, "SYS_close must be 3");
         assert_eq!(syscall_nr::DUP, 32, "SYS_dup must be 32");
         assert_eq!(syscall_nr::DUP2, 33, "SYS_dup2 must be 33");
+        assert_eq!(syscall_nr::FCNTL, 72, "SYS_fcntl must be 72");
         assert_eq!(syscall_nr::LSEEK, 8, "SYS_lseek must be 8");
 
         // Memory management

--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -313,9 +313,7 @@ pub unsafe fn sys_openat_impl(dfd: i32, path_uva: u64, flags: u64, mode: u64) ->
         guard,
     );
     let backend: Arc<dyn FileBackend> = Arc::new(VfsBackend { open_file: of });
-    let fd_flags =
-        (flags as u32) & (oflags::O_RDONLY | oflags::O_WRONLY | oflags::O_RDWR | oflags::O_CLOEXEC);
-    install_fd(backend, fd_flags)
+    install_fd(backend, flags as u32)
 }
 
 /// `stat(path, *statbuf)` (follow=true) / `lstat(path, *statbuf)`

--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -150,8 +150,8 @@ fn install_fd(backend: Arc<dyn FileBackend>, flags: u32) -> i64 {
     // Creation-time / path-resolution bits (O_CREAT, O_EXCL, O_TRUNC,
     // O_DIRECTORY, O_NOFOLLOW) affect open() only and must not surface
     // via fcntl(F_GETFL).
-    let status_flags = flags
-        & (oflags::O_ACCMODE | oflags::O_APPEND | oflags::O_NONBLOCK | oflags::O_ASYNC);
+    let status_flags =
+        flags & (oflags::O_ACCMODE | oflags::O_APPEND | oflags::O_NONBLOCK | oflags::O_ASYNC);
     let desc = Arc::new(FileDescription::new(backend, status_flags));
     let tbl = crate::task::current_fd_table();
     let result = tbl.lock().alloc_fd_with_flags(desc, fd_flags);

--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -141,12 +141,13 @@ fn stat_into_user(inode: &Arc<Inode>, user_statbuf: u64) -> i64 {
 /// caller's `O_*` flags; access-mode bits go into `FileDescription.flags`
 /// and `O_CLOEXEC` is split into the per-fd slot via `alloc_fd_with_flags`.
 fn install_fd(backend: Arc<dyn FileBackend>, flags: u32) -> i64 {
-    let access_flags = flags & (oflags::O_RDONLY | oflags::O_WRONLY | oflags::O_RDWR);
+    // Preserve every status flag the caller passed (access mode, O_APPEND,
+    // O_NONBLOCK, etc.) on the open-file description so fcntl(F_GETFL)
+    // returns the full set. The per-fd O_CLOEXEC bit is split out into the
+    // slot's fd_flags — dup'd fds must not inherit it.
     let fd_flags = flags & oflags::O_CLOEXEC;
-    let desc = Arc::new(FileDescription {
-        backend,
-        flags: access_flags,
-    });
+    let status_flags = flags & !oflags::O_CLOEXEC;
+    let desc = Arc::new(FileDescription::new(backend, status_flags));
     let tbl = crate::task::current_fd_table();
     let result = tbl.lock().alloc_fd_with_flags(desc, fd_flags);
     match result {

--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -146,7 +146,12 @@ fn install_fd(backend: Arc<dyn FileBackend>, flags: u32) -> i64 {
     // returns the full set. The per-fd O_CLOEXEC bit is split out into the
     // slot's fd_flags — dup'd fds must not inherit it.
     let fd_flags = flags & oflags::O_CLOEXEC;
-    let status_flags = flags & !oflags::O_CLOEXEC;
+    // Only POSIX file-status flags persist on the open-file description.
+    // Creation-time / path-resolution bits (O_CREAT, O_EXCL, O_TRUNC,
+    // O_DIRECTORY, O_NOFOLLOW) affect open() only and must not surface
+    // via fcntl(F_GETFL).
+    let status_flags = flags
+        & (oflags::O_ACCMODE | oflags::O_APPEND | oflags::O_NONBLOCK | oflags::O_ASYNC);
     let desc = Arc::new(FileDescription::new(backend, status_flags));
     let tbl = crate::task::current_fd_table();
     let result = tbl.lock().alloc_fd_with_flags(desc, fd_flags);

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -361,16 +361,6 @@ impl FileDescTable {
         self.alloc_fd_with_flags(desc, 0)
     }
 
-    /// Make `newfd` an alias for `oldfd`'s description. Returns `newfd`.
-    ///
-    /// - If `newfd == oldfd` and it is open, returns `newfd` without any
-    ///   change.
-    /// - If `newfd` was already open, it is closed silently before
-    ///   reassignment (POSIX `dup2` semantics).
-    /// - Returns `EBADF` if `oldfd` is not open.
-    /// - Returns `EINVAL` if `newfd >= MAX_FD`.
-    ///
-    /// The new fd starts with `FD_CLOEXEC` cleared (POSIX `dup2` semantics).
     /// Return the open-file description's status flags for `fd`
     /// (`fcntl(fd, F_GETFL)`).
     pub fn get_status_flags(&self, fd: u32) -> Result<u32, i64> {
@@ -473,6 +463,16 @@ impl FileDescTable {
         Ok(fd)
     }
 
+    /// Make `newfd` an alias for `oldfd`'s description. Returns `newfd`.
+    ///
+    /// - If `newfd == oldfd` and it is open, returns `newfd` without any
+    ///   change.
+    /// - If `newfd` was already open, it is closed silently before
+    ///   reassignment (POSIX `dup2` semantics).
+    /// - Returns `EBADF` if `oldfd` is not open.
+    /// - Returns `EINVAL` if `newfd >= MAX_FD`.
+    ///
+    /// The new fd starts with `FD_CLOEXEC` cleared (POSIX `dup2` semantics).
     pub fn dup2(&mut self, oldfd: u32, newfd: u32) -> Result<u32, i64> {
         if newfd as usize >= MAX_FD {
             return Err(EINVAL);

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -392,12 +392,10 @@ impl FileDescTable {
         let mut cur = desc.flags.load(Ordering::Relaxed);
         loop {
             let next = (cur & !mutable) | (new_flags & mutable);
-            match desc.flags.compare_exchange_weak(
-                cur,
-                next,
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-            ) {
+            match desc
+                .flags
+                .compare_exchange_weak(cur, next, Ordering::Relaxed, Ordering::Relaxed)
+            {
                 Ok(_) => return Ok(()),
                 Err(observed) => cur = observed,
             }

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -19,6 +19,7 @@
 
 use alloc::sync::Arc;
 use alloc::vec::Vec;
+use core::sync::atomic::{AtomicU32, Ordering};
 
 use crate::poll::{PollMask, PollTable, DEFAULT_POLLMASK};
 
@@ -117,6 +118,8 @@ pub mod flags {
     pub const O_APPEND: u32 = 0o2000;
     /// Non-blocking I/O on fifos, sockets, and character devices.
     pub const O_NONBLOCK: u32 = 0o4000;
+    /// 0o20000 = 0x2000 = 8192
+    pub const O_ASYNC: u32 = 0o20000;
     /// Require the resolved path to refer to a directory (`ENOTDIR` if not).
     pub const O_DIRECTORY: u32 = 0o200000;
     /// Do not follow a symlink in the final path component (`ELOOP`).
@@ -153,11 +156,39 @@ pub mod flags {
 /// count; the last `close()` drops it.
 pub struct FileDescription {
     pub backend: Arc<dyn FileBackend>,
-    pub flags: u32,
+    /// OFD status flags (access mode + mutable bits like `O_APPEND`,
+    /// `O_NONBLOCK`, `O_ASYNC`). Interior-mutable so `fcntl(F_SETFL)` can
+    /// mutate them through the `Arc` shared by dup'd fds — POSIX requires
+    /// the change to be visible on every fd that aliases this description.
+    pub flags: AtomicU32,
+}
+
+impl FileDescription {
+    /// Construct a new description with initial status `flags`.
+    pub fn new(backend: Arc<dyn FileBackend>, flags: u32) -> Self {
+        Self {
+            backend,
+            flags: AtomicU32::new(flags),
+        }
+    }
 }
 
 /// Maximum number of simultaneously open fds per process.
 const MAX_FD: usize = 1024;
+
+/// `fcntl(2)` commands. Numeric values match the Linux x86_64 ABI
+/// (`<asm-generic/fcntl.h>`). `F_DUPFD_CLOEXEC` is Linux-only (since 2.6.24)
+/// but widely relied on.
+pub const F_DUPFD: u32 = 0;
+pub const F_GETFD: u32 = 1;
+pub const F_SETFD: u32 = 2;
+pub const F_GETFL: u32 = 3;
+pub const F_SETFL: u32 = 4;
+pub const F_DUPFD_CLOEXEC: u32 = 1030;
+
+/// Per-fd flag returned by `F_GETFD` / accepted by `F_SETFD`. Internally
+/// stored as `flags::O_CLOEXEC`.
+pub const FD_CLOEXEC: u32 = 1;
 
 /// Linux errno constants (negated so they match syscall return values).
 pub const ENOENT: i64 = -2;
@@ -211,24 +242,15 @@ impl FileDescTable {
     ) -> Self {
         let mut t = Self::new();
         t.slots.push(Some((
-            Arc::new(FileDescription {
-                backend: stdin,
-                flags: flags::O_RDONLY,
-            }),
+            Arc::new(FileDescription::new(stdin, flags::O_RDONLY)),
             0,
         )));
         t.slots.push(Some((
-            Arc::new(FileDescription {
-                backend: stdout,
-                flags: flags::O_WRONLY,
-            }),
+            Arc::new(FileDescription::new(stdout, flags::O_WRONLY)),
             0,
         )));
         t.slots.push(Some((
-            Arc::new(FileDescription {
-                backend: stderr,
-                flags: flags::O_WRONLY,
-            }),
+            Arc::new(FileDescription::new(stderr, flags::O_WRONLY)),
             0,
         )));
         t
@@ -349,6 +371,110 @@ impl FileDescTable {
     /// - Returns `EINVAL` if `newfd >= MAX_FD`.
     ///
     /// The new fd starts with `FD_CLOEXEC` cleared (POSIX `dup2` semantics).
+    /// Return the open-file description's status flags for `fd`
+    /// (`fcntl(fd, F_GETFL)`).
+    pub fn get_status_flags(&self, fd: u32) -> Result<u32, i64> {
+        let desc = self.get_desc(fd)?;
+        Ok(desc.flags.load(Ordering::Relaxed))
+    }
+
+    /// Mutate the open-file description's status flags for `fd`
+    /// (`fcntl(fd, F_SETFL, flags)`).
+    ///
+    /// Per POSIX only `O_APPEND`, `O_NONBLOCK`, and `O_ASYNC` are writable;
+    /// other bits in `new_flags` are silently ignored, and the access-mode
+    /// plus creation-time bits already on the description are preserved.
+    pub fn set_status_flags(&mut self, fd: u32, new_flags: u32) -> Result<(), i64> {
+        let desc = self.get_desc(fd)?;
+        let mutable = flags::O_APPEND | flags::O_NONBLOCK | flags::O_ASYNC;
+        // Atomic swap under a tight loop so concurrent `F_SETFL` callers on
+        // dup'd fds can't lose each other's edits.
+        let mut cur = desc.flags.load(Ordering::Relaxed);
+        loop {
+            let next = (cur & !mutable) | (new_flags & mutable);
+            match desc.flags.compare_exchange_weak(
+                cur,
+                next,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return Ok(()),
+                Err(observed) => cur = observed,
+            }
+        }
+    }
+
+    /// Return the per-fd flags for `fd` (`fcntl(fd, F_GETFD)`).
+    ///
+    /// Today the only defined per-fd flag is `FD_CLOEXEC` (bit 0). Internally
+    /// we store it as `flags::O_CLOEXEC` in the slot's `fd_flags`; this
+    /// method translates it to the userspace `FD_CLOEXEC` bit.
+    pub fn get_fd_flags(&self, fd: u32) -> Result<u32, i64> {
+        let (_, fd_flags) = self
+            .slots
+            .get(fd as usize)
+            .and_then(Option::as_ref)
+            .ok_or(EBADF)?;
+        if *fd_flags & flags::O_CLOEXEC != 0 {
+            Ok(FD_CLOEXEC)
+        } else {
+            Ok(0)
+        }
+    }
+
+    /// Mutate the per-fd flags for `fd` (`fcntl(fd, F_SETFD, flags)`).
+    ///
+    /// Accepts the userspace `FD_CLOEXEC` bit and translates it to the
+    /// internal `O_CLOEXEC` storage. Other bits in `new_flags` are silently
+    /// ignored (Linux behaviour).
+    pub fn set_fd_flags(&mut self, fd: u32, new_flags: u32) -> Result<(), i64> {
+        let slot = self
+            .slots
+            .get_mut(fd as usize)
+            .and_then(Option::as_mut)
+            .ok_or(EBADF)?;
+        if new_flags & FD_CLOEXEC != 0 {
+            slot.1 |= flags::O_CLOEXEC;
+        } else {
+            slot.1 &= !flags::O_CLOEXEC;
+        }
+        Ok(())
+    }
+
+    /// Allocate the lowest free fd `>= min_fd` and duplicate `oldfd` into
+    /// it. Backs `fcntl(oldfd, F_DUPFD, min_fd)` and
+    /// `fcntl(oldfd, F_DUPFD_CLOEXEC, min_fd)`.
+    ///
+    /// Returns `EINVAL` if `min_fd >= MAX_FD`, `EMFILE` when the table is
+    /// full, and `EBADF` if `oldfd` is not open.
+    pub fn dupfd_from(&mut self, oldfd: u32, min_fd: u32, cloexec: bool) -> Result<u32, i64> {
+        if min_fd as usize >= MAX_FD {
+            return Err(EINVAL);
+        }
+        let desc = self.get_desc(oldfd)?;
+        let fd_flags = if cloexec { flags::O_CLOEXEC } else { 0 };
+        // Search existing slots from `min_fd` upward for a hole.
+        if (min_fd as usize) < self.slots.len() {
+            for (i, slot) in self.slots.iter_mut().enumerate().skip(min_fd as usize) {
+                if slot.is_none() {
+                    *slot = Some((desc, fd_flags));
+                    return Ok(i as u32);
+                }
+            }
+        }
+        // No hole at or after `min_fd`; extend the vec, padding with holes
+        // from the current end up to `min_fd`, then push.
+        if self.slots.len() >= MAX_FD {
+            return Err(EMFILE);
+        }
+        while self.slots.len() < min_fd as usize {
+            self.slots.push(None);
+        }
+        let fd = self.slots.len() as u32;
+        self.slots.push(Some((desc, fd_flags)));
+        Ok(fd)
+    }
+
     pub fn dup2(&mut self, oldfd: u32, newfd: u32) -> Result<u32, i64> {
         if newfd as usize >= MAX_FD {
             return Err(EINVAL);
@@ -504,10 +630,7 @@ mod tests {
     }
 
     fn null_desc() -> Arc<FileDescription> {
-        Arc::new(FileDescription {
-            backend: null(),
-            flags: 0,
-        })
+        Arc::new(FileDescription::new(null(), 0))
     }
 
     fn make_table() -> FileDescTable {

--- a/kernel/src/fs/vfs/backend.rs
+++ b/kernel/src/fs/vfs/backend.rs
@@ -292,7 +292,7 @@ mod tests {
             open_file: of.clone(),
         }) as Arc<dyn FileBackend>;
         let mut parent = FileDescTable::new();
-        let desc = Arc::new(FileDescription { backend, flags: 0 });
+        let desc = Arc::new(FileDescription::new(backend, 0));
         let fd = parent.alloc_fd(desc).expect("alloc_fd");
 
         // Fork — child shares the Arc<OpenFile>.
@@ -446,10 +446,7 @@ mod tests {
             open_file: of.clone(),
         }) as Arc<dyn FileBackend>;
         let mut parent = FileDescTable::new();
-        let desc = Arc::new(FileDescription {
-            backend: parent_backend,
-            flags: 0,
-        });
+        let desc = Arc::new(FileDescription::new(parent_backend, 0));
         let fd = parent.alloc_fd(desc).expect("alloc_fd");
         let child = parent.clone_for_fork();
 
@@ -467,10 +464,7 @@ mod tests {
             open_file: of.clone(),
         }) as Arc<dyn FileBackend>;
         let mut t = FileDescTable::new();
-        let cloexec_desc = Arc::new(FileDescription {
-            backend,
-            flags: flags::O_CLOEXEC,
-        });
+        let cloexec_desc = Arc::new(FileDescription::new(backend, flags::O_CLOEXEC));
         let fd = t.alloc_fd(cloexec_desc).expect("alloc_fd");
 
         // Allocate a non-cloexec fd too.
@@ -483,10 +477,10 @@ mod tests {
                 Ok(buf.len())
             }
         }
-        let null_desc = Arc::new(FileDescription {
-            backend: Arc::new(NullBackend) as Arc<dyn FileBackend>,
-            flags: 0,
-        });
+        let null_desc = Arc::new(FileDescription::new(
+            Arc::new(NullBackend) as Arc<dyn FileBackend>,
+            0,
+        ));
         let null_fd = t.alloc_fd(null_desc).expect("alloc null fd");
 
         t.close_cloexec();

--- a/kernel/src/fs/vfs/backend.rs
+++ b/kernel/src/fs/vfs/backend.rs
@@ -464,8 +464,10 @@ mod tests {
             open_file: of.clone(),
         }) as Arc<dyn FileBackend>;
         let mut t = FileDescTable::new();
-        let cloexec_desc = Arc::new(FileDescription::new(backend, flags::O_CLOEXEC));
-        let fd = t.alloc_fd(cloexec_desc).expect("alloc_fd");
+        let cloexec_desc = Arc::new(FileDescription::new(backend, 0));
+        let fd = t
+            .alloc_fd_with_flags(cloexec_desc, flags::O_CLOEXEC)
+            .expect("alloc_fd");
 
         // Allocate a non-cloexec fd too.
         struct NullBackend;

--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -462,14 +462,14 @@ pub unsafe fn sys_pipe2(pipefd_uva: u64, flags: u32) -> i64 {
 
     let pipe = Pipe::new();
 
-    let read_desc = Arc::new(FileDescription {
-        backend: Arc::new(PipeReadEnd::new(pipe.clone(), nonblocking)),
-        flags: if nonblocking { O_NONBLOCK } else { 0 },
-    });
-    let write_desc = Arc::new(FileDescription {
-        backend: Arc::new(PipeWriteEnd::new(pipe, nonblocking)),
-        flags: if nonblocking { O_NONBLOCK } else { 0 },
-    });
+    let read_desc = Arc::new(FileDescription::new(
+        Arc::new(PipeReadEnd::new(pipe.clone(), nonblocking)),
+        if nonblocking { O_NONBLOCK } else { 0 },
+    ));
+    let write_desc = Arc::new(FileDescription::new(
+        Arc::new(PipeWriteEnd::new(pipe, nonblocking)),
+        if nonblocking { O_NONBLOCK } else { 0 },
+    ));
 
     let fd_table_arc = crate::task::current_fd_table();
     let mut fd_table = fd_table_arc.lock();

--- a/kernel/tests/fd_table.rs
+++ b/kernel/tests/fd_table.rs
@@ -78,10 +78,7 @@ fn null() -> Arc<dyn FileBackend> {
 }
 
 fn null_desc() -> Arc<FileDescription> {
-    Arc::new(FileDescription {
-        backend: null(),
-        flags: 0,
-    })
+    Arc::new(FileDescription::new(null(), 0))
 }
 
 fn make_table() -> FileDescTable {

--- a/kernel/tests/syscall_fcntl.rs
+++ b/kernel/tests/syscall_fcntl.rs
@@ -19,7 +19,9 @@ use core::panic::PanicInfo;
 use core::ptr;
 
 use vibix::arch::x86_64::syscall::syscall_dispatch;
-use vibix::fs::{EBADF, EINVAL, FD_CLOEXEC, F_DUPFD, F_DUPFD_CLOEXEC, F_GETFD, F_GETFL, F_SETFD, F_SETFL};
+use vibix::fs::{
+    EBADF, EINVAL, FD_CLOEXEC, F_DUPFD, F_DUPFD_CLOEXEC, F_GETFD, F_GETFL, F_SETFD, F_SETFL,
+};
 use vibix::mem::vmatree::{Share, Vma};
 use vibix::mem::vmobject::AnonObject;
 use vibix::{
@@ -60,12 +62,27 @@ fn panic(info: &PanicInfo) -> ! {
 
 fn run_tests() {
     let tests: &[(&str, &dyn Testable)] = &[
-        ("fcntl_getfl_reflects_open_flags", &(fcntl_getfl_reflects_open_flags as fn())),
-        ("fcntl_setfl_mutates_only_mutable_bits", &(fcntl_setfl_mutates_only_mutable_bits as fn())),
-        ("fcntl_getfd_setfd_roundtrip_cloexec", &(fcntl_getfd_setfd_roundtrip_cloexec as fn())),
+        (
+            "fcntl_getfl_reflects_open_flags",
+            &(fcntl_getfl_reflects_open_flags as fn()),
+        ),
+        (
+            "fcntl_setfl_mutates_only_mutable_bits",
+            &(fcntl_setfl_mutates_only_mutable_bits as fn()),
+        ),
+        (
+            "fcntl_getfd_setfd_roundtrip_cloexec",
+            &(fcntl_getfd_setfd_roundtrip_cloexec as fn()),
+        ),
         ("fcntl_dupfd_uses_floor", &(fcntl_dupfd_uses_floor as fn())),
-        ("fcntl_dupfd_cloexec_sets_bit_only_on_new", &(fcntl_dupfd_cloexec_sets_bit_only_on_new as fn())),
-        ("fcntl_unknown_cmd_einval", &(fcntl_unknown_cmd_einval as fn())),
+        (
+            "fcntl_dupfd_cloexec_sets_bit_only_on_new",
+            &(fcntl_dupfd_cloexec_sets_bit_only_on_new as fn()),
+        ),
+        (
+            "fcntl_unknown_cmd_einval",
+            &(fcntl_unknown_cmd_einval as fn()),
+        ),
         ("fcntl_bad_fd_ebadf", &(fcntl_bad_fd_ebadf as fn())),
     ];
     for (name, t) in tests {

--- a/kernel/tests/syscall_fcntl.rs
+++ b/kernel/tests/syscall_fcntl.rs
@@ -1,0 +1,249 @@
+//! Integration test for issue #415: `fcntl(2)` syscall.
+//!
+//! Exercises the `SYS_FCNTL` dispatcher arm end-to-end:
+//! - `F_GETFL` reflects the flags passed to `open`.
+//! - `F_SETFL` mutates only `O_APPEND | O_NONBLOCK | O_ASYNC`; the access
+//!   mode and other bits are preserved.
+//! - `F_GETFD` / `F_SETFD` round-trip the `FD_CLOEXEC` bit.
+//! - `F_DUPFD` allocates the lowest free fd `>= min_fd`.
+//! - `F_DUPFD_CLOEXEC` sets `FD_CLOEXEC` on the new fd without
+//!   touching the source fd.
+//! - Unknown cmd returns `EINVAL`; bad fd returns `EBADF`.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use core::ptr;
+
+use vibix::arch::x86_64::syscall::syscall_dispatch;
+use vibix::fs::{EBADF, EINVAL, FD_CLOEXEC, F_DUPFD, F_DUPFD_CLOEXEC, F_GETFD, F_GETFL, F_SETFD, F_SETFL};
+use vibix::mem::vmatree::{Share, Vma};
+use vibix::mem::vmobject::AnonObject;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+use x86_64::structures::paging::PageTableFlags;
+
+const SYS_OPEN: u64 = 2;
+const SYS_CLOSE: u64 = 3;
+const SYS_FCNTL: u64 = 72;
+
+const O_RDONLY: u32 = 0o0;
+const O_APPEND: u32 = 0o2000;
+const O_NONBLOCK: u32 = 0o4000;
+const O_ASYNC: u32 = 0o20000;
+const O_DIRECTORY: u32 = 0o200000;
+
+const HOSTNAME_PATH: &[u8] = b"/etc/hostname\0";
+
+const USER_PAGE_VA: usize = 0x0000_2001_0000_0000;
+const USER_PAGE_LEN: usize = 4 * 4096;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    vibix::task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("fcntl_getfl_reflects_open_flags", &(fcntl_getfl_reflects_open_flags as fn())),
+        ("fcntl_setfl_mutates_only_mutable_bits", &(fcntl_setfl_mutates_only_mutable_bits as fn())),
+        ("fcntl_getfd_setfd_roundtrip_cloexec", &(fcntl_getfd_setfd_roundtrip_cloexec as fn())),
+        ("fcntl_dupfd_uses_floor", &(fcntl_dupfd_uses_floor as fn())),
+        ("fcntl_dupfd_cloexec_sets_bit_only_on_new", &(fcntl_dupfd_cloexec_sets_bit_only_on_new as fn())),
+        ("fcntl_unknown_cmd_einval", &(fcntl_unknown_cmd_einval as fn())),
+        ("fcntl_bad_fd_ebadf", &(fcntl_bad_fd_ebadf as fn())),
+    ];
+    for (name, t) in tests {
+        serial_println!("syscall_fcntl: {}", name);
+        t.run();
+    }
+}
+
+fn install_user_staging_vma() {
+    static INSTALLED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+    if INSTALLED.swap(true, core::sync::atomic::Ordering::SeqCst) {
+        return;
+    }
+    let prot_pte =
+        (PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE).bits();
+    vibix::task::install_vma_on_current(Vma::new(
+        USER_PAGE_VA,
+        USER_PAGE_VA + USER_PAGE_LEN,
+        0x3,
+        prot_pte,
+        Share::Private,
+        AnonObject::new(Some(USER_PAGE_LEN / 4096)),
+        0,
+    ));
+    unsafe {
+        ptr::write_volatile(USER_PAGE_VA as *mut u8, 0);
+    }
+}
+
+fn stage(bytes: &[u8]) -> u64 {
+    install_user_staging_vma();
+    assert!(bytes.len() < USER_PAGE_LEN);
+    unsafe {
+        let dst = USER_PAGE_VA as *mut u8;
+        for (i, b) in bytes.iter().enumerate() {
+            ptr::write_volatile(dst.add(i), *b);
+        }
+    }
+    USER_PAGE_VA as u64
+}
+
+fn open_with_flags(path: &[u8], flags: u32) -> i64 {
+    let uva = stage(path);
+    unsafe { syscall_dispatch(SYS_OPEN, uva, flags as u64, 0, 0, 0, 0) }
+}
+
+fn close(fd: i64) -> i64 {
+    unsafe { syscall_dispatch(SYS_CLOSE, fd as u64, 0, 0, 0, 0, 0) }
+}
+
+fn fcntl(fd: i64, cmd: u32, arg: u64) -> i64 {
+    unsafe { syscall_dispatch(SYS_FCNTL, fd as u64, cmd as u64, arg, 0, 0, 0) }
+}
+
+fn fcntl_getfl_reflects_open_flags() {
+    // Open read-only; F_GETFL must include O_RDONLY (value 0) and nothing
+    // else mutable.
+    let fd = open_with_flags(HOSTNAME_PATH, O_RDONLY);
+    assert!(fd >= 3, "open failed: {}", fd);
+    let fl = fcntl(fd, F_GETFL, 0);
+    assert!(fl >= 0, "F_GETFL returned {}", fl);
+    assert_eq!(fl as u32 & 0o3, O_RDONLY);
+    assert_eq!(fl as u32 & O_NONBLOCK, 0);
+    assert_eq!(fl as u32 & O_APPEND, 0);
+    close(fd);
+
+    // Open with O_NONBLOCK: F_GETFL must show the bit.
+    let fd = open_with_flags(HOSTNAME_PATH, O_RDONLY | O_NONBLOCK);
+    assert!(fd >= 3);
+    let fl = fcntl(fd, F_GETFL, 0);
+    assert!(fl >= 0);
+    assert_eq!(fl as u32 & O_NONBLOCK, O_NONBLOCK);
+    close(fd);
+}
+
+fn fcntl_setfl_mutates_only_mutable_bits() {
+    let fd = open_with_flags(HOSTNAME_PATH, O_RDONLY);
+    assert!(fd >= 3);
+
+    // Flip O_NONBLOCK on via F_SETFL; F_GETFL sees it.
+    let r = fcntl(fd, F_SETFL, O_NONBLOCK as u64);
+    assert_eq!(r, 0, "F_SETFL returned {}", r);
+    let fl = fcntl(fd, F_GETFL, 0);
+    assert_eq!(fl as u32 & O_NONBLOCK, O_NONBLOCK);
+    // Access mode (O_RDONLY=0) is preserved — no O_WRONLY/O_RDWR snuck in.
+    assert_eq!(fl as u32 & 0o3, O_RDONLY);
+
+    // Flip O_APPEND + O_ASYNC on, O_NONBLOCK off in a single call.
+    let r = fcntl(fd, F_SETFL, (O_APPEND | O_ASYNC) as u64);
+    assert_eq!(r, 0);
+    let fl = fcntl(fd, F_GETFL, 0) as u32;
+    assert_eq!(fl & O_APPEND, O_APPEND);
+    assert_eq!(fl & O_ASYNC, O_ASYNC);
+    assert_eq!(fl & O_NONBLOCK, 0);
+
+    // Non-mutable bits in the arg are silently ignored — access mode
+    // doesn't get clobbered, O_DIRECTORY doesn't stick.
+    let r = fcntl(fd, F_SETFL, O_DIRECTORY as u64);
+    assert_eq!(r, 0);
+    let fl = fcntl(fd, F_GETFL, 0) as u32;
+    assert_eq!(fl & 0o3, O_RDONLY, "access mode must survive F_SETFL");
+    assert_eq!(fl & O_DIRECTORY, 0, "O_DIRECTORY is not a mutable bit");
+
+    close(fd);
+}
+
+fn fcntl_getfd_setfd_roundtrip_cloexec() {
+    let fd = open_with_flags(HOSTNAME_PATH, O_RDONLY);
+    assert!(fd >= 3);
+
+    // Freshly-opened fds without O_CLOEXEC report FD_CLOEXEC=0.
+    let r = fcntl(fd, F_GETFD, 0);
+    assert_eq!(r, 0);
+
+    // Set FD_CLOEXEC; F_GETFD must observe it.
+    let r = fcntl(fd, F_SETFD, FD_CLOEXEC as u64);
+    assert_eq!(r, 0);
+    let r = fcntl(fd, F_GETFD, 0);
+    assert_eq!(r as u32, FD_CLOEXEC);
+
+    // Clear it again.
+    let r = fcntl(fd, F_SETFD, 0);
+    assert_eq!(r, 0);
+    let r = fcntl(fd, F_GETFD, 0);
+    assert_eq!(r, 0);
+
+    close(fd);
+}
+
+fn fcntl_dupfd_uses_floor() {
+    let fd = open_with_flags(HOSTNAME_PATH, O_RDONLY);
+    assert!(fd >= 3);
+
+    // Dup with a floor of 42: result must be >= 42.
+    let new_fd = fcntl(fd, F_DUPFD, 42);
+    assert!(new_fd >= 42, "F_DUPFD returned {} with floor 42", new_fd);
+
+    // New fd starts with FD_CLOEXEC cleared.
+    let r = fcntl(new_fd, F_GETFD, 0);
+    assert_eq!(r, 0);
+
+    close(new_fd);
+    close(fd);
+}
+
+fn fcntl_dupfd_cloexec_sets_bit_only_on_new() {
+    let fd = open_with_flags(HOSTNAME_PATH, O_RDONLY);
+    assert!(fd >= 3);
+
+    let new_fd = fcntl(fd, F_DUPFD_CLOEXEC, 10);
+    assert!(new_fd >= 10);
+
+    // New fd has FD_CLOEXEC set.
+    let r = fcntl(new_fd, F_GETFD, 0);
+    assert_eq!(r as u32, FD_CLOEXEC);
+    // Source fd is untouched.
+    let r = fcntl(fd, F_GETFD, 0);
+    assert_eq!(r, 0);
+
+    close(new_fd);
+    close(fd);
+}
+
+fn fcntl_unknown_cmd_einval() {
+    let fd = open_with_flags(HOSTNAME_PATH, O_RDONLY);
+    assert!(fd >= 3);
+    // 999 is not a defined F_* cmd.
+    let r = fcntl(fd, 999, 0);
+    assert_eq!(r, EINVAL);
+    close(fd);
+}
+
+fn fcntl_bad_fd_ebadf() {
+    // fd 4242 was never opened.
+    let r = fcntl(4242, F_GETFL, 0);
+    assert_eq!(r, EBADF);
+    let r = fcntl(4242, F_SETFD, FD_CLOEXEC as u64);
+    assert_eq!(r, EBADF);
+    let r = fcntl(4242, F_DUPFD, 0);
+    assert_eq!(r, EBADF);
+}

--- a/kernel/tests/vfs_backend.rs
+++ b/kernel/tests/vfs_backend.rs
@@ -150,7 +150,7 @@ fn read_advances_offset() {
         open_file: of.clone(),
     }) as Arc<dyn FileBackend>;
     let mut t = FileDescTable::new();
-    let desc = Arc::new(FileDescription { backend, flags: 0 });
+    let desc = Arc::new(FileDescription::new(backend, 0));
     let fd = t.alloc_fd(desc).expect("alloc_fd");
 
     let b = t.get(fd).expect("fd open");
@@ -168,7 +168,7 @@ fn write_advances_offset() {
         open_file: of.clone(),
     }) as Arc<dyn FileBackend>;
     let mut t = FileDescTable::new();
-    let desc = Arc::new(FileDescription { backend, flags: 0 });
+    let desc = Arc::new(FileDescription::new(backend, 0));
     let fd = t.alloc_fd(desc).expect("alloc_fd");
 
     let b = t.get(fd).expect("fd open");
@@ -192,7 +192,7 @@ fn fork_shares_open_file_description() {
         open_file: of.clone(),
     }) as Arc<dyn FileBackend>;
     let mut parent = FileDescTable::new();
-    let desc = Arc::new(FileDescription { backend, flags: 0 });
+    let desc = Arc::new(FileDescription::new(backend, 0));
     let fd = parent.alloc_fd(desc).expect("alloc_fd");
 
     // Fork the fd table.
@@ -234,10 +234,7 @@ fn close_cloexec_drops_vfs_backend() {
     let of = make_open_file(0);
     let cloexec_backend = Arc::new(VfsBackend { open_file: of }) as Arc<dyn FileBackend>;
     let mut t = FileDescTable::new();
-    let cloexec_desc = Arc::new(FileDescription {
-        backend: cloexec_backend,
-        flags: 0,
-    });
+    let cloexec_desc = Arc::new(FileDescription::new(cloexec_backend, 0));
     let cloexec_fd = t
         .alloc_fd_with_flags(cloexec_desc, flags::O_CLOEXEC)
         .expect("alloc cloexec fd");
@@ -245,10 +242,7 @@ fn close_cloexec_drops_vfs_backend() {
     // A non-cloexec VfsBackend fd must survive exec.
     let of2 = make_open_file(0);
     let keep_backend = Arc::new(VfsBackend { open_file: of2 }) as Arc<dyn FileBackend>;
-    let keep_desc = Arc::new(FileDescription {
-        backend: keep_backend,
-        flags: 0,
-    });
+    let keep_desc = Arc::new(FileDescription::new(keep_backend, 0));
     let keep_fd = t.alloc_fd(keep_desc).expect("alloc keep fd");
 
     t.close_cloexec();


### PR DESCRIPTION
Closes #415

## Summary
- Wires `SYS_FCNTL` (72) for the commands userspace libc actually relies on: `F_GETFD`/`F_SETFD` (per-fd `FD_CLOEXEC`), `F_GETFL`/`F_SETFL` (OFD status flags, with POSIX `O_APPEND|O_NONBLOCK|O_ASYNC` mutable-bit mask), and `F_DUPFD`/`F_DUPFD_CLOEXEC` (lowest free fd ≥ `arg`, optionally with close-on-exec).
- Converts `FileDescription.flags` to `AtomicU32` so `F_SETFL` can mutate the open-file description through the `Arc` shared by dup'd fds — POSIX requires the change to be visible on every aliasing fd.
- `install_fd` now preserves every non-`O_CLOEXEC` status flag from `open()`, so `F_GETFL` returns the full set instead of just the access-mode bits.
- Adds new `FD_CLOEXEC` / `F_*` / `O_ASYNC` constants + a `FileDescription::new` constructor; updates every creation site (kernel + host tests + QEMU tests).
- Adds ABI pin `SYS_fcntl == 72` and a QEMU integration test in `kernel/tests/syscall_fcntl.rs` covering the golden path, bad fd → `EBADF`, unknown cmd → `EINVAL`, and `F_DUPFD_CLOEXEC` isolation (source fd untouched).

## Test plan
- [ ] `cargo xtask build`
- [ ] `cargo xtask test` — host unit tests + QEMU integration tests (new `syscall_fcntl`)
- [ ] `cargo xtask smoke`
