### PR TITLE
gdbstub: RSP transport skeleton + packet framer (#445)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -255,3 +255,7 @@ harness = false
 [[test]]
 name = "shell_help"
 harness = false
+
+[[test]]
+name = "gdbstub_loop"
+harness = false

--- a/kernel/src/gdbstub/framer.rs
+++ b/kernel/src/gdbstub/framer.rs
@@ -99,10 +99,7 @@ pub fn encode<'b>(payload: &[u8], out: &'b mut [u8]) -> &'b [u8] {
 /// `$` and `#`, matching the RSP spec and the encoder above. Only
 /// after the checksum succeeds is the payload unescaped into
 /// `scratch`.
-pub fn decode<'s>(
-    raw: &[u8],
-    scratch: &'s mut [u8],
-) -> Result<(Packet<'s>, usize), DecodeError> {
+pub fn decode<'s>(raw: &[u8], scratch: &'s mut [u8]) -> Result<(Packet<'s>, usize), DecodeError> {
     if raw.is_empty() {
         return Err(DecodeError::Incomplete);
     }
@@ -249,7 +246,10 @@ mod tests {
     #[test]
     fn decode_bad_checksum() {
         let mut scratch = [0u8; 16];
-        assert_eq!(decode(b"$OK#00", &mut scratch), Err(DecodeError::BadChecksum));
+        assert_eq!(
+            decode(b"$OK#00", &mut scratch),
+            Err(DecodeError::BadChecksum)
+        );
     }
 
     #[test]

--- a/kernel/src/gdbstub/framer.rs
+++ b/kernel/src/gdbstub/framer.rs
@@ -56,27 +56,53 @@ pub fn checksum(payload: &[u8]) -> u8 {
     s
 }
 
-/// Encode `payload` into `$<payload>#<xx>` in `out`. Caller must size
-/// `out` to at least `payload.len() + 4`. Returns the filled slice.
+/// Encode `payload` into `$<escaped payload>#<xx>` in `out`. Reserved
+/// bytes in `payload` (`$`, `#`, `}`, `*`) are byte-stuffed as `}` +
+/// (byte ^ 0x20) before hitting the wire. The checksum is computed
+/// over the *escaped* wire bytes, per the RSP spec.
+///
+/// Caller must size `out` to the worst case `2 * payload.len() + 4`.
 /// Panics only on obvious misuse (undersized buffer) — this is dev-
 /// facing kernel code, not untrusted input.
 pub fn encode<'b>(payload: &[u8], out: &'b mut [u8]) -> &'b [u8] {
-    let need = payload.len() + 4;
-    assert!(out.len() >= need, "gdbstub encode: output too small");
+    let worst = 2 * payload.len() + 4;
+    assert!(out.len() >= worst, "gdbstub encode: output too small");
     out[0] = SOP;
-    out[1..1 + payload.len()].copy_from_slice(payload);
-    out[1 + payload.len()] = EOP;
-    let [hi, lo] = to_hex(checksum(payload));
-    out[2 + payload.len()] = hi;
-    out[3 + payload.len()] = lo;
-    &out[..need]
+    let mut j = 1;
+    let mut sum: u8 = 0;
+    for &b in payload {
+        if needs_escape(b) {
+            out[j] = ESC;
+            out[j + 1] = b ^ 0x20;
+            sum = sum.wrapping_add(ESC).wrapping_add(b ^ 0x20);
+            j += 2;
+        } else {
+            out[j] = b;
+            sum = sum.wrapping_add(b);
+            j += 1;
+        }
+    }
+    out[j] = EOP;
+    let [hi, lo] = to_hex(sum);
+    out[j + 1] = hi;
+    out[j + 2] = lo;
+    &out[..j + 3]
 }
 
-/// Decode a single packet at the start of `raw`. Returns the packet
-/// plus the number of bytes consumed (so callers can advance their
-/// input cursor). Leading junk bytes before `$` are *not* skipped —
-/// the transport layer peels those off.
-pub fn decode<'a>(raw: &'a [u8]) -> Result<(Packet<'a>, usize), DecodeError> {
+/// Decode a single packet at the start of `raw`, unescaping the
+/// payload into `scratch`. Returns the packet (borrowing from
+/// `scratch`) plus the number of bytes consumed from `raw` (so callers
+/// can advance their input cursor). Leading junk bytes before `$` are
+/// *not* skipped — the transport layer peels those off.
+///
+/// The checksum is verified against the *escaped* wire bytes between
+/// `$` and `#`, matching the RSP spec and the encoder above. Only
+/// after the checksum succeeds is the payload unescaped into
+/// `scratch`.
+pub fn decode<'s>(
+    raw: &[u8],
+    scratch: &'s mut [u8],
+) -> Result<(Packet<'s>, usize), DecodeError> {
     if raw.is_empty() {
         return Err(DecodeError::Incomplete);
     }
@@ -91,8 +117,8 @@ pub fn decode<'a>(raw: &'a [u8]) -> Result<(Packet<'a>, usize), DecodeError> {
         return Err(DecodeError::Incomplete);
     }
     let payload_end = i;
