### PR TITLE
tty: job-control ioctls (TIOCSCTTY/SPGRP/GPGRP/GSID/NOTTY) + ctty-on-open

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -239,3 +239,7 @@ harness = false
 [[test]]
 name = "session_syscalls"
 harness = false
+
+[[test]]
+name = "tty_jobctl_ioctls"
+harness = false

--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -198,7 +198,17 @@ fn legacy_dev_backend(path: &[u8], flags: u64) -> Option<i64> {
     let safe_flags =
         (flags as u32) & (oflags::O_RDONLY | oflags::O_WRONLY | oflags::O_RDWR | oflags::O_CLOEXEC);
     let backend: Arc<dyn FileBackend> = Arc::new(crate::fs::SerialBackend::new());
-    Some(install_fd(backend, safe_flags))
+    let rc = install_fd(backend, safe_flags);
+    // Linux `open(tty, !O_NOCTTY)` on a session leader with no existing
+    // ctty acquires the tty as the session's controlling terminal. Every
+    // legacy /dev/* path points at the same console tty until multi-tty
+    // support lands (#374).
+    if rc >= 0 && (flags as u32) & oflags::O_NOCTTY == 0 {
+        let caller = crate::process::current_pid();
+        let tty = crate::tty::console_tty();
+        let _ = crate::tty::acquire_ctty_on_open(caller, &tty);
+    }
+    Some(rc)
 }
 
 /// Shared `open` body: used by `sys_open` (dfd == AT_FDCWD) and

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -607,10 +607,8 @@ impl FileBackend for SerialBackend {
                     return Ok(rc);
                 }
                 let pgid = rc as u32;
