### PR TITLE
fs: make fcntl(F_SETFL) propagate to backend state

### DIFF
--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -393,6 +393,10 @@ impl FileBackend for FifoRdwrBackend {
     fn poll(&self, pt: &mut crate::poll::PollTable) -> crate::poll::PollMask {
         self.read_end.poll(pt) | self.write_end.poll(pt)
     }
+    fn set_flags(&self, new_flags: u32) {
+        self.read_end.set_flags(new_flags);
+        self.write_end.set_flags(new_flags);
+    }
 }
 
 /// `stat(path, *statbuf)` (follow=true) / `lstat(path, *statbuf)`

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -91,6 +91,21 @@ pub trait FileBackend: Send + Sync {
     fn as_vfs(&self) -> Option<&vfs::VfsBackend> {
         None
     }
+
+    /// Propagate mutable open-file status flags into backend-local state.
+    ///
+    /// Called from [`FileDescTable::set_status_flags`] after the
+    /// `FileDescription.flags` CAS succeeds. `new_flags` is the full
+    /// post-update flag word (the description's canonical value) so that
+    /// backends holding a duplicate atomic (e.g. pipes' `nonblocking`) can
+    /// synchronise their own bits without re-deriving them.
+    ///
+    /// Only `O_APPEND`, `O_NONBLOCK`, and `O_ASYNC` will ever change here —
+    /// POSIX pins the other bits. The default is a no-op, which is correct
+    /// for backends that either read the description's flags directly on
+    /// every I/O (regular files snap `O_APPEND` from `OpenFile.flags`) or
+    /// that simply don't care about status flags (serial stdio).
+    fn set_flags(&self, _new_flags: u32) {}
 }
 
 /// Open-file flags. Values match the Linux x86_64 ABI exactly so userspace
