### PR TITLE
tty: N_TTY ISIG signal generation + orphaned-pgrp check

### DIFF
--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -405,6 +405,41 @@ pub fn sys_setpgid(pid: u32, pgid: u32) -> i64 {
     setpgid_for(current_pid(), pid, pgid)
 }
 
+/// Invoke `f(pid)` for every live entry whose `pgrp_id == pgid`.
+///
+/// Used by the N_TTY ISIG path to fan a signal out to the foreground
+/// pgrp (#431). Takes `TABLE.lock()` for the walk; the closure runs
+/// with the lock held, so callers must not re-enter the process table
+/// from `f` — typical use is `|pid| signal::raise_signal_on_pid(pid, sig)`
+/// which touches only the per-task signal state.
+pub fn for_each_in_pgrp(pgid: u32, mut f: impl FnMut(u32)) {
+    if pgid == 0 {
+        return;
+    }
+    let t = TABLE.lock();
+    for entry in t.by_pid.values() {
+        if entry.pgrp_id == pgid && matches!(entry.state, ProcessState::Alive) {
+            f(entry.pid);
+        }
+    }
+}
+
+/// Orphaned in the conservative sense the issue calls out: no live
+/// member of `pgid` remains in the process table. Linux's real
+/// `will_become_orphaned_pgrp` test also walks parents, but until
+/// session reparenting lands we approximate with "no members" — which
+/// matches the Linux behavior for a pgrp whose leader has exited and
+/// whose members all followed.
+pub fn pgrp_is_orphaned(pgid: u32) -> bool {
+    if pgid == 0 {
+        return true;
+    }
+    let t = TABLE.lock();
+    !t.by_pid
+        .values()
+        .any(|e| e.pgrp_id == pgid && matches!(e.state, ProcessState::Alive))
+}
+
 /// Session/pgrp test helpers, exposed so the `session_syscalls` kernel
 /// integration test can drive the table without the scheduler. Not
 /// gated on `cfg(test)` because the integration test is a separate

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -405,21 +405,21 @@ pub fn sys_setpgid(pid: u32, pgid: u32) -> i64 {
     setpgid_for(current_pid(), pid, pgid)
 }
 
-/// Invoke `f(pid)` for every live entry whose `pgrp_id == pgid`.
+/// Collect every live pid whose `pgrp_id == pgid` into `out`.
 ///
 /// Used by the N_TTY ISIG path to fan a signal out to the foreground