-                unsafe {
-                    crate::arch::x86_64::uaccess::copy_to_user(arg, &pgid.to_ne_bytes())
-                }
-                .map_err(|e| e.as_errno())?;
+                unsafe { crate::arch::x86_64::uaccess::copy_to_user(arg, &pgid.to_ne_bytes()) }
+                    .map_err(|e| e.as_errno())?;
                 return Ok(0);
             }
             TIOCGSID => {
@@ -623,10 +621,8 @@ impl FileBackend for SerialBackend {
                     return Ok(rc);
                 }
                 let sid = rc as u32;
-                unsafe {
-                    crate::arch::x86_64::uaccess::copy_to_user(arg, &sid.to_ne_bytes())
-                }
-                .map_err(|e| e.as_errno())?;
+                unsafe { crate::arch::x86_64::uaccess::copy_to_user(arg, &sid.to_ne_bytes()) }
+                    .map_err(|e| e.as_errno())?;
                 return Ok(0);
             }
             TIOCNOTTY => {

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -124,6 +124,10 @@ pub mod flags {
     pub const O_DIRECTORY: u32 = 0o200000;
     /// Do not follow a symlink in the final path component (`ELOOP`).
     pub const O_NOFOLLOW: u32 = 0o400000;
+    /// Do not acquire the opened tty as the caller session's controlling
+    /// terminal. Linux convention: `open(tty, !O_NOCTTY)` on a session
+    /// leader with no ctty implicitly attaches; `O_NOCTTY` suppresses.
+    pub const O_NOCTTY: u32 = 0o400;
     /// Close this fd on the next `exec()`.
     pub const O_CLOEXEC: u32 = 0o2000000;
     /// Open a stat-only fd (no I/O permitted).
@@ -565,7 +569,71 @@ impl FileBackend for SerialBackend {
     }
 
     fn ioctl(&self, cmd: u32, arg: usize) -> Result<i64, i64> {
-        use crate::tty::termios::{Termios, TCGETS, TCSETS, TCSETSF, TCSETSW};
+        use crate::tty::termios::{
+            Termios, TCGETS, TCSETS, TCSETSF, TCSETSW, TIOCGPGRP, TIOCGSID, TIOCNOTTY, TIOCSCTTY,
+            TIOCSPGRP,
+        };
+        // Job-control ioctls act on the shared console tty. #374/#403 will
+        // replace this with a per-driver Tty lookup; until then every legacy
+        // /dev/{tty,console,serial,std*} fd shares one tty identity.
+        let caller = crate::process::current_pid();
+        match cmd {
+            TIOCSCTTY => {
+                let force = arg != 0;
+                // No credentials subsystem yet → treat all callers as root.
+                // Once UIDs land, this `true` becomes `uid == 0`.
+                let is_root = true;
+                let tty = crate::tty::console_tty();
+                return Ok(crate::tty::tiocsctty_for(caller, &tty, force, is_root));
+            }
+            TIOCSPGRP => {
+                if arg == 0 {
+                    return Err(EFAULT);
+                }
+                let mut pgid_bytes = [0u8; 4];
+                unsafe { crate::arch::x86_64::uaccess::copy_from_user(&mut pgid_bytes, arg) }
+                    .map_err(|e| e.as_errno())?;
+                let pgid = u32::from_ne_bytes(pgid_bytes);
+                let tty = crate::tty::console_tty();
+                return Ok(crate::tty::tiocspgrp_for(caller, &tty, pgid));
+            }
+            TIOCGPGRP => {
+                if arg == 0 {
+                    return Err(EFAULT);
+                }
+                let tty = crate::tty::console_tty();
+                let rc = crate::tty::tiocgpgrp_for(&tty);
+                if rc < 0 {
+                    return Ok(rc);
+                }
+                let pgid = rc as u32;
+                unsafe {
+                    crate::arch::x86_64::uaccess::copy_to_user(arg, &pgid.to_ne_bytes())
+                }
+                .map_err(|e| e.as_errno())?;
+                return Ok(0);
+            }
+            TIOCGSID => {
+                if arg == 0 {
+                    return Err(EFAULT);
+                }
+                let tty = crate::tty::console_tty();
+                let rc = crate::tty::tiocgsid_for(&tty);
+                if rc < 0 {
+                    return Ok(rc);
+                }
+                let sid = rc as u32;
+                unsafe {
+                    crate::arch::x86_64::uaccess::copy_to_user(arg, &sid.to_ne_bytes())
+                }
+                .map_err(|e| e.as_errno())?;
+                return Ok(0);
+            }
+            TIOCNOTTY => {
+                return Ok(crate::tty::tiocnotty_for(caller));
+            }
+            _ => {}
+        }
         match cmd {
             TCGETS => {
                 if arg == 0 {

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -336,6 +336,40 @@ pub fn session_using_tty(tty: &Arc<Tty>) -> Option<SessionId> {
         })
 }
 
+/// Atomic ctty acquisition: check session-leader, no existing ctty, and
+/// `tty` unattached — if all hold, attach under a single TABLE → `tty.ctrl`
+/// critical section. Returns `true` if the attach happened.
+///
+/// The check-then-set pattern in the caller is TOCTOU-vulnerable otherwise:
+/// two leaders could each observe "no ctty / tty free" before either writes,
+/// and the resulting state would violate the one-ctty-per-session invariant.
+/// Collapsing everything into one critical section matches the documented
+/// lock order (TABLE → `tty.ctrl`) and keeps the invariant mechanically.
+pub fn try_acquire_ctty_atomic(pid: u32, tty: &Arc<Tty>) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    let mut t = TABLE.lock();
+    let Some(entry) = t.by_pid.get(&pid) else {
+        return false;
+    };
+    if entry.session_id != pid {
+        return false;
+    }
+    if entry.controlling_tty.is_some() {
+        return false;
+    }
+    let sid = entry.session_id;
+    let mut ctrl = tty.ctrl.lock();
+    if ctrl.session.is_some() {
+        return false;
+    }
+    t.by_pid.get_mut(&pid).unwrap().controlling_tty = Some(Arc::clone(tty));
+    ctrl.session = Some(sid);
+    ctrl.set_pgrp(Some(pid));
+    true
+}
+
 /// Clear the controlling tty on every member of `sid`. Returns the
 /// number of entries affected. Called by `TIOCNOTTY` on a session
 /// leader and by `TIOCSCTTY(force)` when stealing from an old session.

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -269,6 +269,87 @@ pub fn task_id_for_pid(pid: u32) -> Option<usize> {
 const EPERM: i64 = -1;
 const ESRCH: i64 = -3;
 const EINVAL: i64 = -22;
+const ENOTTY: i64 = -25;
+
+// ── Controlling-terminal accessors ─────────────────────────────────────────
+//
+// All cross-process inspection of `ProcessEntry.controlling_tty`, session,
+// and pgrp happens here so TABLE locking stays inside the process module.
+// The tty ioctl helpers in `crate::tty` call these and never take TABLE
+// directly — keeps the lock-ordering documentation (TABLE → `tty.ctrl`)
+// mechanically enforceable.
+
+/// Return the controlling tty of `pid`, if any.
+pub fn ctty_of(pid: u32) -> Option<Arc<Tty>> {
+    TABLE
+        .lock()
+        .by_pid
+        .get(&pid)
+        .and_then(|e| e.controlling_tty.clone())
+}
+
+/// Set (or clear) the controlling tty of `pid`.
+pub fn set_ctty(pid: u32, tty: Option<Arc<Tty>>) {
+    if let Some(e) = TABLE.lock().by_pid.get_mut(&pid) {
+        e.controlling_tty = tty;
+    }
+}
+
+/// Session id of `pid`, if the entry exists.
+pub fn session_of(pid: u32) -> Option<SessionId> {
+    TABLE.lock().by_pid.get(&pid).map(|e| e.session_id)
+}
+
+/// Whether `pid` is the session leader of its session
+/// (POSIX: `session_id == pid`).
+pub fn is_session_leader(pid: u32) -> bool {
+    TABLE
+        .lock()
+        .by_pid
+        .get(&pid)
+        .map(|e| e.session_id == pid)
+        .unwrap_or(false)
+}
+
+/// Whether `pgid` names an existing process group inside session `sid`.
+/// A pgrp exists iff some live entry has that `pgrp_id`; it's in `sid`
+/// iff that entry's `session_id == sid`.
+pub fn pgrp_is_in_session(pgid: ProcessGroupId, sid: SessionId) -> bool {
+    TABLE
+        .lock()
+        .by_pid
+        .values()
+        .any(|e| e.pgrp_id == pgid && e.session_id == sid)
+}
+
+/// If some session currently has `tty` as its controlling terminal,
+/// return that session id. Uses `Arc::ptr_eq` — tty Arcs propagate on
+/// fork via `Arc::clone`, so ptr-equality is sound.
+pub fn session_using_tty(tty: &Arc<Tty>) -> Option<SessionId> {
+    TABLE
+        .lock()
+        .by_pid
+        .values()
+        .find_map(|e| match &e.controlling_tty {
+            Some(t) if Arc::ptr_eq(t, tty) => Some(e.session_id),
+            _ => None,
+        })
+}
+
+/// Clear the controlling tty on every member of `sid`. Returns the
+/// number of entries affected. Called by `TIOCNOTTY` on a session
+/// leader and by `TIOCSCTTY(force)` when stealing from an old session.
+pub fn clear_ctty_for_session(sid: SessionId) -> usize {
+    let mut t = TABLE.lock();
+    let mut n = 0;
+    for e in t.by_pid.values_mut() {
+        if e.session_id == sid && e.controlling_tty.is_some() {
+            e.controlling_tty = None;
+            n += 1;
+        }
+    }
+    n
+}
 
 /// Pure helper behind `setsid()` — see [`sys_setsid`]. Accepts the caller
 /// pid explicitly so host unit tests can drive it without going through
@@ -468,7 +549,16 @@ pub mod test_helpers {
         }
     }
 
+    /// Set session + pgrp on an existing entry from a test.
+    pub fn set_session_pgrp(pid: u32, session_id: SessionId, pgrp_id: ProcessGroupId) {
+        patch(pid, |e| {
+            e.session_id = session_id;
+            e.pgrp_id = pgrp_id;
+        });
+    }
+
     pub const EPERM_I64: i64 = EPERM;
     pub const ESRCH_I64: i64 = ESRCH;
     pub const EINVAL_I64: i64 = EINVAL;
+    pub const ENOTTY_I64: i64 = ENOTTY;
 }

--- a/kernel/src/tty/mod.rs
+++ b/kernel/src/tty/mod.rs
@@ -24,12 +24,17 @@ use core::sync::atomic::{AtomicU32, Ordering};
 use crate::poll::WaitQueue;
 #[cfg(target_os = "none")]
 use crate::sync::IrqLock;
+#[cfg(target_os = "none")]
+use spin::Lazy;
 use termios::Termios;
 
 // Host tests can't use IrqLock (it touches RFLAGS.IF) — fall back to a
 // plain spin mutex, which has the same external API for our purposes.
 #[cfg(all(test, not(target_os = "none")))]
 use spin::Mutex as IrqLock;
+
+#[cfg(target_os = "none")]
+use crate::process;
 
 /// POSIX session identifier. `0` is reserved for "no session" (bootstrap
 /// kernel tasks before the process table is populated).
@@ -247,6 +252,170 @@ impl Default for Tty {
     }
 }
 
+/// The single system-wide console tty backing `/dev/{tty,console,serial,std*}`.
+/// A real multi-tty world (pty, serial[N], vt[N]) arrives with #374/#403 —
+/// until then every legacy `/dev/*` open refers to the same `Arc<Tty>` so
+/// session/pgrp identity is shared across fds as POSIX expects.
+#[cfg(target_os = "none")]
+pub static CONSOLE_TTY: Lazy<Arc<Tty>> = Lazy::new(|| Arc::new(Tty::new()));
+
+/// Return the shared console tty.
+#[cfg(target_os = "none")]
+pub fn console_tty() -> Arc<Tty> {
+    Arc::clone(&CONSOLE_TTY)
+}
+
+// ── Job-control ioctl helpers ─────────────────────────────────────────────
+//
+// Each `*_for` function takes the caller pid explicitly so host unit tests
+// can drive them without going through the scheduler. They return a POSIX
+// errno as `i64` (0 or positive on success), matching the `setsid_for` /
+// `setpgid_for` convention in `process::mod`.
+//
+// Lock order: TABLE (via `process::*`) → `tty.ctrl`. Every helper releases
+// TABLE before taking `tty.ctrl.lock()`. Do not invert.
+
+/// POSIX errno constants, shared with `process::mod`.
+#[cfg(target_os = "none")]
+const EPERM: i64 = -1;
+#[cfg(target_os = "none")]
+const ENOTTY: i64 = -25;
+
+/// `TIOCSCTTY(force)` — acquire `tty` as the caller session's controlling
+/// terminal. Only a session leader may acquire a ctty. If `tty` already
+/// has a session, `force && is_root` steals it (clearing the old session's
+/// ctty on every member).
+#[cfg(target_os = "none")]
+pub fn tiocsctty_for(caller_pid: u32, tty: &Arc<Tty>, force: bool, is_root: bool) -> i64 {
+    if caller_pid == 0 {
+        return EPERM;
+    }
+    if !process::is_session_leader(caller_pid) {
+        return EPERM;
+    }
+    let caller_sid = match process::session_of(caller_pid) {
+        Some(s) => s,
+        None => return EPERM,
+    };
+    if let Some(existing) = process::session_using_tty(tty) {
+        if existing == caller_sid {
+            return 0;
+        }
+        if !force || !is_root {
+            return EPERM;
+        }
+        process::clear_ctty_for_session(existing);
+    }
+    // Attach tty to the caller; pgrp snapshot mirrors caller's pgrp.
+    process::set_ctty(caller_pid, Some(Arc::clone(tty)));
+    let mut ctrl = tty.ctrl.lock();
+    ctrl.session = Some(caller_sid);
+    ctrl.set_pgrp(Some(caller_pid));
+    0
+}
+
+/// `TIOCSPGRP(pgid)` — set `pgid` as `tty`'s foreground pgrp. Caller must
+/// be in the same session as `tty`, and `pgid` must name an existing pgrp
+/// in that session.
+#[cfg(target_os = "none")]
+pub fn tiocspgrp_for(caller_pid: u32, tty: &Tty, pgid: ProcessGroupId) -> i64 {
+    if caller_pid == 0 {
+        return EPERM;
+    }
+    let tty_sid = match tty.ctrl.lock().session {
+        Some(s) => s,
+        None => return ENOTTY,
+    };
+    match process::session_of(caller_pid) {
+        Some(s) if s == tty_sid => {}
+        _ => return EPERM,
+    }
+    if !process::pgrp_is_in_session(pgid, tty_sid) {
+        return EPERM;
+    }
+    tty.ctrl.lock().set_pgrp(Some(pgid));
+    0
+}
+
+/// `TIOCGPGRP` — return `tty`'s foreground pgrp, or `ENOTTY` if none.
+#[cfg(target_os = "none")]
+pub fn tiocgpgrp_for(tty: &Tty) -> i64 {
+    match tty.ctrl.lock().pgrp {
+        Some(p) => p as i64,
+        None => ENOTTY,
+    }
+}
+
+/// `TIOCGSID` — return `tty`'s session id, or `ENOTTY` if none.
+#[cfg(target_os = "none")]
+pub fn tiocgsid_for(tty: &Tty) -> i64 {
+    match tty.ctrl.lock().session {
+        Some(s) => s as i64,
+        None => ENOTTY,
+    }
+}
+
+/// `TIOCNOTTY` — detach the caller's session from its controlling
+/// terminal. If the caller is the session leader, every session member
+/// loses its ctty and the tty's `session`/`pgrp` clear. Non-leaders only
+/// drop their own reference. Wait-queue wakeup for blocked readers/writers
+/// lands with #429/#430 — TODO below is deliberate.
+#[cfg(target_os = "none")]
+pub fn tiocnotty_for(caller_pid: u32) -> i64 {
+    if caller_pid == 0 {
+        return EPERM;
+    }
+    let tty = match process::ctty_of(caller_pid) {
+        Some(t) => t,
+        None => return ENOTTY,
+    };
+    if process::is_session_leader(caller_pid) {
+        let sid = match process::session_of(caller_pid) {
+            Some(s) => s,
+            None => return EPERM,
+        };
+        process::clear_ctty_for_session(sid);
+        let mut ctrl = tty.ctrl.lock();
+        ctrl.session = None;
+        ctrl.set_pgrp(None);
+        // TODO(#429/#430): wake blocked readers/writers once wait queues land.
+    } else {
+        process::set_ctty(caller_pid, None);
+    }
+    0
+}
+
+/// Open-path hook: `open(tty, !O_NOCTTY)` on a session leader with no
+/// existing ctty implicitly acquires `tty` as the ctty. No-op in every
+/// other case (non-leader, already-attached, or the tty already has a
+/// session). Returns `true` if a ctty was acquired. Errors are swallowed
+/// because this is a best-effort side-effect of `open`, not a gate on it.
+#[cfg(target_os = "none")]
+pub fn acquire_ctty_on_open(caller_pid: u32, tty: &Arc<Tty>) -> bool {
+    if caller_pid == 0 {
+        return false;
+    }
+    if !process::is_session_leader(caller_pid) {
+        return false;
+    }
+    if process::ctty_of(caller_pid).is_some() {
+        return false;
+    }
+    if tty.ctrl.lock().session.is_some() {
+        return false;
+    }
+    let sid = match process::session_of(caller_pid) {
+        Some(s) => s,
+        None => return false,
+    };
+    process::set_ctty(caller_pid, Some(Arc::clone(tty)));
+    let mut ctrl = tty.ctrl.lock();
+    ctrl.session = Some(sid);
+    ctrl.set_pgrp(Some(caller_pid));
+    true
+}
+
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -307,3 +476,4 @@ mod tests {
         assert_eq!(d.write(b"hi"), 2);
     }
 }
