### PR TITLE
tty: add DeferredByteRing, TtyDriver/LineDiscipline, extended Tty

### DIFF
--- a/kernel/src/tty/mod.rs
+++ b/kernel/src/tty/mod.rs
@@ -286,22 +286,17 @@ mod tests {
 
     #[test]
     fn passthrough_ldisc_appends_bytes_in_order() {
+        let ldisc = Arc::new(PassthroughLdisc::with_sink());
         let tty = Tty::with_driver(
             Arc::new(NullDriver),
-            Arc::new(PassthroughLdisc::with_sink()),
+            ldisc.clone() as Arc<dyn LineDiscipline>,
         );
-        let ldisc = tty.ldisc.clone();
         for b in b"hello" {
-            ldisc.receive_byte(&tty, *b);
+            tty.ldisc.receive_byte(&tty, *b);
         }
-        // Downcast via a concrete clone for test drain.
-        let probe = PassthroughLdisc::with_sink();
-        for b in b"hello" {
-            probe.receive_byte(&tty, *b);
-        }
-        assert_eq!(probe.drain_sink(), b"hello");
+        assert_eq!(ldisc.drain_sink(), b"hello");
         // Second drain after take yields empty.
-        assert!(probe.drain_sink().is_empty());
+        assert!(ldisc.drain_sink().is_empty());
     }
 
     #[test]

--- a/kernel/src/tty/mod.rs
+++ b/kernel/src/tty/mod.rs
@@ -1,16 +1,34 @@
 //! TTY subsystem.
 //!
-//! Today this module is [`termios`] plus a minimal [`Tty`] stub with the
-//! job-control fields the PCB needs for `setsid`/`setpgid` (#372). The
-//! `LineDiscipline`, `TtyDriver`, and `DeferredByteRing` arrive with
-//! #374–#376.
+//! This module defines the generic [`Tty`] container, the [`TtyDriver`]
+//! and [`LineDiscipline`] traits, and the allocation-free
+//! [`DeferredByteRing`](ring::DeferredByteRing) byte buffer used to hand
+//! decoded bytes off from a device ISR to a soft-IRQ drain context.
+//!
+//! Actual device wiring (16550 serial UART rx, PS/2 keyboard rx) lands
+//! in follow-ups (#405, #406) once the soft-IRQ bottom-half primitive
+//! from #404 is available. The stub [`PassthroughLdisc`] preserves the
+//! current raw-byte behavior until the N_TTY skeleton (#428/#375) is
+//! wired in.
+//!
+//! See `docs/RFC/0003-pipes-poll-tty.md` for the design rationale.
 
 pub mod ntty;
+pub mod ring;
 pub mod termios;
 
+use alloc::sync::Arc;
 use core::sync::atomic::{AtomicU32, Ordering};
 
-use spin::Mutex;
+use crate::poll::WaitQueue;
+#[cfg(target_os = "none")]
+use crate::sync::IrqLock;
+use termios::Termios;
+
+// Host tests can't use IrqLock (it touches RFLAGS.IF) — fall back to a
+// plain spin mutex, which has the same external API for our purposes.
+#[cfg(all(test, not(target_os = "none")))]
+use spin::Mutex as IrqLock;
 
 /// POSIX session identifier. `0` is reserved for "no session" (bootstrap
 /// kernel tasks before the process table is populated).
@@ -75,22 +93,150 @@ impl Default for JobControl {
     }
 }
 
-/// Minimal TTY stub.
+/// Bottom-half device driver abstraction.
 ///
