### PR TITLE
tty: N_TTY skeleton + c_iflag input transforms

### DIFF
--- a/kernel/src/tty/mod.rs
+++ b/kernel/src/tty/mod.rs
@@ -5,6 +5,7 @@
 //! `LineDiscipline`, `TtyDriver`, and `DeferredByteRing` arrive with
 //! #374–#376.
 
+pub mod ntty;
 pub mod termios;
 
 use core::sync::atomic::{AtomicU32, Ordering};

--- a/kernel/src/tty/ntty.rs
+++ b/kernel/src/tty/ntty.rs
@@ -1,0 +1,153 @@
+//! N_TTY line-discipline skeleton (RFC 0003 §N_TTY input).
+//!
+//! This slice implements only the byte-level `c_iflag` input transforms —
+//! pure functions of `Termios.iflag` with no signal generation, line
+//! buffering, or output path. ICANON / ISIG / OPOST / echo arrive in later
+//! sub-issues of #375.
+
+use spin::Mutex;
+
+use super::termios::{ICRNL, IGNCR, INLCR, ISTRIP, Termios};
+
+/// Interior N_TTY state. Guarded by lock class "2d" per RFC 0003 §Lock
+/// order. Kept a unit placeholder until the `DeferredByteRing` primitive
+/// (#376) lands; receive_byte does not currently need the lock but the
+/// public `NTty` type is stabilised here so follow-up PRs extend state in
+/// place without churning callers.
+#[allow(dead_code)]
+struct NTtyState;
+
+pub struct NTty {
+    #[allow(dead_code)]
+    state: Mutex<NTtyState>,
+}
+
+impl NTty {
+    pub const fn new() -> Self {
+        Self {
+            state: Mutex::new(NTtyState),
+        }
+    }
+
+    /// Apply the `c_iflag` input transforms to one raw byte.
+    ///
+    /// Returns `None` when the byte is consumed (IGNCR drop). Processing
+    /// order mirrors Linux `drivers/tty/n_tty.c` `n_tty_receive_char`:
+    ///
+    /// 1. `ISTRIP` — clear the high bit.
+    /// 2. `IGNCR` on `\r` — drop the byte.
+    /// 3. `ICRNL` on `\r` — remap to `\n`.
+    /// 4. `INLCR` on `\n` — remap to `\r`.
+    ///
+    /// IGNCR wins over ICRNL; the CR rewrite happens before the NL check
+    /// so a single byte is never ping-ponged when both `ICRNL` and `INLCR`
+    /// are set.
+    pub fn receive_byte(&self, termios: &Termios, b: u8) -> Option<u8> {
+        let iflag = termios.c_iflag;
+        let mut b = b;
+        if iflag & ISTRIP != 0 {
+            b &= 0x7f;
+        }
+        if b == b'\r' {
+            if iflag & IGNCR != 0 {
+                return None;
+            }
+            if iflag & ICRNL != 0 {
+                return Some(b'\n');
+            }
+        } else if b == b'\n' && iflag & INLCR != 0 {
+            return Some(b'\r');
+        }
+        Some(b)
+    }
+}
+
+impl Default for NTty {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tty::termios::Termios;
+
+    fn termios_with(iflag: u32) -> Termios {
+        let mut t = Termios::sane();
+        t.c_iflag = iflag;
+        t
+    }
+
+    #[test]
+    fn passthrough_when_iflag_zero() {
+        let n = NTty::new();
+        let t = termios_with(0);
+        assert_eq!(n.receive_byte(&t, 0x41), Some(0x41));
+        assert_eq!(n.receive_byte(&t, b'\r'), Some(b'\r'));
+        assert_eq!(n.receive_byte(&t, b'\n'), Some(b'\n'));
+        assert_eq!(n.receive_byte(&t, 0xFF), Some(0xFF));
+    }
+
+    #[test]
+    fn istrip_clears_high_bit() {
+        let n = NTty::new();
+        let t = termios_with(ISTRIP);
+        assert_eq!(n.receive_byte(&t, 0xE1), Some(0x61));
+        assert_eq!(n.receive_byte(&t, b'\r'), Some(b'\r'));
+        assert_eq!(n.receive_byte(&t, b'\n'), Some(b'\n'));
+    }
+
+    #[test]
+    fn inlcr_maps_nl_to_cr() {
+        let n = NTty::new();
+        let t = termios_with(INLCR);
+        assert_eq!(n.receive_byte(&t, b'\n'), Some(b'\r'));
+        assert_eq!(n.receive_byte(&t, b'\r'), Some(b'\r'));
+    }
+
+    #[test]
+    fn igncr_drops_cr() {
+        let n = NTty::new();
+        let t = termios_with(IGNCR);
+        assert_eq!(n.receive_byte(&t, b'\r'), None);
+        assert_eq!(n.receive_byte(&t, b'\n'), Some(b'\n'));
+    }
+
+    #[test]
+    fn icrnl_maps_cr_to_nl() {
+        let n = NTty::new();
+        let t = termios_with(ICRNL);
+        assert_eq!(n.receive_byte(&t, b'\r'), Some(b'\n'));
+        assert_eq!(n.receive_byte(&t, b'\n'), Some(b'\n'));
+    }
+
+    #[test]
+    fn igncr_wins_over_icrnl() {
+        let n = NTty::new();
+        let t = termios_with(IGNCR | ICRNL);
+        assert_eq!(n.receive_byte(&t, b'\r'), None);
+    }
+
+    #[test]
+    fn icrnl_plus_inlcr_no_pingpong() {
+        let n = NTty::new();
+        let t = termios_with(ICRNL | INLCR);
+        assert_eq!(n.receive_byte(&t, b'\r'), Some(b'\n'));
+        assert_eq!(n.receive_byte(&t, b'\n'), Some(b'\r'));
+    }
+
+    #[test]
+    fn istrip_then_icrnl() {
+        let n = NTty::new();
+        let t = termios_with(ISTRIP | ICRNL);
+        assert_eq!(n.receive_byte(&t, 0x8D), Some(b'\n'));
+    }
+
+    #[test]
+    fn istrip_then_igncr() {
+        let n = NTty::new();
+        let t = termios_with(ISTRIP | IGNCR);
+        assert_eq!(n.receive_byte(&t, 0x8D), None);
+    }
+}

