### PR TITLE
Add mkfifo/mknod FIFO support (#377)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -255,3 +255,7 @@ harness = false
 [[test]]
 name = "shell_help"
 harness = false
+
+[[test]]
+name = "syscall_mkfifo"
+harness = false

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -581,6 +581,12 @@ pub unsafe extern "C" fn syscall_dispatch(
         // pipe2(pipefd, flags) — like pipe() but with O_NONBLOCK/O_CLOEXEC.
         PIPE2 => crate::ipc::pipe::sys_pipe2(a0, a1 as u32),
 
+        // mknod(path, mode, dev) — create a FIFO or regular file.
+        MKNOD => super::syscalls::vfs::sys_mknod_impl(a0, a1, a2),
+
+        // mknodat(dfd, path, mode, dev) — like mknod relative to dfd.
+        MKNODAT => super::syscalls::vfs::sys_mknodat_impl(a0 as i32, a1, a2, a3),
+
         // poll(fds, nfds, timeout_ms) — wait for readiness on a set of fds.
         POLL => crate::poll::syscalls::sys_poll(a0, a1, a2 as i64),
 
@@ -1112,6 +1118,8 @@ pub mod syscall_nr {
     pub const CHDIR: u64 = 80;
     pub const PIPE: u64 = 22;
     pub const PIPE2: u64 = 293;
+    pub const MKNOD: u64 = 133;
+    pub const MKNODAT: u64 = 259;
     pub const POLL: u64 = 7;
     pub const SELECT: u64 = 23;
     pub const PSELECT6: u64 = 270;
@@ -1182,5 +1190,11 @@ mod tests {
         assert_eq!(syscall_nr::SETSID, 112, "SYS_setsid must be 112");
         assert_eq!(syscall_nr::GETPGID, 121, "SYS_getpgid must be 121");
         assert_eq!(syscall_nr::GETSID, 124, "SYS_getsid must be 124");
+
+        // IPC / FIFO
+        assert_eq!(syscall_nr::PIPE, 22, "SYS_pipe must be 22");
+        assert_eq!(syscall_nr::PIPE2, 293, "SYS_pipe2 must be 293");
+        assert_eq!(syscall_nr::MKNOD, 133, "SYS_mknod must be 133");
+        assert_eq!(syscall_nr::MKNODAT, 259, "SYS_mknodat must be 259");
     }
 }

--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -302,6 +302,52 @@ pub unsafe fn sys_openat_impl(dfd: i32, path_uva: u64, flags: u64, mode: u64) ->
         }
     }
 
+    // 7a. FIFO detour: on an `InodeKind::Fifo`, `open(2)` rendezvous
+    //     semantics (POSIX §open) take over — we never build a
+    //     `VfsBackend` / `OpenFile` for the FIFO body. Instead the fd
+    //     gets a bare `PipeReadEnd` / `PipeWriteEnd` bound to the
+    //     FIFO's shared `Arc<Pipe>` via `Pipe::open_read`/`open_write`.
+    if inode.kind == InodeKind::Fifo {
+        let pipe = match inode.ops.fifo_pipe() {
+            Some(p) => p,
+            // A FIFO inode must always carry a pipe — surface the bug
+            // as ENXIO (same errno used for a write-side rendezvous
+            // failure) rather than panic.
+            None => return crate::fs::ENXIO,
+        };
+        let nonblocking = flags32 & oflags::O_NONBLOCK != 0;
+        let access = flags32 & oflags::O_ACCMODE;
+        let backend: Arc<dyn FileBackend> = match access {
+            oflags::O_RDONLY => match pipe.open_read(nonblocking) {
+                Ok(r) => r,
+                Err(e) => return e,
+            },
+            oflags::O_WRONLY => match pipe.open_write(nonblocking) {
+                Ok(w) => w,
+                Err(e) => return e,
+            },
+            oflags::O_RDWR => {
+                // Linux extension: `O_RDWR` on a FIFO always succeeds.
+                // We install the read end as the fd's backend — the
+                // same inode retains both a reader and writer count
+                // for the caller, so a later `read`/`write` on the fd
+                // sees the ring in whichever direction is populated.
+                let (r, w) = pipe.open_rdwr();
+                // Keep the write end alive alongside the read end by
+                // wrapping both in a small struct. Since an `O_RDWR`
+                // FIFO must be both readable and writable from the
+                // same fd, the backend needs to route `read` to `r`
+                // and `write` to `w`.
+                Arc::new(FifoRdwrBackend {
+                    read_end: r,
+                    write_end: w,
+                })
+            }
+            _ => return EINVAL,
+        };
+        return install_fd(backend, flags as u32);
+    }
+
     // 7. Build the OpenFile. The edge list in `nd` keeps the SB alive
     //    until we've successfully acquired our own `SbActiveGuard`.
     let sb = match inode.sb.upgrade() {
@@ -326,6 +372,27 @@ pub unsafe fn sys_openat_impl(dfd: i32, path_uva: u64, flags: u64, mode: u64) ->
     );
     let backend: Arc<dyn FileBackend> = Arc::new(VfsBackend { open_file: of });
     install_fd(backend, flags as u32)
+}
+
+/// FileBackend used when a FIFO is opened `O_RDWR`. Routes `read` to
+/// the held `PipeReadEnd` and `write` to the held `PipeWriteEnd`; both
+/// refer to the same underlying `Arc<Pipe>`, so a write by the caller
+/// is observable on a subsequent read (and vice versa on the same fd).
+struct FifoRdwrBackend {
+    read_end: Arc<crate::ipc::pipe::PipeReadEnd>,
+    write_end: Arc<crate::ipc::pipe::PipeWriteEnd>,
+}
+
+impl FileBackend for FifoRdwrBackend {
+    fn read(&self, buf: &mut [u8]) -> Result<usize, i64> {
+        self.read_end.read(buf)
+    }
+    fn write(&self, buf: &[u8]) -> Result<usize, i64> {
+        self.write_end.write(buf)
+    }
+    fn poll(&self, pt: &mut crate::poll::PollTable) -> crate::poll::PollMask {
+        self.read_end.poll(pt) | self.write_end.poll(pt)
+    }
 }
 
 /// `stat(path, *statbuf)` (follow=true) / `lstat(path, *statbuf)`