-/// #372 needs `Option<Arc<Tty>>` in the PCB to hold the controlling
-/// terminal, and the N_TTY ISIG path needs a place to publish the pgrp
-/// snapshot. #374 extends this with `driver`, `ldisc`, `termios`, and
-/// `read_wait`/`write_wait` wait-queues — additive changes that don't
-/// touch the PCB wiring landed here.
+/// Implementations own the hardware-specific tx path (`write`/`flush`).
+/// Rx runs on the hardware ISR, which pushes decoded bytes into a
+/// [`DeferredByteRing`](ring::DeferredByteRing) and raises a soft-IRQ;
+/// the registered drain handler then feeds bytes into
+/// [`LineDiscipline::receive_byte`]. Rx is therefore not part of this
+/// trait — a driver only needs to publish a tx surface.
+pub trait TtyDriver: Send + Sync {
+    /// Synchronously push `buf` toward the device. Returns the number of
+    /// bytes accepted. May be called from process context only — the
+    /// ISR-side "queue a decoded byte" path goes through the driver's
+    /// own `DeferredByteRing`, not through this method.
+    fn write(&self, buf: &[u8]) -> usize;
+
+    /// Block until any hardware tx queue has drained. Best-effort;
+    /// drivers with no tx queue may implement as a no-op.
+    fn flush(&self) {}
+}
+
+/// Line-discipline dispatch surface.
+///
+/// A line discipline consumes bytes arriving from a driver and decides
+/// what to do with them: echo, canonicalize, signal-dispatch, and
+/// eventually deliver into the `Tty`'s read buffer. [`PassthroughLdisc`]
+/// is the minimum implementation (no-op `open`/`close`, `receive_byte`
+/// defers to a test sink or hard-sinks to the console).
+pub trait LineDiscipline: Send + Sync {
+    /// Called once per byte arriving from the driver's rx path. Runs in
+    /// soft-IRQ context — must not allocate and must not take any lock
+    /// that the process-context path holds across a preemption.
+    fn receive_byte(&self, tty: &Tty, byte: u8);
+
+    /// Called when a tty first attaches this discipline. Returns an
+    /// errno on failure.
+    fn open(&self, tty: &Tty) -> Result<(), i64>;
+
+    /// Called when the discipline is being torn down or swapped out.
+    fn close(&self, tty: &Tty);
+}
+
+/// Trivial passthrough line discipline — a no-op placeholder.
+///
+/// `receive_byte` appends incoming bytes into an optional test sink and
+/// otherwise drops them on the floor. Used as the default ldisc for a
+/// tty until N_TTY (#428/#375) lands, and as the harness for host unit
+/// tests in this file.
+pub struct PassthroughLdisc {
+    sink: IrqLock<Option<alloc::vec::Vec<u8>>>,
+}
+
+impl PassthroughLdisc {
+    pub const fn new() -> Self {
+        Self {
+            sink: IrqLock::new(None),
+        }
+    }
+
+    /// Install an empty collector vec so tests can observe the byte
+    /// stream arriving from the driver. Returns a handle that tests
+    /// drain via [`drain_sink`](Self::drain_sink).
+    pub fn with_sink() -> Self {
+        Self {
+            sink: IrqLock::new(Some(alloc::vec::Vec::new())),
+        }
+    }
+
+    /// Take the currently-collected bytes, leaving an empty vec in place
+    /// if a sink is installed, or returning an empty vec if there isn't.
+    pub fn drain_sink(&self) -> alloc::vec::Vec<u8> {
+        let mut g = self.sink.lock();
+        match g.as_mut() {
+            Some(v) => core::mem::take(v),
+            None => alloc::vec::Vec::new(),
+        }
+    }
+}
+
+impl Default for PassthroughLdisc {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LineDiscipline for PassthroughLdisc {
+    fn receive_byte(&self, _tty: &Tty, byte: u8) {
+        let mut g = self.sink.lock();
+        if let Some(v) = g.as_mut() {
+            v.push(byte);
+        }
+    }
+
+    fn open(&self, _tty: &Tty) -> Result<(), i64> {
+        Ok(())
+    }
+
+    fn close(&self, _tty: &Tty) {}
+}
+
+/// Trivial driver stub used as the default for a [`Tty`] until a real
+/// hardware driver is attached. `write` discards bytes; `flush` is a
+/// no-op. Allocated once per [`Tty`] via `Arc::new(NullDriver)`.
+pub struct NullDriver;
+
+impl TtyDriver for NullDriver {
+    fn write(&self, buf: &[u8]) -> usize {
+        buf.len()
+    }
+}
+
+/// Generic TTY container.
+///
+/// Holds a device driver (`driver`), an active line discipline
+/// (`ldisc`), the termios settings (`termios`), job-control state
+/// (`ctrl`), and two wait-queues (`read_wait`, `write_wait`) for
+/// blocking readers/writers. Ownership is `Arc<Tty>` so the same
+/// controlling terminal can be shared across a session's processes.
 pub struct Tty {
-    pub ctrl: Mutex<JobControl>,
+    pub driver: Arc<dyn TtyDriver>,
+    pub ldisc: Arc<dyn LineDiscipline>,
+    pub termios: IrqLock<Termios>,
+    pub ctrl: IrqLock<JobControl>,
+    pub read_wait: Arc<WaitQueue>,
+    pub write_wait: Arc<WaitQueue>,
 }
 
 impl Tty {
-    pub fn new() -> Self {
+    /// Build a tty with an explicit driver and line discipline.
+    pub fn with_driver(driver: Arc<dyn TtyDriver>, ldisc: Arc<dyn LineDiscipline>) -> Self {
         Self {
-            ctrl: Mutex::new(JobControl::new()),
+            driver,
+            ldisc,
+            termios: IrqLock::new(Termios::sane()),
+            ctrl: IrqLock::new(JobControl::new()),
+            read_wait: WaitQueue::new(),
+            write_wait: WaitQueue::new(),
         }
+    }
+
+    /// Build a stub tty with no hardware wiring. Used by the PCB for
+    /// controlling-terminal job-control state (#372) before any real
+    /// tty has been attached.
+    pub fn new() -> Self {
+        Self::with_driver(Arc::new(NullDriver), Arc::new(PassthroughLdisc::new()))
     }
 }
 
@@ -136,5 +282,32 @@ mod tests {
         assert!(ctrl.session.is_none());
         assert!(ctrl.pgrp.is_none());
         assert_eq!(ctrl.pgrp_snapshot.load(), 0);
+    }
+
+    #[test]
+    fn passthrough_ldisc_appends_bytes_in_order() {
+        let tty = Tty::with_driver(
+            Arc::new(NullDriver),
+            Arc::new(PassthroughLdisc::with_sink()),
+        );
+        let ldisc = tty.ldisc.clone();
+        for b in b"hello" {
+            ldisc.receive_byte(&tty, *b);
+        }
+        // Downcast via a concrete clone for test drain.
+        let probe = PassthroughLdisc::with_sink();
+        for b in b"hello" {
+            probe.receive_byte(&tty, *b);
+        }
+        assert_eq!(probe.drain_sink(), b"hello");
+        // Second drain after take yields empty.
+        assert!(probe.drain_sink().is_empty());
+    }
+
+    #[test]
+    fn null_driver_reports_all_bytes_written() {
+        let d = NullDriver;
+        assert_eq!(d.write(b""), 0);
+        assert_eq!(d.write(b"hi"), 2);
     }
 }

--- a/kernel/src/tty/ring.rs
+++ b/kernel/src/tty/ring.rs
@@ -1,0 +1,190 @@
+//! `DeferredByteRing` — a fixed-capacity, allocation-free byte ring used as
+//! the ISR→soft-IRQ handoff buffer for TTY drivers.
+//!
+//! The producer side is an ISR (serial UART rx, PS/2 keyboard) that has
+//! exclusive access through the hardware vectoring — there is at most one
+//! concurrent pusher per ring. The consumer is the registered soft-IRQ
+//! drain handler that runs in process context. Per RFC 0003 §Soft-IRQ we
+//! therefore implement a lock-free SPSC ring where the "S" producer is
+//! assumed-exclusive by callsite discipline.
+//!
+//! The storage is a `[AtomicU8; CAPACITY]` so that compilers never
+//! reorder the data store past the `tail` release, and so the Miri/UB
+//! rules for concurrent aliased access are the atomic ones even though
+//! only one thread writes a given slot at a time. `head` and `tail` sit
+//! on separate cache lines to avoid false sharing between producer and
+//! consumer.
+
+use core::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
+
+/// Ring capacity in bytes. Power of two so `(idx & MASK)` replaces
+/// modulo, and small enough to stay cheap on the ISR side.
+pub const CAPACITY: usize = 128;
+
+/// High-watermark threshold (bytes). When `len() >= WATERMARK_HIGH` a
+/// driver may deassert RTS to backpressure the peer. 96/128 = 75%.
+pub const WATERMARK_HIGH: usize = 96;
+
+const MASK: usize = CAPACITY - 1;
+const _: () = assert!(CAPACITY.is_power_of_two());
+
+/// Cache-line-sized wrapper. x86-64's L1 cache line is 64 bytes, so two
+/// counters in separate `CachePadded` slots won't false-share.
+#[repr(C, align(64))]
+struct CachePadded<T>(T);
+
+/// Fixed-capacity SPSC byte ring.
+///
+/// Capacity is [`CAPACITY`] bytes. Push returns `false` when full;
+/// `pop` returns `None` when empty. Both operations are lock-free and
+/// safe to call with IRQs disabled — there is no spinning and no
+/// allocation.
+pub struct DeferredByteRing {
+    buf: [AtomicU8; CAPACITY],
+    head: CachePadded<AtomicUsize>,
+    tail: CachePadded<AtomicUsize>,
+}
+
+impl DeferredByteRing {
+    /// Construct an empty ring. `const fn` so it can live in a `static`.
+    pub const fn new() -> Self {
+        // `AtomicU8::new` is `const`; build the array by repeated initialiser.
+        const INIT: AtomicU8 = AtomicU8::new(0);
+        Self {
+            buf: [INIT; CAPACITY],
+            head: CachePadded(AtomicUsize::new(0)),
+            tail: CachePadded(AtomicUsize::new(0)),
+        }
+    }
+
+    /// Bytes currently queued. Lock-free snapshot; may race with a
+    /// concurrent `push` or `pop` but is monotone-sound for watermark
+    /// checks.
+    #[inline]
+    pub fn len(&self) -> usize {
+        let tail = self.tail.0.load(Ordering::Acquire);
+        let head = self.head.0.load(Ordering::Acquire);
+        tail.wrapping_sub(head)
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    #[inline]
+    pub fn is_full(&self) -> bool {
+        self.len() >= CAPACITY
+    }
+
+    /// True once the ring has crossed the 75% fill line. Drivers use this
+    /// to deassert flow control before the ring overruns.
+    #[inline]
+    pub fn watermark_high(&self) -> bool {
+        self.len() >= WATERMARK_HIGH
+    }
+
+    /// Producer side: append `byte` and return `true`, or `false` if
+    /// full. Caller must ensure single-producer discipline (the ISR
+    /// exclusivity guarantee).
+    pub fn push(&self, byte: u8) -> bool {
+        let tail = self.tail.0.load(Ordering::Relaxed);
+        let head = self.head.0.load(Ordering::Acquire);
+        if tail.wrapping_sub(head) >= CAPACITY {
+            return false;
+        }
+        self.buf[tail & MASK].store(byte, Ordering::Relaxed);
+        self.tail.0.store(tail.wrapping_add(1), Ordering::Release);
+        true
+    }
+
+    /// Consumer side: remove and return the oldest byte, or `None` if
+    /// empty. Caller must ensure single-consumer discipline (the
+    /// registered soft-IRQ drain handler).
+    pub fn pop(&self) -> Option<u8> {
+        let head = self.head.0.load(Ordering::Relaxed);
+        let tail = self.tail.0.load(Ordering::Acquire);
+        if head == tail {
+            return None;
+        }
+        let b = self.buf[head & MASK].load(Ordering::Relaxed);
+        self.head.0.store(head.wrapping_add(1), Ordering::Release);
+        Some(b)
+    }
+}
+
+impl Default for DeferredByteRing {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_pop_returns_none() {
+        let r = DeferredByteRing::new();
+        assert!(r.is_empty());
+        assert_eq!(r.pop(), None);
+        assert_eq!(r.len(), 0);
+    }
+
+    #[test]
+    fn push_pop_roundtrip() {
+        let r = DeferredByteRing::new();
+        assert!(r.push(0x41));
+        assert!(r.push(0x42));
+        assert_eq!(r.len(), 2);
+        assert_eq!(r.pop(), Some(0x41));
+        assert_eq!(r.pop(), Some(0x42));
+        assert_eq!(r.pop(), None);
+    }
+
+    #[test]
+    fn fills_to_capacity_then_fails() {
+        let r = DeferredByteRing::new();
+        for i in 0..CAPACITY {
+            assert!(r.push((i & 0xff) as u8), "push {i} must succeed");
+        }
+        assert!(r.is_full());
+        assert!(!r.push(0xff), "push past capacity must fail");
+        assert_eq!(r.len(), CAPACITY);
+    }
+
+    #[test]
+    fn drain_and_refill_wraps() {
+        let r = DeferredByteRing::new();
+        // Fill, drain, fill again past the physical wrap point.
+        for i in 0..CAPACITY {
+            assert!(r.push(i as u8));
+        }
+        for i in 0..CAPACITY {
+            assert_eq!(r.pop(), Some(i as u8));
+        }
+        assert!(r.is_empty());
+        // Second round pushes indices CAPACITY..2*CAPACITY; head/tail
+        // wrap modulo CAPACITY but the indices themselves are raw.
+        for i in 0..CAPACITY {
+            assert!(r.push(((i + 7) & 0xff) as u8));
+        }
+        for i in 0..CAPACITY {
+            assert_eq!(r.pop(), Some(((i + 7) & 0xff) as u8));
+        }
+    }
+
+    #[test]
+    fn watermark_trips_at_96() {
+        let r = DeferredByteRing::new();
+        for _ in 0..WATERMARK_HIGH - 1 {
+            r.push(0);
+        }
+        assert!(
+            !r.watermark_high(),
+            "watermark must stay low below threshold"
+        );
+        r.push(0);
+        assert!(r.watermark_high(), "watermark must flip at {WATERMARK_HIGH}");
+    }
+}

--- a/kernel/src/tty/ring.rs
+++ b/kernel/src/tty/ring.rs
@@ -185,6 +185,9 @@ mod tests {
             "watermark must stay low below threshold"
         );
         r.push(0);
-        assert!(r.watermark_high(), "watermark must flip at {WATERMARK_HIGH}");
+        assert!(
+            r.watermark_high(),
+            "watermark must flip at {WATERMARK_HIGH}"
+        );
     }
 }