--- a/kernel/src/tty/ntty.rs
+++ b/kernel/src/tty/ntty.rs
@@ -1,7 +1,7 @@
 //! N_TTY line-discipline skeleton (RFC 0003 §N_TTY input).
 //!
 //! This slice implements only the byte-level `c_iflag` input transforms —
-//! pure functions of `Termios.iflag` with no signal generation, line
+//! pure functions of `Termios.c_iflag` with no signal generation, line
 //! buffering, or output path. ICANON / ISIG / OPOST / echo arrive in later
 //! sub-issues of #375.
 

--- a/kernel/src/tty/ntty.rs
+++ b/kernel/src/tty/ntty.rs
@@ -7,7 +7,7 @@
 
 use spin::Mutex;
 
-use super::termios::{ICRNL, IGNCR, INLCR, ISTRIP, Termios};
+use super::termios::{Termios, ICRNL, IGNCR, INLCR, ISTRIP};
 
 /// Interior N_TTY state. Guarded by lock class "2d" per RFC 0003 §Lock
 /// order. Kept a unit placeholder until the `DeferredByteRing` primitive


### PR DESCRIPTION
Closes #428

## Summary

- Adds `kernel/src/tty/ntty.rs` implementing the N_TTY module skeleton per RFC 0003 §N_TTY input.
- `NTty::receive_byte(&Termios, u8) -> Option<u8>` applies `ISTRIP`, `IGNCR`, `ICRNL`, and `INLCR` only — no ICANON/ISIG/OPOST/echo. Processing order mirrors Linux `drivers/tty/n_tty.c`: ISTRIP → (IGNCR drop on CR) → (ICRNL rewrite CR) → (INLCR rewrite NL), so a single byte never ping-pongs when both ICRNL and INLCR are set.
- `NTtyState` is a unit placeholder guarded by a `Mutex` (lock class "2d" per RFC 0003). The public type is stabilised now so follow-up sub-issues (ICANON #429, OPOST/echo #430, ISIG #431) extend state in place without churning callers or re-routing the ISR path.

## Test plan

- [x] `cargo xtask build` clean (pre-existing `is_guard_hit` dead-code warning only).
- [x] `cargo test -p vibix --lib --target x86_64-unknown-linux-gnu tty::ntty` — 9/9 pass.
- [x] `cargo xtask smoke` — all 30 markers present.
- [ ] `cargo xtask test` — rwlock_writer_exclusion flake (see #385 / PR #436); unrelated to this change.