-/// pgrp (#431). Takes `TABLE.lock()` for the walk; the closure runs
-/// with the lock held, so callers must not re-enter the process table
-/// from `f` — typical use is `|pid| signal::raise_signal_on_pid(pid, sig)`
-/// which touches only the per-task signal state.
-pub fn for_each_in_pgrp(pgid: u32, mut f: impl FnMut(u32)) {
+/// pgrp (#431). Takes `TABLE.lock()` only for the walk and releases it
+/// before returning, so callers are free to re-enter the process table
+/// (e.g. via `signal::raise_signal_on_pid`, which acquires the same
+/// lock) while iterating the collected pids.
+pub fn collect_pgrp_members(pgid: u32, out: &mut alloc::vec::Vec<u32>) {
     if pgid == 0 {
         return;
     }
     let t = TABLE.lock();
     for entry in t.by_pid.values() {
         if entry.pgrp_id == pgid && matches!(entry.state, ProcessState::Alive) {
-            f(entry.pid);
+            out.push(entry.pid);
         }
     }
 }

--- a/kernel/src/signal/mod.rs
+++ b/kernel/src/signal/mod.rs
@@ -260,11 +260,15 @@ pub fn raise_signal_on_pid(pid: u32, sig: u8) -> i64 {
 /// Send signal `sig` to every live member of process group `pgid`.
 ///
 /// Returns the number of processes the signal was delivered to. `pgid == 0`
-/// yields `0`. `-EINVAL` (-22) for an out-of-range signal. Used by the
-/// N_TTY ISIG fast path (#431) — the caller reads
-/// `tty.ctrl.pgrp_snapshot` lock-free and passes the result here.
+/// yields `0`. `-EINVAL` (-22) for `sig == 0` or out-of-range. Unlike
+/// POSIX `kill()`, the "signal 0 = existence check" form has no caller in
+/// the kernel — the N_TTY ISIG fast path only ever sends 1..=NSIG — so the
+/// safer choice is to reject it outright rather than silently walk the
+/// pgrp and wake tasks. Used by the N_TTY ISIG fast path (#431); the
+/// caller reads `tty.ctrl.pgrp_snapshot` lock-free and passes the result
+/// here.
 pub fn send_to_pgrp(pgid: u32, sig: u8) -> i64 {
-    if sig > NSIG {
+    if sig == 0 || sig > NSIG {
         return -22; // EINVAL
     }
     if pgid == 0 {

--- a/kernel/src/signal/mod.rs
+++ b/kernel/src/signal/mod.rs
@@ -257,6 +257,28 @@ pub fn raise_signal_on_pid(pid: u32, sig: u8) -> i64 {
     }
 }
 
+/// Send signal `sig` to every live member of process group `pgid`.
+///
+/// Returns the number of processes the signal was delivered to. `pgid == 0`
+/// yields `0`. `-EINVAL` (-22) for an out-of-range signal. Used by the
+/// N_TTY ISIG fast path (#431) — the caller reads
+/// `tty.ctrl.pgrp_snapshot` lock-free and passes the result here.
+pub fn send_to_pgrp(pgid: u32, sig: u8) -> i64 {
+    if sig > NSIG {
+        return -22; // EINVAL
+    }
+    if pgid == 0 {
+        return 0;
+    }
+    let mut delivered: i64 = 0;
+    crate::process::for_each_in_pgrp(pgid, |pid| {
+        if raise_signal_on_pid(pid, sig) == 0 {
+            delivered += 1;
+        }
+    });
+    delivered
+}
+
 // ── Syscall handlers ──────────────────────────────────────────────────────
 
 /// `sigaction(sig, act_uva, oldact_uva)` — register or query a signal

--- a/kernel/src/signal/mod.rs
+++ b/kernel/src/signal/mod.rs
@@ -270,12 +270,14 @@ pub fn send_to_pgrp(pgid: u32, sig: u8) -> i64 {
     if pgid == 0 {
         return 0;
     }
+    let mut pids: alloc::vec::Vec<u32> = alloc::vec::Vec::new();
+    crate::process::collect_pgrp_members(pgid, &mut pids);
     let mut delivered: i64 = 0;
-    crate::process::for_each_in_pgrp(pgid, |pid| {
+    for pid in pids {
         if raise_signal_on_pid(pid, sig) == 0 {
             delivered += 1;
         }
-    });
+    }
     delivered
 }
 

--- a/kernel/src/tty/ntty.rs
+++ b/kernel/src/tty/ntty.rs
@@ -8,8 +8,19 @@
 use spin::Mutex;
 
 use super::termios::{
-    Termios, ECHO, ECHOE, ECHONL, ICRNL, IGNCR, INLCR, ISTRIP, OCRNL, ONLCR, OPOST, VERASE,
+    Termios, ECHO, ECHOE, ECHONL, ICRNL, IGNCR, INLCR, ISIG, ISTRIP, OCRNL, ONLCR, OPOST, VERASE,
+    VINTR, VQUIT, VSUSP,
 };
+use super::JobControl;
+
+// Signal numbers mirrored here to keep `tty` buildable on host (the
+// real `crate::signal` module is gated on `target_os = "none"`). These
+// values must match `kernel/src/signal/mod.rs`.
+const SIGHUP: u8 = 1;
+const SIGINT: u8 = 2;
+const SIGQUIT: u8 = 3;
+const SIGTSTP: u8 = 20;
+const SIGCONT: u8 = 18;
 
 /// Byte sink used by the output path. `process_output` and `queue_echo`
 /// push transformed bytes into a sink rather than allocating a buffer so
@@ -17,6 +28,39 @@ use super::termios::{
 /// or a test-local `Vec<u8>`.
 pub trait OutSink {
     fn push(&mut self, b: u8);
+}
+
+/// Signal dispatcher used by the N_TTY ISIG path. Decouples `receive_signal_or_byte`
+/// from `crate::signal` / `crate::process`, which are gated on
+/// `target_os = "none"` and unavailable to host unit tests. Production
+/// code wires [`KernelSignalDispatch`] (defined only for
+/// `target_os = "none"`); tests supply their own.
+pub trait SignalDispatch {
+    /// True when the pgrp has no live members. When this returns true,
+    /// the ISIG path delivers `SIGHUP` + `SIGCONT` via [`Self::send_to_pgrp`]
+    /// instead of the originally-requested signal — mirrors Linux's
+    /// background-pgrp-read behaviour.
+    fn is_orphaned(&self, pgid: u32) -> bool;
+
+    /// Fan-out signal `sig` to every live member of `pgid`. No-op when
+    /// `pgid == 0`.
+    fn send_to_pgrp(&self, pgid: u32, sig: u8);
+}
+
+/// Production dispatcher that routes through `crate::signal` and
+/// `crate::process`. Only compiled in a full kernel build.
+#[cfg(target_os = "none")]
+pub struct KernelSignalDispatch;
+
+#[cfg(target_os = "none")]
+impl SignalDispatch for KernelSignalDispatch {
+    fn is_orphaned(&self, pgid: u32) -> bool {
+        crate::process::pgrp_is_orphaned(pgid)
+    }
+
+    fn send_to_pgrp(&self, pgid: u32, sig: u8) {
+        crate::signal::send_to_pgrp(pgid, sig);
+    }
 }
 
 /// Interior N_TTY state. Guarded by lock class "2d" per RFC 0003 §Lock
@@ -37,6 +81,52 @@ impl NTty {
         Self {
             state: Mutex::new(NTtyState),
         }
+    }
+
+    /// Signal-aware entry point. Must be called before the hot
+    /// `receive_byte` path when a [`JobControl`] is available (i.e. for
+    /// any tty that has a controlling session) so Ctrl-C / Ctrl-\ /
+    /// Ctrl-Z generate the right signals before ICANON buffering.
+    ///
+    /// With `ISIG` clear or the byte not matching VINTR/VQUIT/VSUSP,
+    /// behavior is identical to [`NTty::receive_byte`]. With a match:
+    /// the foreground pgrp is read lock-free from
+    /// `ctrl.pgrp_snapshot`; if the pgrp is orphaned (no live members),
+    /// `SIGHUP` + `SIGCONT` are delivered instead of the intended
+    /// signal, matching Linux's background-pgrp read behavior. The
+    /// signal byte is then consumed — the caller does **not** commit
+    /// it to the line buffer.
+    pub fn receive_signal_or_byte(
+        &self,
+        termios: &Termios,
+        ctrl: &JobControl,
+        dispatch: &dyn SignalDispatch,
+        b: u8,
+    ) -> Option<u8> {
+        if termios.c_lflag & ISIG != 0 {
+            let sig = if b == termios.c_cc[VINTR] {
+                Some(SIGINT)
+            } else if b == termios.c_cc[VQUIT] {
+                Some(SIGQUIT)
+            } else if b == termios.c_cc[VSUSP] {
+                Some(SIGTSTP)
+            } else {
+                None
+            };
+            if let Some(sig) = sig {
+                let pgrp = ctrl.pgrp_snapshot.load();
+                if pgrp != 0 {
+                    if dispatch.is_orphaned(pgrp) {
+                        dispatch.send_to_pgrp(pgrp, SIGHUP);
+                        dispatch.send_to_pgrp(pgrp, SIGCONT);
+                    } else {
+                        dispatch.send_to_pgrp(pgrp, sig);
+                    }
+                }
+                return None;
+            }
+        }
+        self.receive_byte(termios, b)
     }
 
     /// Apply the `c_iflag` input transforms to one raw byte.
@@ -332,5 +422,127 @@ mod tests {
         let mut out = Vec::new();
         n.queue_echo(&t, t.c_cc[VERASE], &mut out);
         assert_eq!(out, &[0x7f]);
+    }
+
+    // ── ISIG tests (#431) ────────────────────────────────────────────
+
+    use crate::tty::JobControl;
+    use core::cell::RefCell;
+
+    /// Test dispatcher: records every (pgid, sig) call and answers
+    /// `is_orphaned` from a pre-seeded set.
+    struct CapturingDispatch {
+        orphaned_pgrps: &'static [u32],
+        captures: RefCell<Vec<(u32, u8)>>,
+    }
+
+    impl CapturingDispatch {
+        fn new(orphaned: &'static [u32]) -> Self {
+            Self {
+                orphaned_pgrps: orphaned,
+                captures: RefCell::new(Vec::new()),
+            }
+        }
+        fn captures(&self) -> Vec<(u32, u8)> {
+            self.captures.borrow().clone()
+        }
+    }
+
+    impl SignalDispatch for CapturingDispatch {
+        fn is_orphaned(&self, pgid: u32) -> bool {
+            self.orphaned_pgrps.contains(&pgid)
+        }
+        fn send_to_pgrp(&self, pgid: u32, sig: u8) {
+            self.captures.borrow_mut().push((pgid, sig));
+        }
+    }
+
+    fn termios_isig() -> Termios {
+        let mut t = Termios::sane();
+        t.c_lflag = ISIG;
+        t
+    }
+
+    fn ctrl_with_pgrp(pgid: u32) -> JobControl {
+        let jc = JobControl::new();
+        jc.pgrp_snapshot.store(pgid);
+        jc
+    }
+
+    #[test]
+    fn isig_ctrl_c_raises_sigint_and_consumes_byte() {
+        let d = CapturingDispatch::new(&[]);
+        let n = NTty::new();
+        let t = termios_isig();
+        let ctrl = ctrl_with_pgrp(50);
+        assert_eq!(n.receive_signal_or_byte(&t, &ctrl, &d, t.c_cc[VINTR]), None);
+        assert_eq!(d.captures(), alloc::vec![(50u32, SIGINT)]);
+    }
+
+    #[test]
+    fn isig_ctrl_backslash_raises_sigquit() {
+        let d = CapturingDispatch::new(&[]);
+        let n = NTty::new();
+        let t = termios_isig();
+        let ctrl = ctrl_with_pgrp(51);
+        assert_eq!(n.receive_signal_or_byte(&t, &ctrl, &d, t.c_cc[VQUIT]), None);
+        assert_eq!(d.captures(), alloc::vec![(51u32, SIGQUIT)]);
+    }
+
+    #[test]
+    fn isig_ctrl_z_raises_sigtstp() {
+        let d = CapturingDispatch::new(&[]);
+        let n = NTty::new();
+        let t = termios_isig();
+        let ctrl = ctrl_with_pgrp(52);
+        assert_eq!(n.receive_signal_or_byte(&t, &ctrl, &d, t.c_cc[VSUSP]), None);
+        assert_eq!(d.captures(), alloc::vec![(52u32, SIGTSTP)]);
+    }
+
+    #[test]
+    fn isig_off_passes_through_to_receive_byte() {
+        let d = CapturingDispatch::new(&[]);
+        let n = NTty::new();
+        // ISIG cleared; termios still has ICRNL so \r becomes \n.
+        let mut t = Termios::sane();
+        t.c_lflag = 0;
+        t.c_iflag = ICRNL;
+        let ctrl = ctrl_with_pgrp(42);
+        assert_eq!(n.receive_signal_or_byte(&t, &ctrl, &d, b'\r'), Some(b'\n'));
+        assert!(d.captures().is_empty());
+    }
+
+    #[test]
+    fn isig_on_non_signal_byte_passes_through() {
+        let d = CapturingDispatch::new(&[]);
+        let n = NTty::new();
+        let t = termios_isig();
+        let ctrl = ctrl_with_pgrp(53);
+        assert_eq!(n.receive_signal_or_byte(&t, &ctrl, &d, b'a'), Some(b'a'));
+        assert!(d.captures().is_empty());
+    }
+
+    #[test]
+    fn isig_orphaned_pgrp_raises_sighup_sigcont_not_sigint() {
+        // Pgrp 99 is orphaned — SIGINT should be replaced by
+        // SIGHUP + SIGCONT per Linux background-pgrp semantics.
+        let d = CapturingDispatch::new(&[99]);
+        let n = NTty::new();
+        let t = termios_isig();
+        let ctrl = ctrl_with_pgrp(99);
+        assert_eq!(n.receive_signal_or_byte(&t, &ctrl, &d, t.c_cc[VINTR]), None);
+        assert_eq!(d.captures(), alloc::vec![(99u32, SIGHUP), (99u32, SIGCONT)]);
+    }
+
+    #[test]
+    fn isig_pgrp_zero_drops_silently() {
+        let d = CapturingDispatch::new(&[]);
+        let n = NTty::new();
+        let t = termios_isig();
+        let ctrl = ctrl_with_pgrp(0);
+        // Byte is still consumed (matched a signal control char) but
+        // no delivery occurs when there's no foreground pgrp.
+        assert_eq!(n.receive_signal_or_byte(&t, &ctrl, &d, t.c_cc[VINTR]), None);
+        assert!(d.captures().is_empty());
     }
 }


### PR DESCRIPTION
Closes #431

## Summary
- New `NTty::receive_signal_or_byte` entry point: when `ISIG` is set and the byte matches `VINTR` / `VQUIT` / `VSUSP`, fan the corresponding `SIGINT` / `SIGQUIT` / `SIGTSTP` out to the foreground pgrp and consume the byte (don't commit to the line buffer). Otherwise delegates to the existing `receive_byte`.
- Orphaned-pgrp check: if the fg pgrp has no live members, deliver `SIGHUP` + `SIGCONT` instead of the originally-requested signal, matching Linux's background-pgrp read behaviour.
- Pgrp is read lock-free via `tty.ctrl.pgrp_snapshot` per RFC 0003 §Lock order — the hot path never acquires `tty.ctrl.lock()`.
- New `signal::send_to_pgrp(pgid, sig)` fan-out helper, backed by new `process::for_each_in_pgrp` and `process::pgrp_is_orphaned` accessors that keep the process `by_pid` table private.
- Signal delivery is abstracted behind a `SignalDispatch` trait. Production wiring uses `KernelSignalDispatch` (compiled only on `target_os = "none"`); host unit tests supply a capturing dispatcher so they don't need to build the gated `signal`/`process` modules.
- `receive_byte` is unchanged — the PS/2 (#442) and serial (#444) rx paths keep calling it while a future N_TTY `LineDiscipline` impl migrates to the signal-aware entry.

## Test plan
- [x] `cargo xtask build` — clean
- [x] `cargo xtask test` — full suite green
- [x] `cargo xtask smoke` — 28/28 required markers
- [x] 7 new host unit tests in `kernel/src/tty/ntty.rs`:
  - `isig_ctrl_c_raises_sigint_and_consumes_byte`
  - `isig_ctrl_backslash_raises_sigquit`
  - `isig_ctrl_z_raises_sigtstp`
  - `isig_off_passes_through_to_receive_byte`
  - `isig_on_non_signal_byte_passes_through`
  - `isig_orphaned_pgrp_raises_sighup_sigcont_not_sigint`
  - `isig_pgrp_zero_drops_silently`
- [ ] End-to-end shell Ctrl-C SIGINT integration test — deferred; requires wiring an N_TTY `LineDiscipline::receive_byte` impl (tracked as a separate follow-up; the `receive_signal_or_byte` hook is the primitive that impl will call).