@@ -534,4 +601,76 @@ pub unsafe fn sys_getcwd(buf_uva: u64, len: u64) -> i64 {
         Ok(()) => out.len() as i64,
         Err(e) => e.as_errno(),
     }
+}
+
+/// POSIX file-type bits (mask: `S_IFMT`). Only the values we act on are
+/// spelled out — the full Linux set is larger, but `mknod` in this
+/// kernel only accepts FIFO and regular files today.
+const S_IFMT: u32 = 0o170_000;
+const S_IFREG: u32 = 0o100_000;
+const S_IFIFO: u32 = 0o010_000;
+
+/// Shared body for `mknod(2)` / `mknodat(2)`.
+///
+/// Resolves the parent directory, splits off the leaf name, then dispatches
+/// to `InodeOps::mkfifo` (for `S_IFIFO`) or `InodeOps::create` (for
+/// `S_IFREG`). Any other type — character/block/socket nodes — returns
+/// `-EPERM` since this kernel has no devtmpfs or unix-socket support yet.
+fn mknod_impl(dfd: i32, path_uva: u64, mode: u32, _dev: u64) -> i64 {
+    let buf = match copy_user_path(path_uva) {
+        Ok(b) => b,
+        Err(e) => return e,
+    };
+    let path = buf.as_slice();
+
+    let is_absolute = path.first() == Some(&b'/');
+    if dfd != AT_FDCWD && !is_absolute {
+        return EINVAL;
+    }
+
+    // Refuse if the target already exists. Matches Linux mknod semantics
+    // (EEXIST on pre-existing path).
+    if resolve_inode(path, /* follow */ false).is_ok() {
+        return EEXIST;
+    }
+
+    let (parent_path, leaf) = match split_parent(path) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let (parent_inode, _pnd) = match resolve_inode(parent_path, /* follow */ true) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    if parent_inode.kind != InodeKind::Dir {
+        return ENOTDIR;
+    }
+
+    let perm = (mode & 0o7777) as u16;
+    let typ = mode & S_IFMT;
+    // A zero type field means "regular file" per POSIX.
+    let typ = if typ == 0 { S_IFREG } else { typ };
+
+    match typ {
+        S_IFIFO => match parent_inode.ops.mkfifo(&parent_inode, leaf, perm) {
+            Ok(_) => 0,
+            Err(e) => e,
+        },
+        S_IFREG => match parent_inode.ops.create(&parent_inode, leaf, perm) {
+            Ok(_) => 0,
+            Err(e) => e,
+        },
+        _ => crate::fs::EPERM,
+    }
+}
+
+/// `mknod(path, mode, dev)` — create a FIFO or regular file at `path`.
+pub unsafe fn sys_mknod_impl(path_uva: u64, mode: u64, dev: u64) -> i64 {
+    mknod_impl(AT_FDCWD, path_uva, mode as u32, dev)
+}
+
+/// `mknodat(dfd, path, mode, dev)` — like `mknod` but relative to `dfd`.
+/// Only `AT_FDCWD` and absolute paths are honored today.
+pub unsafe fn sys_mknodat_impl(dfd: i32, path_uva: u64, mode: u64, dev: u64) -> i64 {
+    mknod_impl(dfd, path_uva, mode as u32, dev)
 }

--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -332,7 +332,7 @@ pub unsafe fn sys_openat_impl(dfd: i32, path_uva: u64, flags: u64, mode: u64) ->
                 // same inode retains both a reader and writer count
                 // for the caller, so a later `read`/`write` on the fd
                 // sees the ring in whichever direction is populated.
-                let (r, w) = pipe.open_rdwr();
+                let (r, w) = pipe.open_rdwr(nonblocking);
                 // Keep the write end alive alongside the read end by
                 // wrapping both in a small struct. Since an `O_RDWR`
                 // FIFO must be both readable and writable from the