@@ -393,16 +408,41 @@ impl FileDescTable {
         // Atomic swap under a tight loop so concurrent `F_SETFL` callers on
         // dup'd fds can't lose each other's edits.
         let mut cur = desc.flags.load(Ordering::Relaxed);
-        loop {
+        let mut desired = loop {
             let next = (cur & !mutable) | (new_flags & mutable);
             match desc
                 .flags
                 .compare_exchange_weak(cur, next, Ordering::Relaxed, Ordering::Relaxed)
             {
-                Ok(_) => return Ok(()),
+                Ok(_) => break next,
                 Err(observed) => cur = observed,
             }
+        };
+        // POSIX requires the status-flag change to take effect on live I/O
+        // through the description — backends that cache flag state (pipes'
+        // `nonblocking`, VFS files' `OpenFile.flags`) need to observe the
+        // edit before the next read/write, not only after the next dup or
+        // fork. Hand the post-update flag word to the backend's hook now.
+        //
+        // Winning the CAS does not guarantee our `backend.set_flags(desired)`
+        // runs before a later, concurrent `F_SETFL` also wins its CAS and
+        // mirrors — if thread A wins the CAS with `desired_A`, is preempted,
+        // and thread B wins with `desired_B` and mirrors, A resuming here
+        // would overwrite the backend with the stale `desired_A`. Re-check
+        // the live atomic after mirroring and, if a newer edit has landed,
+        // re-mirror with that value. The loop converges because each
+        // iteration's mirror reflects the flag word observed after the
+        // previous CAS, so the final mirror always matches the winning
+        // atomic state regardless of scheduler order.
+        loop {
+            desc.backend.set_flags(desired);
+            let observed = desc.flags.load(Ordering::Relaxed);
+            if observed == desired {
+                break;
+            }
+            desired = observed;
         }
+        Ok(())
     }
 
     /// Return the per-fd flags for `fd` (`fcntl(fd, F_GETFD)`).

--- a/kernel/src/fs/vfs/backend.rs
+++ b/kernel/src/fs/vfs/backend.rs
@@ -528,10 +528,8 @@ mod tests {
         // set_flags call that only passes O_NONBLOCK must clear O_APPEND
         // (not in the new mask) but leave O_RDWR untouched.
         let ops = Arc::new(CountingOps { fill_byte: 0 });
-        let of = make_open_file_with_ops_flags(
-            ops,
-            flags::O_RDWR | flags::O_APPEND | flags::O_CLOEXEC,
-        );
+        let of =
+            make_open_file_with_ops_flags(ops, flags::O_RDWR | flags::O_APPEND | flags::O_CLOEXEC);
         let backend = VfsBackend {
             open_file: of.clone(),
         };
@@ -539,7 +537,11 @@ mod tests {
         let post = of.flags.load(Ordering::Relaxed);
         assert_eq!(post & flags::O_ACCMODE, flags::O_RDWR, "access mode kept");
         assert_eq!(post & flags::O_APPEND, 0, "O_APPEND cleared");
-        assert_eq!(post & flags::O_NONBLOCK, flags::O_NONBLOCK, "O_NONBLOCK set");
+        assert_eq!(
+            post & flags::O_NONBLOCK,
+            flags::O_NONBLOCK,
+            "O_NONBLOCK set"
+        );
         assert_eq!(
             post & flags::O_CLOEXEC,
             flags::O_CLOEXEC,

--- a/kernel/src/fs/vfs/backend.rs
+++ b/kernel/src/fs/vfs/backend.rs
@@ -21,6 +21,7 @@
 //! `OpenFile`) when the flag is set. No special handling is needed here.
 
 use alloc::sync::Arc;
+use core::sync::atomic::Ordering;
 
 use crate::fs::{flags as oflags, FileBackend, EINVAL, EOVERFLOW};
 
@@ -69,7 +70,12 @@ impl FileBackend for VfsBackend {
         // POSIX O_APPEND: under the offset mutex (which also serialises
         // writes through dup'd fds that share this open-file description),
         // snap the write position to end-of-file before dispatching.
-        let write_off = if self.open_file.flags & oflags::O_APPEND != 0 {
+        // Read the current O_APPEND state under the offset mutex. Using
+        // Relaxed is safe: the mutex serialises writers through this open-
+        // file description, so no acquire fence is needed to see the flag
+        // a concurrent `fcntl(F_SETFL)` just published — the next write
+        // picks it up, which is all POSIX guarantees.
+        let write_off = if self.open_file.flags.load(Ordering::Relaxed) & oflags::O_APPEND != 0 {
             self.open_file.inode.meta.read().size
         } else {
             *off
@@ -107,6 +113,31 @@ impl FileBackend for VfsBackend {
     fn getdents64(&self, buf: &mut [u8]) -> Result<usize, i64> {
         let mut off = self.open_file.offset.lock();
         self.open_file.ops.getdents(&self.open_file, buf, &mut *off)
+    }
+
+    /// Propagate a `fcntl(F_SETFL)` update into the underlying `OpenFile`.
+    ///
+    /// CAS-swaps only `O_APPEND | O_NONBLOCK | O_ASYNC` into the shared
+    /// `OpenFile.flags` atomic, preserving the access mode and creation-
+    /// time bits. The matching bits on `FileDescription.flags` are already
+    /// set by `FileDescTable::set_status_flags` — this hook exists so the
+    /// `O_APPEND` check in `write` (which reads `OpenFile.flags`, not the
+    /// description's copy) sees the new value on the very next write.
+    fn set_flags(&self, new_flags: u32) {
+        let mutable = oflags::O_APPEND | oflags::O_NONBLOCK | oflags::O_ASYNC;
+        let mut cur = self.open_file.flags.load(Ordering::Relaxed);
+        loop {
+            let next = (cur & !mutable) | (new_flags & mutable);
+            match self.open_file.flags.compare_exchange_weak(
+                cur,
+                next,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return,
+                Err(observed) => cur = observed,
+            }
+        }
     }
 }
 
@@ -455,6 +486,95 @@ mod tests {
         // Child sees the same offset via its own fd — via the shared OpenFile.
         assert!(child.get(fd).is_ok());
         assert_eq!(*of.offset.lock(), 42);
+    }
+
+    #[test]
+    fn set_flags_toggles_o_append_and_affects_next_write() {
+        // Open without O_APPEND → first write lands at the tracked offset;
+        // set_flags(O_APPEND) → next write snaps to EOF.
+        let ops = Arc::new(RecordingWriteOps {
+            last_off: AtomicU64::new(0),
+        });
+        let of = make_open_file_with_ops_flags_meta(
+            ops.clone(),
+            0,
+            InodeMeta {
+                size: 100,
+                ..Default::default()
+            },
+        );
+        *of.offset.lock() = 7;
+        let backend = VfsBackend {
+            open_file: of.clone(),
+        };
+        backend.write(b"xyz").expect("write");
+        assert_eq!(ops.last_off.load(Ordering::SeqCst), 7);
+
+        // Reset the offset, flip O_APPEND on via set_flags (the path
+        // F_SETFL takes), and confirm the next write goes to EOF instead.
+        *of.offset.lock() = 0;
+        backend.set_flags(flags::O_APPEND);
+        backend.write(b"abcd").expect("write");
+        assert_eq!(
+            ops.last_off.load(Ordering::SeqCst),
+            100,
+            "F_SETFL(O_APPEND) must make the next write snap to inode size"
+        );
+    }
+
+    #[test]
+    fn set_flags_preserves_access_mode_bits() {
+        // Construct an OpenFile with O_RDWR | O_APPEND already set. A
+        // set_flags call that only passes O_NONBLOCK must clear O_APPEND
+        // (not in the new mask) but leave O_RDWR untouched.
+        let ops = Arc::new(CountingOps { fill_byte: 0 });
+        let of = make_open_file_with_ops_flags(
+            ops,
+            flags::O_RDWR | flags::O_APPEND | flags::O_CLOEXEC,
+        );
+        let backend = VfsBackend {
+            open_file: of.clone(),
+        };
+        backend.set_flags(flags::O_NONBLOCK);
+        let post = of.flags.load(Ordering::Relaxed);
+        assert_eq!(post & flags::O_ACCMODE, flags::O_RDWR, "access mode kept");
+        assert_eq!(post & flags::O_APPEND, 0, "O_APPEND cleared");
+        assert_eq!(post & flags::O_NONBLOCK, flags::O_NONBLOCK, "O_NONBLOCK set");
+        assert_eq!(
+            post & flags::O_CLOEXEC,
+            flags::O_CLOEXEC,
+            "O_CLOEXEC is not a mutable status bit"
+        );
+    }
+
+    #[test]
+    fn set_status_flags_propagates_to_vfs_backend() {
+        // End-to-end through FileDescTable: allocate a fd backed by
+        // VfsBackend, call set_status_flags(O_APPEND), confirm
+        // OpenFile.flags carries O_APPEND afterwards.
+        let ops = Arc::new(RecordingWriteOps {
+            last_off: AtomicU64::new(0),
+        });
+        let of = make_open_file_with_ops_flags_meta(
+            ops.clone(),
+            flags::O_RDWR,
+            InodeMeta {
+                size: 50,
+                ..Default::default()
+            },
+        );
+        let backend = Arc::new(VfsBackend {
+            open_file: of.clone(),
+        }) as Arc<dyn FileBackend>;
+        let mut t = FileDescTable::new();
+        let desc = Arc::new(FileDescription::new(backend, flags::O_RDWR));
+        let fd = t.alloc_fd(desc).expect("alloc_fd");
+        t.set_status_flags(fd, flags::O_APPEND)
+            .expect("set_status_flags");
+        // OpenFile.flags carries the updated status bits — not stale.
+        let post = of.flags.load(Ordering::Relaxed);
+        assert_eq!(post & flags::O_APPEND, flags::O_APPEND);
+        assert_eq!(post & flags::O_ACCMODE, flags::O_RDWR, "access mode kept");
     }
 
     #[test]

--- a/kernel/src/fs/vfs/open_file.rs
+++ b/kernel/src/fs/vfs/open_file.rs
@@ -11,7 +11,7 @@
 
 use alloc::sync::Arc;
 use core::mem;
-use core::sync::atomic::Ordering;
+use core::sync::atomic::{AtomicU32, Ordering};
 
 use crate::sync::BlockingMutex;
 
@@ -27,7 +27,13 @@ pub struct OpenFile {
     /// Serialises `read`/`write`/`lseek` offset mutation — matches
     /// POSIX "one offset per open file description" semantics.
     pub offset: BlockingMutex<u64>,
-    pub flags: u32,
+    /// Open-file status flags. Interior-mutable so `fcntl(F_SETFL)` can
+    /// flip `O_APPEND`/`O_NONBLOCK`/`O_ASYNC` and have the change become
+    /// visible to every dup'd fd that shares this `Arc<OpenFile>` — POSIX
+    /// requires it. Read on every `write` (for the `O_APPEND` snap-to-EOF
+    /// check) with `Relaxed` ordering; the write-path offset mutex already
+    /// serialises writers through the same open-file description.
+    pub flags: AtomicU32,
     pub ops: Arc<dyn FileOps>,
     pub sb: Arc<SuperBlock>,
 }
@@ -56,7 +62,7 @@ impl OpenFile {
             dentry,
             inode,
             offset: BlockingMutex::new(0),
-            flags,
+            flags: AtomicU32::new(flags),
             ops,
             sb,
         })

--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -22,14 +22,19 @@
 //!
 //! `FileBackend::read/write` don't receive the open-file flags, so each
 //! backend stores its own `nonblocking` flag at construction time.
-//! A future `fcntl(F_SETFL)` implementation must update both the
-//! `FileDescription.flags` field and `PipeReadEnd/PipeWriteEnd.nonblocking`.
+//! `fcntl(F_SETFL)` propagates into the pipe ends via
+//! [`FileBackend::set_flags`], which mirrors the `O_NONBLOCK` bit from the
+//! description's flag word into the local `nonblocking` atomic so the next
+//! `read`/`write` sees the new state without having to look the flag up
+//! through the description on every call.
 
 use alloc::boxed::Box;
 use alloc::sync::Arc;
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
-use crate::fs::{FileBackend, FileDescription, EAGAIN, EBADF, EINVAL, ENXIO, EPIPE};
+use crate::fs::{
+    flags as oflags, FileBackend, FileDescription, EAGAIN, EBADF, EINVAL, ENXIO, EPIPE,
+};
 use crate::poll::{PollMask, PollTable, POLLHUP, POLLIN, POLLOUT, POLLRDNORM, POLLWRNORM};
 
 // On the kernel target use IrqLock (which saves/restores RFLAGS.IF).
@@ -465,6 +470,14 @@ impl FileBackend for PipeReadEnd {
         }
         mask
     }
+
+    /// Mirror `O_NONBLOCK` from the description's post-update flag word
+    /// into the local `nonblocking` atomic. Other bits (`O_APPEND`,
+    /// `O_ASYNC`) are ignored — they have no meaning on a pipe read end.
+    fn set_flags(&self, new_flags: u32) {
+        self.nonblocking
+            .store(new_flags & oflags::O_NONBLOCK != 0, Ordering::Relaxed);
+    }
 }
 
 // ── PipeWriteEnd ───────────────────────────────────────────────────────────
@@ -602,6 +615,14 @@ impl FileBackend for PipeWriteEnd {
             mask |= POLLOUT | POLLWRNORM;
         }
         mask
+    }
+
+    /// Mirror `O_NONBLOCK` from the description's post-update flag word
+    /// into the local `nonblocking` atomic. `O_APPEND`/`O_ASYNC` have no
+    /// meaning on a pipe write end and are ignored.
+    fn set_flags(&self, new_flags: u32) {
+        self.nonblocking
+            .store(new_flags & oflags::O_NONBLOCK != 0, Ordering::Relaxed);
     }
 }
 
@@ -967,5 +988,57 @@ mod tests {
         };
         assert_eq!(e, EAGAIN);
         assert_eq!(fifo.writers.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn pipe_set_flags_toggles_read_nonblocking() {
+        // Build a blocking read end, call set_flags(O_NONBLOCK) the way
+        // F_SETFL does, then confirm read() on an empty pipe returns
+        // EAGAIN instead of parking the caller.
+        let pipe = Pipe::new();
+        let read = PipeReadEnd::new(pipe.clone(), false);
+        let _write = PipeWriteEnd::new(pipe, false);
+        read.set_flags(oflags::O_NONBLOCK);
+        let mut buf = [0u8; 4];
+        assert_eq!(
+            read.read(&mut buf),
+            Err(EAGAIN),
+            "F_SETFL(O_NONBLOCK) must flip the backend into non-blocking mode"
+        );
+        // Flip it back off — the nonblocking atomic must clear so the
+        // backend would block again (host test can't park, but we can
+        // at least confirm the atomic state changed).
+        read.set_flags(0);
+        assert!(!read.nonblocking.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn pipe_set_flags_toggles_write_nonblocking() {
+        // Fill the ring, then flip the write end to non-blocking via
+        // set_flags. A further write must return EAGAIN (or a partial
+        // count) rather than blocking.
+        let pipe = Pipe::new();
+        let _read = PipeReadEnd::new(pipe.clone(), false);
+        let write = PipeWriteEnd::new(pipe, false);
+        // Fill the ring to capacity - 1.
+        let big = vec![0u8; PIPE_CAPACITY - 1];
+        assert_eq!(write.write(&big), Ok(PIPE_CAPACITY - 1));
+        write.set_flags(oflags::O_NONBLOCK);
+        // Write would block without O_NONBLOCK; with it we must get EAGAIN.
+        assert_eq!(write.write(b"x"), Err(EAGAIN));
+    }
+
+    #[test]
+    fn pipe_set_flags_ignores_non_o_nonblock_bits() {
+        // Ensure O_APPEND/O_ASYNC don't somehow flip the nonblocking
+        // atomic — they have no meaning on a pipe.
+        let pipe = Pipe::new();
+        let read = PipeReadEnd::new(pipe.clone(), false);
+        let _write = PipeWriteEnd::new(pipe, false);
+        read.set_flags(oflags::O_APPEND | oflags::O_ASYNC);
+        assert!(
+            !read.nonblocking.load(Ordering::Relaxed),
+            "only O_NONBLOCK should set nonblocking"
+        );
     }
 }

--- a/kernel/tests/syscall_fcntl.rs
+++ b/kernel/tests/syscall_fcntl.rs
@@ -20,8 +20,7 @@ use core::ptr;
 
 use vibix::arch::x86_64::syscall::syscall_dispatch;
 use vibix::fs::{
-    EAGAIN, EBADF, EINVAL, FD_CLOEXEC, F_DUPFD, F_DUPFD_CLOEXEC, F_GETFD, F_GETFL, F_SETFD,
-    F_SETFL,
+    EAGAIN, EBADF, EINVAL, FD_CLOEXEC, F_DUPFD, F_DUPFD_CLOEXEC, F_GETFD, F_GETFL, F_SETFD, F_SETFL,
 };
 use vibix::mem::vmatree::{Share, Vma};
 use vibix::mem::vmobject::AnonObject;

--- a/kernel/tests/syscall_fcntl.rs
+++ b/kernel/tests/syscall_fcntl.rs
@@ -20,7 +20,8 @@ use core::ptr;
 
 use vibix::arch::x86_64::syscall::syscall_dispatch;
 use vibix::fs::{
-    EBADF, EINVAL, FD_CLOEXEC, F_DUPFD, F_DUPFD_CLOEXEC, F_GETFD, F_GETFL, F_SETFD, F_SETFL,
+    EAGAIN, EBADF, EINVAL, FD_CLOEXEC, F_DUPFD, F_DUPFD_CLOEXEC, F_GETFD, F_GETFL, F_SETFD,
+    F_SETFL,
 };
 use vibix::mem::vmatree::{Share, Vma};
 use vibix::mem::vmobject::AnonObject;
@@ -31,11 +32,17 @@ use vibix::{
 };
 use x86_64::structures::paging::PageTableFlags;
 
+const SYS_READ: u64 = 0;
+const SYS_WRITE: u64 = 1;
 const SYS_OPEN: u64 = 2;
 const SYS_CLOSE: u64 = 3;
 const SYS_FCNTL: u64 = 72;
+const SYS_PIPE2: u64 = 293;
 
 const O_RDONLY: u32 = 0o0;
+const O_WRONLY: u32 = 0o1;
+const O_RDWR: u32 = 0o2;
+const O_CREAT: u32 = 0o100;
 const O_APPEND: u32 = 0o2000;
 const O_NONBLOCK: u32 = 0o4000;
 const O_ASYNC: u32 = 0o20000;
@@ -84,6 +91,14 @@ fn run_tests() {
             &(fcntl_unknown_cmd_einval as fn()),
         ),
         ("fcntl_bad_fd_ebadf", &(fcntl_bad_fd_ebadf as fn())),
+        (
+            "fcntl_setfl_o_append_writes_at_eof",
+            &(fcntl_setfl_o_append_writes_at_eof as fn()),
+        ),
+        (
+            "fcntl_setfl_o_nonblock_on_pipe_read_returns_eagain",
+            &(fcntl_setfl_o_nonblock_on_pipe_read_returns_eagain as fn()),
+        ),
     ];
     for (name, t) in tests {
         serial_println!("syscall_fcntl: {}", name);
@@ -129,12 +144,72 @@ fn open_with_flags(path: &[u8], flags: u32) -> i64 {
     unsafe { syscall_dispatch(SYS_OPEN, uva, flags as u64, 0, 0, 0, 0) }
 }
 
+fn open_rw(path: &[u8], flags: u32, mode: u32) -> i64 {
+    let uva = stage(path);
+    unsafe { syscall_dispatch(SYS_OPEN, uva, flags as u64, mode as u64, 0, 0, 0) }
+}
+
 fn close(fd: i64) -> i64 {
     unsafe { syscall_dispatch(SYS_CLOSE, fd as u64, 0, 0, 0, 0, 0) }
 }
 
 fn fcntl(fd: i64, cmd: u32, arg: u64) -> i64 {
     unsafe { syscall_dispatch(SYS_FCNTL, fd as u64, cmd as u64, arg, 0, 0, 0) }
+}
+
+/// Copy `bytes` into a scratch region of the staging page that won't
+/// collide with a path staged at USER_PAGE_VA. Returns the VA.
+fn stage_payload(bytes: &[u8]) -> u64 {
+    install_user_staging_vma();
+    let va = USER_PAGE_VA as u64 + 4096;
+    assert!(bytes.len() <= USER_PAGE_LEN - 4096);
+    unsafe {
+        let dst = va as *mut u8;
+        for (i, b) in bytes.iter().enumerate() {
+            ptr::write_volatile(dst.add(i), *b);
+        }
+    }
+    va
+}
+
+fn write_bytes(fd: i64, bytes: &[u8]) -> i64 {
+    let uva = stage_payload(bytes);
+    unsafe { syscall_dispatch(SYS_WRITE, fd as u64, uva, bytes.len() as u64, 0, 0, 0) }
+}
+
+fn read_bytes(fd: i64, out: &mut [u8]) -> i64 {
+    install_user_staging_vma();
+    let buf_va = USER_PAGE_VA as u64 + 2 * 4096;
+    let n = unsafe { syscall_dispatch(SYS_READ, fd as u64, buf_va, out.len() as u64, 0, 0, 0) };
+    if n > 0 {
+        unsafe {
+            let src = buf_va as *const u8;
+            for i in 0..n as usize {
+                out[i] = ptr::read_volatile(src.add(i));
+            }
+        }
+    }
+    n
+}
+
+/// Call sys_pipe2 and return [read_fd, write_fd] on success.
+/// The pipefd array is written to the 3rd page of the staging VMA to
+/// avoid clobbering staged paths or payloads.
+fn pipe2(flags: u32) -> (i32, i32) {
+    install_user_staging_vma();
+    let fds_va = USER_PAGE_VA as u64 + 3 * 4096;
+    // Zero the slot first so a failed syscall can't leave stale values.
+    unsafe {
+        let p = fds_va as *mut i32;
+        ptr::write_volatile(p, 0);
+        ptr::write_volatile(p.add(1), 0);
+    }
+    let r = unsafe { syscall_dispatch(SYS_PIPE2, fds_va, flags as u64, 0, 0, 0, 0) };
+    assert_eq!(r, 0, "pipe2 failed: {}", r);
+    unsafe {
+        let p = fds_va as *const i32;
+        (ptr::read_volatile(p), ptr::read_volatile(p.add(1)))
+    }
 }
 
 fn fcntl_getfl_reflects_open_flags() {
@@ -263,4 +338,83 @@ fn fcntl_bad_fd_ebadf() {
     assert_eq!(r, EBADF);
     let r = fcntl(4242, F_DUPFD, 0);
     assert_eq!(r, EBADF);
+}
+
+/// Regression for issue #435 (VFS path): `fcntl(F_SETFL, O_APPEND)` on a
+/// file that was opened without `O_APPEND` must cause subsequent writes
+/// to snap to EOF. Before the fix, F_SETFL flipped the bit on
+/// `FileDescription.flags` but not on the underlying `OpenFile.flags`
+/// (the field the write-path actually consults), so appends silently
+/// landed at the tracked offset instead.
+fn fcntl_setfl_o_append_writes_at_eof() {
+    // Clean slate: create (or truncate) the file, then seed it.
+    let fd_seed = open_rw(
+        b"/tmp/fcntl_setfl_append\0",
+        O_WRONLY | O_CREAT | 0o1000, /* O_TRUNC */
+        0o644,
+    );
+    assert!(fd_seed >= 3, "open seed failed: {}", fd_seed);
+    assert_eq!(write_bytes(fd_seed, b"AAAA"), 4);
+    assert_eq!(close(fd_seed), 0);
+
+    // Open O_RDWR *without* O_APPEND. Flip O_APPEND on via F_SETFL and
+    // write — the write must land at EOF (offset 4), not at the tracked
+    // offset (0).
+    let fd = open_rw(b"/tmp/fcntl_setfl_append\0", O_RDWR, 0);
+    assert!(fd >= 3);
+    let r = fcntl(fd, F_SETFL, O_APPEND as u64);
+    assert_eq!(r, 0, "F_SETFL(O_APPEND) returned {}", r);
+    // F_GETFL must now show O_APPEND — sanity for the description path.
+    let fl = fcntl(fd, F_GETFL, 0);
+    assert_eq!(fl as u32 & O_APPEND, O_APPEND);
+    // Write something — it must append at EOF.
+    assert_eq!(write_bytes(fd, b"BBBB"), 4);
+    assert_eq!(close(fd), 0);
+
+    // Read the file back: must be "AAAABBBB", not "BBBB" (that would
+    // indicate the write clobbered the seed at offset 0, i.e. the
+    // F_SETFL update didn't reach VfsBackend::write).
+    let fd_r = open_rw(b"/tmp/fcntl_setfl_append\0", O_RDONLY, 0);
+    assert!(fd_r >= 3);
+    let mut buf = [0u8; 16];
+    let n = read_bytes(fd_r, &mut buf);
+    assert_eq!(n, 8, "file length after F_SETFL(O_APPEND) write");
+    assert_eq!(
+        &buf[..8],
+        b"AAAABBBB",
+        "F_SETFL(O_APPEND) must make next write land at EOF"
+    );
+    assert_eq!(close(fd_r), 0);
+}
+
+/// Regression for issue #435 (pipe path): `fcntl(F_SETFL, O_NONBLOCK)`
+/// on the read end of an empty pipe must cause the next `read` to
+/// return `EAGAIN` instead of blocking. Before the fix, F_SETFL flipped
+/// the bit on `FileDescription.flags` but not on
+/// `PipeReadEnd.nonblocking`, so the read would still park the caller.
+fn fcntl_setfl_o_nonblock_on_pipe_read_returns_eagain() {
+    // Create a blocking pipe (flags = 0).
+    let (rfd, wfd) = pipe2(0);
+    assert!(rfd >= 3 && wfd >= 3);
+
+    // Flip O_NONBLOCK on the read end via F_SETFL.
+    let r = fcntl(rfd as i64, F_SETFL, O_NONBLOCK as u64);
+    assert_eq!(r, 0, "F_SETFL(O_NONBLOCK) on pipe rfd returned {}", r);
+    let fl = fcntl(rfd as i64, F_GETFL, 0);
+    assert_eq!(fl as u32 & O_NONBLOCK, O_NONBLOCK);
+
+    // read on empty pipe must now return EAGAIN, not block. We call
+    // read_bytes directly (not through a helper that asserts positive)
+    // so we can check the errno.
+    install_user_staging_vma();
+    let buf_va = USER_PAGE_VA as u64 + 2 * 4096;
+    let n = unsafe { syscall_dispatch(SYS_READ, rfd as u64, buf_va, 8, 0, 0, 0) };
+    assert_eq!(
+        n, EAGAIN,
+        "F_SETFL(O_NONBLOCK) must make pipe read return EAGAIN on empty pipe, got {}",
+        n
+    );
+
+    assert_eq!(close(rfd as i64), 0);
+    assert_eq!(close(wfd as i64), 0);
 }


### PR DESCRIPTION
Closes #435

## Summary

- `fcntl(F_SETFL)` flipped the mutable status bits on `FileDescription.flags` but every live I/O path consulted a separate cached copy, so the edits were silently ignored on the very next read/write. `VfsBackend::write` reads `OpenFile.flags` for the `O_APPEND` EOF snap, and the pipe ends each carry their own `nonblocking: AtomicBool`.
- Fix with a new `FileBackend::set_flags` hook that `set_status_flags` calls after the CAS on the description succeeds. Hand the post-update flag word to the backend; each impl mirrors the subset it cares about. Default is a no-op so `SerialBackend` stays untouched.
- `OpenFile.flags` is promoted from `u32` to `AtomicU32` so concurrent `F_SETFL` through dup'd fds is lock-free.

## Test plan
- [x] Host unit tests: `VfsBackend::set_flags` toggling `O_APPEND` drives the next write to EOF; access mode + `O_CLOEXEC` preserved; end-to-end via `FileDescTable::set_status_flags`; both pipe ends flip/clear `nonblocking` and ignore non-`O_NONBLOCK` bits.
- [x] Integration tests: `fcntl_setfl_o_append_writes_at_eof` (seed `/tmp` file → F_SETFL(O_APPEND) → next write lands at EOF) and `fcntl_setfl_o_nonblock_on_pipe_read_returns_eagain` (blocking pipe → F_SETFL(O_NONBLOCK) on rfd → empty read returns EAGAIN).
- [x] `cargo xtask build`
- [x] `cargo xtask test-integration` — all green including the two new fcntl tests
- [x] `cargo xtask smoke`