### PR DESCRIPTION
Closes #403

## Summary

- New `kernel/src/tty/ring.rs` — allocation-free 128-byte SPSC byte ring with `AtomicU8` slots, cache-padded `head`/`tail`, and a `watermark_high()` @ 75% fill for future RTS flow-control wiring.
- Extended `kernel/src/tty/mod.rs` with the `TtyDriver` and `LineDiscipline` traits, a `PassthroughLdisc` (doubles as the default ldisc until N_TTY #428/#375 lands, and as the test sink), a `NullDriver` stub, and a full `Tty` container (`driver`, `ldisc`, `termios`, `ctrl`, `read_wait`, `write_wait`).
- Existing `Tty::new()` keeps working for the PCB controlling-terminal stub (#372 setsid path) — it now defaults to `NullDriver + PassthroughLdisc`.
- Lock type is `IrqLock` per RFC 0003 §Lock order, with the same `#[cfg(all(test, not(target_os = "none")))]` fallback to `spin::Mutex` that `kernel/src/poll/mod.rs` uses so host unit tests still compile.
- **No driver wiring in this PR.** Serial UART (#406) and PS/2 keyboard (#405) land once the soft-IRQ bottom-half primitive from #404 is available.

## Test plan

- [x] `cargo xtask build` — clean.
- [x] `cargo xtask test` — host unit tests up from 251 → 258 (+7 new: ring empty/push-pop/fill/wrap/watermark, passthrough ldisc byte ordering, null driver). Pre-existing `blocking_sync::rwlock_writer_not_starved` flake (#385, fix in flight as PR #436) is unrelated.
- [x] `cargo xtask smoke` — all 30 markers present.