+

--- a/kernel/src/tty/mod.rs
+++ b/kernel/src/tty/mod.rs
@@ -401,7 +401,6 @@ pub fn acquire_ctty_on_open(caller_pid: u32, tty: &Arc<Tty>) -> bool {
     process::try_acquire_ctty_atomic(caller_pid, tty)
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -462,4 +461,3 @@ mod tests {
         assert_eq!(d.write(b"hi"), 2);
     }
 }
-

--- a/kernel/src/tty/mod.rs
+++ b/kernel/src/tty/mod.rs
@@ -293,6 +293,12 @@ pub fn tiocsctty_for(caller_pid: u32, tty: &Arc<Tty>, force: bool, is_root: bool
     if !process::is_session_leader(caller_pid) {
         return EPERM;
     }
+    if let Some(existing_tty) = process::ctty_of(caller_pid) {
+        if Arc::ptr_eq(&existing_tty, tty) {
+            return 0;
+        }
+        return EPERM;
+    }
     let caller_sid = match process::session_of(caller_pid) {
         Some(s) => s,
         None => return EPERM,
@@ -392,27 +398,7 @@ pub fn tiocnotty_for(caller_pid: u32) -> i64 {
 /// because this is a best-effort side-effect of `open`, not a gate on it.
 #[cfg(target_os = "none")]
 pub fn acquire_ctty_on_open(caller_pid: u32, tty: &Arc<Tty>) -> bool {
-    if caller_pid == 0 {
-        return false;
-    }
-    if !process::is_session_leader(caller_pid) {
-        return false;
-    }
-    if process::ctty_of(caller_pid).is_some() {
-        return false;
-    }
-    if tty.ctrl.lock().session.is_some() {
-        return false;
-    }
-    let sid = match process::session_of(caller_pid) {
-        Some(s) => s,
-        None => return false,
-    };
-    process::set_ctty(caller_pid, Some(Arc::clone(tty)));
-    let mut ctrl = tty.ctrl.lock();
-    ctrl.session = Some(sid);
-    ctrl.set_pgrp(Some(caller_pid));
-    true
+    process::try_acquire_ctty_atomic(caller_pid, tty)
 }
 
 

--- a/kernel/src/tty/termios.rs
+++ b/kernel/src/tty/termios.rs
@@ -89,6 +89,14 @@ pub const TCSETS: u32 = 0x5402;
 pub const TCSETSW: u32 = 0x5403;
 pub const TCSETSF: u32 = 0x5404;
 
+// --- Job-control ioctl command numbers (Linux <asm-generic/ioctls.h>) -----
+
+pub const TIOCSCTTY: u32 = 0x540E;
+pub const TIOCGPGRP: u32 = 0x540F;
+pub const TIOCSPGRP: u32 = 0x5410;
+pub const TIOCNOTTY: u32 = 0x5422;
+pub const TIOCGSID: u32 = 0x5429;
+
 impl Termios {
     /// A "sane" default termios suitable for an interactive console:
     /// canonical mode, echo on, input CR→NL, output NL→CRNL, signals
@@ -207,6 +215,11 @@ mod tests {
         assert_eq!(TCSETS, 0x5402);
         assert_eq!(TCSETSW, 0x5403);
         assert_eq!(TCSETSF, 0x5404);
+        assert_eq!(TIOCSCTTY, 0x540E);
+        assert_eq!(TIOCGPGRP, 0x540F);
+        assert_eq!(TIOCSPGRP, 0x5410);
+        assert_eq!(TIOCNOTTY, 0x5422);
+        assert_eq!(TIOCGSID, 0x5429);
     }
 
     #[test]

--- a/kernel/tests/tty_jobctl_ioctls.rs
+++ b/kernel/tests/tty_jobctl_ioctls.rs
@@ -15,8 +15,8 @@ use core::panic::PanicInfo;
 
 use vibix::process::{self, test_helpers as h};
 use vibix::tty::{
-    acquire_ctty_on_open, tiocgpgrp_for, tiocgsid_for, tiocnotty_for, tiocsctty_for,
-    tiocspgrp_for, Tty,
+    acquire_ctty_on_open, tiocgpgrp_for, tiocgsid_for, tiocnotty_for, tiocsctty_for, tiocspgrp_for,
+    Tty,
 };
 use vibix::{
     exit_qemu, serial_println,

--- a/kernel/tests/tty_jobctl_ioctls.rs
+++ b/kernel/tests/tty_jobctl_ioctls.rs
@@ -64,6 +64,10 @@ fn run_tests() {
             &(tiocsctty_idempotent_within_same_session as fn()),
         ),
         (
+            "tiocsctty_rejects_when_leader_already_owns_other_tty",
+            &(tiocsctty_rejects_when_leader_already_owns_other_tty as fn()),
+        ),
+        (
             "tiocspgrp_rejects_cross_session",
             &(tiocspgrp_rejects_cross_session as fn()),
         ),
@@ -186,6 +190,21 @@ fn tiocsctty_idempotent_within_same_session() {
     let tty = fresh_tty();
     assert_eq!(tiocsctty_for(7, &tty, false, false), 0);
     assert_eq!(tiocsctty_for(7, &tty, false, false), 0);
+}
+
+fn tiocsctty_rejects_when_leader_already_owns_other_tty() {
+    h::reset_table();
+    h::insert(7, 0, 7, 7);
+    let tty_a = fresh_tty();
+    let tty_b = fresh_tty();
+    assert_eq!(tiocsctty_for(7, &tty_a, false, false), 0);
+    // Attempting to switch to a different tty must fail, leaving tty_a untouched.
+    assert_eq!(tiocsctty_for(7, &tty_b, false, false), h::EPERM_I64);
+    assert_eq!(tiocsctty_for(7, &tty_b, true, true), h::EPERM_I64);
+    assert!(tty_b.ctrl.lock().session.is_none());
+    let ctrl_a = tty_a.ctrl.lock();
+    assert_eq!(ctrl_a.session, Some(7));
+    assert_eq!(ctrl_a.pgrp, Some(7));
 }
 
 fn tiocspgrp_rejects_cross_session() {

--- a/kernel/tests/tty_jobctl_ioctls.rs
+++ b/kernel/tests/tty_jobctl_ioctls.rs
@@ -1,0 +1,312 @@
+//! Integration test: controlling-terminal job-control ioctls (#432).
+//!
+//! Exercises `tty::tiocsctty_for` / `tiocspgrp_for` / `tiocgpgrp_for` /
+//! `tiocgsid_for` / `tiocnotty_for` / `acquire_ctty_on_open` against the
+//! process-table test helpers. End-to-end ring-3 ioctl dispatch is
+//! covered once userspace has `tcsetpgrp` helpers.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use core::panic::PanicInfo;
+
+use vibix::process::{self, test_helpers as h};
+use vibix::tty::{
+    acquire_ctty_on_open, tiocgpgrp_for, tiocgsid_for, tiocnotty_for, tiocsctty_for,
+    tiocspgrp_for, Tty,
+};
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    serial_println!("tty_jobctl_ioctls: init ok");
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "tiocsctty_requires_session_leader",
+            &(tiocsctty_requires_session_leader as fn()),
+        ),
+        (
+            "tiocsctty_leader_attaches_and_sets_pgrp",
+            &(tiocsctty_leader_attaches_and_sets_pgrp as fn()),
+        ),
+        (
+            "tiocsctty_without_force_fails_when_tty_has_other_session",
+            &(tiocsctty_without_force_fails_when_tty_has_other_session as fn()),
+        ),
+        (
+            "tiocsctty_force_without_root_fails",
+            &(tiocsctty_force_without_root_fails as fn()),
+        ),
+        (
+            "tiocsctty_force_with_root_steals_and_clears_old_session",
+            &(tiocsctty_force_with_root_steals_and_clears_old_session as fn()),
+        ),
+        (
+            "tiocsctty_idempotent_within_same_session",
+            &(tiocsctty_idempotent_within_same_session as fn()),
+        ),
+        (
+            "tiocspgrp_rejects_cross_session",
+            &(tiocspgrp_rejects_cross_session as fn()),
+        ),
+        (
+            "tiocspgrp_rejects_unknown_pgid",
+            &(tiocspgrp_rejects_unknown_pgid as fn()),
+        ),
+        (
+            "tiocspgrp_updates_pgrp_and_snapshot",
+            &(tiocspgrp_updates_pgrp_and_snapshot as fn()),
+        ),
+        (
+            "tiocspgrp_returns_enotty_when_no_session_attached",
+            &(tiocspgrp_returns_enotty_when_no_session_attached as fn()),
+        ),
+        (
+            "tiocgpgrp_and_tiocgsid_return_enotty_without_attachment",
+            &(tiocgpgrp_and_tiocgsid_return_enotty_without_attachment as fn()),
+        ),
+        (
+            "tiocgpgrp_and_tiocgsid_return_ids_after_attach",
+            &(tiocgpgrp_and_tiocgsid_return_ids_after_attach as fn()),
+        ),
+        (
+            "tiocnotty_nonleader_detaches_only_caller",
+            &(tiocnotty_nonleader_detaches_only_caller as fn()),
+        ),
+        (
+            "tiocnotty_leader_clears_session_members",
+            &(tiocnotty_leader_clears_session_members as fn()),
+        ),
+        (
+            "tiocnotty_returns_enotty_without_ctty",
+            &(tiocnotty_returns_enotty_without_ctty as fn()),
+        ),
+        (
+            "acquire_ctty_on_open_succeeds_for_leader_with_none",
+            &(acquire_ctty_on_open_succeeds_for_leader_with_none as fn()),
+        ),
+        (
+            "acquire_ctty_on_open_noop_for_nonleader",
+            &(acquire_ctty_on_open_noop_for_nonleader as fn()),
+        ),
+        (
+            "acquire_ctty_on_open_noop_when_leader_already_has_ctty",
+            &(acquire_ctty_on_open_noop_when_leader_already_has_ctty as fn()),
+        ),
+        (
+            "acquire_ctty_on_open_noop_when_tty_already_attached",
+            &(acquire_ctty_on_open_noop_when_tty_already_attached as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+fn fresh_tty() -> Arc<Tty> {
+    Arc::new(Tty::new())
+}
+
+fn tiocsctty_requires_session_leader() {
+    h::reset_table();
+    h::insert(10, 0, 5, 10);
+    let tty = fresh_tty();
+    assert_eq!(tiocsctty_for(10, &tty, false, false), h::EPERM_I64);
+}
+
+fn tiocsctty_leader_attaches_and_sets_pgrp() {
+    h::reset_table();
+    h::insert(7, 0, 7, 7);
+    let tty = fresh_tty();
+    assert_eq!(tiocsctty_for(7, &tty, false, false), 0);
+    let ctrl = tty.ctrl.lock();
+    assert_eq!(ctrl.session, Some(7));
+    assert_eq!(ctrl.pgrp, Some(7));
+    assert_eq!(ctrl.pgrp_snapshot.load(), 7);
+}
+
+fn tiocsctty_without_force_fails_when_tty_has_other_session() {
+    h::reset_table();
+    h::insert(7, 0, 7, 7);
+    let tty = fresh_tty();
+    assert_eq!(tiocsctty_for(7, &tty, false, false), 0);
+    h::insert(9, 0, 9, 9);
+    assert_eq!(tiocsctty_for(9, &tty, false, false), h::EPERM_I64);
+}
+
+fn tiocsctty_force_without_root_fails() {
+    h::reset_table();
+    h::insert(7, 0, 7, 7);
+    let tty = fresh_tty();
+    assert_eq!(tiocsctty_for(7, &tty, false, false), 0);
+    h::insert(9, 0, 9, 9);
+    assert_eq!(tiocsctty_for(9, &tty, true, false), h::EPERM_I64);
+}
+
+fn tiocsctty_force_with_root_steals_and_clears_old_session() {
+    h::reset_table();
+    h::insert(7, 0, 7, 7);
+    h::insert(8, 7, 7, 7);
+    let tty = fresh_tty();
+    assert_eq!(tiocsctty_for(7, &tty, false, false), 0);
+    h::patch(8, |e| e.controlling_tty = Some(Arc::clone(&tty)));
+    h::insert(9, 0, 9, 9);
+    assert_eq!(tiocsctty_for(9, &tty, true, true), 0);
+    assert!(process::ctty_of(7).is_none());
+    assert!(process::ctty_of(8).is_none());
+    assert!(process::ctty_of(9).is_some());
+    let ctrl = tty.ctrl.lock();
+    assert_eq!(ctrl.session, Some(9));
+    assert_eq!(ctrl.pgrp, Some(9));
+}
+
+fn tiocsctty_idempotent_within_same_session() {
+    h::reset_table();
+    h::insert(7, 0, 7, 7);
+    let tty = fresh_tty();
+    assert_eq!(tiocsctty_for(7, &tty, false, false), 0);
+    assert_eq!(tiocsctty_for(7, &tty, false, false), 0);
+}
+
+fn tiocspgrp_rejects_cross_session() {
+    h::reset_table();
+    h::insert(7, 0, 7, 7);
+    let tty = fresh_tty();
+    tiocsctty_for(7, &tty, false, false);
+    h::insert(20, 0, 20, 20);
+    assert_eq!(tiocspgrp_for(20, &tty, 20), h::EPERM_I64);
+}
+
+fn tiocspgrp_rejects_unknown_pgid() {
+    h::reset_table();
+    h::insert(7, 0, 7, 7);
+    let tty = fresh_tty();
+    tiocsctty_for(7, &tty, false, false);
+    assert_eq!(tiocspgrp_for(7, &tty, 999), h::EPERM_I64);
+}
+
+fn tiocspgrp_updates_pgrp_and_snapshot() {
+    h::reset_table();
+    h::insert(7, 0, 7, 7);
+    h::insert(8, 7, 7, 8);
+    let tty = fresh_tty();
+    tiocsctty_for(7, &tty, false, false);
+    assert_eq!(tiocspgrp_for(7, &tty, 8), 0);
+    let ctrl = tty.ctrl.lock();
+    assert_eq!(ctrl.pgrp, Some(8));
+    assert_eq!(ctrl.pgrp_snapshot.load(), 8);
+}
+
+fn tiocspgrp_returns_enotty_when_no_session_attached() {
+    h::reset_table();
+    h::insert(7, 0, 7, 7);
+    let tty = fresh_tty();
+    assert_eq!(tiocspgrp_for(7, &tty, 7), h::ENOTTY_I64);
+}
+
+fn tiocgpgrp_and_tiocgsid_return_enotty_without_attachment() {
+    let tty = fresh_tty();
+    assert_eq!(tiocgpgrp_for(&tty), h::ENOTTY_I64);
+    assert_eq!(tiocgsid_for(&tty), h::ENOTTY_I64);
+}
+
+fn tiocgpgrp_and_tiocgsid_return_ids_after_attach() {
+    h::reset_table();
+    h::insert(7, 0, 7, 7);
+    let tty = fresh_tty();
+    tiocsctty_for(7, &tty, false, false);
+    assert_eq!(tiocgpgrp_for(&tty), 7);
+    assert_eq!(tiocgsid_for(&tty), 7);
+}
+
+fn tiocnotty_nonleader_detaches_only_caller() {
+    h::reset_table();
+    h::insert(7, 0, 7, 7);
+    h::insert(8, 7, 7, 7);
+    let tty = fresh_tty();
+    tiocsctty_for(7, &tty, false, false);
+    h::patch(8, |e| e.controlling_tty = Some(Arc::clone(&tty)));
+    assert_eq!(tiocnotty_for(8), 0);
+    assert!(process::ctty_of(8).is_none());
+    assert!(process::ctty_of(7).is_some());
+    assert_eq!(tty.ctrl.lock().session, Some(7));
+}
+
+fn tiocnotty_leader_clears_session_members() {
+    h::reset_table();
+    h::insert(7, 0, 7, 7);
+    h::insert(8, 7, 7, 7);
+    let tty = fresh_tty();
+    tiocsctty_for(7, &tty, false, false);
+    h::patch(8, |e| e.controlling_tty = Some(Arc::clone(&tty)));
+    assert_eq!(tiocnotty_for(7), 0);
+    assert!(process::ctty_of(7).is_none());
+    assert!(process::ctty_of(8).is_none());
+    let ctrl = tty.ctrl.lock();
+    assert!(ctrl.session.is_none());
+    assert!(ctrl.pgrp.is_none());
+    assert_eq!(ctrl.pgrp_snapshot.load(), 0);
+}
+
+fn tiocnotty_returns_enotty_without_ctty() {
+    h::reset_table();
+    h::insert(7, 0, 7, 7);
+    assert_eq!(tiocnotty_for(7), h::ENOTTY_I64);
+}
+
+fn acquire_ctty_on_open_succeeds_for_leader_with_none() {
+    h::reset_table();
+    h::insert(7, 0, 7, 7);
+    let tty = fresh_tty();
+    assert!(acquire_ctty_on_open(7, &tty));
+    assert!(process::ctty_of(7).is_some());
+    assert_eq!(tty.ctrl.lock().session, Some(7));
+}
+
+fn acquire_ctty_on_open_noop_for_nonleader() {
+    h::reset_table();
+    h::insert(10, 0, 5, 10);
+    let tty = fresh_tty();
+    assert!(!acquire_ctty_on_open(10, &tty));
+    assert!(tty.ctrl.lock().session.is_none());
+}
+
+fn acquire_ctty_on_open_noop_when_leader_already_has_ctty() {
+    h::reset_table();
+    h::insert(7, 0, 7, 7);
+    let tty_a = fresh_tty();
+    let tty_b = fresh_tty();
+    assert!(acquire_ctty_on_open(7, &tty_a));
+    assert!(!acquire_ctty_on_open(7, &tty_b));
+    assert!(tty_b.ctrl.lock().session.is_none());
+}
+
+fn acquire_ctty_on_open_noop_when_tty_already_attached() {
+    h::reset_table();
+    h::insert(7, 0, 7, 7);
+    h::insert(9, 0, 9, 9);
+    let tty = fresh_tty();
+    assert!(acquire_ctty_on_open(7, &tty));
+    assert!(!acquire_ctty_on_open(9, &tty));
+    assert_eq!(tty.ctrl.lock().session, Some(7));
+}


### PR DESCRIPTION
Closes #432

## Summary
- Adds kernel helpers `tiocsctty_for`/`tiocspgrp_for`/`tiocgpgrp_for`/`tiocgsid_for`/`tiocnotty_for` and an `acquire_ctty_on_open` hook in `kernel/src/tty/mod.rs`, each taking the caller pid explicitly and returning an errno `i64` to match the `setsid_for`/`setpgid_for` convention. Lock order is TABLE → `tty.ctrl`.
- Adds controlling-terminal accessors in `kernel/src/process/mod.rs` (`ctty_of`, `set_ctty`, `session_of`, `is_session_leader`, `pgrp_is_in_session`, `session_using_tty`, `clear_ctty_for_session`) plus `ENOTTY` and a `set_session_pgrp` test helper.
- Wires the ioctls into `SerialBackend::ioctl` against a shared `CONSOLE_TTY`, and honors `O_NOCTTY` on legacy `/dev/{tty,console,serial,std*}` opens so a session leader picks up the ctty implicitly.
- Adds the `TIOC*` ioctl numbers to `termios.rs` and extends the Linux-match test.

Ioctl semantics mirror Linux: only session leaders can `TIOCSCTTY`; `force` requires root to steal a tty from another session and clears ctty on every member of that session; `TIOCSPGRP` requires caller and target pgid to be in the tty's session; `TIOCNOTTY` clears every session member when the leader calls it.

## Test plan
- [x] `cargo xtask build`
- [x] `cargo xtask test` — new `tty_jobctl_ioctls` integration test (19 cases) passes alongside the full suite
- [x] `cargo xtask smoke` — all 30 markers present