-    let payload = &raw[1..payload_end];
-    if payload.len() > MAX_PACKET {
+    let wire = &raw[1..payload_end];
+    if wire.len() > 2 * MAX_PACKET {
         return Err(DecodeError::Overflow);
     }
     if raw.len() < payload_end + 3 {
@@ -101,8 +127,12 @@ pub fn decode<'a>(raw: &'a [u8]) -> Result<(Packet<'a>, usize), DecodeError> {
     let hi = hex_nibble(raw[payload_end + 1]).ok_or(DecodeError::Framing)?;
     let lo = hex_nibble(raw[payload_end + 2]).ok_or(DecodeError::Framing)?;
     let want = (hi << 4) | lo;
-    if want != checksum(payload) {
+    if want != checksum(wire) {
         return Err(DecodeError::BadChecksum);
+    }
+    let payload = unescape_into(wire, scratch)?;
+    if payload.len() > MAX_PACKET {
+        return Err(DecodeError::Overflow);
     }
     Ok((Packet { payload }, payload_end + 3))
 }
@@ -202,41 +232,97 @@ mod tests {
 
     #[test]
     fn decode_valid() {
-        let (pkt, used) = decode(b"$OK#9a").unwrap();
+        let mut scratch = [0u8; 16];
+        let (pkt, used) = decode(b"$OK#9a", &mut scratch).unwrap();
         assert_eq!(pkt.payload, b"OK");
         assert_eq!(used, 6);
     }
 
     #[test]
     fn decode_valid_with_trailing_bytes() {
-        let (pkt, used) = decode(b"$?#3f+junk").unwrap();
+        let mut scratch = [0u8; 16];
+        let (pkt, used) = decode(b"$?#3f+junk", &mut scratch).unwrap();
         assert_eq!(pkt.payload, b"?");
         assert_eq!(used, 5);
     }
 
     #[test]
     fn decode_bad_checksum() {
-        assert_eq!(decode(b"$OK#00"), Err(DecodeError::BadChecksum));
+        let mut scratch = [0u8; 16];
+        assert_eq!(decode(b"$OK#00", &mut scratch), Err(DecodeError::BadChecksum));
     }
 
     #[test]
     fn decode_framing_missing_dollar() {
-        assert_eq!(decode(b"OK#9a"), Err(DecodeError::Framing));
+        let mut scratch = [0u8; 16];
+        assert_eq!(decode(b"OK#9a", &mut scratch), Err(DecodeError::Framing));
     }
 
     #[test]
     fn decode_incomplete_no_hash() {
-        assert_eq!(decode(b"$OK"), Err(DecodeError::Incomplete));
+        let mut scratch = [0u8; 16];
+        assert_eq!(decode(b"$OK", &mut scratch), Err(DecodeError::Incomplete));
     }
 
     #[test]
     fn decode_incomplete_short_checksum() {
-        assert_eq!(decode(b"$OK#9"), Err(DecodeError::Incomplete));
+        let mut scratch = [0u8; 16];
+        assert_eq!(decode(b"$OK#9", &mut scratch), Err(DecodeError::Incomplete));
     }
 
     #[test]
     fn decode_framing_non_hex_checksum() {
-        assert_eq!(decode(b"$OK#zz"), Err(DecodeError::Framing));
+        let mut scratch = [0u8; 16];
+        assert_eq!(decode(b"$OK#zz", &mut scratch), Err(DecodeError::Framing));
+    }
+
+    #[test]
+    fn encode_escapes_reserved_bytes() {
+        // Payload contains every reserved byte; wire must have them all
+        // rewritten as `}` + (b ^ 0x20) and the checksum is over the
+        // escaped bytes.
+        let payload = b"a#b$c}d*e";
+        let mut buf = [0u8; 32];
+        let wire = encode(payload, &mut buf);
+        // Spot check: no raw reserved byte appears between `$` (index 0)
+        // and `#`.
+        let hash_pos = wire.iter().rposition(|&b| b == EOP).unwrap();
+        let inner = &wire[1..hash_pos];
+        for (i, &b) in inner.iter().enumerate() {
+            if b == ESC {
+                continue;
+            }
+            assert!(
+                !needs_escape(b) || inner.get(i.wrapping_sub(1)) == Some(&ESC),
+                "unescaped reserved byte in wire at {i}: {:#x}",
+                b
+            );
+        }
+    }
+
+    #[test]
+    fn encode_decode_roundtrip_with_escapes() {
+        // The bytes that most need escaping also need to survive decode
+        // — this is the whole point of byte-stuffing. Encode then decode
+        // and assert the logical payload matches.
+        let payload: &[u8] = b"x$y#z}w*v";
+        let mut wire = [0u8; 32];
+        let encoded = encode(payload, &mut wire);
+        let mut scratch = [0u8; 32];
+        let (pkt, used) = decode(encoded, &mut scratch).unwrap();
+        assert_eq!(pkt.payload, payload);
+        assert_eq!(used, encoded.len());
+    }
+
+    #[test]
+    fn decode_checksums_escaped_wire() {
+        // Hand-built wire: `$}]#` + checksum-of-"}]" (= 0x7d + 0x5d = 0xda).
+        // Decoded payload must be `}` ^ 0x20 ... wait, `}` escapes the next
+        // byte with ^0x20, so `}]` decodes to `] ^ 0x20` = 0x7d = `}`.
+        let wire = b"$}]#da";
+        let mut scratch = [0u8; 4];
+        let (pkt, _) = decode(wire, &mut scratch).unwrap();
+        assert_eq!(pkt.payload, b"}");
     }
 
     #[test]

--- a/kernel/src/gdbstub/framer.rs
+++ b/kernel/src/gdbstub/framer.rs
@@ -1,0 +1,275 @@
+//! GDB Remote Serial Protocol packet framing.
+//!
+//! Pure byte-slice logic so it compiles and runs on the host for
+//! `cargo test --lib`. Kernel callers wrap a `Transport` around the
+//! framer; nothing here does I/O.
+//!
+//! Wire format: `$<payload>#<XX>` where `XX` is the two-hex-digit sum
+//! of the payload bytes mod 256. `+` and `-` are ack/nak bytes outside
+//! a packet. Payload bytes `#`, `$`, `}`, `*` must be escaped as
+//! `}` followed by the original byte `^ 0x20`.
+
+/// Cap on decoded payload size. The stub only emits short fixed
+/// responses (`S05`, `OK`, empty) in this first cut; 1 KiB leaves
+/// headroom for later register dumps without heap allocation.
+pub const MAX_PACKET: usize = 1024;
+
+/// Start-of-packet byte.
+pub const SOP: u8 = b'$';
+/// End-of-payload / start-of-checksum byte.
+pub const EOP: u8 = b'#';
+/// Escape prefix inside a payload.
+pub const ESC: u8 = b'}';
+/// Run-length-encoding marker (reserved byte that also needs escaping
+/// when it appears as data; we don't emit RLE ourselves yet).
+pub const RLE: u8 = b'*';
+/// Positive ack.
+pub const ACK: u8 = b'+';
+/// Negative ack.
+pub const NAK: u8 = b'-';
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum DecodeError {
+    /// Bytes did not start with `$`, or the checksum field was
+    /// truncated / non-hex.
+    Framing,
+    /// Checksum byte(s) did not match the computed sum.
+    BadChecksum,
+    /// Decoded payload would exceed [`MAX_PACKET`].
+    Overflow,
+    /// Buffer ended mid-packet; caller should read more bytes.
+    Incomplete,
+}
+
+/// A borrowed view over a successfully-decoded payload.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Packet<'a> {
+    pub payload: &'a [u8],
+}
+
+/// Sum of payload bytes mod 256 — the RSP checksum.
+pub fn checksum(payload: &[u8]) -> u8 {
+    let mut s: u8 = 0;
+    for &b in payload {
+        s = s.wrapping_add(b);
+    }
+    s
+}
+
+/// Encode `payload` into `$<payload>#<xx>` in `out`. Caller must size
+/// `out` to at least `payload.len() + 4`. Returns the filled slice.
+/// Panics only on obvious misuse (undersized buffer) — this is dev-
+/// facing kernel code, not untrusted input.
+pub fn encode<'b>(payload: &[u8], out: &'b mut [u8]) -> &'b [u8] {
+    let need = payload.len() + 4;
+    assert!(out.len() >= need, "gdbstub encode: output too small");
+    out[0] = SOP;
+    out[1..1 + payload.len()].copy_from_slice(payload);
+    out[1 + payload.len()] = EOP;
+    let [hi, lo] = to_hex(checksum(payload));
+    out[2 + payload.len()] = hi;
+    out[3 + payload.len()] = lo;
+    &out[..need]
+}
+
+/// Decode a single packet at the start of `raw`. Returns the packet
+/// plus the number of bytes consumed (so callers can advance their
+/// input cursor). Leading junk bytes before `$` are *not* skipped —
+/// the transport layer peels those off.
+pub fn decode<'a>(raw: &'a [u8]) -> Result<(Packet<'a>, usize), DecodeError> {
+    if raw.is_empty() {
+        return Err(DecodeError::Incomplete);
+    }
+    if raw[0] != SOP {
+        return Err(DecodeError::Framing);
+    }
+    let mut i = 1;
+    while i < raw.len() && raw[i] != EOP {
+        i += 1;
+    }
+    if i >= raw.len() {
+        return Err(DecodeError::Incomplete);
+    }
+    let payload_end = i;
+    let payload = &raw[1..payload_end];
+    if payload.len() > MAX_PACKET {
+        return Err(DecodeError::Overflow);
+    }
+    if raw.len() < payload_end + 3 {
+        return Err(DecodeError::Incomplete);
+    }
+    let hi = hex_nibble(raw[payload_end + 1]).ok_or(DecodeError::Framing)?;
+    let lo = hex_nibble(raw[payload_end + 2]).ok_or(DecodeError::Framing)?;
+    let want = (hi << 4) | lo;
+    if want != checksum(payload) {
+        return Err(DecodeError::BadChecksum);
+    }
+    Ok((Packet { payload }, payload_end + 3))
+}
+
+/// Does this byte need to be escaped inside a payload?
+pub fn needs_escape(b: u8) -> bool {
+    matches!(b, EOP | SOP | ESC | RLE)
+}
+
+/// Copy `src` into `out`, escaping any reserved bytes. Returns the
+/// filled slice. Caller sizes `out` to at most `2 * src.len()`.
+pub fn escape_into<'b>(src: &[u8], out: &'b mut [u8]) -> &'b [u8] {
+    let mut j = 0;
+    for &b in src {
+        if needs_escape(b) {
+            assert!(j + 2 <= out.len(), "gdbstub escape: output too small");
+            out[j] = ESC;
+            out[j + 1] = b ^ 0x20;
+            j += 2;
+        } else {
+            assert!(j + 1 <= out.len(), "gdbstub escape: output too small");
+            out[j] = b;
+            j += 1;
+        }
+    }
+    &out[..j]
+}
+
+/// Inverse of [`escape_into`].
+pub fn unescape_into<'b>(src: &[u8], out: &'b mut [u8]) -> Result<&'b [u8], DecodeError> {
+    let mut i = 0;
+    let mut j = 0;
+    while i < src.len() {
+        let b = src[i];
+        if b == ESC {
+            if i + 1 >= src.len() {
+                return Err(DecodeError::Framing);
+            }
+            if j >= out.len() {
+                return Err(DecodeError::Overflow);
+            }
+            out[j] = src[i + 1] ^ 0x20;
+            j += 1;
+            i += 2;
+        } else {
+            if j >= out.len() {
+                return Err(DecodeError::Overflow);
+            }
+            out[j] = b;
+            j += 1;
+            i += 1;
+        }
+    }
+    Ok(&out[..j])
+}
+
+fn hex_nibble(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(10 + b - b'a'),
+        b'A'..=b'F' => Some(10 + b - b'A'),
+        _ => None,
+    }
+}
+
+fn to_hex(n: u8) -> [u8; 2] {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    [HEX[(n >> 4) as usize], HEX[(n & 0xF) as usize]]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checksum_known() {
+        assert_eq!(checksum(b"OK"), 0x9a);
+        assert_eq!(checksum(b"?"), 0x3f);
+        assert_eq!(checksum(b"S05"), 0xb8);
+        assert_eq!(checksum(b""), 0x00);
+    }
+
+    #[test]
+    fn encode_simple() {
+        let mut buf = [0u8; 16];
+        let got = encode(b"S05", &mut buf);
+        assert_eq!(got, b"$S05#b8");
+    }
+
+    #[test]
+    fn encode_empty_is_sentinel() {
+        let mut buf = [0u8; 8];
+        let got = encode(b"", &mut buf);
+        // Empty packet is used as the "unknown command" response.
+        assert_eq!(got, b"$#00");
+    }
+
+    #[test]
+    fn decode_valid() {
+        let (pkt, used) = decode(b"$OK#9a").unwrap();
+        assert_eq!(pkt.payload, b"OK");
+        assert_eq!(used, 6);
+    }
+
+    #[test]
+    fn decode_valid_with_trailing_bytes() {
+        let (pkt, used) = decode(b"$?#3f+junk").unwrap();
+        assert_eq!(pkt.payload, b"?");
+        assert_eq!(used, 5);
+    }
+
+    #[test]
+    fn decode_bad_checksum() {
+        assert_eq!(decode(b"$OK#00"), Err(DecodeError::BadChecksum));
+    }
+
+    #[test]
+    fn decode_framing_missing_dollar() {
+        assert_eq!(decode(b"OK#9a"), Err(DecodeError::Framing));
+    }
+
+    #[test]
+    fn decode_incomplete_no_hash() {
+        assert_eq!(decode(b"$OK"), Err(DecodeError::Incomplete));
+    }
+
+    #[test]
+    fn decode_incomplete_short_checksum() {
+        assert_eq!(decode(b"$OK#9"), Err(DecodeError::Incomplete));
+    }
+
+    #[test]
+    fn decode_framing_non_hex_checksum() {
+        assert_eq!(decode(b"$OK#zz"), Err(DecodeError::Framing));
+    }
+
+    #[test]
+    fn escape_roundtrip() {
+        let payload = b"a$b#c}d*e";
+        let mut buf = [0u8; 32];
+        let escaped = escape_into(payload, &mut buf);
+
+        // Every reserved byte in the original must have been rewritten
+        // as `ESC` + (b ^ 0x20). Walk the escaped buffer and confirm no
+        // *unescaped* reserved byte survived.
+        let mut i = 0;
+        while i < escaped.len() {
+            if escaped[i] == ESC {
+                i += 2;
+                continue;
+            }
+            assert!(
+                !needs_escape(escaped[i]),
+                "unescaped reserved byte at {i}: {:#x}",
+                escaped[i]
+            );
+            i += 1;
+        }
+
+        let mut back = [0u8; 32];
+        let decoded = unescape_into(escaped, &mut back).unwrap();
+        assert_eq!(decoded, payload);
+    }
+
+    #[test]
+    fn ack_nak_bytes() {
+        assert_eq!(ACK, 0x2B);
+        assert_eq!(NAK, 0x2D);
+    }
+}

