### PR TITLE
tty: SIGTTIN on background-pgrp read of controlling terminal (#433)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -247,3 +247,7 @@ harness = false
 [[test]]
 name = "tty_tostop_sigttou"
 harness = false
+
+[[test]]
+name = "tty_sigttin_read"
+harness = false

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -198,6 +198,7 @@ pub const FD_CLOEXEC: u32 = 1;
 pub const EPERM: i64 = -1;
 pub const ENOENT: i64 = -2;
 pub const EINTR: i64 = -4;
+pub const EIO: i64 = -5;
 pub const EBADF: i64 = -9;
 pub const EAGAIN: i64 = -11;
 pub const ENOMEM: i64 = -12;
@@ -549,6 +550,14 @@ impl FileBackend for SerialBackend {
     /// blocking semantics must re-try in a loop (the blocking wait-queue path
     /// lives in a future `read` syscall extension).
     fn read(&self, buf: &mut [u8]) -> Result<usize, i64> {
+        let caller = crate::process::current_pid();
+        let tty = crate::tty::console_tty();
+        if let Some(rc) = crate::tty::tty_check_sigttin(&tty, caller) {
+            if rc == crate::tty::KERN_ERESTARTSYS {
+                return Err(EINTR);
+            }
+            return Err(rc);
+        }
         for (i, byte) in buf.iter_mut().enumerate() {
             match crate::serial::try_read_byte() {
                 Some(b) => *byte = b,

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -330,6 +330,9 @@ pub fn raise_signal_on_pgrp(pgid: ProcessGroupId, sig: u8) -> usize {
 /// TABLE is released before the signal mutex is taken.
 pub fn is_signal_blocked_or_ignored(pid: u32, sig: u8) -> bool {
     use crate::signal::{sig_bit, Disposition};
+    if sig == 0 || sig > crate::signal::NSIG {
+        return false;
+    }
     let signals = {
         let t = TABLE.lock();
         match t.by_pid.get(&pid) {

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -324,6 +324,26 @@ pub fn raise_signal_on_pgrp(pgid: ProcessGroupId, sig: u8) -> usize {
     n
 }
 
+/// Whether signal `sig` is blocked or ignored by the process with the
+/// given `pid`. Returns `true` if either condition holds, `false` if the
+/// pid has no process entry or the signal would be delivered normally.
+/// TABLE is released before the signal mutex is taken.
+pub fn is_signal_blocked_or_ignored(pid: u32, sig: u8) -> bool {
+    use crate::signal::{sig_bit, Disposition};
+    let signals = {
+        let t = TABLE.lock();
+        match t.by_pid.get(&pid) {
+            Some(e) => Arc::clone(&e.signals),
+            None => return false,
+        }
+    };
+    let state = signals.lock();
+    if state.blocked & sig_bit(sig) != 0 {
+        return true;
+    }
+    matches!(state.dispositions[(sig - 1) as usize], Disposition::Ignore)
+}
+
 /// Whether `pid` is the session leader of its session
 /// (POSIX: `session_id == pid`).
 pub fn is_session_leader(pid: u32) -> bool {

--- a/kernel/src/tty/mod.rs
+++ b/kernel/src/tty/mod.rs
@@ -281,6 +281,7 @@ pub fn console_tty() -> Arc<Tty> {
 const EPERM: i64 = -1;
 #[cfg(target_os = "none")]
 const ENOTTY: i64 = -25;
+pub const EIO: i64 = -5;
 
 /// Linux-internal "restart this syscall" sentinel. Not user-visible: the
 /// syscall trampoline either restarts the call transparently (SA_RESTART)
@@ -442,6 +443,36 @@ pub fn tty_check_tostop(tty: &Tty, caller_pid: u32) -> Option<i64> {
         return None;
     }
     process::raise_signal_on_pgrp(caller_pgrp, crate::signal::SIGTTOU);
+    Some(KERN_ERESTARTSYS)
+}
+
+/// POSIX background-pgrp read gate for `read(tty, ...)`.
+///
+/// When a background-pgrp process attempts `read()` on its controlling
+/// terminal, POSIX requires SIGTTIN. Unlike `tty_check_tostop` this is
+/// unconditional — no termios flag gates it. If SIGTTIN is blocked or
+/// ignored by the caller, returns `Some(EIO)` instead of raising the
+/// signal. Returns `None` when the read should proceed.
+#[cfg(target_os = "none")]
+pub fn tty_check_sigttin(tty: &Tty, caller_pid: u32) -> Option<i64> {
+    if caller_pid == 0 {
+        return None;
+    }
+    let fg = tty.ctrl.lock().pgrp_snapshot.load();
+    if fg == 0 {
+        return None;
+    }
+    let caller_pgrp = match process::pgrp_of(caller_pid) {
+        Some(p) => p,
+        None => return None,
+    };
+    if caller_pgrp == fg {
+        return None;
+    }
+    if process::is_signal_blocked_or_ignored(caller_pid, crate::signal::SIGTTIN) {
+        return Some(EIO);
+    }
+    process::raise_signal_on_pgrp(caller_pgrp, crate::signal::SIGTTIN);
     Some(KERN_ERESTARTSYS)
 }
 

--- a/kernel/tests/tty_sigttin_read.rs
+++ b/kernel/tests/tty_sigttin_read.rs
@@ -1,0 +1,173 @@
+//! Integration test: SIGTTIN on background-pgrp tty read (#433).
+//!
+//! Exercises `tty::tty_check_sigttin` against the process-table test helpers.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use core::panic::PanicInfo;
+
+use vibix::process::{self, test_helpers as h};
+use vibix::signal::{sig_bit, Disposition, SIGTTIN};
+use vibix::tty::{tty_check_sigttin, Tty, EIO, KERN_ERESTARTSYS};
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    serial_println!("tty_sigttin_read: init ok");
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "foreground_pgrp_reads_succeed",
+            &(foreground_pgrp_reads_succeed as fn()),
+        ),
+        (
+            "background_pgrp_raises_sigttin",
+            &(background_pgrp_raises_sigttin as fn()),
+        ),
+        (
+            "no_fg_pgrp_allows_read",
+            &(no_fg_pgrp_allows_read as fn()),
+        ),
+        (
+            "caller_pid_zero_allows_read",
+            &(caller_pid_zero_allows_read as fn()),
+        ),
+        (
+            "sigttin_blocked_returns_eio",
+            &(sigttin_blocked_returns_eio as fn()),
+        ),
+        (
+            "sigttin_ignored_returns_eio",
+            &(sigttin_ignored_returns_eio as fn()),
+        ),
+        (
+            "sigttin_delivered_to_every_pgrp_member",
+            &(sigttin_delivered_to_every_pgrp_member as fn()),
+        ),
+        (
+            "unattached_caller_allows_read",
+            &(unattached_caller_allows_read as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+fn fresh_tty_with_fg(sid: u32, pgrp: u32) -> Arc<Tty> {
+    let tty = Arc::new(Tty::new());
+    {
+        let mut ctrl = tty.ctrl.lock();
+        ctrl.session = Some(sid);
+        ctrl.set_pgrp(Some(pgrp));
+    }
+    tty
+}
+
+fn pending_bits_for_pid(pid: u32) -> u64 {
+    process::with_signal_state_for_task(pid as usize, |s| s.pending).unwrap_or(0)
+}
+
+fn foreground_pgrp_reads_succeed() {
+    h::reset_table();
+    h::insert(10, 0, 5, 9);
+    let tty = fresh_tty_with_fg(5, 9);
+    assert!(tty_check_sigttin(&tty, 10).is_none());
+    assert_eq!(pending_bits_for_pid(10) & sig_bit(SIGTTIN), 0);
+}
+
+fn background_pgrp_raises_sigttin() {
+    h::reset_table();
+    h::insert(10, 0, 5, 5);
+    h::insert(20, 0, 5, 9);
+    let tty = fresh_tty_with_fg(5, 9);
+    let rc = tty_check_sigttin(&tty, 10);
+    assert_eq!(rc, Some(KERN_ERESTARTSYS));
+    assert_ne!(pending_bits_for_pid(10) & sig_bit(SIGTTIN), 0);
+    assert_eq!(pending_bits_for_pid(20) & sig_bit(SIGTTIN), 0);
+}
+
+fn no_fg_pgrp_allows_read() {
+    h::reset_table();
+    h::insert(10, 0, 5, 5);
+    let tty = Arc::new(Tty::new());
+    assert!(tty_check_sigttin(&tty, 10).is_none());
+    assert_eq!(pending_bits_for_pid(10) & sig_bit(SIGTTIN), 0);
+}
+
+fn caller_pid_zero_allows_read() {
+    h::reset_table();
+    let tty = fresh_tty_with_fg(5, 9);
+    assert!(tty_check_sigttin(&tty, 0).is_none());
+}
+
+fn sigttin_blocked_returns_eio() {
+    h::reset_table();
+    h::insert(10, 0, 5, 5);
+    h::insert(20, 0, 5, 9);
+    h::patch(10, |e| {
+        e.signals.lock().blocked |= sig_bit(SIGTTIN);
+    });
+    let tty = fresh_tty_with_fg(5, 9);
+    let rc = tty_check_sigttin(&tty, 10);
+    assert_eq!(rc, Some(EIO));
+    assert_eq!(pending_bits_for_pid(10) & sig_bit(SIGTTIN), 0);
+}
+
+fn sigttin_ignored_returns_eio() {
+    h::reset_table();
+    h::insert(10, 0, 5, 5);
+    h::insert(20, 0, 5, 9);
+    h::patch(10, |e| {
+        e.signals.lock().dispositions[(SIGTTIN - 1) as usize] = Disposition::Ignore;
+    });
+    let tty = fresh_tty_with_fg(5, 9);
+    let rc = tty_check_sigttin(&tty, 10);
+    assert_eq!(rc, Some(EIO));
+    assert_eq!(pending_bits_for_pid(10) & sig_bit(SIGTTIN), 0);
+}
+
+fn sigttin_delivered_to_every_pgrp_member() {
+    h::reset_table();
+    h::insert(10, 0, 5, 5);
+    h::insert(11, 0, 5, 5);
+    h::insert(12, 0, 5, 5);
+    h::insert(30, 0, 5, 9);
+    let tty = fresh_tty_with_fg(5, 9);
+    let rc = tty_check_sigttin(&tty, 10);
+    assert_eq!(rc, Some(KERN_ERESTARTSYS));
+    for &pid in &[10u32, 11, 12] {
+        assert_ne!(
+            pending_bits_for_pid(pid) & sig_bit(SIGTTIN),
+            0,
+            "pid {pid} missing SIGTTIN"
+        );
+    }
+    assert_eq!(pending_bits_for_pid(30) & sig_bit(SIGTTIN), 0);
+}
+
+fn unattached_caller_allows_read() {
+    h::reset_table();
+    let tty = fresh_tty_with_fg(5, 9);
+    assert!(tty_check_sigttin(&tty, 99).is_none());
+}

--- a/kernel/tests/tty_sigttin_read.rs
+++ b/kernel/tests/tty_sigttin_read.rs
@@ -42,10 +42,7 @@ fn run_tests() {
             "background_pgrp_raises_sigttin",
             &(background_pgrp_raises_sigttin as fn()),
         ),
-        (
-            "no_fg_pgrp_allows_read",
-            &(no_fg_pgrp_allows_read as fn()),
-        ),
+        ("no_fg_pgrp_allows_read", &(no_fg_pgrp_allows_read as fn())),
         (
             "caller_pid_zero_allows_read",
             &(caller_pid_zero_allows_read as fn()),


### PR DESCRIPTION
Closes #433

## Summary

- Add `tty_check_sigttin()` — the read-side counterpart to `tty_check_tostop()`. Unconditional (no termios flag gate): any background-pgrp `read()` on the controlling terminal raises SIGTTIN on the caller's pgrp.
- When SIGTTIN is blocked or ignored by the caller, return `EIO` instead of raising the signal (POSIX requirement).
- Add `process::is_signal_blocked_or_ignored(pid, sig)` helper that checks both the blocked mask and disposition table.
- Wire the guard into `SerialBackend::read` so `sys_read` on `/dev/tty` raises SIGTTIN before consuming any bytes.

## Test plan

- [x] 8 new QEMU integration tests (`tty_sigttin_read.rs`): foreground pgrp succeeds, background pgrp raises SIGTTIN, no-fg-pgrp allows read, pid-0 short-circuit, SIGTTIN-blocked returns EIO, SIGTTIN-ignored returns EIO, pgrp-wide delivery, unattached caller
- [x] 301 host unit tests pass
- [x] All existing QEMU integration tests pass (including `tty_tostop_sigttou`)
- [x] Smoke test: 28/28 required markers present