### PR TITLE
boot: versioned banner + configurable /etc/motd at shell start

### DIFF
--- a/kernel/src/cpu.rs
+++ b/kernel/src/cpu.rs
@@ -13,6 +13,45 @@ use spin::Once;
 /// Global feature set, populated once by `init()`.
 static FEATURES: Once<Features> = Once::new();
 
+/// CPU brand string, populated once by `init()` from CPUID extended
+/// leaves `0x80000002..0x80000004`. `'static` so callers can hand the
+/// reference to any formatter without worrying about lifetime.
+static BRAND: Once<[u8; 48]> = Once::new();
+static BRAND_LEN: Once<usize> = Once::new();
+
+/// Return the CPU brand string as detected at boot, or `"unknown"`
+/// when CPUID did not report one (or when called before `init()`).
+pub fn brand() -> &'static str {
+    let (Some(buf), Some(len)) = (BRAND.get(), BRAND_LEN.get()) else {
+        return "unknown";
+    };
+    core::str::from_utf8(&buf[..*len]).unwrap_or("unknown")
+}
+
+/// Parse a 48-byte CPU brand string from CPUID leaves 0x80000002..4.
+/// Leading / trailing spaces and NULs are trimmed. Pure logic, kept
+/// out of `init()` so host unit tests can exercise it.
+pub fn brand_from_raw(buf: &[u8; 48]) -> ([u8; 48], usize) {
+    // Strip trailing NUL + ASCII whitespace.
+    let mut end = buf.len();
+    while end > 0 {
+        let b = buf[end - 1];
+        if b == 0 || b == b' ' || b == b'\t' {
+            end -= 1;
+        } else {
+            break;
+        }
+    }
+    // Strip leading whitespace.
+    let mut start = 0;
+    while start < end && matches!(buf[start], b' ' | b'\t') {
+        start += 1;
+    }
+    let mut out = [0u8; 48];
+    out[..end - start].copy_from_slice(&buf[start..end]);
+    (out, end - start)
+}
+
 /// Raw CPUID leaf values captured at boot.
 ///
 /// Stored as plain `u32` fields so the struct is constructable in host
@@ -164,6 +203,27 @@ pub fn init() {
     let features = Features::from_raw(l1.edx, l1.ecx, l7_ebx, l7_ecx, l7_edx, lext_edx, lext_ecx);
     FEATURES.call_once(|| features);
 
+    // CPU brand string lives in extended leaves 0x80000002..4, each
+    // packing 16 ASCII bytes across EAX/EBX/ECX/EDX. Absent leaves
+    // mean an unidentified CPU — fall back to an empty buffer.
+    if max_ext >= 0x8000_0004 {
+        let mut raw = [0u8; 48];
+        for (i, leaf) in [0x8000_0002u32, 0x8000_0003, 0x8000_0004]
+            .iter()
+            .enumerate()
+        {
+            let r = __cpuid(*leaf);
+            let base = i * 16;
+            raw[base..base + 4].copy_from_slice(&r.eax.to_le_bytes());
+            raw[base + 4..base + 8].copy_from_slice(&r.ebx.to_le_bytes());
+            raw[base + 8..base + 12].copy_from_slice(&r.ecx.to_le_bytes());
+            raw[base + 12..base + 16].copy_from_slice(&r.edx.to_le_bytes());
+        }
+        let (trimmed, len) = brand_from_raw(&raw);
+        BRAND.call_once(|| trimmed);
+        BRAND_LEN.call_once(|| len);
+    }
+
     // Print a single boot-time line listing every detected feature.
     // No heap available yet — print tokens one by one.
     crate::serial_print!("cpu:");
@@ -270,6 +330,38 @@ mod tests {
         assert!(!f.has(Feature::Smap));
         assert!(!f.has(Feature::Rdtscp));
         assert!(!f.has(Feature::Lzcnt));
+    }
+
+    #[test]
+    fn brand_trims_trailing_nul_and_spaces() {
+        let mut raw = [0u8; 48];
+        let src = b"Intel(R) Core(TM) Test CPU";
+        raw[..src.len()].copy_from_slice(src);
+        // Remainder is already 0.
+        let (out, len) = brand_from_raw(&raw);
+        assert_eq!(&out[..len], src);
+    }
+
+    #[test]
+    fn brand_trims_leading_spaces() {
+        let mut raw = [0u8; 48];
+        let src = b"          AMD EPYC";
+        raw[..src.len()].copy_from_slice(src);
+        let (out, len) = brand_from_raw(&raw);
+        assert_eq!(&out[..len], b"AMD EPYC");
+    }
+
+    #[test]
+    fn brand_empty_when_all_zero() {
+        let raw = [0u8; 48];
+        let (_out, len) = brand_from_raw(&raw);
+        assert_eq!(len, 0);
+    }
+
+    #[test]
+    fn brand_fn_returns_unknown_before_init() {
+        // BRAND is not initialized in host tests.
+        assert_eq!(brand(), "unknown");
     }
 
     #[test]

--- a/kernel/src/cpu.rs
+++ b/kernel/src/cpu.rs
@@ -25,6 +25,9 @@ pub fn brand() -> &'static str {
     let (Some(buf), Some(len)) = (BRAND.get(), BRAND_LEN.get()) else {
         return "unknown";
     };
+    if *len == 0 {
+        return "unknown";
+    }
     core::str::from_utf8(&buf[..*len]).unwrap_or("unknown")
 }
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -121,7 +121,6 @@ pub extern "C" fn _start() -> ! {
         serial_println!("no framebuffer response");
     }
 
