### PR TITLE
fs: add sys_dup3 with EINVAL on equal fd and O_CLOEXEC flag (#414)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -205,6 +205,10 @@ name = "syscall_fcntl"
 harness = false
 
 [[test]]
+name = "syscall_dup_family"
+harness = false
+
+[[test]]
 name = "syscall_open_flags"
 harness = false
 

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -444,6 +444,20 @@ pub unsafe extern "C" fn syscall_dispatch(
             }
         }
 
+        // dup3(oldfd, newfd, flags) — like dup2 but returns EINVAL if
+        // oldfd == newfd and accepts an O_CLOEXEC flag for the new fd.
+        DUP3 => {
+            let oldfd = a0 as u32;
+            let newfd = a1 as u32;
+            let flags = a2 as u32;
+            let tbl = crate::task::current_fd_table();
+            let result = tbl.lock().dup3(oldfd, newfd, flags);
+            match result {
+                Ok(fd) => fd as i64,
+                Err(e) => e,
+            }
+        }
+
         // brk(addr) — set the program break; returns the new break on success
         // or the current (unchanged) break on failure.
         BRK => {
@@ -1103,6 +1117,7 @@ pub mod syscall_nr {
     pub const CLOSE: u64 = 3;
     pub const DUP: u64 = 32;
     pub const DUP2: u64 = 33;
+    pub const DUP3: u64 = 292;
     pub const FCNTL: u64 = 72;
     pub const FSTAT: u64 = 5;
     pub const STAT: u64 = 4;
@@ -1144,6 +1159,7 @@ mod tests {
         assert_eq!(syscall_nr::CLOSE, 3, "SYS_close must be 3");
         assert_eq!(syscall_nr::DUP, 32, "SYS_dup must be 32");
         assert_eq!(syscall_nr::DUP2, 33, "SYS_dup2 must be 33");
+        assert_eq!(syscall_nr::DUP3, 292, "SYS_dup3 must be 292");
         assert_eq!(syscall_nr::FCNTL, 72, "SYS_fcntl must be 72");
         assert_eq!(syscall_nr::LSEEK, 8, "SYS_lseek must be 8");
 

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -447,11 +447,14 @@ pub unsafe extern "C" fn syscall_dispatch(
         // dup3(oldfd, newfd, flags) — like dup2 but returns EINVAL if
         // oldfd == newfd and accepts an O_CLOEXEC flag for the new fd.
         DUP3 => {
-            let oldfd = a0 as u32;
-            let newfd = a1 as u32;
+            let oldfd = a0 as i32;
+            let newfd = a1 as i32;
             let flags = a2 as u32;
+            if oldfd < 0 || newfd < 0 {
+                return crate::fs::EBADF;
+            }
             let tbl = crate::task::current_fd_table();
-            let result = tbl.lock().dup3(oldfd, newfd, flags);
+            let result = tbl.lock().dup3(oldfd as u32, newfd as u32, flags);
             match result {
                 Ok(fd) => fd as i64,
                 Err(e) => e,

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -503,6 +503,37 @@ impl FileDescTable {
         self.slots[newfd as usize] = Some((desc, 0));
         Ok(newfd)
     }
+
+    /// Like [`dup2`], but:
+    /// - Returns `EINVAL` if `oldfd == newfd` (POSIX `dup3`).
+    /// - Accepts a `flags` argument; only `O_CLOEXEC` is legal. Any other
+    ///   bit returns `EINVAL`. When `O_CLOEXEC` is set, `newfd` is created
+    ///   with `FD_CLOEXEC`; the source fd's per-fd flags are untouched.
+    ///
+    /// Returns `EBADF` if `oldfd` is not open, `EINVAL` if
+    /// `newfd >= MAX_FD`.
+    pub fn dup3(&mut self, oldfd: u32, newfd: u32, flags: u32) -> Result<u32, i64> {
+        if oldfd == newfd {
+            return Err(EINVAL);
+        }
+        if flags & !flags::O_CLOEXEC != 0 {
+            return Err(EINVAL);
+        }
+        if newfd as usize >= MAX_FD {
+            return Err(EINVAL);
+        }
+        let desc = self.get_desc(oldfd)?;
+        while self.slots.len() <= newfd as usize {
+            self.slots.push(None);
+        }
+        let fd_flags = if flags & flags::O_CLOEXEC != 0 {
+            flags::O_CLOEXEC
+        } else {
+            0
+        };
+        self.slots[newfd as usize] = Some((desc, fd_flags));
+        Ok(newfd)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -811,6 +842,60 @@ mod tests {
     fn dup2_einval_newfd_too_large() {
         let mut t = make_table();
         assert_eq!(t.dup2(1, MAX_FD as u32), Err(EINVAL));
+    }
+
+    #[test]
+    fn dup3_einval_on_equal_fd() {
+        let mut t = make_table();
+        assert_eq!(t.dup3(1, 1, 0), Err(EINVAL));
+        // Even with O_CLOEXEC: dup3(fd, fd, _) is always EINVAL.
+        assert_eq!(t.dup3(1, 1, flags::O_CLOEXEC), Err(EINVAL));
+    }
+
+    #[test]
+    fn dup3_sets_cloexec_only_on_new_fd() {
+        let mut t = make_table();
+        // dup3(1, 5, O_CLOEXEC): fd 5 gets FD_CLOEXEC, fd 1 does not.
+        assert_eq!(t.dup3(1, 5, flags::O_CLOEXEC).unwrap(), 5);
+        assert_eq!(t.get_fd_flags(5).unwrap(), FD_CLOEXEC);
+        assert_eq!(t.get_fd_flags(1).unwrap(), 0);
+    }
+
+    #[test]
+    fn dup3_without_cloexec_clears_fd_flags() {
+        let mut t = make_table();
+        assert_eq!(t.dup3(1, 5, 0).unwrap(), 5);
+        assert_eq!(t.get_fd_flags(5).unwrap(), 0);
+    }
+
+    #[test]
+    fn dup3_einval_on_unknown_flag() {
+        let mut t = make_table();
+        // O_NONBLOCK is valid on pipe2 but not on dup3.
+        assert_eq!(t.dup3(1, 5, flags::O_NONBLOCK), Err(EINVAL));
+        // An entirely unknown bit also returns EINVAL.
+        assert_eq!(t.dup3(1, 5, 0x1), Err(EINVAL));
+    }
+
+    #[test]
+    fn dup3_closes_newfd_if_open() {
+        let mut t = make_table();
+        // fd 2 is open; dup3(1, 2, _) silently replaces it.
+        assert_eq!(t.dup3(1, 2, 0).unwrap(), 2);
+        assert!(t.get(2).is_ok());
+    }
+
+    #[test]
+    fn dup3_ebadf_on_closed_oldfd() {
+        let mut t = make_table();
+        t.close_fd(2).unwrap();
+        assert_eq!(t.dup3(2, 5, 0), Err(EBADF));
+    }
+
+    #[test]
+    fn dup3_einval_newfd_too_large() {
+        let mut t = make_table();
+        assert_eq!(t.dup3(1, MAX_FD as u32, 0), Err(EINVAL));
     }
 
     #[test]

--- a/kernel/tests/syscall_dup_family.rs
+++ b/kernel/tests/syscall_dup_family.rs
@@ -1,0 +1,297 @@
+//! Integration test for issue #414: `dup(2)`, `dup2(2)`, `dup3(2)` syscalls.
+//!
+//! Exercises the `SYS_DUP`, `SYS_DUP2`, `SYS_DUP3` dispatcher arms end-to-end:
+//! - `dup(oldfd)` returns the lowest-numbered free fd aliasing `oldfd`.
+//! - `dup2(oldfd, newfd)` closes `newfd` if open and reassigns it.
+//! - `dup2(fd, fd)` is a no-op when `fd` is open.
+//! - Duplicated fds share the open-file description's seek offset.
+//! - `dup3(fd, fd, _)` returns `EINVAL`.
+//! - `dup3(oldfd, newfd, O_CLOEXEC)` sets `FD_CLOEXEC` on `newfd` without
+//!   touching the source fd's per-fd flags.
+//! - `dup3(_, _, unknown_flag)` returns `EINVAL`.
+//! - `dup`/`dup2`/`dup3` on a closed `oldfd` return `EBADF`.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use core::ptr;
+
+use vibix::arch::x86_64::syscall::syscall_dispatch;
+use vibix::fs::{EBADF, EINVAL, FD_CLOEXEC, F_GETFD};
+use vibix::mem::vmatree::{Share, Vma};
+use vibix::mem::vmobject::AnonObject;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+use x86_64::structures::paging::PageTableFlags;
+
+const SYS_READ: u64 = 0;
+const SYS_OPEN: u64 = 2;
+const SYS_CLOSE: u64 = 3;
+const SYS_LSEEK: u64 = 8;
+const SYS_DUP: u64 = 32;
+const SYS_DUP2: u64 = 33;
+const SYS_FCNTL: u64 = 72;
+const SYS_DUP3: u64 = 292;
+
+const SEEK_SET: u64 = 0;
+const SEEK_CUR: u64 = 1;
+
+const O_RDONLY: u32 = 0o0;
+const O_NONBLOCK: u32 = 0o4000;
+const O_CLOEXEC: u32 = 0o2000000;
+
+/// Rootfs file populated by `xtask::ensure_initrd`. Content is `b"vibix\n"`.
+const HOSTNAME_PATH: &[u8] = b"/etc/hostname\0";
+const HOSTNAME_CONTENT: &[u8] = b"vibix\n";
+
+const USER_PAGE_VA: usize = 0x0000_2001_0000_0000;
+const USER_PAGE_LEN: usize = 4 * 4096;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    vibix::task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "dup_returns_lowest_free_fd",
+            &(dup_returns_lowest_free_fd as fn()),
+        ),
+        (
+            "dup2_replaces_open_newfd",
+            &(dup2_replaces_open_newfd as fn()),
+        ),
+        ("dup2_same_fd_noop", &(dup2_same_fd_noop as fn())),
+        ("dup_shares_seek_offset", &(dup_shares_seek_offset as fn())),
+        (
+            "dup3_einval_on_equal_fd",
+            &(dup3_einval_on_equal_fd as fn()),
+        ),
+        (
+            "dup3_cloexec_sets_bit_only_on_new",
+            &(dup3_cloexec_sets_bit_only_on_new as fn()),
+        ),
+        (
+            "dup3_einval_on_unknown_flag",
+            &(dup3_einval_on_unknown_flag as fn()),
+        ),
+        (
+            "dup_family_ebadf_on_closed",
+            &(dup_family_ebadf_on_closed as fn()),
+        ),
+    ];
+    for (name, t) in tests {
+        serial_println!("syscall_dup_family: {}", name);
+        t.run();
+    }
+}
+
+fn install_user_staging_vma() {
+    static INSTALLED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+    if INSTALLED.swap(true, core::sync::atomic::Ordering::SeqCst) {
+        return;
+    }
+    let prot_pte =
+        (PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE).bits();
+    vibix::task::install_vma_on_current(Vma::new(
+        USER_PAGE_VA,
+        USER_PAGE_VA + USER_PAGE_LEN,
+        0x3,
+        prot_pte,
+        Share::Private,
+        AnonObject::new(Some(USER_PAGE_LEN / 4096)),
+        0,
+    ));
+    unsafe {
+        ptr::write_volatile(USER_PAGE_VA as *mut u8, 0);
+    }
+}
+
+fn stage(bytes: &[u8]) -> u64 {
+    install_user_staging_vma();
+    assert!(bytes.len() < USER_PAGE_LEN);
+    unsafe {
+        let dst = USER_PAGE_VA as *mut u8;
+        for (i, b) in bytes.iter().enumerate() {
+            ptr::write_volatile(dst.add(i), *b);
+        }
+    }
+    USER_PAGE_VA as u64
+}
+
+fn open_ro(path: &[u8]) -> i64 {
+    let uva = stage(path);
+    unsafe { syscall_dispatch(SYS_OPEN, uva, O_RDONLY as u64, 0, 0, 0, 0) }
+}
+
+fn close(fd: i64) -> i64 {
+    unsafe { syscall_dispatch(SYS_CLOSE, fd as u64, 0, 0, 0, 0, 0) }
+}
+
+fn dup(fd: i64) -> i64 {
+    unsafe { syscall_dispatch(SYS_DUP, fd as u64, 0, 0, 0, 0, 0) }
+}
+
+fn dup2(oldfd: i64, newfd: i64) -> i64 {
+    unsafe { syscall_dispatch(SYS_DUP2, oldfd as u64, newfd as u64, 0, 0, 0, 0) }
+}
+
+fn dup3(oldfd: i64, newfd: i64, flags: u32) -> i64 {
+    unsafe { syscall_dispatch(SYS_DUP3, oldfd as u64, newfd as u64, flags as u64, 0, 0, 0) }
+}
+
+fn fcntl(fd: i64, cmd: u32, arg: u64) -> i64 {
+    unsafe { syscall_dispatch(SYS_FCNTL, fd as u64, cmd as u64, arg, 0, 0, 0) }
+}
+
+fn lseek(fd: i64, off: i64, whence: u64) -> i64 {
+    unsafe { syscall_dispatch(SYS_LSEEK, fd as u64, off as u64, whence, 0, 0, 0) }
+}
+
+fn read_bytes(fd: i64, out: &mut [u8]) -> i64 {
+    // Stash the read at USER_PAGE_VA + 256 so it doesn't clobber the path.
+    let buf_va = USER_PAGE_VA as u64 + 256;
+    let n = unsafe { syscall_dispatch(SYS_READ, fd as u64, buf_va, out.len() as u64, 0, 0, 0) };
+    if n > 0 {
+        unsafe {
+            let src = buf_va as *const u8;
+            for i in 0..n as usize {
+                out[i] = ptr::read_volatile(src.add(i));
+            }
+        }
+    }
+    n
+}
+
+fn dup_returns_lowest_free_fd() {
+    let fd = open_ro(HOSTNAME_PATH);
+    assert!(fd >= 3, "open /etc/hostname failed: {}", fd);
+    // dup(fd) must allocate the lowest free fd, which is fd+1 here.
+    let new_fd = dup(fd);
+    assert!(new_fd >= 3);
+    assert_ne!(new_fd, fd);
+    // Both fds must be readable.
+    let mut buf = [0u8; 6];
+    assert_eq!(read_bytes(new_fd, &mut buf), HOSTNAME_CONTENT.len() as i64);
+    assert_eq!(&buf, HOSTNAME_CONTENT);
+    close(new_fd);
+    close(fd);
+}
+
+fn dup2_replaces_open_newfd() {
+    let fd_a = open_ro(HOSTNAME_PATH);
+    let fd_b = open_ro(HOSTNAME_PATH);
+    assert!(fd_a >= 3 && fd_b >= 3 && fd_a != fd_b);
+
+    // Advance fd_a's offset so we can tell the two descriptions apart.
+    assert_eq!(lseek(fd_a, 2, SEEK_SET), 2);
+
+    // dup2(fd_a, fd_b): fd_b now aliases fd_a's description; its old
+    // description is dropped. Reading from fd_b should see fd_a's offset.
+    assert_eq!(dup2(fd_a, fd_b), fd_b);
+    let mut buf = [0u8; 4];
+    let n = read_bytes(fd_b, &mut buf);
+    assert_eq!(n, 4);
+    assert_eq!(&buf, b"bix\n");
+
+    close(fd_a);
+    close(fd_b);
+}
+
+fn dup2_same_fd_noop() {
+    let fd = open_ro(HOSTNAME_PATH);
+    assert!(fd >= 3);
+    assert_eq!(dup2(fd, fd), fd);
+    // fd still readable after the no-op.
+    let mut buf = [0u8; 6];
+    assert_eq!(read_bytes(fd, &mut buf), HOSTNAME_CONTENT.len() as i64);
+    assert_eq!(&buf, HOSTNAME_CONTENT);
+    close(fd);
+}
+
+fn dup_shares_seek_offset() {
+    // POSIX: dup'd fds share the open-file description, so the seek
+    // offset is shared too. Prove it by reading through one fd and
+    // observing that the other fd sees the advanced position.
+    let fd = open_ro(HOSTNAME_PATH);
+    assert!(fd >= 3);
+    let alias = dup(fd);
+    assert!(alias >= 3);
+
+    // Read 2 bytes via fd; the alias's offset advances too.
+    let mut buf = [0u8; 2];
+    assert_eq!(read_bytes(fd, &mut buf), 2);
+    assert_eq!(&buf, b"vi");
+
+    // Confirm the alias now starts at offset 2 by reading the next 2 bytes.
+    let mut buf2 = [0u8; 2];
+    assert_eq!(read_bytes(alias, &mut buf2), 2);
+    assert_eq!(&buf2, b"bi");
+
+    // SEEK_CUR +0 via the alias must report offset 4 — shared cursor.
+    assert_eq!(lseek(alias, 0, SEEK_CUR), 4);
+
+    close(alias);
+    close(fd);
+}
+
+fn dup3_einval_on_equal_fd() {
+    let fd = open_ro(HOSTNAME_PATH);
+    assert!(fd >= 3);
+    assert_eq!(dup3(fd, fd, 0), EINVAL);
+    assert_eq!(dup3(fd, fd, O_CLOEXEC), EINVAL);
+    close(fd);
+}
+
+fn dup3_cloexec_sets_bit_only_on_new() {
+    let fd = open_ro(HOSTNAME_PATH);
+    assert!(fd >= 3);
+    // Pick a newfd well above any currently open fd.
+    let newfd = (fd + 10) as i64;
+    let r = dup3(fd, newfd, O_CLOEXEC);
+    assert_eq!(r, newfd);
+
+    // newfd has FD_CLOEXEC set.
+    let flags_new = fcntl(newfd, F_GETFD, 0);
+    assert_eq!(flags_new as u32, FD_CLOEXEC);
+    // Source fd is untouched.
+    let flags_old = fcntl(fd, F_GETFD, 0);
+    assert_eq!(flags_old, 0);
+
+    close(newfd);
+    close(fd);
+}
+
+fn dup3_einval_on_unknown_flag() {
+    let fd = open_ro(HOSTNAME_PATH);
+    assert!(fd >= 3);
+    let newfd = (fd + 20) as i64;
+    // O_NONBLOCK is a status flag, not a valid dup3 flag.
+    assert_eq!(dup3(fd, newfd, O_NONBLOCK), EINVAL);
+    // Arbitrary unknown bit.
+    assert_eq!(dup3(fd, newfd, 0x1), EINVAL);
+    close(fd);
+}
+
+fn dup_family_ebadf_on_closed() {
+    // fd 9999 was never opened.
+    assert_eq!(dup(9999), EBADF);
+    assert_eq!(dup2(9999, 5), EBADF);
+    assert_eq!(dup3(9999, 5, 0), EBADF);
+}

--- a/kernel/tests/syscall_dup_family.rs
+++ b/kernel/tests/syscall_dup_family.rs
@@ -184,8 +184,11 @@ fn dup_returns_lowest_free_fd() {
     assert!(fd >= 3, "open /etc/hostname failed: {}", fd);
     // dup(fd) must allocate the lowest free fd, which is fd+1 here.
     let new_fd = dup(fd);
-    assert!(new_fd >= 3);
-    assert_ne!(new_fd, fd);
+    assert_eq!(
+        new_fd,
+        fd + 1,
+        "dup must return the lowest-numbered free fd"
+    );
     // Both fds must be readable.
     let mut buf = [0u8; 6];
     assert_eq!(read_bytes(new_fd, &mut buf), HOSTNAME_CONTENT.len() as i64);
@@ -294,4 +297,7 @@ fn dup_family_ebadf_on_closed() {
     assert_eq!(dup(9999), EBADF);
     assert_eq!(dup2(9999, 5), EBADF);
     assert_eq!(dup3(9999, 5, 0), EBADF);
+    // Linux returns EBADF (not EINVAL) for negative fds on dup3.
+    assert_eq!(dup3(-1, 5, 0), EBADF);
+    assert_eq!(dup3(3, -1, 0), EBADF);
 }


### PR DESCRIPTION
Closes #414.

## Summary
- Add `FileDescTable::dup3(oldfd, newfd, flags)` covering the two semantics that distinguish `dup3` from `dup2`: `EINVAL` when `oldfd == newfd`, and an `O_CLOEXEC` flag bit that sets `FD_CLOEXEC` on the new fd without touching the source fd's per-fd flags. Any flag bit outside `O_CLOEXEC` returns `EINVAL`.
- Assign `SYS_DUP3 = 292` (Linux x86_64 ABI) and add the dispatcher arm in `kernel/src/arch/x86_64/syscall.rs`. The number is pinned by a new assertion in the existing `syscall_numbers_match_linux_x86_64_abi` regression test.
- Seek-offset sharing across duped fds was already a property of the `Arc<FileDescription>` slot design — no new code required, but the new integration test pins it so a future refactor can't silently break it.

`dup` (SYS_DUP = 32) and `dup2` (SYS_DUP2 = 33) were already implemented and wired; `dup3` was the remaining gap called out by #414.

## Test plan
- [x] `cargo xtask build` — clean (only the pre-existing `is_guard_hit` dead-code warning).
- [x] `cargo xtask test-integration` — full suite green, including the new `syscall_dup_family` binary (8 test cases covering lowest-free-fd allocation, `dup2` open-newfd replacement, `dup2(fd, fd)` no-op, shared seek offset, `dup3` EINVAL on equal fd, `dup3` O_CLOEXEC only on new fd, `dup3` EINVAL on unknown flag, and EBADF for closed oldfd across all three syscalls).
- [x] `cargo xtask smoke` — 30/30 markers present.
- [x] New host unit tests in `kernel/src/fs/mod.rs::tests`: `dup3_einval_on_equal_fd`, `dup3_sets_cloexec_only_on_new_fd`, `dup3_without_cloexec_clears_fd_flags`, `dup3_einval_on_unknown_flag`, `dup3_closes_newfd_if_open`, `dup3_ebadf_on_closed_oldfd`, `dup3_einval_newfd_too_large`. Local host-unit run blocked by the aarch64 host container (pic8259 is x86_64-only); CI's `ubuntu-latest` lane will run them.