### PR TITLE
task: soft-IRQ bottom-half worker primitive (#404)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -73,6 +73,10 @@ name = "preempt"
 harness = false
 
 [[test]]
+name = "softirq"
+harness = false
+
+[[test]]
 name = "pml4_switch"
 harness = false
 

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -34,6 +34,7 @@
 
 pub mod priority;
 mod scheduler;
+pub mod softirq;
 mod switch;
 mod task;
 
@@ -905,6 +906,12 @@ fn reaper_loop() -> ! {
 /// a waitqueue); both paths restore a correct IF on return to task
 /// code.
 pub fn preempt_tick() {
+    // Drain any pending soft-IRQs before touching the scheduler lock.
+    // Handlers run IRQ-off on the interrupted task's stack; keeping
+    // them outside the SCHED critical section means a handler that
+    // wakes a task doesn't deadlock on our own lock.
+    softirq::drain();
+
     // `try_lock` + bail: block_current (or another preempt tick
     // mid-switch) may already hold SCHED. We'll get another tick in
     // 10 ms.

--- a/kernel/src/task/softirq.rs
+++ b/kernel/src/task/softirq.rs
@@ -1,0 +1,115 @@
+//! Soft-IRQ (bottom-half) primitive per RFC 0003.
+//!
+//! Hardware ISRs stay tiny: touch device state, EOI, return. Any work
+//! that can run later — parsing a scancode, pulling bytes through a
+//! line discipline, poking a waitqueue — is deferred here. The ISR
+//! calls [`raise`] to latch a bit into the pending mask; the drain
+//! runs at the tail of [`crate::task::preempt_tick`] and invokes the
+//! registered handler for every set bit.
+//!
+//! Design choices for a single-CPU kernel:
+//!
+//! - Pending bits live in a single `AtomicU32`. `raise` is a lock-free
+//!   `fetch_or`, safe from ISR context.
+//! - The handler table is a fixed array of `AtomicPtr` keyed by vector
+//!   index. `register` is expected at init time; calling it from a
+//!   running system is tolerated but racy (a `raise` between the
+//!   pending-set and pointer-store can drop the event, matching
+//!   Linux's own "register before enabling the IRQ" convention).
+//! - Handlers run with IRQs masked, on whatever kernel stack the
+//!   drainer ran on (today: the interrupted task's stack via
+//!   `preempt_tick`). Must be O(1) stack. Re-raising inside a handler
+//!   re-sets the pending bit and is picked up on the next tick — the
+//!   latch is atomic, so no re-entry guard is needed as long as the
+//!   drainer runs IRQ-off.
+
+use core::sync::atomic::{AtomicPtr, AtomicU32, Ordering};
+
+/// Soft-IRQ vectors. Keep small; each adds a pending bit and a handler
+/// slot. Discriminants double as the bit index in [`PENDING`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum SoftIrq {
+    SerialRx = 0,
+    PS2Rx = 1,
+    /// Reserved for future wiring. Keeps the table a stable size so
+    /// tests can rely on indices without churn.
+    Reserved2 = 2,
+    Reserved3 = 3,
+}
+
+impl SoftIrq {
+    const fn index(self) -> usize {
+        self as usize
+    }
+
+    const fn bit(self) -> u32 {
+        1u32 << (self as u8)
+    }
+}
+
+const NUM_VECTORS: usize = 4;
+
+static PENDING: AtomicU32 = AtomicU32::new(0);
+
+static HANDLERS: [AtomicPtr<()>; NUM_VECTORS] = [
+    AtomicPtr::new(core::ptr::null_mut()),
+    AtomicPtr::new(core::ptr::null_mut()),
+    AtomicPtr::new(core::ptr::null_mut()),
+    AtomicPtr::new(core::ptr::null_mut()),
+];
+
+/// Latch a pending bit for `vec`. Safe from ISR context.
+pub fn raise(vec: SoftIrq) {
+    PENDING.fetch_or(vec.bit(), Ordering::Release);
+}
+
+/// Register the handler for `vec`. Intended to be called at init,
+/// before the corresponding IRQ source is unmasked. Replacing a
+/// handler at runtime is allowed but carries the race noted in the
+/// module docs.
+pub fn register(vec: SoftIrq, handler: fn()) {
+    HANDLERS[vec.index()].store(handler as *mut (), Ordering::Release);
+}
+
+/// Drain the pending mask: for each set bit, clear it, look up the
+/// handler, and invoke it. Must run with IRQs masked. Safe to call
+/// when nothing is pending (cheap: one atomic load + branch).
+pub fn drain() {
+    loop {
+        let pending = PENDING.swap(0, Ordering::AcqRel);
+        if pending == 0 {
+            return;
+        }
+        let mut mask = pending;
+        while mask != 0 {
+            let bit = mask.trailing_zeros() as usize;
+            mask &= mask - 1;
+            if bit >= NUM_VECTORS {
+                continue;
+            }
+            let raw = HANDLERS[bit].load(Ordering::Acquire);
+            if raw.is_null() {
+                continue;
+            }
+            // SAFETY: `register` only ever stores values obtained from
+            // `fn() as *mut ()`. Converting back yields the original
+            // function pointer. Null was filtered above.
+            let handler: fn() = unsafe { core::mem::transmute::<*mut (), fn()>(raw) };
+            handler();
+        }
+        // Loop once more in case a handler re-raised its own bit or
+        // another vector fired during handler execution. Bounded by
+        // the number of distinct vectors times whatever latch rate
+        // handlers produce; callers are expected to make progress.
+    }
+}
+
+/// Clear all pending bits and registered handlers. Intended for
+/// integration tests that want a clean slate between cases.
+pub fn reset_for_test() {
+    PENDING.store(0, Ordering::Release);
+    for h in HANDLERS.iter() {
+        h.store(core::ptr::null_mut(), Ordering::Release);
+    }
+}

--- a/kernel/tests/softirq.rs
+++ b/kernel/tests/softirq.rs
@@ -1,0 +1,158 @@
+//! Integration test: soft-IRQ primitive (#404).
+//!
+//! Verifies the raise/drain flow end-to-end. We register a handler,
+//! raise the bit from task context, and let the drain at the tail of
+//! `preempt_tick` run it on the next timer IRQ. The latch case
+//! re-raises inside the handler and asserts it fires again.
+
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicU32, Ordering};
+
+use vibix::task::softirq::{drain, raise, register, reset_for_test, SoftIrq};
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "drain_with_nothing_pending_is_noop",
+            &(drain_with_nothing_pending_is_noop as fn()),
+        ),
+        (
+            "unregistered_vector_is_silently_dropped",
+            &(unregistered_vector_is_silently_dropped as fn()),
+        ),
+        (
+            "multiple_raises_coalesce_to_one_run",
+            &(multiple_raises_coalesce_to_one_run as fn()),
+        ),
+        ("two_vectors_both_fire", &(two_vectors_both_fire as fn())),
+        (
+            "raise_fires_handler_on_next_tick",
+            &(raise_fires_handler_on_next_tick as fn()),
+        ),
+        (
+            "re_raise_inside_handler_latches",
+            &(re_raise_inside_handler_latches as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+static RAN: AtomicU32 = AtomicU32::new(0);
+fn ran_handler() {
+    RAN.fetch_add(1, Ordering::Relaxed);
+}
+
+static A_COUNT: AtomicU32 = AtomicU32::new(0);
+fn handler_a() {
+    A_COUNT.fetch_add(1, Ordering::Relaxed);
+}
+
+static B_COUNT: AtomicU32 = AtomicU32::new(0);
+fn handler_b() {
+    B_COUNT.fetch_add(1, Ordering::Relaxed);
+}
+
+fn drain_with_nothing_pending_is_noop() {
+    reset_for_test();
+    A_COUNT.store(0, Ordering::Relaxed);
+    register(SoftIrq::SerialRx, handler_a);
+    drain();
+    assert_eq!(A_COUNT.load(Ordering::Relaxed), 0);
+}
+
+fn unregistered_vector_is_silently_dropped() {
+    reset_for_test();
+    raise(SoftIrq::PS2Rx);
+    drain();
+}
+
+fn multiple_raises_coalesce_to_one_run() {
+    reset_for_test();
+    A_COUNT.store(0, Ordering::Relaxed);
+    register(SoftIrq::SerialRx, handler_a);
+    raise(SoftIrq::SerialRx);
+    raise(SoftIrq::SerialRx);
+    raise(SoftIrq::SerialRx);
+    drain();
+    assert_eq!(A_COUNT.load(Ordering::Relaxed), 1);
+}
+
+fn two_vectors_both_fire() {
+    reset_for_test();
+    A_COUNT.store(0, Ordering::Relaxed);
+    B_COUNT.store(0, Ordering::Relaxed);
+    register(SoftIrq::SerialRx, handler_a);
+    register(SoftIrq::PS2Rx, handler_b);
+    raise(SoftIrq::SerialRx);
+    raise(SoftIrq::PS2Rx);
+    drain();
+    assert_eq!(A_COUNT.load(Ordering::Relaxed), 1);
+    assert_eq!(B_COUNT.load(Ordering::Relaxed), 1);
+}
+
+fn raise_fires_handler_on_next_tick() {
+    reset_for_test();
+    RAN.store(0, Ordering::Relaxed);
+    register(SoftIrq::SerialRx, ran_handler);
+    raise(SoftIrq::SerialRx);
+    // Let preempt_tick drain at least once. At 100 Hz a handful of
+    // hlts is plenty.
+    for _ in 0..10 {
+        x86_64::instructions::hlt();
+    }
+    assert!(
+        RAN.load(Ordering::Relaxed) >= 1,
+        "softirq handler did not run"
+    );
+}
+
+static LATCH_COUNT: AtomicU32 = AtomicU32::new(0);
+fn latch_handler() {
+    let n = LATCH_COUNT.fetch_add(1, Ordering::Relaxed);
+    // Re-raise exactly once so the next drain runs us a second time.
+    // Guarded so we don't loop forever if the drain somehow replays
+    // inside the same call.
+    if n == 0 {
+        raise(SoftIrq::PS2Rx);
+    }
+}
+
+fn re_raise_inside_handler_latches() {
+    reset_for_test();
+    LATCH_COUNT.store(0, Ordering::Relaxed);
+    register(SoftIrq::PS2Rx, latch_handler);
+    raise(SoftIrq::PS2Rx);
+    for _ in 0..20 {
+        x86_64::instructions::hlt();
+    }
+    assert!(
+        LATCH_COUNT.load(Ordering::Relaxed) >= 2,
+        "re-raised softirq did not fire a second time: {}",
+        LATCH_COUNT.load(Ordering::Relaxed)
+    );
+}


### PR DESCRIPTION
Closes #404

## Summary
- New `kernel/src/task/softirq.rs`: fixed set of vectors (`SerialRx`, `PS2Rx`, two reserved slots), ISR-safe `raise`, init-time `register`, lock-free `drain`. Pending bits live in a single `AtomicU32`; handler slots are `AtomicPtr<()>` so neither the ISR path nor the drain takes a lock.
- `drain()` is called at the head of `preempt_tick` — runs with IRQs masked on the interrupted task's stack, before the scheduler lock is taken (so a handler that wakes a task can't deadlock on `SCHED`).
- Coalescing via `fetch_or` + `swap`: multiple raises between ticks run the handler exactly once. Re-raises inside a handler re-set the pending bit and are picked up on the next tick.
- No existing ISR is touched in this PR, per the scope cap in #404. Serial-UART (#406) and PS/2 (#405) follow-ups will wire the actual ISR→softirq edges.

## Test plan
- [x] `cargo xtask build` clean
- [x] New `tests/softirq.rs` with 6 cases: noop-drain, unregistered-drop, coalescing, multi-vector, handler-runs-on-tick, re-raise-latch — all pass
- [x] `tests/timer_tick.rs` and `tests/preempt.rs` still pass (drain hook doesn't perturb either path)
- [x] `cargo xtask smoke` — 30/30 markers
- [x] Host unit tests (`cargo test --lib`): 250/250 pass
- [x] `cargo fmt --all` clean; `cargo clippy --package xtask -- -D warnings` clean
- [ ] CI on PR