@@ -626,6 +626,13 @@ fn mknod_impl(dfd: i32, path_uva: u64, mode: u32, _dev: u64) -> i64 {
     let is_absolute = path.first() == Some(&b'/');
     if dfd != AT_FDCWD && !is_absolute {
         return EINVAL;
+    }
+
+    // mknod never names a directory — a trailing slash on the leaf is
+    // invalid. split_parent strips it silently, so the check has to
+    // happen here.
+    if path.len() > 1 && path.last() == Some(&b'/') {
+        return ENOTDIR;
     }
 
     // Refuse if the target already exists. Matches Linux mknod semantics

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -914,6 +914,7 @@ mod tests {
         assert_eq!(EPERM, -1);
         assert_eq!(ENOENT, -2);
         assert_eq!(EINTR, -4);
+        assert_eq!(ENXIO, -6);
         assert_eq!(EBADF, -9);
         assert_eq!(EAGAIN, -11);
         assert_eq!(ENOMEM, -12);

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -199,6 +199,7 @@ pub const EPERM: i64 = -1;
 pub const ENOENT: i64 = -2;
 pub const EINTR: i64 = -4;
 pub const EIO: i64 = -5;
+pub const ENXIO: i64 = -6;
 pub const EBADF: i64 = -9;
 pub const EAGAIN: i64 = -11;
 pub const ENOMEM: i64 = -12;

--- a/kernel/src/fs/vfs/ops.rs
+++ b/kernel/src/fs/vfs/ops.rs
@@ -232,6 +232,21 @@ pub trait InodeOps: Send + Sync {
     fn permission(&self, inode: &Inode, cred: &Credential, access: Access) -> Result<(), i64> {
         default_permission(inode, cred, access)
     }
+
+    /// Create a new FIFO (named pipe) inode under `dir` with the given
+    /// `name` and `mode`. Regular filesystems return `EPERM`; only
+    /// in-memory FSes that support `InodeKind::Fifo` override this.
+    fn mkfifo(&self, _dir: &Inode, _name: &[u8], _mode: u16) -> Result<Arc<Inode>, i64> {
+        Err(EPERM)
+    }
+
+    /// If this inode is a FIFO, return the shared `Arc<Pipe>` backing
+    /// it. Used by `open(2)` on a `InodeKind::Fifo` inode to bind a
+    /// `PipeReadEnd` / `PipeWriteEnd` to the caller's fd. Any filesystem
+    /// that ever stores a `InodeKind::Fifo` inode must override this.
+    fn fifo_pipe(&self) -> Option<Arc<crate::ipc::pipe::Pipe>> {
+        None
+    }
 }
 
 /// Per-open-file operations. Regular-file I/O, directory reading,

--- a/kernel/src/fs/vfs/ramfs.rs
+++ b/kernel/src/fs/vfs/ramfs.rs
@@ -77,6 +77,12 @@ pub(super) enum RamfsBody {
     Sym {
         target: Vec<u8>,
     },
+    /// FIFO (named pipe). The `Arc<Pipe>` is the shared byte-stream
+    /// backend; opening the FIFO inode binds a `PipeReadEnd` /
+    /// `PipeWriteEnd` to it via `Pipe::open_read`/`open_write`.
+    Fifo {
+        pipe: Arc<crate::ipc::pipe::Pipe>,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -564,6 +570,46 @@ impl InodeOps for RamfsInode {
         Ok(child)
     }
 
+    fn mkfifo(&self, dir: &Inode, name: &[u8], mode: u16) -> Result<Arc<Inode>, i64> {
+        let sb = dir.sb.upgrade().ok_or(ENOENT)?;
+        let _guard = dir.dir_rwsem.write();
+        let key = DString::try_from_bytes(name)?;
+        {
+            let body = self.body.lock();
+            match &*body {
+                RamfsBody::Dir { children, .. } if children.contains_key(&key) => {
+                    return Err(crate::fs::EEXIST);
+                }
+                RamfsBody::Dir { .. } => {}
+                _ => return Err(ENOTDIR),
+            }
+        }
+        let child = alloc_inode(
+            &sb,
+            &self.state,
+            InodeKind::Fifo,
+            mode & 0o7777,
+            1,
+            RamfsBody::Fifo {
+                pipe: crate::ipc::pipe::Pipe::new_for_fifo(),
+            },
+        );
+        self.body
+            .lock()
+            .as_dir_mut()
+            .unwrap()
+            .insert(key, child.clone());
+        Ok(child)
+    }
+
+    fn fifo_pipe(&self) -> Option<Arc<crate::ipc::pipe::Pipe>> {
+        let body = self.body.lock();
+        match &*body {
+            RamfsBody::Fifo { pipe } => Some(pipe.clone()),
+            _ => None,
+        }
+    }
+
     fn readlink(&self, _inode: &Inode, buf: &mut [u8]) -> Result<usize, i64> {
         let body = self.body.lock();
         match &*body {
@@ -583,7 +629,7 @@ impl InodeOps for RamfsInode {
             match &*body {
                 RamfsBody::Reg { data } => data.len() as u64,
                 RamfsBody::Sym { target } => target.len() as u64,
-                RamfsBody::Dir { .. } => 0,
+                RamfsBody::Dir { .. } | RamfsBody::Fifo { .. } => 0,
             }
         };
         inode.meta.write().size = size;
@@ -600,7 +646,7 @@ impl InodeOps for RamfsInode {
                     data.resize(attr.size as usize, 0);
                 }
                 RamfsBody::Dir { .. } => return Err(EISDIR),
-                RamfsBody::Sym { .. } => return Err(EINVAL),
+                RamfsBody::Sym { .. } | RamfsBody::Fifo { .. } => return Err(EINVAL),
             }
         }
         let mut meta = inode.meta.write();
@@ -635,7 +681,11 @@ impl FileOps for RamfsInode {
                 Ok(n)
             }
             RamfsBody::Dir { .. } => Err(EISDIR),
-            RamfsBody::Sym { .. } => Err(EINVAL),
+            // FIFOs never reach the VFS read path — `open(2)` detours
+            // through `open_read`/`open_write` and hands the fd a pipe
+            // backend directly. Guard with EINVAL so any stray route
+            // through the file_ops path surfaces clearly.
+            RamfsBody::Sym { .. } | RamfsBody::Fifo { .. } => Err(EINVAL),
         }
     }
 
@@ -654,7 +704,7 @@ impl FileOps for RamfsInode {
                 Ok(buf.len())
             }
             RamfsBody::Dir { .. } => Err(EISDIR),
-            RamfsBody::Sym { .. } => Err(EINVAL),
+            RamfsBody::Sym { .. } | RamfsBody::Fifo { .. } => Err(EINVAL),
         }
     }
 
