### PR TITLE
tty: SIGTTOU + TOSTOP background-pgrp write gate (#434)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -243,3 +243,7 @@ harness = false
 [[test]]
 name = "tty_jobctl_ioctls"
 harness = false
+
+[[test]]
+name = "tty_tostop_sigttou"
+harness = false

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -563,7 +563,22 @@ impl FileBackend for SerialBackend {
     /// Write path acquires `COM1.lock()` inside `without_interrupts` via
     /// `crate::serial::write_bytes`. No deadlock risk: this call chain
     /// never calls `serial_println!` or re-enters the COM1 mutex.
+    ///
+    /// Job-control gate: if the caller's pgrp is not the console tty's
+    /// foreground pgrp and `TOSTOP` is set, raise `SIGTTOU` and fail the
+    /// write with `EINTR`. Real `ERESTARTSYS` semantics (SA_RESTART-aware
+    /// transparent restart) arrive with the syscall trampoline follow-up.
     fn write(&self, buf: &[u8]) -> Result<usize, i64> {
+        let caller = crate::process::current_pid();
+        let tty = crate::tty::console_tty();
+        if let Some(rc) = crate::tty::tty_check_tostop(&tty, caller) {
+            // KERN_ERESTARTSYS → EINTR at the syscall boundary until the
+            // trampoline honours restart semantics.
+            if rc == crate::tty::KERN_ERESTARTSYS {
+                return Err(EINTR);
+            }
+            return Err(rc);
+        }
         crate::serial::write_bytes(buf);
         Ok(buf.len())
     }

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -300,6 +300,30 @@ pub fn session_of(pid: u32) -> Option<SessionId> {
     TABLE.lock().by_pid.get(&pid).map(|e| e.session_id)
 }
 
+/// Process-group id of `pid`, if the entry exists.
+pub fn pgrp_of(pid: u32) -> Option<ProcessGroupId> {
+    TABLE.lock().by_pid.get(&pid).map(|e| e.pgrp_id)
+}
+
+/// Raise `sig` on every task whose process-group id matches `pgid`.
+/// Returns the number of tasks signaled. TABLE is released before the
+/// raise calls to preserve the TABLE → signal/WaitQueue lock order.
+pub fn raise_signal_on_pgrp(pgid: ProcessGroupId, sig: u8) -> usize {
+    let task_ids: alloc::vec::Vec<usize> = {
+        let t = TABLE.lock();
+        t.by_pid
+            .values()
+            .filter(|e| e.pgrp_id == pgid)
+            .map(|e| e.task_id)
+            .collect()
+    };
+    let n = task_ids.len();
+    for tid in task_ids {
+        crate::signal::raise_signal_on_task(tid, sig);
+    }
+    n
+}
+
 /// Whether `pid` is the session leader of its session
 /// (POSIX: `session_id == pid`).
 pub fn is_session_leader(pid: u32) -> bool {

--- a/kernel/src/signal/mod.rs
+++ b/kernel/src/signal/mod.rs
@@ -64,6 +64,8 @@ pub const SIGCHLD: u8 = 17;
 pub const SIGCONT: u8 = 18;
 pub const SIGSTOP: u8 = 19;
 pub const SIGTSTP: u8 = 20;
+pub const SIGTTIN: u8 = 21;
+pub const SIGTTOU: u8 = 22;
 
 /// Maximum signal number supported.  Linux defines 64 but we only need the
 /// standard 31 for now.  The bitmask is a `u64` so the representation is
@@ -124,7 +126,7 @@ pub fn default_action(sig: u8) -> DefaultAction {
     match sig {
         SIGCHLD => DefaultAction::Ignore,
         SIGCONT => DefaultAction::Continue,
-        SIGSTOP | SIGTSTP => DefaultAction::Stop,
+        SIGSTOP | SIGTSTP | SIGTTIN | SIGTTOU => DefaultAction::Stop,
         SIGURG | 28 => DefaultAction::Ignore, // SIGWINCH=28, SIGURG=23
         _ => DefaultAction::Terminate,
     }

--- a/kernel/src/tty/mod.rs
+++ b/kernel/src/tty/mod.rs
@@ -416,8 +416,11 @@ pub fn acquire_ctty_on_open(caller_pid: u32, tty: &Arc<Tty>) -> bool {
 /// when the write should proceed: TOSTOP clear, no foreground pgrp, caller
 /// unattached (`pid == 0`) or caller pgrp matches.
 ///
-/// The pgrp identity check reads `ctrl.pgrp_snapshot` without taking
-/// `ctrl.lock()` (RFC 0003 §Lock order, fast path).
+/// The pgrp identity check loads `ctrl.pgrp_snapshot` (an `AtomicU32`)
+/// while briefly holding `ctrl.lock()`. The atomic load itself is
+/// lock-free; promoting it to a true `Tty`-level atomic so the gate
+/// could skip the lock entirely is a follow-up (see RFC 0003 §Lock
+/// order, fast path).
 #[cfg(target_os = "none")]
 pub fn tty_check_tostop(tty: &Tty, caller_pid: u32) -> Option<i64> {
     if caller_pid == 0 {

--- a/kernel/src/tty/mod.rs
+++ b/kernel/src/tty/mod.rs
@@ -281,6 +281,12 @@ const EPERM: i64 = -1;
 #[cfg(target_os = "none")]
 const ENOTTY: i64 = -25;
 
+/// Linux-internal "restart this syscall" sentinel. Not user-visible: the
+/// syscall trampoline either restarts the call transparently (SA_RESTART)
+/// or converts it to `EINTR` (-4). Until the trampoline lands (tracked as
+/// a follow-up to #434), callers translate this to `EINTR` directly.
+pub const KERN_ERESTARTSYS: i64 = -512;
+
 /// `TIOCSCTTY(force)` — acquire `tty` as the caller session's controlling
 /// terminal. Only a session leader may acquire a ctty. If `tty` already
 /// has a session, `force && is_root` steals it (clearing the old session's
@@ -399,6 +405,40 @@ pub fn tiocnotty_for(caller_pid: u32) -> i64 {
 #[cfg(target_os = "none")]
 pub fn acquire_ctty_on_open(caller_pid: u32, tty: &Arc<Tty>) -> bool {
     process::try_acquire_ctty_atomic(caller_pid, tty)
+}
+
+/// POSIX background-pgrp write gate for `write(tty, ...)`.
+///
+/// If `TOSTOP` is set in `tty.termios.c_lflag`, the tty has a foreground
+/// pgrp, and `caller_pid` is in a different pgrp, raise `SIGTTOU` on the
+/// caller's pgrp and return `Some(KERN_ERESTARTSYS)` — the caller (syscall
+/// path) either restarts the write or converts to `EINTR`. Returns `None`
+/// when the write should proceed: TOSTOP clear, no foreground pgrp, caller
+/// unattached (`pid == 0`) or caller pgrp matches.
+///
+/// The pgrp identity check reads `ctrl.pgrp_snapshot` without taking
+/// `ctrl.lock()` (RFC 0003 §Lock order, fast path).
+#[cfg(target_os = "none")]
+pub fn tty_check_tostop(tty: &Tty, caller_pid: u32) -> Option<i64> {
+    if caller_pid == 0 {
+        return None;
+    }
+    if tty.termios.lock().c_lflag & termios::TOSTOP == 0 {
+        return None;
+    }
+    let fg = tty.ctrl.lock().pgrp_snapshot.load();
+    if fg == 0 {
+        return None;
+    }
+    let caller_pgrp = match process::pgrp_of(caller_pid) {
+        Some(p) => p,
+        None => return None,
+    };
+    if caller_pgrp == fg {
+        return None;
+    }
+    process::raise_signal_on_pgrp(caller_pgrp, crate::signal::SIGTTOU);
+    Some(KERN_ERESTARTSYS)
 }
 
 #[cfg(test)]

--- a/kernel/tests/tty_tostop_sigttou.rs
+++ b/kernel/tests/tty_tostop_sigttou.rs
@@ -1,0 +1,161 @@
+//! Integration test: SIGTTOU + TOSTOP on background-pgrp tty write (#434).
+//!
+//! Exercises `tty::tty_check_tostop` against the process-table test helpers.
+//! End-to-end user-visible EINTR delivery on `write(2)` is covered once the
+//! shell exercises job control from ring 3.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use core::panic::PanicInfo;
+
+use vibix::process::{self, test_helpers as h};
+use vibix::signal::{sig_bit, SIGTTOU};
+use vibix::tty::{termios, tty_check_tostop, Tty, KERN_ERESTARTSYS};
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    serial_println!("tty_tostop_sigttou: init ok");
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "tostop_clear_allows_write",
+            &(tostop_clear_allows_write as fn()),
+        ),
+        (
+            "caller_matches_fg_pgrp_allows_write",
+            &(caller_matches_fg_pgrp_allows_write as fn()),
+        ),
+        (
+            "no_foreground_pgrp_allows_write",
+            &(no_foreground_pgrp_allows_write as fn()),
+        ),
+        (
+            "unattached_caller_allows_write",
+            &(unattached_caller_allows_write as fn()),
+        ),
+        (
+            "background_pgrp_with_tostop_raises_sigttou",
+            &(background_pgrp_with_tostop_raises_sigttou as fn()),
+        ),
+        (
+            "sigttou_delivered_to_every_pgrp_member",
+            &(sigttou_delivered_to_every_pgrp_member as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+fn fresh_tty_with_fg(sid: u32, pgrp: u32, tostop: bool) -> Arc<Tty> {
+    let tty = Arc::new(Tty::new());
+    {
+        let mut ctrl = tty.ctrl.lock();
+        ctrl.session = Some(sid);
+        ctrl.set_pgrp(Some(pgrp));
+    }
+    if tostop {
+        let mut t = tty.termios.lock();
+        t.c_lflag |= termios::TOSTOP;
+    } else {
+        let mut t = tty.termios.lock();
+        t.c_lflag &= !termios::TOSTOP;
+    }
+    tty
+}
+
+fn pending_bits_for_pid(pid: u32) -> u64 {
+    process::with_signal_state_for_task(pid as usize, |s| s.pending).unwrap_or(0)
+}
+
+fn tostop_clear_allows_write() {
+    h::reset_table();
+    h::insert(10, 0, 5, 5); // caller in pgrp 5
+    h::insert(20, 0, 5, 9); // fg pgrp 9 owner in same session
+    let tty = fresh_tty_with_fg(5, 9, false);
+    // Caller pgrp (5) != fg (9), but TOSTOP is clear → no gate, no signal.
+    assert!(tty_check_tostop(&tty, 10).is_none());
+    assert_eq!(pending_bits_for_pid(10) & sig_bit(SIGTTOU), 0);
+}
+
+fn caller_matches_fg_pgrp_allows_write() {
+    h::reset_table();
+    h::insert(10, 0, 5, 9);
+    let tty = fresh_tty_with_fg(5, 9, true);
+    // Caller IS in the foreground pgrp → no gate, no signal, even with TOSTOP.
+    assert!(tty_check_tostop(&tty, 10).is_none());
+    assert_eq!(pending_bits_for_pid(10) & sig_bit(SIGTTOU), 0);
+}
+
+fn no_foreground_pgrp_allows_write() {
+    h::reset_table();
+    h::insert(10, 0, 5, 5);
+    let tty = Arc::new(Tty::new());
+    {
+        let mut t = tty.termios.lock();
+        t.c_lflag |= termios::TOSTOP;
+    }
+    // No fg pgrp (snapshot == 0) → no gate regardless of TOSTOP.
+    assert!(tty_check_tostop(&tty, 10).is_none());
+    assert_eq!(pending_bits_for_pid(10) & sig_bit(SIGTTOU), 0);
+}
+
+fn unattached_caller_allows_write() {
+    h::reset_table();
+    let tty = fresh_tty_with_fg(5, 9, true);
+    // pid 0 (no process context) short-circuits — kernel writes proceed.
+    assert!(tty_check_tostop(&tty, 0).is_none());
+}
+
+fn background_pgrp_with_tostop_raises_sigttou() {
+    h::reset_table();
+    h::insert(10, 0, 5, 5);
+    h::insert(20, 0, 5, 9);
+    let tty = fresh_tty_with_fg(5, 9, true);
+    let rc = tty_check_tostop(&tty, 10);
+    assert_eq!(rc, Some(KERN_ERESTARTSYS));
+    assert_ne!(pending_bits_for_pid(10) & sig_bit(SIGTTOU), 0);
+    // Foreground pgrp member must NOT receive the signal.
+    assert_eq!(pending_bits_for_pid(20) & sig_bit(SIGTTOU), 0);
+}
+
+fn sigttou_delivered_to_every_pgrp_member() {
+    h::reset_table();
+    h::insert(10, 0, 5, 5);
+    h::insert(11, 0, 5, 5);
+    h::insert(12, 0, 5, 5);
+    h::insert(30, 0, 5, 9);
+    let tty = fresh_tty_with_fg(5, 9, true);
+    let rc = tty_check_tostop(&tty, 10);
+    assert_eq!(rc, Some(KERN_ERESTARTSYS));
+    // Every member of caller's pgrp (5) must have SIGTTOU pending.
+    for &pid in &[10u32, 11, 12] {
+        assert_ne!(
+            pending_bits_for_pid(pid) & sig_bit(SIGTTOU),
+            0,
+            "pid {pid} missing SIGTTOU"
+        );
+    }
+    assert_eq!(pending_bits_for_pid(30) & sig_bit(SIGTTOU), 0);
+}


### PR DESCRIPTION
Closes #434.

## Summary
- Adds POSIX background-pgrp write gate: if `TOSTOP` is set, the tty has a foreground pgrp, and the caller is in a different pgrp, raise `SIGTTOU` on the caller's pgrp and fail the write.
- Introduces `KERN_ERESTARTSYS = -512` sentinel (Linux-internal). Until the syscall trampoline honours `SA_RESTART`, the gate is translated to `EINTR` at the syscall boundary. A follow-up issue tracks real `ERESTARTSYS` semantics.
- Adds `SIGTTIN` (21) and `SIGTTOU` (22) to the signal table; both default to `DefaultAction::Stop`. Adds `process::pgrp_of()` and `process::raise_signal_on_pgrp()` shared helpers (the latter preserves the TABLE → signal lock order).
- Wires the gate into `SerialBackend::write`.

## Test plan
- [x] `cargo xtask build` — clean.
- [x] `cargo xtask test` — 279 host unit tests pass; new `tty_tostop_sigttou` integration test (6 cases) passes:
  - TOSTOP clear → allows write
  - Caller in fg pgrp → allows write
  - No fg pgrp → allows write
  - pid 0 (kernel task) → allows write
  - Background pgrp + TOSTOP → `KERN_ERESTARTSYS` + SIGTTOU pending on caller's pgrp (not fg members)
  - pgrp-wide delivery: SIGTTOU lands on every member of caller's pgrp
- [x] `cargo xtask smoke` — all 30 markers present.
