### PR TITLE
console: render Unicode glyphs from font8x8 extended tables (#68)

### DIFF
--- a/kernel/src/framebuffer.rs
+++ b/kernel/src/framebuffer.rs
@@ -29,6 +29,51 @@ use spin::Mutex;
 const GLYPH_W: usize = 8;
 const GLYPH_H: usize = 8;
 
+// ─── unicode glyph fallback ────────────────────────────────────────────────
+
+/// Final fallback used when neither the requested code point nor U+FFFD is
+/// covered by any linked font8x8 table. A 2×2 dotted check pattern is
+/// distinct enough from any letterform that the user can tell rendering
+/// failed without it dominating the screen.
+const REPLACEMENT_GLYPH: [u8; 8] = [0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA];
+
+/// Resolve `c` to an 8×8 glyph by trying every linked font8x8 table in turn,
+/// then U+FFFD, then [`REPLACEMENT_GLYPH`]. Tables are searched in roughly
+/// "most likely" order so the common ASCII path resolves on the first
+/// lookup.
+fn lookup_glyph(c: char) -> [u8; 8] {
+    if let Some(g) = font8x8::BASIC_FONTS.get(c) {
+        return g;
+    }
+    if let Some(g) = font8x8::LATIN_FONTS.get(c) {
+        return g;
+    }
+    if let Some(g) = font8x8::BOX_FONTS.get(c) {
+        return g;
+    }
+    if let Some(g) = font8x8::BLOCK_FONTS.get(c) {
+        return g;
+    }
+    if let Some(g) = font8x8::GREEK_FONTS.get(c) {
+        return g;
+    }
+    if let Some(g) = font8x8::HIRAGANA_FONTS.get(c) {
+        return g;
+    }
+    if let Some(g) = font8x8::MISC_FONTS.get(c) {
+        return g;
+    }
+    if let Some(g) = font8x8::SGA_FONTS.get(c) {
+        return g;
+    }
+    if c != '\u{FFFD}' {
+        if let Some(g) = font8x8::MISC_FONTS.get('\u{FFFD}') {
+            return g;
+        }
+    }
+    REPLACEMENT_GLYPH
+}
+
 // ─── default colours ───────────────────────────────────────────────────────
 
 const DEFAULT_FG: u32 = 0x00E0_E0E0; // near-white
@@ -239,9 +284,7 @@ impl Console {
 
     /// Render a single `Cell` to the framebuffer at grid position (col, row).
     fn render_cell_at(&mut self, col: usize, row: usize, cell: Cell) {
-        let glyph = font8x8::BASIC_FONTS
-            .get(cell.ch)
-            .unwrap_or_else(|| font8x8::BASIC_FONTS.get(' ').unwrap());
+        let glyph = lookup_glyph(cell.ch);
         let px = col * GLYPH_W;
         let py = row * GLYPH_H;
         for (dy, bits) in glyph.iter().enumerate() {


### PR DESCRIPTION
Closes #68.

## Summary
- Add `lookup_glyph` helper that walks `font8x8`'s linked `BASIC`, `LATIN`, `BOX`, `BLOCK`, `GREEK`, `HIRAGANA`, `MISC`, and `SGA` tables before falling back to U+FFFD and finally a deterministic checkerboard `REPLACEMENT_GLYPH`.
- Switch `Console::render_cell_at` to use the new helper, so every character `Console::write_str` already decoded from UTF-8 actually has a chance to render instead of collapsing to blank space.

## Why
`Console::write_str` already iterates `&str::chars()`, so the cell grid stores genuine `char` values. Previously `render_cell_at` only consulted `BASIC_FONTS`, so any non-ASCII codepoint silently rendered as the blank fallback — kernel log lines containing box-drawing characters or Greek letters disappeared entirely on the framebuffer console even though they came through fine on serial. The other font8x8 tables ship behind the `unicode` feature we already enable in `Cargo.toml`, so this change costs nothing at link time beyond what was already paid.

The fallback chain ordering (BASIC first, then Latin/box/block/etc.) keeps the hot ASCII path resolving on the very first `if let Some` check, so per-cell render cost is unchanged for typical output.

## Test plan
- [x] `cargo xtask build` — clean (only the pre-existing `is_guard_hit` dead-code warning).
- [x] `cargo xtask test` — all integration tests green.
- [x] `cargo xtask smoke` — all 30 markers present.
- [ ] Visual confirmation of Unicode rendering in QEMU is left for a follow-up; the boot console still exercises ASCII through the new code path on every line of kernel log.