### PR TITLE
mem: seed AT_RANDOM from RDRAND/RDSEED

### DIFF
--- a/kernel/src/arch/x86_64/csprng.rs
+++ b/kernel/src/arch/x86_64/csprng.rs
@@ -66,14 +66,22 @@ pub fn rdrand16() -> Option<[u8; 16]> {
     Some(out)
 }
 
-/// Produce 16 bytes for AT_RANDOM. Prefers [`rdrand16`]; if the CPU
-/// supports neither RDRAND nor RDSEED (or every retry failed), falls
-/// back to splatting `seed` across the buffer — **insecure**, documented
-/// as such, and intended only to keep old QEMU configs bootable.
-pub fn at_random_or_fallback(seed: u64) -> [u8; 16] {
-    if let Some(bytes) = rdrand16() {
-        return bytes;
-    }
+/// Deterministic AT_RANDOM fallback for hosts where RDRAND/RDSEED are
+/// unavailable. Splats `seed` across the 16-byte buffer — **insecure**,
+/// documented as such, and intended only to keep old QEMU configs
+/// bootable. Callers must invoke [`rdrand16`] first and only reach this
+/// helper on the `None` branch (with a serial warning).
+///
+/// When `seed == 0`, the seed is replaced with a fixed non-zero
+/// constant (the SplitMix64 / golden-ratio nothing-up-my-sleeve value)
+/// so the buffer is never all-zero — an all-zero AT_RANDOM is the
+/// worst possible "random" value to hand userspace.
+pub fn deterministic_at_random_fallback(seed: u64) -> [u8; 16] {
+    let seed = if seed == 0 {
+        0x9e37_79b9_7f4a_7c15
+    } else {
+        seed
+    };
     let mut out = [0u8; 16];
     for (i, b) in out.iter_mut().enumerate() {
         *b = ((seed >> ((i % 8) * 8)) & 0xFF) as u8;
@@ -124,18 +132,19 @@ mod tests {
 
     #[test]
     fn fallback_derives_bytes_from_seed() {
-        let bytes = at_random_or_fallback(0xdead_beef_cafe_babe);
+        let bytes = deterministic_at_random_fallback(0xdead_beef_cafe_babe);
         // Seed splatted across 16 bytes: first 8 = seed LE, next 8 = same pattern.
         assert_eq!(&bytes[..8], &0xdead_beef_cafe_babe_u64.to_le_bytes());
         assert_eq!(&bytes[8..], &0xdead_beef_cafe_babe_u64.to_le_bytes());
     }
 
     #[test]
-    fn fallback_zero_seed_is_all_zero() {
-        // Documents the known-insecure fallback: seed=0 yields an
-        // all-zero array. The kernel must never rely on the fallback
-        // for anything security-sensitive — the `serial_println!`
-        // warning in the call sites is the user-visible signal.
-        assert_eq!(at_random_or_fallback(0), [0u8; 16]);
+    fn fallback_zero_seed_is_never_all_zero() {
+        // Handing userspace an all-zero AT_RANDOM is the worst possible
+        // failure mode of the fallback, so seed==0 must be remapped to
+        // a fixed non-zero constant before splatting.
+        let bytes = deterministic_at_random_fallback(0);
+        assert_ne!(bytes, [0u8; 16]);
+        assert_eq!(&bytes[..8], &0x9e37_79b9_7f4a_7c15_u64.to_le_bytes());
     }
 }

--- a/kernel/src/arch/x86_64/csprng.rs
+++ b/kernel/src/arch/x86_64/csprng.rs
@@ -1,0 +1,141 @@
+//! CPU hardware random-number helpers.
+//!
+//! Wraps the `RDRAND` and `RDSEED` instructions behind CPUID-gated
+//! accessors. Callers that need a 16-byte block for AT_RANDOM use
+//! [`rdrand16`]; it tries RDRAND first, falls back to RDSEED, and
+//! returns `None` when neither is available (QEMU without `-cpu max`,
+//! or ancient hardware). In that case the caller is expected to fall
+//! back to a documented-insecure deterministic derivation with a
+//! warning — see `init_process::launch` and `syscall::exec_atomic`.
+//!
+//! Host unit tests exercise only the feature-gated fallback: `cpu::has`
+//! returns `false` when `FEATURES` is uninitialised, so the public
+//! wrappers take the `None` path and callers get to test their fallback
+//! logic without executing RDRAND on the test host.
+
+use crate::cpu::{self, Feature};
+
+/// Intel SDM recommends 10 retries for RDRAND (one per 64-bit pull).
+const RDRAND_RETRIES: u32 = 10;
+/// Intel SDM recommends longer retry bounds for RDSEED; 100 is the
+/// commonly-cited figure.
+const RDSEED_RETRIES: u32 = 100;
+
+/// Attempt one RDRAND read. Returns `None` if RDRAND is not supported
+/// or every retry returned CF=0.
+pub fn rdrand64() -> Option<u64> {
+    if !cpu::has(Feature::Rdrand) {
+        return None;
+    }
+    #[cfg(target_arch = "x86_64")]
+    {
+        unsafe { rdrand64_inner() }
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        None
+    }
+}
+
+/// Attempt one RDSEED read. Returns `None` if RDSEED is not supported
+/// or every retry returned CF=0.
+pub fn rdseed64() -> Option<u64> {
+    if !cpu::has(Feature::Rdseed) {
+        return None;
+    }
+    #[cfg(target_arch = "x86_64")]
+    {
+        unsafe { rdseed64_inner() }
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        None
+    }
+}
+
+/// Fill a 16-byte buffer from the CPU RNG. Tries RDRAND for both
+/// 64-bit halves first; if either half fails, falls back to RDSEED for
+/// that half. Returns `None` only when neither RDRAND nor RDSEED can
+/// produce a value — callers must then use their documented fallback.
+pub fn rdrand16() -> Option<[u8; 16]> {
+    let lo = rdrand64().or_else(rdseed64)?;
+    let hi = rdrand64().or_else(rdseed64)?;
+    let mut out = [0u8; 16];
+    out[..8].copy_from_slice(&lo.to_le_bytes());
+    out[8..].copy_from_slice(&hi.to_le_bytes());
+    Some(out)
+}
+
+/// Produce 16 bytes for AT_RANDOM. Prefers [`rdrand16`]; if the CPU
+/// supports neither RDRAND nor RDSEED (or every retry failed), falls
+/// back to splatting `seed` across the buffer — **insecure**, documented
+/// as such, and intended only to keep old QEMU configs bootable.
+pub fn at_random_or_fallback(seed: u64) -> [u8; 16] {
+    if let Some(bytes) = rdrand16() {
+        return bytes;
+    }
+    let mut out = [0u8; 16];
+    for (i, b) in out.iter_mut().enumerate() {
+        *b = ((seed >> ((i % 8) * 8)) & 0xFF) as u8;
+    }
+    out
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "rdrand")]
+unsafe fn rdrand64_inner() -> Option<u64> {
+    use core::arch::x86_64::_rdrand64_step;
+    let mut val: u64 = 0;
+    for _ in 0..RDRAND_RETRIES {
+        if _rdrand64_step(&mut val) == 1 {
+            return Some(val);
+        }
+    }
+    None
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "rdseed")]
+unsafe fn rdseed64_inner() -> Option<u64> {
+    use core::arch::x86_64::_rdseed64_step;
+    let mut val: u64 = 0;
+    for _ in 0..RDSEED_RETRIES {
+        if _rdseed64_step(&mut val) == 1 {
+            return Some(val);
+        }
+    }
+    None
+}
+
+#[cfg(all(test, not(target_os = "none")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wrappers_return_none_without_cpu_init() {
+        // FEATURES is uninitialised in host tests — cpu::has always
+        // returns false, so the public gates short-circuit before any
+        // intrinsic call. Proves the fallback path is reachable from
+        // host tests without executing RDRAND on the developer box.
+        assert_eq!(rdrand64(), None);
+        assert_eq!(rdseed64(), None);
+        assert_eq!(rdrand16(), None);
+    }
+
+    #[test]
+    fn fallback_derives_bytes_from_seed() {
+        let bytes = at_random_or_fallback(0xdead_beef_cafe_babe);
+        // Seed splatted across 16 bytes: first 8 = seed LE, next 8 = same pattern.
+        assert_eq!(&bytes[..8], &0xdead_beef_cafe_babe_u64.to_le_bytes());
+        assert_eq!(&bytes[8..], &0xdead_beef_cafe_babe_u64.to_le_bytes());
+    }
+
+    #[test]
+    fn fallback_zero_seed_is_all_zero() {
+        // Documents the known-insecure fallback: seed=0 yields an
+        // all-zero array. The kernel must never rely on the fallback
+        // for anything security-sensitive — the `serial_println!`
+        // warning in the call sites is the user-visible signal.
+        assert_eq!(at_random_or_fallback(0), [0u8; 16]);
+    }
+}