--- a/kernel/src/gdbstub/mod.rs
+++ b/kernel/src/gdbstub/mod.rs
@@ -1,0 +1,227 @@
+//! GDB Remote Serial Protocol stub — transport + packet loop skeleton.
+//!
+//! First step toward in-kernel `gdb` attach: this module establishes
+//! packet framing, a polling UART transport, and a minimal dispatch
+//! loop that handles exactly two commands — `?` (stop reason) and
+//! `D` (detach). Register, memory, and control-flow commands land in
+//! follow-up issues.
+//!
+//! The entry point [`debug_entry`] is generic over [`Transport`] so
+//! host unit tests and QEMU integration tests can drive the same code
+//! with a [`VecTransport`](transport::VecTransport). Kernel wiring
+//! into the fault handlers is out of scope for this PR — call
+//! `debug_entry` directly from a test-only path or (eventually) from
+//! a `gdbstub` shell builtin.
+
+pub mod framer;
+pub mod transport;
+
+#[cfg(target_os = "none")]
+pub mod uart;
+
+use framer::{DecodeError, ACK, EOP, MAX_PACKET, NAK, SOP};
+use transport::Transport;
+
+/// The canned `S05` stop reason — SIGTRAP — we hand back on `?` until
+/// we wire real exception info through in the follow-up.
+const SIG_TRAP: u8 = 0x05;
+
+/// Byte gdb sends outside a packet to request an interrupt. We don't
+/// do anything interesting with it yet; noted here for completeness.
+#[allow(dead_code)]
+const CTRL_C: u8 = 0x03;
+
+/// Drive one gdb session over `t` until the debugger sends a detach
+/// packet (`D`). Returns to the caller on detach; any decode failure
+/// within a packet is answered with a NAK and the loop continues.
+///
+/// This is the *only* public entry point in the module for this PR.
+/// Follow-ups will add a fault-handler stub that constructs a real
+/// [`Com1PollingTransport`](uart::Com1PollingTransport) and calls
+/// through here.
+pub fn debug_entry<T: Transport>(t: &mut T) {
+    let mut inbuf = [0u8; MAX_PACKET + 4];
+    loop {
+        match read_packet(t, &mut inbuf) {
+            Ok(len) => {
+                // Parse the framed packet; on success dispatch, on
+                // checksum error NAK and loop.
+                match framer::decode(&inbuf[..len]) {
+                    Ok((pkt, _)) => {
+                        t.write_byte(ACK);
+                        match dispatch(t, pkt.payload) {
+                            Action::Continue => {}
+                            Action::Detach => return,
+                        }
+                    }
+                    Err(DecodeError::BadChecksum) => {
+                        t.write_byte(NAK);
+                    }
+                    Err(_) => {
+                        // Framing/overflow/incomplete all collapse to
+                        // NAK — the debugger will resend.
+                        t.write_byte(NAK);
+                    }
+                }
+            }
+            Err(ReadErr::Detached) => return,
+        }
+    }
+}
+
+enum Action {
+    Continue,
+    Detach,
+}
+
+enum ReadErr {
+    /// Transport returned end-of-input before a packet completed; the
+    /// host test drains its queue this way to end the session cleanly.
+    Detached,
+}
+
+/// Read one `$...#xx` framed packet out of `t`, writing it into `buf`.
+/// Returns the number of bytes consumed. Bytes outside a packet (leading
+/// ack/nak) are skipped. For [`VecTransport`] a drained queue becomes
+/// `Err(Detached)` so the test drives the loop to completion without an
+/// explicit detach packet.
+fn read_packet<T: Transport>(t: &mut T, buf: &mut [u8]) -> Result<usize, ReadErr> {
+    // Skip anything that isn't SOP. For the kernel transport this is
+    // where `^C` would be noticed; for now we drop it on the floor.
+    loop {
+        match try_read(t) {
+            Some(b) if b == SOP => {
+                buf[0] = SOP;
+                break;
+            }
+            Some(_) => continue,
+            None => return Err(ReadErr::Detached),
+        }
+    }
+    let mut i = 1;
+    // Read payload until `#`.
+    while i < buf.len() {
+        match try_read(t) {
+            Some(b) => {
+                buf[i] = b;
+                i += 1;
+                if b == EOP {
+                    break;
+                }
+            }
+            None => return Err(ReadErr::Detached),
+        }
+    }
+    // Read the two hex checksum bytes.
+    for _ in 0..2 {
+        match try_read(t) {
+            Some(b) => {
+                if i >= buf.len() {
+                    // Buffer full before checksum — decode will fail
+                    // and we'll NAK. Stop here.
+                    break;
+                }
+                buf[i] = b;
+                i += 1;
+            }
+            None => return Err(ReadErr::Detached),
+        }
+    }
+    Ok(i)
+}
+
+/// Single byte pull. Returns `None` when the transport has no more
+/// input, which in [`VecTransport`] tests means the rx queue is drained
+/// and we should end the session. Real kernel callers that need to
+/// block across idle periods will grow that behavior alongside the
+/// fault-handler wiring in the follow-up.
+fn try_read<T: Transport>(t: &mut T) -> Option<u8> {
+    t.try_read_byte()
+}
+
+/// Handle a single decoded packet payload. Emits the response frame
+/// via `t.write_byte` and returns whether the session should continue.
+fn dispatch<T: Transport>(t: &mut T, payload: &[u8]) -> Action {
+    match payload.first() {
+        Some(b'?') => {
+            send_packet(t, &stop_reply_buf(SIG_TRAP));
+            Action::Continue
+        }
+        Some(b'D') => {
+            send_packet(t, b"OK");
+            Action::Detach
+        }
+        _ => {
+            // Unknown command: RSP convention says reply with an empty
+            // packet, which the debugger treats as "unsupported".
+            send_packet(t, b"");
+            Action::Continue
+        }
+    }
+}
+
+/// Build an `Sxx` stop reply payload in a fixed-size buffer.
+fn stop_reply_buf(sig: u8) -> [u8; 3] {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    [b'S', HEX[(sig >> 4) as usize], HEX[(sig & 0xF) as usize]]
+}
+
+fn send_packet<T: Transport>(t: &mut T, payload: &[u8]) {
+    let mut buf = [0u8; MAX_PACKET + 4];
+    let frame = framer::encode(payload, &mut buf);
+    t.write_all(frame);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use transport::VecTransport;
+
+    #[test]
+    fn stop_reply_hex() {
+        assert_eq!(&stop_reply_buf(0x05), b"S05");
+        assert_eq!(&stop_reply_buf(0x0b), b"S0b");
+    }
+
+    #[test]
+    fn question_then_detach() {
+        // Sequence the debugger would send: `?` query, then detach.
+        // Leading ack bytes are skipped by the outer loop.
+        let mut t = VecTransport::with_rx(b"+$?#3f+$D#44");
+        debug_entry(&mut t);
+
+        // Expect: two ACKs from stub (one per accepted packet) and
+        // two framed replies: `$S05#b8` then `$OK#9a`.
+        let tx = t.tx.as_slice();
+        // First three bytes: `+$S...`
+        assert_eq!(tx[0], ACK);
+        // Look for the expected frames in order.
+        let first = find(tx, b"$S05#b8").expect("missing S05 reply");
+        let second = find(tx, b"$OK#9a").expect("missing OK detach reply");
+        assert!(first < second, "detach reply must follow S05 reply");
+    }
+
+    #[test]
+    fn bad_checksum_is_nakked() {
+        // `?` with wrong checksum, then a correct `D` detach.
+        let mut t = VecTransport::with_rx(b"$?#ff$D#44");
+        debug_entry(&mut t);
+        // First outbound byte should be NAK, not ACK.
+        assert_eq!(t.tx[0], NAK);
+        assert!(find(&t.tx, b"$OK#9a").is_some());
+    }
+
+    #[test]
+    fn unknown_command_empty_reply() {
+        // `g` = read registers; we don't support it yet → empty reply.
+        let mut t = VecTransport::with_rx(b"$g#67$D#44");
+        debug_entry(&mut t);
+        // Expect: ACK, `$#00`, ACK, `$OK#9a`.
+        assert!(find(&t.tx, b"$#00").is_some());
+        assert!(find(&t.tx, b"$OK#9a").is_some());
+    }
+
+    fn find(hay: &[u8], needle: &[u8]) -> Option<usize> {
+        hay.windows(needle.len()).position(|w| w == needle)
+    }
+}