@@ -666,6 +716,7 @@ impl FileOps for RamfsInode {
                 RamfsBody::Reg { data } => data.len() as i64,
                 RamfsBody::Dir { children, .. } => children.len() as i64,
                 RamfsBody::Sym { target } => target.len() as i64,
+                RamfsBody::Fifo { .. } => return Err(crate::fs::ESPIPE),
             }
         };
         let new_off = match whence {

--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -29,7 +29,7 @@ use alloc::boxed::Box;
 use alloc::sync::Arc;
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
-use crate::fs::{FileBackend, FileDescription, EAGAIN, EBADF, EINVAL, EPIPE};
+use crate::fs::{FileBackend, FileDescription, EAGAIN, EBADF, EINVAL, ENXIO, EPIPE};
 use crate::poll::{PollMask, PollTable, POLLHUP, POLLIN, POLLOUT, POLLRDNORM, POLLWRNORM};
 
 // On the kernel target use IrqLock (which saves/restores RFLAGS.IF).
@@ -180,6 +180,13 @@ pub struct Pipe {
     readers: AtomicUsize,
     /// Number of live write ends (decremented by `PipeWriteEnd::drop`).
     writers: AtomicUsize,
+    /// Open-rendezvous queues for FIFOs. `open_wait_r` parks an
+    /// `O_RDONLY` opener until a writer appears; `open_wait_w` parks
+    /// an `O_WRONLY` opener until a reader appears. Unused for
+    /// anonymous pipes (where both ends are created atomically by
+    /// `Pipe::new`).
+    open_wait_r: Arc<crate::poll::WaitQueue>,
+    open_wait_w: Arc<crate::poll::WaitQueue>,
 }
 
 impl Pipe {
@@ -191,7 +198,170 @@ impl Pipe {
             wr_wait: crate::poll::WaitQueue::new(),
             readers: AtomicUsize::new(1),
             writers: AtomicUsize::new(1),
+            open_wait_r: crate::poll::WaitQueue::new(),
+            open_wait_w: crate::poll::WaitQueue::new(),
         })
+    }
+
+    /// Allocate an empty pipe for a FIFO (named pipe). Both refcounts
+    /// start at zero — each successful `open(2)` through
+    /// `open_read`/`open_write` increments its side's count, and each
+    /// `close(2)` (via `PipeReadEnd::drop` / `PipeWriteEnd::drop`)
+    /// decrements it.
+    pub fn new_for_fifo() -> Arc<Self> {
+        Arc::new(Pipe {
+            ring: PipeRing::new(),
+            rd_wait: crate::poll::WaitQueue::new(),
+            wr_wait: crate::poll::WaitQueue::new(),
+            readers: AtomicUsize::new(0),
+            writers: AtomicUsize::new(0),
+            open_wait_r: crate::poll::WaitQueue::new(),
+            open_wait_w: crate::poll::WaitQueue::new(),
+        })
+    }
+
+    /// FIFO rendezvous for `O_RDONLY`.
+    ///
+    /// POSIX §open:
+    /// * `O_NONBLOCK` clear: block until a writer opens the FIFO.
+    /// * `O_NONBLOCK` set: return immediately (success).
+    ///
+    /// On a signal during the block, returns
+    /// [`crate::tty::KERN_ERESTARTSYS`] and rolls back the provisional
+    /// reader count so the refcount never leaks.
+    pub fn open_read(self: &Arc<Self>, nonblocking: bool) -> Result<Arc<PipeReadEnd>, i64> {
+        // Provisionally count ourselves as a reader so a racing writer
+        // observes us via `writers > 0`-symmetric wake and the wake_all
+        // below reaches any writer already parked on open_wait_w.
+        self.readers.fetch_add(1, Ordering::AcqRel);
+        self.open_wait_w.wake_all();
+
+        if nonblocking || self.writers.load(Ordering::Acquire) > 0 {
+            return Ok(PipeReadEnd::new_arc(self.clone(), nonblocking));
+        }
+
+        // Blocking rendezvous: wait for a writer.
+        #[cfg(target_os = "none")]
+        {
+            loop {
+                let tid = crate::task::current_id();
+                let tok = self.open_wait_r.register_wait(tid);
+                // Re-check under the latch: a writer may have arrived
+                // between the wake_all above and register_wait.
+                if self.writers.load(Ordering::Acquire) > 0 {
+                    self.open_wait_r.cancel(tok);
+                    return Ok(PipeReadEnd::new_arc(self.clone(), nonblocking));
+                }
+                crate::task::block_current();
+                self.open_wait_r.cancel(tok);
+
+                if self.writers.load(Ordering::Acquire) > 0 {
+                    return Ok(PipeReadEnd::new_arc(self.clone(), nonblocking));
+                }
+
+                if crate::process::with_signal_state_for_task(tid, |s| s.pending != 0)
+                    .unwrap_or(false)
+                {
+                    // Roll back our provisional reader count so a later
+                    // retry sees a clean state, and wake any writer that
+                    // may have parked on us.
+                    let prev = self.readers.fetch_sub(1, Ordering::AcqRel);
+                    if prev == 1 {
+                        self.wr_wait.wake_all();
+                    }
+                    return Err(crate::tty::KERN_ERESTARTSYS);
+                }
+                // Spurious wake — loop back and re-park.
+            }
+        }
+        #[cfg(not(target_os = "none"))]
+        {
+            // Host tests don't exercise the blocking path; match the
+            // rest of this module's host-build behavior (no signals,
+            // no scheduler). Roll back the provisional reader count
+            // so test state stays consistent across calls.
+            let prev = self.readers.fetch_sub(1, Ordering::AcqRel);
+            if prev == 1 {
+                self.wr_wait.wake_all();
+            }
+            Err(EAGAIN)
+        }
+    }
+
+    /// FIFO rendezvous for `O_WRONLY`.
+    ///
+    /// POSIX §open:
+    /// * `O_NONBLOCK` clear: block until a reader opens the FIFO.
+    /// * `O_NONBLOCK` set: return `-ENXIO` if no reader is present.
+    ///
+    /// On a signal during the block, returns
+    /// [`crate::tty::KERN_ERESTARTSYS`] and rolls back the provisional
+    /// writer count so the refcount never leaks.
+    pub fn open_write(self: &Arc<Self>, nonblocking: bool) -> Result<Arc<PipeWriteEnd>, i64> {
+        if nonblocking && self.readers.load(Ordering::Acquire) == 0 {
+            return Err(ENXIO);
+        }
+
+        self.writers.fetch_add(1, Ordering::AcqRel);
+        self.open_wait_r.wake_all();
+
+        if self.readers.load(Ordering::Acquire) > 0 {
+            return Ok(PipeWriteEnd::new_arc(self.clone(), nonblocking));
+        }
+
+        // Blocking rendezvous: wait for a reader.
+        #[cfg(target_os = "none")]
+        {
+            loop {
+                let tid = crate::task::current_id();
+                let tok = self.open_wait_w.register_wait(tid);
+                if self.readers.load(Ordering::Acquire) > 0 {
+                    self.open_wait_w.cancel(tok);
+                    return Ok(PipeWriteEnd::new_arc(self.clone(), nonblocking));
+                }
+                crate::task::block_current();
+                self.open_wait_w.cancel(tok);
+
+                if self.readers.load(Ordering::Acquire) > 0 {
+                    return Ok(PipeWriteEnd::new_arc(self.clone(), nonblocking));
+                }
+
+                if crate::process::with_signal_state_for_task(tid, |s| s.pending != 0)
+                    .unwrap_or(false)
+                {
+                    let prev = self.writers.fetch_sub(1, Ordering::AcqRel);
+                    if prev == 1 {
+                        self.rd_wait.wake_all();
+                    }
+                    return Err(crate::tty::KERN_ERESTARTSYS);
+                }
+            }
+        }
+        #[cfg(not(target_os = "none"))]
+        {
+            let prev = self.writers.fetch_sub(1, Ordering::AcqRel);
+            if prev == 1 {
+                self.rd_wait.wake_all();
+            }
+            Err(EAGAIN)
+        }
+    }
+
+    /// FIFO rendezvous for `O_RDWR` — Linux-compatible extension
+    /// beyond POSIX. Always succeeds immediately, returning a paired
+    /// `(PipeReadEnd, PipeWriteEnd)` that both refer to the same FIFO
+    /// body. Each increments its own refcount and wakes the peer's
+    /// rendezvous queue so any blocked `O_RDONLY` / `O_WRONLY` opener
+    /// observes progress.
+    pub fn open_rdwr(self: &Arc<Self>) -> (Arc<PipeReadEnd>, Arc<PipeWriteEnd>) {
+        self.readers.fetch_add(1, Ordering::AcqRel);
+        self.writers.fetch_add(1, Ordering::AcqRel);
+        self.open_wait_r.wake_all();
+        self.open_wait_w.wake_all();
+        (
+            PipeReadEnd::new_arc(self.clone(), false),
+            PipeWriteEnd::new_arc(self.clone(), false),
+        )
     }
 }
 