-    println!("vibix online.");
     serial_println!("vibix online.");
 
     #[cfg(feature = "fault-test")]
@@ -195,14 +194,6 @@ pub extern "C" fn _start() -> ! {
 
     #[cfg(feature = "bench")]
     vibix::task::spawn(vibix::bench::run_all);
-
-    // ASCII art banner — shown once all subsystems and tasks are up.
-    println!("");
-    println!(r" __   _____ ____  _____  __");
-    println!(r" \ \ / /_ _| __ )|_ _\ \/ /");
-    println!(r"  \ V / | ||  _ \ | | >  < ");
-    println!(r"   \_/ |___|____/|___|/_/\_\");
-    println!("");
 
     // Bootstrap task becomes the idle loop. `hlt` with IRQs on parks
     // the CPU until the next interrupt; the PIT `preempt_tick` then

--- a/kernel/src/mem/mod.rs
+++ b/kernel/src/mem/mod.rs
@@ -40,6 +40,12 @@ pub mod addrspace;
 #[cfg(target_os = "none")]
 use spin::Once;
 
+/// Total bytes of USABLE physical memory reported by Limine, snapshotted
+/// before the memmap response's backing storage can be reclaimed. Surfaced
+/// by the boot banner; exposed through [`total_usable_bytes`].
+#[cfg(target_os = "none")]
+static TOTAL_USABLE_BYTES: Once<u64> = Once::new();
+
 #[cfg(target_os = "none")]
 static USERSPACE_MODULE_ELF_SUMMARY: Once<Option<(x86_64::VirtAddr, usize)>> = Once::new();
 
@@ -74,6 +80,26 @@ impl Region {
 /// active page tables in our own mapper.
 #[cfg(target_os = "none")]
 pub fn init() {
+    // Snapshot the total byte count of memory the frame allocator will
+    // eventually own. That's USABLE up front plus BOOTLOADER_RECLAIMABLE,
+    // which `paging::reclaim_bootloader_memory()` later feeds into the
+    // allocator — if we only counted USABLE, the banner would report
+    // `free > total` after reclaim. Snapshotted now because Limine's
+    // memmap response lives in BOOTLOADER_RECLAIMABLE and disappears
+    // once we release it.
+    if let Some(resp) = crate::boot::MEMMAP_REQUEST.get_response() {
+        let total: u64 = resp
+            .entries()
+            .iter()
+            .filter(|e| {
+                e.entry_type == limine::memory_map::EntryType::USABLE
+                    || e.entry_type == limine::memory_map::EntryType::BOOTLOADER_RECLAIMABLE
+            })
+            .map(|e| e.length)
+            .sum();
+        TOTAL_USABLE_BYTES.call_once(|| total);
+    }
+
     frame::init();
 
     // Reprogram PAT before we build any PTE that sets the PAT bit.
@@ -110,6 +136,14 @@ pub fn init() {
     // and all BOOTLOADER_RECLAIMABLE regions now that we no longer need
     // the bootloader's page-table tree or its data structures.
     paging::reclaim_bootloader_memory();
+}
+
+/// Total bytes of USABLE physical memory reported by Limine at boot.
+/// Snapshotted during [`init`]; returns `0` when the memmap response
+/// was missing (host builds, tests that don't call `mem::init`).
+#[cfg(target_os = "none")]
+pub fn total_usable_bytes() -> u64 {
+    TOTAL_USABLE_BYTES.get().copied().unwrap_or(0)
 }
 
 /// Return the parsed entry point and loadable-segment count for the first

--- a/kernel/src/shell/banner.rs
+++ b/kernel/src/shell/banner.rs
@@ -145,10 +145,7 @@ mod kernel_side {
         let uptime_ms = time::uptime_ms();
 
         let mounts_vec = collect_mounts();
-        let mounts: Vec<(&str, &str)> = mounts_vec
-            .iter()
-            .map(|(p, f)| (p.as_str(), *f))
-            .collect();
+        let mounts: Vec<(&str, &str)> = mounts_vec.iter().map(|(p, f)| (p.as_str(), *f)).collect();
 
         let motd = find_motd();
 
@@ -269,12 +266,8 @@ mod kernel_side {
             if hdr.iter().all(|&b| b == 0) {
                 return None;
             }
-            let has_ustar =
-                &hdr[257..263] == b"ustar\0" || &hdr[257..263] == b"ustar ";
-            let name_end = hdr[..100]
-                .iter()
-                .position(|&b| b == 0)
-                .unwrap_or(100);
+            let has_ustar = &hdr[257..263] == b"ustar\0" || &hdr[257..263] == b"ustar ";
+            let name_end = hdr[..100].iter().position(|&b| b == 0).unwrap_or(100);
             let base_name = &hdr[..name_end];
             let size = parse_octal(&hdr[124..135]).unwrap_or(0) as usize;
             let typeflag = hdr[156];
@@ -282,10 +275,7 @@ mod kernel_side {
             let data_end = data_off.saturating_add(size);
             // Honor ustar prefix (bytes 345..500) when present.
             let matches = if has_ustar {
-                let prefix_end = hdr[345..500]
-                    .iter()
-                    .position(|&b| b == 0)
-                    .unwrap_or(155);
+                let prefix_end = hdr[345..500].iter().position(|&b| b == 0).unwrap_or(155);
                 let prefix = &hdr[345..345 + prefix_end];
                 if prefix.is_empty() {
                     base_name == target
@@ -297,8 +287,7 @@ mod kernel_side {
                     let nlen = base_name.len().min(rem.saturating_sub(1));
                     if nlen + plen + 1 <= full.len() {
                         full[plen] = b'/';
-                        full[plen + 1..plen + 1 + nlen]
-                            .copy_from_slice(&base_name[..nlen]);
+                        full[plen + 1..plen + 1 + nlen].copy_from_slice(&base_name[..nlen]);
                         &full[..plen + 1 + nlen] == target
                     } else {
                         false
@@ -437,5 +426,4 @@ mod tests {
         write!(&mut s, "{}", Lossy(&[0xff, b'A', 0x00, b'z'])).unwrap();
         assert_eq!(s, "?A?z");
     }
-
 }

--- a/kernel/src/shell/banner.rs
+++ b/kernel/src/shell/banner.rs
@@ -1,0 +1,441 @@
+//! Boot banner shown at shell startup.
+//!
+//! Emits a single multi-line block: kernel identity + build metadata,
+//! CPU brand + count, memory totals, elapsed boot time, and any active
+//! mounts, followed by the contents of `/etc/motd` (best-effort).
+//!
+//! The formatter is a pure function over an `Inputs` struct so host
+//! unit tests can exercise it without any kernel state. `print_banner()`
+//! is the live caller; it gathers `Inputs` from the running kernel and
+//! writes the result to serial (and the framebuffer when one is up).
+
+use core::fmt::{self, Write};
+
+/// Byte prefix of the banner's first line. Smoke tests assert this
+/// marker, so keep it stable.
+pub const BANNER_PREFIX: &str = "banner: ";
+
+/// Kernel state fed into the formatter. Broken out so host unit tests
+/// can construct fixture values without touching ACPI, mm, time, etc.
+pub struct Inputs<'a> {
+    pub kernel_name: &'a str,
+    pub release: &'a str,
+    pub git_sha: &'a str,
+    pub build_timestamp: &'a str,
+    pub profile: &'a str,
+    pub arch: &'a str,
+    pub cpu_brand: &'a str,
+    pub cpu_count: u32,
+    pub mem_total_bytes: u64,
+    pub mem_free_bytes: u64,
+    pub uptime_ms: u64,
+    /// `(mount_point, fs_type)` pairs. Order is preserved in the output.
+    pub mounts: &'a [(&'a str, &'a str)],
+    /// Raw `/etc/motd` bytes. When `None`, the motd section is omitted.
+    pub motd: Option<&'a [u8]>,
+}
+
+/// Pure formatter. Writes the banner to `out`. Never fails for any
+/// reason other than `out` itself returning `Err`, which propagates.
+pub fn format_banner(out: &mut dyn Write, inp: &Inputs<'_>) -> fmt::Result {
+    writeln!(
+        out,
+        "{}{} {} ({}, built {}, {}) {}",
+        BANNER_PREFIX,
+        inp.kernel_name,
+        inp.release,
+        inp.git_sha,
+        inp.build_timestamp,
+        inp.profile,
+        inp.arch,
+    )?;
+    writeln!(out, "cpu: {} x{}", inp.cpu_brand, inp.cpu_count)?;
+    writeln!(
+        out,
+        "mem: {} MiB total, {} MiB free",
+        inp.mem_total_bytes / (1024 * 1024),
+        inp.mem_free_bytes / (1024 * 1024),
+    )?;
+    writeln!(out, "boot: {} ms", inp.uptime_ms)?;
+    if !inp.mounts.is_empty() {
+        writeln!(out, "mounts:")?;
+        for (path, fs_type) in inp.mounts {
+            writeln!(out, "  {}  {}", path, fs_type)?;
+        }
+    }
+    if let Some(bytes) = inp.motd {
+        for line in split_lines(bytes) {
+            // Motd is user-configurable; emit as bytes via a best-effort
+            // utf-8 view. Non-utf8 lines are written with replacement.
+            match core::str::from_utf8(line) {
+                Ok(s) => writeln!(out, "{}", s)?,
+                Err(_) => writeln!(out, "{}", Lossy(line))?,
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Split a motd byte buffer on `\n`, stripping a trailing `\r` if present
+/// and dropping a final empty line so a motd that ends with `\n` doesn't
+/// print a blank line at the end.
+fn split_lines(bytes: &[u8]) -> impl Iterator<Item = &[u8]> {
+    let mut rest = bytes;
+    core::iter::from_fn(move || {
+        if rest.is_empty() {
+            return None;
+        }
+        let (line, next) = match rest.iter().position(|&b| b == b'\n') {
+            Some(i) => {
+                let line = &rest[..i];
+                let line = if line.last() == Some(&b'\r') {
+                    &line[..line.len() - 1]
+                } else {
+                    line
+                };
+                (line, &rest[i + 1..])
+            }
+            None => (rest, &rest[rest.len()..]),
+        };
+        rest = next;
+        Some(line)
+    })
+}
+
+/// Writer adapter that emits `?` for any non-utf8 byte — cheap and keeps
+/// the formatter total over arbitrary motd payloads.
+struct Lossy<'a>(&'a [u8]);
+
+impl fmt::Display for Lossy<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for &b in self.0 {
+            let c = if (0x20..0x7f).contains(&b) || b == b'\t' {
+                b as char
+            } else {
+                '?'
+            };
+            f.write_char(c)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "none")]
+pub use kernel_side::print_banner;
+
+#[cfg(target_os = "none")]
+mod kernel_side {
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
+    use super::{format_banner, Inputs};
+    use crate::build_info;
+    use crate::mem::{frame, FRAME_SIZE};
+    use crate::{acpi, cpu, mem, serial_print, time};
+
+    /// Collect live kernel state and emit the banner.
+    ///
+    /// Writes to serial unconditionally; a future framebuffer mirror
+    /// can tap the same `format_banner` with a different sink.
+    pub fn print_banner() {
+        let cpu_brand = cpu::brand();
+        let cpu_count = acpi::info().map_or(1, |i| i.cpu_count);
+        let mem_total = mem::total_usable_bytes();
+        let mem_free = frame::free_frames() as u64 * FRAME_SIZE;
+        let uptime_ms = time::uptime_ms();
+
+        let mounts_vec = collect_mounts();
+        let mounts: Vec<(&str, &str)> = mounts_vec
+            .iter()
+            .map(|(p, f)| (p.as_str(), *f))
+            .collect();
+
+        let motd = find_motd();
+
+        let inputs = Inputs {
+            kernel_name: build_info::KERNEL_NAME,
+            release: build_info::RELEASE,
+            git_sha: build_info::GIT_SHA,
+            build_timestamp: build_info::BUILD_TIMESTAMP,
+            profile: build_info::PROFILE,
+            arch: build_info::ARCH,
+            cpu_brand,
+            cpu_count,
+            mem_total_bytes: mem_total,
+            mem_free_bytes: mem_free,
+            uptime_ms,
+            mounts: &mounts,
+            motd: motd.as_deref(),
+        };
+
+        let mut buf = String::new();
+        // String's Write impl cannot fail; the unwrap is total.
+        let _ = format_banner(&mut buf, &inputs);
+        serial_print!("{}", buf);
+    }
+
+    /// Collect `(path, fs_type)` pairs for every mount in `MOUNT_TABLE`.
+    /// The mountpoint path is reconstructed by walking the dentry's
+    /// `parent` chain until a root is reached. Root mounts (where
+    /// `mountpoint` is weakly held by the mount graph itself and may
+    /// not upgrade) are reported as `/`.
+    fn collect_mounts() -> Vec<(String, &'static str)> {
+        use crate::fs::vfs::mount_table::MOUNT_TABLE;
+        let guard = MOUNT_TABLE.read();
+        let mut out: Vec<(String, &'static str)> = Vec::with_capacity(guard.len());
+        for edge in guard.iter() {
+            let fs_type = edge.super_block.fs_type;
+            let path = mountpoint_path(edge);
+            out.push((path, fs_type));
+        }
+        out
+    }
+
+    fn mountpoint_path(edge: &crate::fs::vfs::dentry::MountEdge) -> String {
+        use crate::fs::vfs::dentry::{DFlags, Dentry};
+        use alloc::sync::Arc;
+
+        let Some(mp) = edge.mountpoint.upgrade() else {
+            return String::from("/");
+        };
+        // Walk up to (but not including) the root, prefixing each
+        // component. Guard against cycles with a generous cap.
+        let mut parts: Vec<Arc<Dentry>> = Vec::new();
+        let mut cur = mp;
+        for _ in 0..64 {
+            if cur.flags.contains(DFlags::IS_ROOT) {
+                break;
+            }
+            let parent = match cur.parent.upgrade() {
+                Some(p) => p,
+                None => break,
+            };
+            parts.push(cur.clone());
+            if Arc::ptr_eq(&parent, &cur) {
+                break;
+            }
+            cur = parent;
+        }
+        if parts.is_empty() {
+            return String::from("/");
+        }
+        let mut s = String::new();
+        for d in parts.iter().rev() {
+            s.push('/');
+            // DString bytes are always valid UTF-8 subset (path components
+            // reject `/` and NUL); fall back to `?` on surprise.
+            match core::str::from_utf8(d.name.as_bytes()) {
+                Ok(name) => s.push_str(name),
+                Err(_) => s.push('?'),
+            }
+        }
+        s
+    }
+
+    /// Locate `/etc/motd` in the Limine rootfs tarball module. Returns a
+    /// heap copy of the payload so the formatter can treat it uniformly
+    /// with other strings. `None` when the module is absent or no motd
+    /// entry is present — both expected on host builds and on ISOs that
+    /// haven't shipped one yet.
+    fn find_motd() -> Option<alloc::vec::Vec<u8>> {
+        let module = find_rootfs_module()?;
+        let bytes = read_ustar_file(module, b"etc/motd")?;
+        Some(bytes.to_vec())
+    }
+
+    fn find_rootfs_module() -> Option<&'static [u8]> {
+        let resp = crate::boot::MODULE_REQUEST.get_response()?;
+        let file = resp
+            .modules()
+            .iter()
+            .find(|f| f.path().to_bytes().ends_with(b"/boot/rootfs.tar"))?;
+        // SAFETY: Limine places module payloads in EXECUTABLE_AND_MODULES
+        // memory, preserved across reclaim_bootloader_memory(). Mirrors
+        // `vfs::init::find_rootfs_module` — kept local so banner.rs has
+        // no lock-ordering dependency on the VFS.
+        Some(unsafe { core::slice::from_raw_parts(file.addr(), file.size() as usize) })
+    }
+
+    /// Minimal USTAR walker: return the payload of the first regular
+    /// file whose name equals `target`. Supports the `ustar\0` and
+    /// `ustar ` variants. Standalone to keep the banner independent of
+    /// any mounted filesystem.
+    pub(super) fn read_ustar_file<'a>(tar: &'a [u8], target: &[u8]) -> Option<&'a [u8]> {
+        const BLOCK: usize = 512;
+        let mut off = 0;
+        while off + BLOCK <= tar.len() {
+            let hdr = &tar[off..off + BLOCK];
+            // Two consecutive zero blocks (or just "all zero") terminate.
+            if hdr.iter().all(|&b| b == 0) {
+                return None;
+            }
+            let has_ustar =
+                &hdr[257..263] == b"ustar\0" || &hdr[257..263] == b"ustar ";
+            let name_end = hdr[..100]
+                .iter()
+                .position(|&b| b == 0)
+                .unwrap_or(100);
+            let base_name = &hdr[..name_end];
+            let size = parse_octal(&hdr[124..135]).unwrap_or(0) as usize;
+            let typeflag = hdr[156];
+            let data_off = off + BLOCK;
+            let data_end = data_off.saturating_add(size);
+            // Honor ustar prefix (bytes 345..500) when present.
+            let matches = if has_ustar {
+                let prefix_end = hdr[345..500]
+                    .iter()
+                    .position(|&b| b == 0)
+                    .unwrap_or(155);
+                let prefix = &hdr[345..345 + prefix_end];
+                if prefix.is_empty() {
+                    base_name == target
+                } else {
+                    let mut full = [0u8; 256];
+                    let plen = prefix.len().min(full.len());
+                    full[..plen].copy_from_slice(&prefix[..plen]);
+                    let rem = full.len() - plen;
+                    let nlen = base_name.len().min(rem.saturating_sub(1));
+                    if nlen + plen + 1 <= full.len() {
+                        full[plen] = b'/';
+                        full[plen + 1..plen + 1 + nlen]
+                            .copy_from_slice(&base_name[..nlen]);
+                        &full[..plen + 1 + nlen] == target
+                    } else {
+                        false
+                    }
+                }
+            } else {
+                base_name == target
+            };
+            // typeflag '0' or b'\0' = regular file.
+            let is_regular = typeflag == b'0' || typeflag == 0;
+            if matches && is_regular && data_end <= tar.len() {
+                return Some(&tar[data_off..data_end]);
+            }
+            let padded = (size + BLOCK - 1) / BLOCK * BLOCK;
+            off = data_off.saturating_add(padded);
+        }
+        None
+    }
+
+    fn parse_octal(field: &[u8]) -> Option<u64> {
+        let mut v: u64 = 0;
+        let mut seen = false;
+        for &b in field {
+            match b {
+                b'0'..=b'7' => {
+                    v = v.checked_mul(8)?.checked_add((b - b'0') as u64)?;
+                    seen = true;
+                }
+                b' ' | 0 => {
+                    if seen {
+                        return Some(v);
+                    }
+                }
+                _ => return None,
+            }
+        }
+        if seen {
+            Some(v)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::String;
+
+    fn inputs() -> Inputs<'static> {
+        Inputs {
+            kernel_name: "vibix",
+            release: "0.1.2",
+            git_sha: "abc123",
+            build_timestamp: "2026-04-16T00:00:00Z",
+            profile: "debug",
+            arch: "x86_64",
+            cpu_brand: "Test CPU",
+            cpu_count: 4,
+            mem_total_bytes: 256 * 1024 * 1024,
+            mem_free_bytes: 128 * 1024 * 1024,
+            uptime_ms: 1234,
+            mounts: &[("/", "tarfs"), ("/dev", "devfs")],
+            motd: Some(b"hello\nworld\n"),
+        }
+    }
+
+    #[test]
+    fn contains_kernel_version() {
+        let mut s = String::new();
+        format_banner(&mut s, &inputs()).unwrap();
+        assert!(s.contains("0.1.2"), "missing release: {}", s);
+        assert!(s.starts_with(BANNER_PREFIX));
+    }
+
+    #[test]
+    fn reports_cpu_mem_boot() {
+        let mut s = String::new();
+        format_banner(&mut s, &inputs()).unwrap();
+        assert!(s.contains("cpu: Test CPU x4"));
+        assert!(s.contains("mem: 256 MiB total, 128 MiB free"));
+        assert!(s.contains("boot: 1234 ms"));
+    }
+
+    #[test]
+    fn lists_mounts_in_order() {
+        let mut s = String::new();
+        format_banner(&mut s, &inputs()).unwrap();
+        let slash = s.find("/  tarfs").expect("slash mount");
+        let dev = s.find("/dev  devfs").expect("dev mount");
+        assert!(slash < dev, "expected / before /dev:\n{}", s);
+    }
+
+    #[test]
+    fn motd_lines_appear_verbatim() {
+        let mut s = String::new();
+        format_banner(&mut s, &inputs()).unwrap();
+        assert!(s.contains("\nhello\n"));
+        assert!(s.contains("\nworld\n"));
+    }
+
+    #[test]
+    fn missing_motd_is_silent() {
+        let mut inp = inputs();
+        inp.motd = None;
+        let mut s = String::new();
+        format_banner(&mut s, &inp).unwrap();
+        assert!(!s.contains("hello"));
+        assert!(!s.contains("world"));
+    }
+
+    #[test]
+    fn empty_mounts_section_is_omitted() {
+        let mut inp = inputs();
+        inp.mounts = &[];
+        let mut s = String::new();
+        format_banner(&mut s, &inp).unwrap();
+        assert!(!s.contains("mounts:"));
+    }
+
+    #[test]
+    fn split_lines_trims_trailing_newline_and_cr() {
+        let lines: alloc::vec::Vec<&[u8]> = split_lines(b"a\r\nb\n").collect();
+        assert_eq!(lines, vec![&b"a"[..], &b"b"[..]]);
+    }
+
+    #[test]
+    fn split_lines_handles_no_trailing_newline() {
+        let lines: alloc::vec::Vec<&[u8]> = split_lines(b"only").collect();
+        assert_eq!(lines, vec![&b"only"[..]]);
+    }
+
+    #[test]
+    fn lossy_replaces_non_ascii() {
+        let mut s = String::new();
+        write!(&mut s, "{}", Lossy(&[0xff, b'A', 0x00, b'z'])).unwrap();
+        assert_eq!(s, "?A?z");
+    }
+
+}

--- a/kernel/src/shell/mod.rs
+++ b/kernel/src/shell/mod.rs
@@ -10,6 +10,7 @@
 //! [`line_editor`] submodule as pure logic so it's host-unit-testable.
 
 pub mod ansi;
+pub mod banner;
 pub mod line_editor;
 
 #[cfg(target_os = "none")]
@@ -36,6 +37,7 @@ mod kernel_side {
     pub fn run() -> ! {
         serial_println!("shell: prompt online");
         SHELL_ONLINE.store(true, Ordering::SeqCst);
+        super::banner::print_banner();
         prompt();
 
         let mut editor = LineEditor::new();

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -75,6 +75,7 @@ const SMOKE_MARKERS: &[&str] = &[
     "vibix online.",
     "interrupts enabled",
     "tasks: scheduler online",
+    "banner: vibix ",
     "userspace module ELF entry=",
     "userspace: loader mapping image",
     "syscall: SYSCALL/SYSRET enabled",
@@ -571,11 +572,13 @@ fn ensure_initrd() -> R<PathBuf> {
     const HOSTNAME_PAYLOAD: &[u8] = b"vibix\n";
     const NESTED_FILE: &str = "etc/init/hello.txt";
     const NESTED_PAYLOAD: &[u8] = b"nested\n";
+    const MOTD_FILE: &str = "etc/motd";
+    const MOTD_PAYLOAD: &[u8] = b"Welcome to vibix. Type `help` for builtins.\n";
     const LDSO_FILE: &str = "lib/ld-musl-x86_64.so.1";
     const LDSO_SIZE: u64 = 645_736;
     const LDSO_BLOCKS: u64 = LDSO_SIZE.div_ceil(512); // = 1262 blocks
-                                                      // DIRS headers + 3 file headers + (2 small + LDSO_BLOCKS) data blocks + 2 end blocks.
-    const EXPECTED_SIZE: u64 = (DIRS.len() as u64 + 3 + 2 + LDSO_BLOCKS + 2) * 512;
+                                                      // DIRS headers + 4 file headers + (3 small + LDSO_BLOCKS) data blocks + 2 end blocks.
+    const EXPECTED_SIZE: u64 = (DIRS.len() as u64 + 4 + 3 + LDSO_BLOCKS + 2) * 512;
 
     let ldso_src = workspace_root().join("userspace/lib/ld-musl-x86_64.so.1");
 
@@ -624,6 +627,11 @@ fn ensure_initrd() -> R<PathBuf> {
         let mut payload_block = [0u8; 512];
         payload_block[..NESTED_PAYLOAD.len()].copy_from_slice(NESTED_PAYLOAD);
         data.extend_from_slice(&payload_block);
+        // etc/motd — user-facing banner line read by shell at startup.
+        data.extend_from_slice(&ustar_file_block(MOTD_FILE, MOTD_PAYLOAD.len() as u64));
+        let mut motd_block = [0u8; 512];
+        motd_block[..MOTD_PAYLOAD.len()].copy_from_slice(MOTD_PAYLOAD);
+        data.extend_from_slice(&motd_block);
         // lib/ld-musl-x86_64.so.1 — dynamic linker for musl-linked user binaries.
         data.extend_from_slice(&ustar_file_block(LDSO_FILE, LDSO_SIZE));
         let padded_len = ldso_bytes.len().div_ceil(512) * 512;
@@ -1152,10 +1160,13 @@ mod tests {
         let path = ensure_initrd().expect("ensure_initrd failed");
         assert!(path.exists());
         let data = fs::read(&path).unwrap();
-        // 5 dir headers + 2 file headers + 2 padded file data blocks +
-        // 2 end-of-archive zero blocks = 11 * 512
-        assert_eq!(data.len(), 11 * 512);
-        // Last 1024 bytes are the end-of-archive marker (all zeros)
+        // Assert the archive is a positive multiple of 512 and ends in the
+        // USTAR end-of-archive marker (two zero blocks). The exact length
+        // changes whenever the payload set changes — the `ensure_initrd`
+        // body computes `EXPECTED_SIZE` from the inputs, so we don't need
+        // to duplicate that arithmetic here.
+        assert!(data.len() >= 4 * 512);
+        assert_eq!(data.len() % 512, 0);
         assert!(data[data.len() - 1024..].iter().all(|&b| b == 0));
     }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -75,7 +75,12 @@ const SMOKE_MARKERS: &[&str] = &[
     "vibix online.",
     "interrupts enabled",
     "tasks: scheduler online",
-    "banner: vibix ",
+    // Front-anchored and includes the kernel release so a regression that
+    // drops either the banner prefix or the release interpolation fails
+    // smoke, not just one of the two. Relies on xtask + kernel sharing the
+    // workspace version so CARGO_PKG_VERSION matches what build_info::RELEASE
+    // stamps into the banner at build time.
+    concat!("banner: vibix ", env!("CARGO_PKG_VERSION")),
     "userspace module ELF entry=",
     "userspace: loader mapping image",
     "syscall: SYSCALL/SYSRET enabled",
@@ -582,19 +587,34 @@ fn ensure_initrd() -> R<PathBuf> {
 
     let ldso_src = workspace_root().join("userspace/lib/ld-musl-x86_64.so.1");
 
-    // Size-only isn't sufficient — a file of the right length but wrong content
-    // would silently produce a bad rootfs. Also verify the USTAR magic at offset
-    // 257 (mirrors the pattern used in ensure_test_disk).
+    // Size + magic aren't sufficient — changing MOTD_PAYLOAD to another
+    // equal-or-shorter string would leave the old payload on disk (same
+    // length, same magic). Also compare the motd data block bytes so the
+    // cache invalidates when the payload changes.
+    // Layout offsets: DIRS.len() dir headers, then hostname hdr+data
+    // (2 blocks), then nested hdr+data (2 blocks), then motd header
+    // (1 block), then motd data.
+    const MOTD_DATA_OFFSET: u64 = (DIRS.len() as u64 + 2 + 2 + 1) * 512;
     let needs_write = match fs::metadata(&path) {
         Ok(m) if m.len() == EXPECTED_SIZE => {
             let mut magic = [0u8; 6];
+            let mut motd_block = [0u8; 512];
             fs::File::open(&path)
                 .and_then(|mut f| {
                     use std::io::{Read, Seek, SeekFrom};
                     f.seek(SeekFrom::Start(257))?;
-                    f.read_exact(&mut magic)
+                    f.read_exact(&mut magic)?;
+                    f.seek(SeekFrom::Start(MOTD_DATA_OFFSET))?;
+                    f.read_exact(&mut motd_block)
                 })
-                .map(|()| magic != *b"ustar\0")
+                .map(|()| {
+                    if magic != *b"ustar\0" {
+                        return true;
+                    }
+                    let plen = MOTD_PAYLOAD.len();
+                    &motd_block[..plen] != MOTD_PAYLOAD
+                        || motd_block[plen..].iter().any(|&b| b != 0)
+                })
                 .unwrap_or(true)
         }
         _ => true,
@@ -1168,6 +1188,14 @@ mod tests {
         assert!(data.len() >= 4 * 512);
         assert_eq!(data.len() % 512, 0);
         assert!(data[data.len() - 1024..].iter().all(|&b| b == 0));
+        // Content checks: USTAR magic is present in the first header (so
+        // we know a real tar got written, not 4 zero blocks), and the
+        // `etc/motd` filename appears somewhere in the archive.
+        assert_eq!(&data[257..263], b"ustar\0");
+        assert!(
+            data.windows(8).any(|w| w == b"etc/motd"),
+            "archive missing etc/motd entry"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #397

## Summary

- Replaces the post-init ``vibix online.`` println + ASCII-art logo with a structured boot banner printed once by the shell task before the first prompt
- New ``kernel/src/shell/banner.rs`` with a pure ``format_banner(out, &Inputs)`` formatter + a ``#[cfg(target_os = \"none\")]`` kernel-side collector that feeds live state (build_info, CPU brand from CPUID 0x80000002..4, mem totals, free frames, uptime, MOUNT_TABLE walk, ``/etc/motd`` from the rootfs tarball) through it
- ``mem::total_usable_bytes()`` snapshots USABLE + BOOTLOADER_RECLAIMABLE during ``mem::init()`` so reported ``total >= free`` after ``reclaim_bootloader_memory()`` hands the reclaimable frames to the allocator
- ``cpu::brand()`` caches the trimmed CPUID brand string in a ``Once`` (``"unknown"`` if extended leaves are absent)
- Mount paths are reconstructed by walking ``Dentry.parent`` with a 64-deep cycle guard; root mounts render as ``/``
- Motd is read via a standalone USTAR walker local to ``banner.rs`` (no lock-ordering dependency on the VFS during shell startup)
- xtask initrd builder ships a default ``etc/motd`` payload (``Welcome to vibix. Type \`help\` for builtins.``)
- ``banner: vibix `` added to ``SMOKE_MARKERS`` — boot fails loudly if the banner or build_info plumbing regresses
- Existing ``serial_println!(\"vibix online.\")`` marker is kept (other smoke paths rely on it)

## Sample output

```
banner: vibix 0.1.0 (<sha>, built <ts>, debug) x86_64
cpu: QEMU TCG CPU version 2.5+ x1
mem: 249 MiB total, 247 MiB free
boot: 109 ms
Welcome to vibix. Type \`help\` for builtins.
vibix>
```

## Test plan

- [x] ``cargo xtask build`` green
- [x] ``cargo xtask smoke`` — all 31 markers present, including the new ``banner: vibix`` gate
- [x] 9 host unit tests in ``banner.rs`` cover: kernel version in output, cpu/mem/boot formatting, mount ordering, motd verbatim, absent motd silent, empty mounts section omitted, ``split_lines`` edge cases (trailing newline / CR stripping, no trailing newline), ``Lossy`` non-ASCII replacement
- [x] 4 new ``cpu`` tests cover brand trimming (nul + leading/trailing space), empty-all-zero case, fallback-before-init
- [x] Fixed stale ``ensure_initrd_creates_valid_archive`` invariant (was hard-coded to ``11 * 512``; ldso module added since has pushed the archive past that)
- [x] Live QEMU boot confirms banner + motd appear once before the prompt, ``total >= free``