--- a/kernel/src/arch/x86_64/mod.rs
+++ b/kernel/src/arch/x86_64/mod.rs
@@ -1,5 +1,6 @@
 pub mod apic;
 pub mod backtrace;
+pub mod csprng;
 pub mod fpu;
 pub mod gdt;
 pub mod idt;

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -701,7 +701,7 @@ pub fn exec_atomic(elf_bytes: &[u8]) -> Result<core::convert::Infallible, i64> {
             crate::serial_println!(
                 "exec: WARNING — RDRAND/RDSEED unavailable, AT_RANDOM is deterministic"
             );
-            super::csprng::at_random_or_fallback(image.entry.as_u64() ^ stack_phys)
+            super::csprng::deterministic_at_random_fallback(image.entry.as_u64() ^ stack_phys)
         }
     };
     let auxv_params = crate::mem::auxv::AuxvParams {

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -692,13 +692,18 @@ pub fn exec_atomic(elf_bytes: &[u8]) -> Result<core::convert::Infallible, i64> {
 
     // Write the System V AMD64 initial stack layout (argc/argv/envp/auxv) into
     // the new stack frame via the HHDM window, matching what init_process does.
-    // TODO: replace with RDRAND once a CSPRNG is wired up.
+    // AT_RANDOM comes from RDRAND/RDSEED; falls back to an insecure XOR-splat
+    // with a warning if the CPU supports neither.
     let stack_phys = stack_frame.start_address().as_u64();
-    let random_seed = image.entry.as_u64() ^ stack_phys;
-    let mut random_bytes = [0u8; 16];
-    for (i, b) in random_bytes.iter_mut().enumerate() {
-        *b = ((random_seed >> (i % 8 * 8)) & 0xFF) as u8;
-    }
+    let random_bytes = match super::csprng::rdrand16() {
+        Some(b) => b,
+        None => {
+            crate::serial_println!(
+                "exec: WARNING — RDRAND/RDSEED unavailable, AT_RANDOM is deterministic"
+            );
+            super::csprng::at_random_or_fallback(image.entry.as_u64() ^ stack_phys)
+        }
+    };
     let auxv_params = crate::mem::auxv::AuxvParams {
         entry: image.entry.as_u64(),
         interp_base: image.interp_base.unwrap_or(0),

--- a/kernel/src/cpu.rs
+++ b/kernel/src/cpu.rs
@@ -67,10 +67,12 @@ impl Features {
             Feature::Popcnt => self.leaf1_ecx & (1 << 23) != 0,
             Feature::Xsave => self.leaf1_ecx & (1 << 26) != 0,
             Feature::Avx => self.leaf1_ecx & (1 << 28) != 0,
+            Feature::Rdrand => self.leaf1_ecx & (1 << 30) != 0,
             // Leaf 7, sub-leaf 0, EBX
             Feature::Fsgsbase => self.leaf7_ebx & (1 << 0) != 0,
             Feature::Avx2 => self.leaf7_ebx & (1 << 5) != 0,
             Feature::Smep => self.leaf7_ebx & (1 << 7) != 0,
+            Feature::Rdseed => self.leaf7_ebx & (1 << 18) != 0,
             Feature::Smap => self.leaf7_ebx & (1 << 20) != 0,
             // Extended leaf 0x8000_0001
             Feature::Rdtscp => self.ext_edx & (1 << 27) != 0,
@@ -114,6 +116,10 @@ pub enum Feature {
     Popcnt,
     /// LZCNT instruction — extended leaf 0x8000_0001, ECX bit 5.
     Lzcnt,
+    /// RDRAND instruction — leaf 1, ECX bit 30.
+    Rdrand,
+    /// RDSEED instruction — leaf 7 sub-leaf 0, EBX bit 18.
+    Rdseed,
 }
 
 /// Return `true` if the CPU supports `f`.
@@ -203,6 +209,12 @@ pub fn init() {
     if features.has(Feature::Lzcnt) {
         crate::serial_print!(" LZCNT");
     }
+    if features.has(Feature::Rdrand) {
+        crate::serial_print!(" RDRAND");
+    }
+    if features.has(Feature::Rdseed) {
+        crate::serial_print!(" RDSEED");
+    }
     crate::serial_println!();
 }
 
@@ -219,8 +231,8 @@ mod tests {
         // Ext ECX:    LZCNT (5)
         let f = Features::from_raw(
             (1 << 16) | (1 << 25) | (1 << 26), // leaf1_edx
-            (1 << 19) | (1 << 20) | (1 << 23) | (1 << 26) | (1 << 28), // leaf1_ecx
-            (1 << 0) | (1 << 5) | (1 << 7) | (1 << 20), // leaf7_ebx
+            (1 << 19) | (1 << 20) | (1 << 23) | (1 << 26) | (1 << 28) | (1 << 30), // leaf1_ecx
+            (1 << 0) | (1 << 5) | (1 << 7) | (1 << 18) | (1 << 20), // leaf7_ebx
             0,                                 // leaf7_ecx
             0,                                 // leaf7_edx
             1 << 27,                           // ext_edx
@@ -241,6 +253,8 @@ mod tests {
         assert!(f.has(Feature::Fsgsbase));
         assert!(f.has(Feature::Rdtscp));
         assert!(f.has(Feature::Lzcnt));
+        assert!(f.has(Feature::Rdrand));
+        assert!(f.has(Feature::Rdseed));
     }
 
     #[test]

--- a/kernel/src/init_process.rs
+++ b/kernel/src/init_process.rs
@@ -133,14 +133,18 @@ pub fn launch(bytes: &[u8]) -> usize {
 
     // 3b. Write the System V AMD64 initial stack layout (argc/argv/envp/auxv)
     //     into the stack frame via the HHDM window before ring-3 entry.
-    //     The 16-byte AT_RANDOM seed is derived deterministically from the
-    //     entry address and stack physical address.
-    //     TODO: replace with RDRAND once a CSPRNG is wired up.
-    let random_seed = image.entry.as_u64() ^ stack_phys;
-    let mut random_bytes = [0u8; 16];
-    for (i, b) in random_bytes.iter_mut().enumerate() {
-        *b = ((random_seed >> (i % 8 * 8)) & 0xFF) as u8;
-    }
+    //     AT_RANDOM comes from RDRAND/RDSEED; if the CPU supports neither
+    //     (e.g. QEMU without `-cpu max`), fall back to a documented-insecure
+    //     XOR-splat with a boot-time warning.
+    let random_bytes = match crate::arch::x86_64::csprng::rdrand16() {
+        Some(b) => b,
+        None => {
+            serial_println!(
+                "init: WARNING — RDRAND/RDSEED unavailable, AT_RANDOM is deterministic"
+            );
+            crate::arch::x86_64::csprng::at_random_or_fallback(image.entry.as_u64() ^ stack_phys)
+        }
+    };
     let auxv_params = crate::mem::auxv::AuxvParams {
         entry: image.entry.as_u64(),
         interp_base: image.interp_base.unwrap_or(0),

--- a/kernel/src/init_process.rs
+++ b/kernel/src/init_process.rs
@@ -142,7 +142,9 @@ pub fn launch(bytes: &[u8]) -> usize {
             serial_println!(
                 "init: WARNING — RDRAND/RDSEED unavailable, AT_RANDOM is deterministic"
             );
-            crate::arch::x86_64::csprng::at_random_or_fallback(image.entry.as_u64() ^ stack_phys)
+            crate::arch::x86_64::csprng::deterministic_at_random_fallback(
+                image.entry.as_u64() ^ stack_phys,
+            )
         }
     };
     let auxv_params = crate::mem::auxv::AuxvParams {


### PR DESCRIPTION
Closes #366

## Summary

- Replaces the deterministic `entry ^ stack_phys` splat used for AT_RANDOM with a CPUID-gated RDRAND/RDSEED read. The prior seed was trivially predictable from the ELF layout, defeating musl/gcc stack-protector canaries.
- New `arch::x86_64::csprng` module wraps `_rdrand64_step` / `_rdseed64_step` behind per-fn `#[target_feature]` so no global target-feature flag is required.
- Adds `cpu::Feature::{Rdrand, Rdseed}` (leaf 1 ECX.30, leaf 7 EBX.18) and extends the boot-time feature-print line.
- Both call sites (`init_process::launch`, `exec_atomic`) try `csprng::rdrand16()` first and fall back to the prior XOR-splat with a WARNING serial line when the CPU supports neither — keeps plain QEMU (no `-cpu max`) bootable while making the insecurity visible.

## Test plan

- [x] `cargo xtask build` — clean.
- [x] `cargo xtask test` — 281 passed (3 new host tests in `csprng`).
- [x] `cargo xtask smoke` — all 30 markers present.
- [x] Host unit tests cover the feature-gated None path and the deterministic fallback.