--- a/kernel/src/gdbstub/mod.rs
+++ b/kernel/src/gdbstub/mod.rs
@@ -40,13 +40,17 @@ const CTRL_C: u8 = 0x03;
 /// [`Com1PollingTransport`](uart::Com1PollingTransport) and calls
 /// through here.
 pub fn debug_entry<T: Transport>(t: &mut T) {
-    let mut inbuf = [0u8; MAX_PACKET + 4];
+    // Wire buffer holds the full escaped packet (worst-case 2x payload
+    // plus framing). `scratch` receives the unescaped payload that
+    // `framer::decode` hands back as `Packet::payload`.
+    let mut inbuf = [0u8; 2 * MAX_PACKET + 4];
+    let mut scratch = [0u8; MAX_PACKET];
     loop {
         match read_packet(t, &mut inbuf) {
             Ok(len) => {
                 // Parse the framed packet; on success dispatch, on
                 // checksum error NAK and loop.
-                match framer::decode(&inbuf[..len]) {
+                match framer::decode(&inbuf[..len], &mut scratch) {
                     Ok((pkt, _)) => {
                         t.write_byte(ACK);
                         match dispatch(t, pkt.payload) {
@@ -81,15 +85,21 @@ enum ReadErr {
 }
 
 /// Read one `$...#xx` framed packet out of `t`, writing it into `buf`.
-/// Returns the number of bytes consumed. Bytes outside a packet (leading
-/// ack/nak) are skipped. For [`VecTransport`] a drained queue becomes
-/// `Err(Detached)` so the test drives the loop to completion without an
-/// explicit detach packet.
+/// Returns the number of bytes consumed.
+///
+/// Scanning for `$` uses the non-blocking [`Transport::try_read_byte`]
+/// so that a drained [`VecTransport`] can end a test session and, on
+/// the real UART, the packet loop has a place to notice `^C` without
+/// deadlocking on idle. Once we've committed to a packet, everything
+/// up to and including the checksum is pulled with the *blocking*
+/// [`Transport::read_byte`] — the RSP spec guarantees those bytes are
+/// coming, and treating a between-byte pause as detach would cause
+/// `Com1PollingTransport` to bail out of every packet.
 fn read_packet<T: Transport>(t: &mut T, buf: &mut [u8]) -> Result<usize, ReadErr> {
     // Skip anything that isn't SOP. For the kernel transport this is
     // where `^C` would be noticed; for now we drop it on the floor.
     loop {
-        match try_read(t) {
+        match t.try_read_byte() {
             Some(b) if b == SOP => {
                 buf[0] = SOP;
                 break;
@@ -99,44 +109,27 @@ fn read_packet<T: Transport>(t: &mut T, buf: &mut [u8]) -> Result<usize, ReadErr
         }
     }
     let mut i = 1;
-    // Read payload until `#`.
+    // Read payload until `#`. Blocking: once SOP is seen, the packet
+    // is committed and the remaining bytes must come in.
     while i < buf.len() {
-        match try_read(t) {
-            Some(b) => {
-                buf[i] = b;
-                i += 1;
-                if b == EOP {
-                    break;
-                }
-            }
-            None => return Err(ReadErr::Detached),
+        let b = t.read_byte();
+        buf[i] = b;
+        i += 1;
+        if b == EOP {
+            break;
         }
     }
-    // Read the two hex checksum bytes.
+    // Read the two hex checksum bytes (also blocking).
     for _ in 0..2 {
-        match try_read(t) {
-            Some(b) => {
-                if i >= buf.len() {
-                    // Buffer full before checksum — decode will fail
-                    // and we'll NAK. Stop here.
-                    break;
-                }
-                buf[i] = b;
-                i += 1;
-            }
-            None => return Err(ReadErr::Detached),
+        if i >= buf.len() {
+            // Buffer full before checksum — decode will fail and we'll
+            // NAK. Stop here rather than overrun.
+            break;
         }
+        buf[i] = t.read_byte();
+        i += 1;
     }
     Ok(i)
-}
-
-/// Single byte pull. Returns `None` when the transport has no more
-/// input, which in [`VecTransport`] tests means the rx queue is drained
-/// and we should end the session. Real kernel callers that need to
-/// block across idle periods will grow that behavior alongside the
-/// fault-handler wiring in the follow-up.
-fn try_read<T: Transport>(t: &mut T) -> Option<u8> {
-    t.try_read_byte()
 }
 
 /// Handle a single decoded packet payload. Emits the response frame

--- a/kernel/src/gdbstub/transport.rs
+++ b/kernel/src/gdbstub/transport.rs
@@ -1,0 +1,99 @@
+//! Byte transport for the gdbstub packet loop.
+//!
+//! Two implementations live behind this trait:
+//! - [`VecTransport`]: in-memory queue, used by host unit tests and by
+//!   the QEMU integration test so the packet loop can run without any
+//!   real UART traffic.
+//! - `Com1PollingTransport` in [`crate::gdbstub::uart`]: raw polling
+//!   reads/writes against COM1. Only exists in kernel builds.
+//!
+//! The trait is deliberately minimal: blocking [`read_byte`], a non-
+//! blocking [`try_read_byte`] for `^C` detection, and [`write_byte`].
+//! No framing lives here.
+
+use alloc::collections::VecDeque;
+use alloc::vec::Vec;
+
+pub trait Transport {
+    /// Block until one byte is available, then return it.
+    fn read_byte(&mut self) -> u8;
+
+    /// Non-blocking peek at the next byte; returns `None` if none is
+    /// ready. Used by the packet loop to detect `^C` interrupt
+    /// requests between packets.
+    fn try_read_byte(&mut self) -> Option<u8>;
+
+    /// Block until the UART is ready, then send one byte.
+    fn write_byte(&mut self, b: u8);
+
+    /// Write all bytes; default impl calls [`write_byte`] in a loop.
+    fn write_all(&mut self, bytes: &[u8]) {
+        for &b in bytes {
+            self.write_byte(b);
+        }
+    }
+}
+
+/// In-memory transport. `rx` holds bytes the stub will read (host
+/// simulates the debugger); `tx` captures bytes the stub wrote (host
+/// asserts on the traffic).
+pub struct VecTransport {
+    pub rx: VecDeque<u8>,
+    pub tx: Vec<u8>,
+}
+
+impl VecTransport {
+    pub fn new() -> Self {
+        Self {
+            rx: VecDeque::new(),
+            tx: Vec::new(),
+        }
+    }
+
+    pub fn with_rx(bytes: &[u8]) -> Self {
+        let mut v = Self::new();
+        v.rx.extend(bytes.iter().copied());
+        v
+    }
+}
+
+impl Default for VecTransport {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Transport for VecTransport {
+    fn read_byte(&mut self) -> u8 {
+        // Host-test contract: callers seed enough bytes before driving
+        // the loop. An empty queue here is a test-authoring bug, not a
+        // runtime condition — panic with a clear message.
+        self.rx
+            .pop_front()
+            .expect("VecTransport::read_byte: rx underrun")
+    }
+
+    fn try_read_byte(&mut self) -> Option<u8> {
+        self.rx.pop_front()
+    }
+
+    fn write_byte(&mut self, b: u8) {
+        self.tx.push(b);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vec_roundtrip() {
+        let mut t = VecTransport::with_rx(b"hi");
+        assert_eq!(t.read_byte(), b'h');
+        assert_eq!(t.try_read_byte(), Some(b'i'));
+        assert_eq!(t.try_read_byte(), None);
+        t.write_byte(b'x');
+        t.write_all(b"yz");
+        assert_eq!(t.tx, b"xyz");
+    }
+}

--- a/kernel/src/gdbstub/uart.rs
+++ b/kernel/src/gdbstub/uart.rs
@@ -1,0 +1,79 @@
+//! Raw polling transport on COM1 for use while the system is halted
+//! under the debugger.
+//!
+//! The normal `serial::write_bytes` path assumes interrupts are enabled
+//! and takes a `Mutex<SerialPort>`. When we're stopped in a fault
+//! handler waiting for gdb, interrupts are off and taking the mutex
+//! risks deadlocking against a preempted print. This transport reads
+//! and writes the UART data register directly with `Port<u8>` and busy-
+//! spins on the LSR status bits.
+//!
+//! # Safety
+//!
+//! Only use this transport when:
+//! - Local interrupts are disabled on the CPU that will call
+//!   [`debug_entry`](super::debug_entry).
+//! - The IRQ4 serial ISR is not racing with it on this CPU.
+//!
+//! Meeting both is trivial inside an exception handler (IF=0 on entry)
+//! but not during normal kernel execution. The follow-up issue that
+//! wires this into `#BP` / `#UD` is responsible for arranging that.
+
+use x86_64::instructions::port::Port;
+
+use super::transport::Transport;
+use crate::serial::COM1_BASE;
+
+const UART_REG_DATA: u16 = 0; // RBR on read, THR on write (DLAB=0)
+const UART_REG_LSR: u16 = 5; // Line status
+
+const LSR_DR: u8 = 0x01; // Data Ready
+const LSR_THRE: u8 = 0x20; // Transmit Holding Register Empty
+
+pub struct Com1PollingTransport {
+    data: Port<u8>,
+    lsr: Port<u8>,
+}
+
+impl Com1PollingTransport {
+    pub const fn new() -> Self {
+        Self {
+            data: Port::new(COM1_BASE + UART_REG_DATA),
+            lsr: Port::new(COM1_BASE + UART_REG_LSR),
+        }
+    }
+
+    fn lsr_bit(&mut self, mask: u8) -> bool {
+        unsafe { self.lsr.read() & mask != 0 }
+    }
+}
+
+impl Default for Com1PollingTransport {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Transport for Com1PollingTransport {
+    fn read_byte(&mut self) -> u8 {
+        while !self.lsr_bit(LSR_DR) {
+            core::hint::spin_loop();
+        }
+        unsafe { self.data.read() }
+    }
+
+    fn try_read_byte(&mut self) -> Option<u8> {
+        if self.lsr_bit(LSR_DR) {
+            Some(unsafe { self.data.read() })
+        } else {
+            None
+        }
+    }
+
+    fn write_byte(&mut self, b: u8) {
+        while !self.lsr_bit(LSR_THRE) {
+            core::hint::spin_loop();
+        }
+        unsafe { self.data.write(b) }
+    }
+}

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -19,6 +19,8 @@ pub mod build_info;
 pub mod cpu;
 #[cfg(any(test, target_os = "none"))]
 pub mod fs;
+#[cfg(any(test, target_os = "none"))]
+pub mod gdbstub;
 pub mod input;
 #[cfg(any(test, target_os = "none"))]
 pub mod ipc;

--- a/kernel/tests/gdbstub_loop.rs
+++ b/kernel/tests/gdbstub_loop.rs
@@ -1,0 +1,69 @@
+//! Integration test: drive `gdbstub::debug_entry` end-to-end with an
+//! in-memory transport. Verifies packet framing and dispatch compile
+//! and run on the `x86_64-unknown-none` target, and that the packet
+//! loop terminates cleanly on a `D` detach.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use vibix::{
+    exit_qemu,
+    gdbstub::{debug_entry, framer, transport::VecTransport},
+    serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    serial_println!("gdbstub_loop: init ok");
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("framer_checksum", &(framer_checksum as fn())),
+        ("question_then_detach", &(question_then_detach as fn())),
+        ("unknown_returns_empty", &(unknown_returns_empty as fn())),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+fn framer_checksum() {
+    assert_eq!(framer::checksum(b"S05"), 0xb8);
+    assert_eq!(framer::checksum(b"OK"), 0x9a);
+    assert_eq!(framer::checksum(b"?"), 0x3f);
+}
+
+fn question_then_detach() {
+    let mut t = VecTransport::with_rx(b"+$?#3f+$D#44");
+    debug_entry(&mut t);
+    let first = find(&t.tx, b"$S05#b8").expect("missing S05 reply");
+    let second = find(&t.tx, b"$OK#9a").expect("missing detach reply");
+    assert!(first < second, "detach reply must follow S05 reply");
+}
+
+fn unknown_returns_empty() {
+    let mut t = VecTransport::with_rx(b"$g#67$D#44");
+    debug_entry(&mut t);
+    assert!(find(&t.tx, b"$#00").is_some(), "missing empty reply");
+    assert!(find(&t.tx, b"$OK#9a").is_some(), "missing detach reply");
+}
+
+fn find(hay: &[u8], needle: &[u8]) -> Option<usize> {
+    hay.windows(needle.len()).position(|w| w == needle)
+}


### PR DESCRIPTION
Closes #445

## Summary

First slice of the GDB Remote Serial Protocol stub — packet framing,
polling UART transport, and a minimal dispatch loop that handles `?`
(stop reason) and `D` (detach). Register/memory/control-flow commands
and the fault-handler wiring land in follow-up issues.

- `kernel/src/gdbstub/framer.rs`: pure byte-slice RSP codec
  (`\$<payload>#<xx>` framing, checksum, `}`-escape). Host-testable.
- `kernel/src/gdbstub/transport.rs`: \`Transport\` trait +
  \`VecTransport\` (in-memory) for tests.
- `kernel/src/gdbstub/uart.rs`: \`Com1PollingTransport\` that busy-polls
  LSR bits on raw 0x3F8 ports — safe from a halted fault-handler
  context where the interrupt-driven serial path would deadlock. Guarded
  behind `#[cfg(target_os = "none")]` so host builds don't need the UART.
- `kernel/src/gdbstub/mod.rs`: \`debug_entry::<T: Transport>\` — the
  packet loop. Unknown commands get an empty reply per RSP convention.

## Test plan

- [x] `cargo xtask build` — clean (pre-existing `is_guard_hit` dead-code
      warning unchanged).
- [x] Host unit tests written under `#[cfg(test)]` for framer (checksum,
      decode valid/bad/incomplete, escape roundtrip) and dispatch
      (`?`, bad checksum → NAK, unknown → empty reply, detach).
- [x] New QEMU integration test `kernel/tests/gdbstub_loop.rs` runs the
      same three scenarios inside a booted kernel to prove the code
      links and executes on `x86_64-unknown-none`.
- [ ] CI: host unit tests + QEMU integration (local test run skipped —
      host is aarch64 and \`pic8259\` requires \`target_arch = "x86_64"\`;
      CI on x86_64 is the source of truth).

## Not in scope

- Fault-handler (#BP/#UD) integration — tracked by the other #118
  sub-issues.
- Register read/write, memory read/write, continue/step.
- A \`gdbstub\` shell builtin to launch the stub manually.