@@ -212,6 +382,10 @@ impl PipeReadEnd {
             pipe,
             nonblocking: AtomicBool::new(nonblocking),
         }
+    }
+
+    pub fn new_arc(pipe: Arc<Pipe>, nonblocking: bool) -> Arc<Self> {
+        Arc::new(Self::new(pipe, nonblocking))
     }
 }
 
@@ -309,6 +483,10 @@ impl PipeWriteEnd {
             pipe,
             nonblocking: AtomicBool::new(nonblocking),
         }
+    }
+
+    pub fn new_arc(pipe: Arc<Pipe>, nonblocking: bool) -> Arc<Self> {
+        Arc::new(Self::new(pipe, nonblocking))
     }
 }
 
@@ -696,5 +874,89 @@ mod tests {
         let read = PipeReadEnd::new(pipe.clone(), false);
         let _write = PipeWriteEnd::new(pipe, false);
         assert_eq!(read.read(&mut []), Ok(0));
+    }
+
+    // ── FIFO rendezvous ───────────────────────────────────────────────────
+
+    #[test]
+    fn fifo_new_starts_with_zero_ends() {
+        let fifo = Pipe::new_for_fifo();
+        assert_eq!(fifo.readers.load(Ordering::Relaxed), 0);
+        assert_eq!(fifo.writers.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn fifo_open_nonblock_rdonly_succeeds_without_writer() {
+        let fifo = Pipe::new_for_fifo();
+        let r = fifo.open_read(/* nonblocking */ true).expect("open_read");
+        assert_eq!(fifo.readers.load(Ordering::Relaxed), 1);
+        drop(r);
+        assert_eq!(fifo.readers.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn fifo_open_nonblock_wronly_enxio_without_reader() {
+        let fifo = Pipe::new_for_fifo();
+        let e = fifo.open_write(/* nonblocking */ true).unwrap_err();
+        assert_eq!(e, ENXIO);
+        assert_eq!(fifo.writers.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn fifo_open_nonblock_wronly_ok_with_reader() {
+        let fifo = Pipe::new_for_fifo();
+        let r = fifo.open_read(true).expect("open_read");
+        let w = fifo.open_write(true).expect("open_write");
+        assert_eq!(fifo.readers.load(Ordering::Relaxed), 1);
+        assert_eq!(fifo.writers.load(Ordering::Relaxed), 1);
+        drop(w);
+        drop(r);
+        assert_eq!(fifo.readers.load(Ordering::Relaxed), 0);
+        assert_eq!(fifo.writers.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn fifo_open_rdwr_always_succeeds_both_counts_one() {
+        let fifo = Pipe::new_for_fifo();
+        let (r, w) = fifo.open_rdwr();
+        assert_eq!(fifo.readers.load(Ordering::Relaxed), 1);
+        assert_eq!(fifo.writers.load(Ordering::Relaxed), 1);
+        drop(w);
+        drop(r);
+        assert_eq!(fifo.readers.load(Ordering::Relaxed), 0);
+        assert_eq!(fifo.writers.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn fifo_read_write_roundtrip_via_shared_pipe() {
+        let fifo = Pipe::new_for_fifo();
+        let r = fifo.open_read(true).expect("open_read");
+        let w = fifo.open_write(true).expect("open_write");
+        assert_eq!(w.write(b"hello"), Ok(5));
+        let mut buf = [0u8; 16];
+        let n = r.read(&mut buf).expect("read");
+        assert_eq!(&buf[..n], b"hello");
+    }
+
+    #[test]
+    fn fifo_blocking_rdonly_without_writer_returns_eagain_on_host() {
+        // On host (no scheduler), the blocking path bails out to EAGAIN
+        // after provisionally incrementing then rolling back the reader
+        // count. Asserts the rollback — counts must be zero again.
+        let fifo = Pipe::new_for_fifo();
+        let e = fifo.open_read(/* nonblocking */ false).unwrap_err();
+        assert_eq!(e, EAGAIN);
+        assert_eq!(fifo.readers.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn fifo_blocking_wronly_without_reader_returns_eagain_on_host() {
+        // Mirror of the read-side host test. When `open_write` is called
+        // without O_NONBLOCK and there is no reader, the provisional
+        // writer increment must be rolled back before returning.
+        let fifo = Pipe::new_for_fifo();
+        let e = fifo.open_write(/* nonblocking */ false).unwrap_err();
+        assert_eq!(e, EAGAIN);
+        assert_eq!(fifo.writers.load(Ordering::Relaxed), 0);
     }
 }

--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -262,12 +262,12 @@ impl Pipe {
                 if crate::process::with_signal_state_for_task(tid, |s| s.pending != 0)
                     .unwrap_or(false)
                 {
-                    // Roll back our provisional reader count so a later
-                    // retry sees a clean state, and wake any writer that
-                    // may have parked on us.
+                    // Roll back our provisional reader count and wake
+                    // any writer parked on the FIFO open rendezvous
+                    // queue — not wr_wait (that's for data writes).
                     let prev = self.readers.fetch_sub(1, Ordering::AcqRel);
                     if prev == 1 {
-                        self.wr_wait.wake_all();
+                        self.open_wait_w.wake_all();
                     }
                     return Err(crate::tty::KERN_ERESTARTSYS);
                 }
@@ -282,7 +282,7 @@ impl Pipe {
             // so test state stays consistent across calls.
             let prev = self.readers.fetch_sub(1, Ordering::AcqRel);
             if prev == 1 {
-                self.wr_wait.wake_all();
+                self.open_wait_w.wake_all();
             }
             Err(EAGAIN)
         }
@@ -331,7 +331,7 @@ impl Pipe {
                 {
                     let prev = self.writers.fetch_sub(1, Ordering::AcqRel);
                     if prev == 1 {
-                        self.rd_wait.wake_all();
+                        self.open_wait_r.wake_all();
                     }
                     return Err(crate::tty::KERN_ERESTARTSYS);
                 }
@@ -341,7 +341,7 @@ impl Pipe {
         {
             let prev = self.writers.fetch_sub(1, Ordering::AcqRel);
             if prev == 1 {
-                self.rd_wait.wake_all();
+                self.open_wait_r.wake_all();
             }
             Err(EAGAIN)
         }
@@ -353,14 +353,14 @@ impl Pipe {
     /// body. Each increments its own refcount and wakes the peer's
     /// rendezvous queue so any blocked `O_RDONLY` / `O_WRONLY` opener
     /// observes progress.
-    pub fn open_rdwr(self: &Arc<Self>) -> (Arc<PipeReadEnd>, Arc<PipeWriteEnd>) {
+    pub fn open_rdwr(self: &Arc<Self>, nonblocking: bool) -> (Arc<PipeReadEnd>, Arc<PipeWriteEnd>) {
         self.readers.fetch_add(1, Ordering::AcqRel);
         self.writers.fetch_add(1, Ordering::AcqRel);
         self.open_wait_r.wake_all();
         self.open_wait_w.wake_all();
         (
-            PipeReadEnd::new_arc(self.clone(), false),
-            PipeWriteEnd::new_arc(self.clone(), false),
+            PipeReadEnd::new_arc(self.clone(), nonblocking),
+            PipeWriteEnd::new_arc(self.clone(), nonblocking),
         )
     }
 }
@@ -921,7 +921,7 @@ mod tests {
     #[test]
     fn fifo_open_rdwr_always_succeeds_both_counts_one() {
         let fifo = Pipe::new_for_fifo();
-        let (r, w) = fifo.open_rdwr();
+        let (r, w) = fifo.open_rdwr(false);
         assert_eq!(fifo.readers.load(Ordering::Relaxed), 1);
         assert_eq!(fifo.writers.load(Ordering::Relaxed), 1);
         drop(w);

--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -897,7 +897,10 @@ mod tests {
     #[test]
     fn fifo_open_nonblock_wronly_enxio_without_reader() {
         let fifo = Pipe::new_for_fifo();
-        let e = fifo.open_write(/* nonblocking */ true).unwrap_err();
+        let e = match fifo.open_write(/* nonblocking */ true) {
+            Ok(_) => panic!("O_NONBLOCK|O_WRONLY without reader must ENXIO"),
+            Err(e) => e,
+        };
         assert_eq!(e, ENXIO);
         assert_eq!(fifo.writers.load(Ordering::Relaxed), 0);
     }
@@ -944,7 +947,10 @@ mod tests {
         // after provisionally incrementing then rolling back the reader
         // count. Asserts the rollback — counts must be zero again.
         let fifo = Pipe::new_for_fifo();
-        let e = fifo.open_read(/* nonblocking */ false).unwrap_err();
+        let e = match fifo.open_read(/* nonblocking */ false) {
+            Ok(_) => panic!("blocking open_read without writer must fail on host"),
+            Err(e) => e,
+        };
         assert_eq!(e, EAGAIN);
         assert_eq!(fifo.readers.load(Ordering::Relaxed), 0);
     }
@@ -955,7 +961,10 @@ mod tests {
         // without O_NONBLOCK and there is no reader, the provisional
         // writer increment must be rolled back before returning.
         let fifo = Pipe::new_for_fifo();
-        let e = fifo.open_write(/* nonblocking */ false).unwrap_err();
+        let e = match fifo.open_write(/* nonblocking */ false) {
+            Ok(_) => panic!("blocking open_write without reader must fail on host"),
+            Err(e) => e,
+        };
         assert_eq!(e, EAGAIN);
         assert_eq!(fifo.writers.load(Ordering::Relaxed), 0);
     }

--- a/kernel/tests/syscall_mkfifo.rs
+++ b/kernel/tests/syscall_mkfifo.rs
@@ -1,0 +1,259 @@
+//! Integration test for issue #377: `mknod(2)` / `mknodat(2)` on FIFOs.
+//!
+//! Drives the SYS_MKNOD / SYS_MKNODAT dispatch arms end-to-end:
+//! - `mknod(path, S_IFIFO|mode, 0)` creates a FIFO in ramfs.
+//! - `open(path, O_NONBLOCK|O_WRONLY)` on a FIFO without a reader
+//!   returns `-ENXIO`.
+//! - `open(path, O_NONBLOCK|O_RDONLY)` on a FIFO without a writer
+//!   succeeds.
+//! - A write to the O_RDWR end of a FIFO is observable on a subsequent
+//!   read from the same fd (same inode ring).
+//! - `mknod` with `S_IFCHR` (unsupported) returns `-EPERM`.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use core::ptr;
+
+use vibix::arch::x86_64::syscall::syscall_dispatch;
+use vibix::fs::{EEXIST, ENXIO, EPERM};
+use vibix::mem::vmatree::{Share, Vma};
+use vibix::mem::vmobject::AnonObject;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+use x86_64::structures::paging::PageTableFlags;
+
+const SYS_READ: u64 = 0;
+const SYS_WRITE: u64 = 1;
+const SYS_OPEN: u64 = 2;
+const SYS_CLOSE: u64 = 3;
+const SYS_MKNOD: u64 = 133;
+const SYS_MKNODAT: u64 = 259;
+
+const AT_FDCWD: i64 = -100;
+
+const O_RDONLY: u64 = 0o0;
+const O_WRONLY: u64 = 0o1;
+const O_RDWR: u64 = 0o2;
+const O_NONBLOCK: u64 = 0o4000;
+
+const S_IFIFO: u64 = 0o010_000;
+const S_IFCHR: u64 = 0o020_000;
+
+const USER_PAGE_VA: usize = 0x0000_2003_0000_0000;
+const USER_PAGE_LEN: usize = 4 * 4096;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    vibix::task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("mknod_creates_fifo", &(mknod_creates_fifo as fn())),
+        (
+            "mknod_fifo_then_open_eexist_on_recreate",
+            &(mknod_fifo_then_open_eexist_on_recreate as fn()),
+        ),
+        (
+            "open_nonblock_wronly_no_reader_enxio",
+            &(open_nonblock_wronly_no_reader_enxio as fn()),
+        ),
+        (
+            "open_nonblock_rdonly_no_writer_ok",
+            &(open_nonblock_rdonly_no_writer_ok as fn()),
+        ),
+        (
+            "fifo_rdwr_roundtrip_same_fd",
+            &(fifo_rdwr_roundtrip_same_fd as fn()),
+        ),
+        (
+            "mknodat_at_fdcwd_creates_fifo",
+            &(mknodat_at_fdcwd_creates_fifo as fn()),
+        ),
+        (
+            "mknod_unsupported_type_eperm",
+            &(mknod_unsupported_type_eperm as fn()),
+        ),
+    ];
+    for (name, t) in tests {
+        serial_println!("syscall_mkfifo: {}", name);
+        t.run();
+    }
+}
+
+fn install_user_staging_vma() {
+    static INSTALLED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+    if INSTALLED.swap(true, core::sync::atomic::Ordering::SeqCst) {
+        return;
+    }
+    let prot_pte =
+        (PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE).bits();
+    vibix::task::install_vma_on_current(Vma::new(
+        USER_PAGE_VA,
+        USER_PAGE_VA + USER_PAGE_LEN,
+        0x3,
+        prot_pte,
+        Share::Private,
+        AnonObject::new(Some(USER_PAGE_LEN / 4096)),
+        0,
+    ));
+    unsafe {
+        let dst = USER_PAGE_VA as *mut u8;
+        let mut i = 0;
+        while i < USER_PAGE_LEN {
+            ptr::write_volatile(dst.add(i), 0);
+            i += 4096;
+        }
+    }
+}
+
+fn stage(bytes: &[u8]) -> u64 {
+    install_user_staging_vma();
+    assert!(bytes.len() < 4096);
+    unsafe {
+        let dst = USER_PAGE_VA as *mut u8;
+        for (i, b) in bytes.iter().enumerate() {
+            ptr::write_volatile(dst.add(i), *b);
+        }
+        ptr::write_volatile(dst.add(bytes.len()), 0);
+    }
+    USER_PAGE_VA as u64
+}
+
+fn stage_payload(bytes: &[u8]) -> u64 {
+    assert!(bytes.len() <= USER_PAGE_LEN - 4096);
+    let va = USER_PAGE_VA as u64 + 4096;
+    unsafe {
+        let dst = va as *mut u8;
+        for (i, b) in bytes.iter().enumerate() {
+            ptr::write_volatile(dst.add(i), *b);
+        }
+    }
+    va
+}
+
+fn mknod(path: &[u8], mode: u64) -> i64 {
+    let uva = stage(path);
+    unsafe { syscall_dispatch(SYS_MKNOD, uva, mode, 0, 0, 0, 0) }
+}
+
+fn mknodat(dfd: i64, path: &[u8], mode: u64) -> i64 {
+    let uva = stage(path);
+    unsafe { syscall_dispatch(SYS_MKNODAT, dfd as u64, uva, mode, 0, 0, 0) }
+}
+
+fn open(path: &[u8], flags: u64) -> i64 {
+    let uva = stage(path);
+    unsafe { syscall_dispatch(SYS_OPEN, uva, flags, 0, 0, 0, 0) }
+}
+
+fn close(fd: i64) -> i64 {
+    unsafe { syscall_dispatch(SYS_CLOSE, fd as u64, 0, 0, 0, 0, 0) }
+}
+
+fn write_bytes(fd: i64, bytes: &[u8]) -> i64 {
+    let uva = stage_payload(bytes);
+    unsafe { syscall_dispatch(SYS_WRITE, fd as u64, uva, bytes.len() as u64, 0, 0, 0) }
+}
+
+fn read_bytes(fd: i64, out: &mut [u8]) -> i64 {
+    let buf_va = USER_PAGE_VA as u64 + 2 * 4096;
+    let n = unsafe { syscall_dispatch(SYS_READ, fd as u64, buf_va, out.len() as u64, 0, 0, 0) };
+    if n > 0 {
+        unsafe {
+            let src = buf_va as *const u8;
+            for i in 0..n as usize {
+                out[i] = ptr::read_volatile(src.add(i));
+            }
+        }
+    }
+    n
+}
+
+// --- Tests ---------------------------------------------------------------
+
+fn mknod_creates_fifo() {
+    let r = mknod(b"/tmp/fifo-basic", S_IFIFO | 0o644);
+    assert_eq!(r, 0, "mknod(S_IFIFO) must return 0, got {}", r);
+}
+
+fn mknod_fifo_then_open_eexist_on_recreate() {
+    let r = mknod(b"/tmp/fifo-eexist", S_IFIFO | 0o644);
+    assert_eq!(r, 0);
+    let r = mknod(b"/tmp/fifo-eexist", S_IFIFO | 0o644);
+    assert_eq!(
+        r, EEXIST,
+        "re-mknod of existing path must EEXIST, got {}",
+        r
+    );
+}
+
+fn open_nonblock_wronly_no_reader_enxio() {
+    let r = mknod(b"/tmp/fifo-wronly", S_IFIFO | 0o644);
+    assert_eq!(r, 0);
+    let r = open(b"/tmp/fifo-wronly", O_WRONLY | O_NONBLOCK);
+    assert_eq!(
+        r, ENXIO,
+        "O_NONBLOCK|O_WRONLY on FIFO w/o reader must ENXIO, got {}",
+        r
+    );
+}
+
+fn open_nonblock_rdonly_no_writer_ok() {
+    let r = mknod(b"/tmp/fifo-rdonly", S_IFIFO | 0o644);
+    assert_eq!(r, 0);
+    let fd = open(b"/tmp/fifo-rdonly", O_RDONLY | O_NONBLOCK);
+    assert!(
+        fd >= 3,
+        "O_NONBLOCK|O_RDONLY on FIFO w/o writer must succeed, got {}",
+        fd
+    );
+    close(fd);
+}
+
+fn fifo_rdwr_roundtrip_same_fd() {
+    let r = mknod(b"/tmp/fifo-rdwr", S_IFIFO | 0o644);
+    assert_eq!(r, 0);
+    // O_RDWR on a FIFO always succeeds and installs a dual-direction
+    // backend; a write then read on the same fd is a legal round-trip.
+    let fd = open(b"/tmp/fifo-rdwr", O_RDWR);
+    assert!(fd >= 3, "O_RDWR on FIFO must succeed, got {}", fd);
+
+    let payload = b"hello\0pipe";
+    let n = write_bytes(fd, payload);
+    assert_eq!(n as usize, payload.len(), "write returned {}", n);
+
+    let mut out = [0u8; 16];
+    let n = read_bytes(fd, &mut out[..payload.len()]);
+    assert_eq!(n as usize, payload.len(), "read returned {}", n);
+    assert_eq!(&out[..payload.len()], payload);
+
+    close(fd);
+}
+
+fn mknodat_at_fdcwd_creates_fifo() {
+    let r = mknodat(AT_FDCWD, b"/tmp/fifo-at", S_IFIFO | 0o644);
+    assert_eq!(r, 0, "mknodat(AT_FDCWD, S_IFIFO) must return 0, got {}", r);
+}
+
+fn mknod_unsupported_type_eperm() {
+    // S_IFCHR is not supported — no devtmpfs yet.
+    let r = mknod(b"/tmp/char-dev", S_IFCHR | 0o644);
+    assert_eq!(r, EPERM, "mknod(S_IFCHR) must return EPERM, got {}", r);
+}


### PR DESCRIPTION
Closes #377

## Summary
- Extends the VFS `InodeOps` trait with `mkfifo` and `fifo_pipe` methods (default bodies keep non-FIFO filesystems untouched) and grows ramfs with a `Fifo` body carrying a shared `Arc<Pipe>`.
- Teaches `Pipe` POSIX FIFO open rendezvous: new `open_read` / `open_write` / `open_rdwr` entry points drive blocking/NONBLOCK readers/writers against `open_wait_r` / `open_wait_w` queues with signal-safe rollback of the reader/writer refcount.
- Wires `SYS_MKNOD` (133) and `SYS_MKNODAT` (259) in the x86_64 dispatcher and teaches `openat()` a FIFO detour that installs a `PipeReadEnd` / `PipeWriteEnd` / dual-ended `FifoRdwrBackend` instead of a `VfsBackend`.
- Adds a `syscall_mkfifo` QEMU integration test covering the happy path, `EEXIST` on re-mknod, `ENXIO` on nonblocking O_WRONLY without a reader, nonblocking O_RDONLY without a writer, `O_RDWR` round-trip, `mknodat(AT_FDCWD)`, and `EPERM` for unsupported file types.

## Test plan
- [x] `cargo xtask build`
- [x] `cargo xtask smoke` (all 30 markers present)
- [x] `cargo test -p vibix --test syscall_mkfifo --target x86_64-unknown-none ...` — all 7 tests pass under QEMU
- [x] `cargo fmt --all -- --check` clean
- [ ] CI host unit tests (run on amd64 runner — local host is aarch64, pic8259 is x86-only)