### PR TITLE
shell: per-command help via BUILTINS registry (#399)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -251,3 +251,7 @@ harness = false
 [[test]]
 name = "tty_sigttin_read"
 harness = false
+
+[[test]]
+name = "shell_help"
+harness = false

--- a/kernel/src/shell/mod.rs
+++ b/kernel/src/shell/mod.rs
@@ -176,7 +176,9 @@ mod kernel_side {
     }
 
     /// Source-of-truth dispatch table. Order is alphabetical so the
-    /// `help` listing reads naturally; a host unit test enforces this.
+    /// `help` listing reads naturally — hand-maintained, since the table
+    /// only compiles under `target_os = "none"` and can't be checked by
+    /// a host-side unit test.
     const BUILTINS: &[Builtin] = &[
         Builtin {
             name: "clear",

--- a/kernel/src/shell/mod.rs
+++ b/kernel/src/shell/mod.rs
@@ -158,6 +158,145 @@ mod kernel_side {
         serial_print!("{}", PROMPT);
     }
 
+    /// Per-builtin help text. `summary` feeds the global `help` listing;
+    /// `usage` and `examples` are shown by `help <cmd>`.
+    pub struct BuiltinHelp {
+        pub summary: &'static str,
+        pub usage: &'static str,
+        pub examples: &'static [&'static str],
+    }
+
+    /// One row of the dispatch table. Pairing the runner and the help
+    /// text in one struct means new builtins can't be added without
+    /// supplying both.
+    struct Builtin {
+        name: &'static str,
+        run: fn(&str),
+        help: BuiltinHelp,
+    }
+
+    /// Source-of-truth dispatch table. Order is alphabetical so the
+    /// `help` listing reads naturally; a host unit test enforces this.
+    const BUILTINS: &[Builtin] = &[
+        Builtin {
+            name: "clear",
+            run: cmd_clear_wrap,
+            help: BuiltinHelp {
+                summary: "clear the screen (VT100)",
+                usage: "clear",
+                examples: &["clear"],
+            },
+        },
+        Builtin {
+            name: "date",
+            run: cmd_date_wrap,
+            help: BuiltinHelp {
+                summary: "wall-clock time from the RTC (UTC)",
+                usage: "date",
+                examples: &["date"],
+            },
+        },
+        Builtin {
+            name: "echo",
+            run: cmd_echo,
+            help: BuiltinHelp {
+                summary: "echo the rest of the line",
+                usage: "echo <args...>",
+                examples: &["echo hello world"],
+            },
+        },
+        Builtin {
+            name: "help",
+            run: cmd_help,
+            help: BuiltinHelp {
+                summary: "list builtins, or describe one",
+                usage: "help [cmd]",
+                examples: &["help", "help tasks"],
+            },
+        },
+        Builtin {
+            name: "mem",
+            run: cmd_mem_wrap,
+            help: BuiltinHelp {
+                summary: "heap + free-frame counters",
+                usage: "mem",
+                examples: &["mem"],
+            },
+        },
+        Builtin {
+            name: "panic",
+            run: cmd_panic,
+            help: BuiltinHelp {
+                summary: "trigger a kernel panic (test aid)",
+                usage: "panic",
+                examples: &["panic"],
+            },
+        },
+        Builtin {
+            name: "pci",
+            run: cmd_pci_wrap,
+            help: BuiltinHelp {
+                summary: "enumerated PCI devices on bus 0",
+                usage: "pci",
+                examples: &["pci"],
+            },
+        },
+        Builtin {
+            name: "tasks",
+            run: cmd_tasks_wrap,
+            help: BuiltinHelp {
+                summary: "live task ids, states, and remaining slices",
+                usage: "tasks",
+                examples: &["tasks"],
+            },
+        },
+        Builtin {
+            name: "time",
+            run: cmd_time_wrap,
+            help: BuiltinHelp {
+                summary: "seconds since boot, ms precision",
+                usage: "time",
+                examples: &["time"],
+            },
+        },
+        Builtin {
+            name: "uname",
+            run: cmd_uname,
+            help: BuiltinHelp {
+                summary: "print kernel name / release / arch",
+                usage: "uname [-asrvm]",
+                examples: &["uname", "uname -a", "uname -srm"],
+            },
+        },
+        Builtin {
+            name: "uptime",
+            run: cmd_uptime_wrap,
+            help: BuiltinHelp {
+                summary: "milliseconds since boot",
+                usage: "uptime",
+                examples: &["uptime"],
+            },
+        },
+        Builtin {
+            name: "version",
+            run: cmd_version_wrap,
+            help: BuiltinHelp {
+                summary: "kernel version + build metadata",
+                usage: "version",
+                examples: &["version"],
+            },
+        },
+        Builtin {
+            name: "whoami",
+            run: cmd_whoami_wrap,
+            help: BuiltinHelp {
+                summary: "print effective user name",
+                usage: "whoami",
+                examples: &["whoami"],
+            },
+        },
+    ];
+
     fn dispatch(line: &str) {
         if line.is_empty() {
             return;
@@ -166,21 +305,9 @@ mod kernel_side {
             Some((c, r)) => (c, r),
             None => (line, ""),
         };
-        match cmd {
-            "help" => cmd_help(),
-            "uptime" => cmd_uptime(),
-            "time" => cmd_time(),
-            "mem" => cmd_mem(),
-            "tasks" => cmd_tasks(),
-            "pci" => cmd_pci(),
-            "uname" => cmd_uname(rest),
-            "version" => cmd_version(),
-            "whoami" => cmd_whoami(),
-            "clear" => cmd_clear(),
-            "date" => cmd_date(),
-            "echo" => serial_println!("{}", rest),
-            "panic" => panic!("shell: panic builtin invoked"),
-            _ => serial_println!("unknown command: {} (try `help`)", cmd),
+        match BUILTINS.iter().find(|b| b.name == cmd) {
+            Some(b) => (b.run)(rest),
+            None => serial_println!("unknown command: {} (try `help`)", cmd),
         }
     }
 
@@ -191,21 +318,72 @@ mod kernel_side {
         dispatch(line);
     }
 
-    fn cmd_help() {
-        serial_println!("builtins:");
-        serial_println!("  help            show this list");
-        serial_println!("  uptime          milliseconds since boot");
-        serial_println!("  time            seconds since boot, ms precision");
-        serial_println!("  mem             heap + free-frame counters");
-        serial_println!("  tasks           live task ids and remaining slices");
-        serial_println!("  pci             enumerated PCI devices on bus 0");
-        serial_println!("  uname [-asrvm]  print kernel name / release / arch");
-        serial_println!("  version         kernel version + build metadata");
-        serial_println!("  whoami          print effective user name");
-        serial_println!("  clear           clear the screen (Ctrl+L with no key)");
-        serial_println!("  date            wall-clock time from the RTC (UTC)");
-        serial_println!("  echo <args>     echo the rest of the line");
-        serial_println!("  panic           trigger a kernel panic (test aid)");
+    fn cmd_help(args: &str) {
+        let arg = args.trim();
+        if arg.is_empty() {
+            serial_println!("builtins:");
+            for b in BUILTINS {
+                serial_println!("  {:<8}  {}", b.name, b.help.summary);
+            }
+            return;
+        }
+        match BUILTINS.iter().find(|b| b.name == arg) {
+            Some(b) => {
+                serial_println!("{}", b.help.summary);
+                serial_println!("usage: {}", b.help.usage);
+                if !b.help.examples.is_empty() {
+                    serial_println!("examples:");
+                    for ex in b.help.examples {
+                        serial_println!("  $ {}", ex);
+                    }
+                }
+            }
+            None => serial_println!("help: no help for `{}`", arg),
+        }
+    }
+
+    fn cmd_echo(rest: &str) {
+        serial_println!("{}", rest);
+    }
+
+    fn cmd_panic(_: &str) {
+        panic!("shell: panic builtin invoked");
+    }
+
+    fn cmd_uptime_wrap(_: &str) {
+        cmd_uptime();
+    }
+
+    fn cmd_time_wrap(_: &str) {
+        cmd_time();
+    }
+
+    fn cmd_pci_wrap(_: &str) {
+        cmd_pci();
+    }
+
+    fn cmd_tasks_wrap(_: &str) {
+        cmd_tasks();
+    }
+
+    fn cmd_version_wrap(_: &str) {
+        cmd_version();
+    }
+
+    fn cmd_whoami_wrap(_: &str) {
+        cmd_whoami();
+    }
+
+    fn cmd_clear_wrap(_: &str) {
+        cmd_clear();
+    }
+
+    fn cmd_date_wrap(_: &str) {
+        cmd_date();
+    }
+
+    fn cmd_mem_wrap(_: &str) {
+        cmd_mem();
     }
 
     fn cmd_uptime() {

--- a/kernel/tests/shell_help.rs
+++ b/kernel/tests/shell_help.rs
@@ -38,11 +38,26 @@ fn panic(info: &PanicInfo) -> ! {
 
 fn run_tests() {
     let tests: &[(&str, &dyn Testable)] = &[
-        ("help_no_args_lists_builtins", &(help_no_args_lists_builtins as fn())),
-        ("help_help_describes_itself", &(help_help_describes_itself as fn())),
-        ("help_known_builtins_dispatch", &(help_known_builtins_dispatch as fn())),
-        ("help_unknown_does_not_panic", &(help_unknown_does_not_panic as fn())),
-        ("help_with_extra_whitespace", &(help_with_extra_whitespace as fn())),
+        (
+            "help_no_args_lists_builtins",
+            &(help_no_args_lists_builtins as fn()),
+        ),
+        (
+            "help_help_describes_itself",
+            &(help_help_describes_itself as fn()),
+        ),
+        (
+            "help_known_builtins_dispatch",
+            &(help_known_builtins_dispatch as fn()),
+        ),
+        (
+            "help_unknown_does_not_panic",
+            &(help_unknown_does_not_panic as fn()),
+        ),
+        (
+            "help_with_extra_whitespace",
+            &(help_with_extra_whitespace as fn()),
+        ),
     ];
     serial_println!("running {} tests", tests.len());
     for (name, t) in tests {
@@ -63,7 +78,13 @@ fn help_help_describes_itself() {
 }
 
 fn help_known_builtins_dispatch() {
-    for cmd in ["help tasks", "help echo", "help mem", "help uname", "help clear"] {
+    for cmd in [
+        "help tasks",
+        "help echo",
+        "help mem",
+        "help uname",
+        "help clear",
+    ] {
         dispatch_for_test(cmd);
     }
 }
@@ -77,6 +98,11 @@ fn help_unknown_does_not_panic() {
 }
 
 fn help_with_extra_whitespace() {
-    // Trailing whitespace inside the argument should also resolve.
-    dispatch_for_test("help tasks");
+    // `cmd_help` trims its argument, so trailing spaces and collapsed
+    // multi-space separators between `help` and its argument must still
+    // resolve to the same builtin rather than falling through to the
+    // unknown-command branch.
+    dispatch_for_test("help tasks ");
+    dispatch_for_test("help  tasks");
+    dispatch_for_test("help tasks   ");
 }

--- a/kernel/tests/shell_help.rs
+++ b/kernel/tests/shell_help.rs
@@ -1,0 +1,82 @@
+//! Integration test: `help` and `help <cmd>` route through the dispatch
+//! table without panicking, and `help unknown` produces an error
+//! (still no panic).
+//!
+//! UART loopback would be needed to assert the printed text byte-for-byte,
+//! but the full `help` listing is several hundred bytes — well past the
+//! 16-byte 16550 RX FIFO that integrity-tests like `shell_introspection`
+//! rely on. We follow the introspection-test convention of
+//! "larger outputs are smoke-only" and verify only that each path
+//! dispatches cleanly.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+
+use vibix::{
+    exit_qemu, serial_println,
+    shell::dispatch_for_test,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("help_no_args_lists_builtins", &(help_no_args_lists_builtins as fn())),
+        ("help_help_describes_itself", &(help_help_describes_itself as fn())),
+        ("help_known_builtins_dispatch", &(help_known_builtins_dispatch as fn())),
+        ("help_unknown_does_not_panic", &(help_unknown_does_not_panic as fn())),
+        ("help_with_extra_whitespace", &(help_with_extra_whitespace as fn())),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+fn help_no_args_lists_builtins() {
+    dispatch_for_test("help");
+}
+
+fn help_help_describes_itself() {
+    // `help help` exercises the recursive lookup path — `help` is itself
+    // a `BUILTINS` entry, so this should resolve cleanly rather than
+    // taking the unknown-command branch.
+    dispatch_for_test("help help");
+}
+
+fn help_known_builtins_dispatch() {
+    for cmd in ["help tasks", "help echo", "help mem", "help uname", "help clear"] {
+        dispatch_for_test(cmd);
+    }
+}
+
+fn help_unknown_does_not_panic() {
+    // ENOENT-style error message; must not abort the kernel.
+    dispatch_for_test("help nosuch");
+    dispatch_for_test("help ");
+    // Whitespace-only argument trims to empty → falls back to the
+    // listing path, not the unknown-command path.
+}
+
+fn help_with_extra_whitespace() {
+    // Trailing whitespace inside the argument should also resolve.
+    dispatch_for_test("help tasks");
+}


### PR DESCRIPTION
Closes #399.

## Summary
- Replace the hand-rolled `match cmd` chain in `shell::dispatch` with a `BUILTINS` table whose rows pair each command's runner with a `BuiltinHelp { summary, usage, examples }` block.
- `help` (no args) walks the table and prints `name  summary` per row.
- `help <cmd>` prints `summary`, `usage:` line, and an `examples:` block. Unknown commands get `help: no help for \`<name>\``.
- `help help` resolves recursively because `help` is itself an entry.
- Add `kernel/tests/shell_help.rs` covering the listing path, recursive `help help`, unknown-command, and a sample of `help <cmd>` lookups.

## Why
The kernel shell already had a no-arg `help` that printed a flat list, but no way to ask \"how do I use `tasks`?\" or \"what flags does `uname` accept?\". As the issue notes, every new builtin needed a one-line summary anyway; promoting the help text into a typed struct co-located with each builtin makes that requirement structural — adding a builtin without `BuiltinHelp` is now a compile error rather than a documentation oversight.

The `BUILTINS` slice is alphabetically ordered by hand. A future host-side sort assertion would be ideal but the dispatch table only compiles for `target_os = \"none\"`, so the order is left to code review.

## Test plan
- [x] `cargo xtask build` — clean (only the pre-existing `is_guard_hit` dead-code warning).
- [x] `cargo xtask test` — full suite green; `shell_help` registers all 5 cases as `[ok]`.
- [x] `cargo xtask smoke` — 28/28 required markers present (the two soft `hello`/`init` markers remain known-flaky on this branch and unrelated to this PR).