### PR TITLE
xtask: unblock smoke poll loop; add pre-IRETQ kernel marker

### DIFF
--- a/kernel/src/init_process.rs
+++ b/kernel/src/init_process.rs
@@ -238,6 +238,11 @@ fn init_ring3_entry() -> ! {
         initial_rsp
     );
 
+    // Final marker before IRETQ. If smoke sees this but never sees
+    // "init: hello from pid 1", the regression is on the ring-3 side
+    // (IRETQ fault or first userspace write), not kernel init.
+    serial_println!("init: iretq to ring-3");
+
     // Drop to ring-3. Never returns.
     unsafe { syscall::jump_to_ring3(entry, initial_rsp) }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -84,6 +84,10 @@ const SMOKE_MARKERS: &[&str] = &[
     "userspace module ELF entry=",
     "userspace: loader mapping image",
     "syscall: SYSCALL/SYSRET enabled",
+    // Kernel emits this immediately before IRETQ. If it fires but
+    // "init: hello from pid 1" doesn't, the regression is in the ring-3
+    // return path or the first userspace write, not kernel init.
+    "init: iretq to ring-3",
     "init: hello from pid 1",
 ];
 
@@ -969,7 +973,6 @@ fn test_all() -> R<()> {
 
 fn smoke(opts: &BuildOpts) -> R<()> {
     use std::collections::HashSet;
-    use std::io::BufRead as _;
     use std::time::Instant;
 
     let iso = iso(opts)?;
@@ -1028,21 +1031,37 @@ fn smoke(opts: &BuildOpts) -> R<()> {
     let mut remaining: HashSet<&'static str> = SMOKE_MARKERS.iter().copied().collect();
     let mut soft_remaining: HashSet<&'static str> = SMOKE_SOFT_MARKERS.iter().copied().collect();
     let mut accumulated = String::new();
-    let mut reader = std::io::BufReader::new(stdout);
-    let mut line = String::new();
     let mut panicked = false;
 
-    // Read QEMU serial output one line at a time.  read_line() blocks until
-    // a newline arrives or the pipe closes (after kill).  We check for
-    // early exit after every line — typical runs complete in a few seconds.
-    loop {
-        if Instant::now() >= deadline {
-            break;
+    // Read QEMU serial output off the main thread: `BufReader::read_line`
+    // blocks until a newline arrives, so a completion check on the main
+    // thread would park inside the read for up to HARD_CAP after the last
+    // marker arrived. Offload reads to a thread and fan lines through an
+    // mpsc channel; the main loop polls with a short timeout so it can
+    // notice completion promptly without busy-waiting.
+    let (tx, rx) = std::sync::mpsc::channel::<String>();
+    let reader_handle = std::thread::spawn(move || {
+        use std::io::BufRead as _;
+        let mut reader = std::io::BufReader::new(stdout);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) => break, // pipe closed (QEMU killed or exited)
+                Ok(_) => {
+                    if tx.send(line.clone()).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
         }
-        line.clear();
-        match reader.read_line(&mut line) {
-            Ok(0) => break, // pipe closed (QEMU killed by watchdog or exited)
-            Ok(_) => {
+    });
+
+    const TICK: Duration = Duration::from_millis(100);
+    while Instant::now() < deadline {
+        match rx.recv_timeout(TICK) {
+            Ok(line) => {
                 accumulated.push_str(&line);
                 if line.contains(PANIC_MARKER) {
                     panicked = true;
@@ -1054,13 +1073,16 @@ fn smoke(opts: &BuildOpts) -> R<()> {
                     break;
                 }
             }
-            Err(_) => break,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
         }
     }
 
-    // Ensure QEMU is dead (idempotent if watchdog already fired).
+    // Ensure QEMU is dead (idempotent if watchdog already fired). Killing
+    // the child closes the pipe, which unblocks the reader thread.
     let _ = Command::new("kill").arg(pid.to_string()).status();
     let _ = watchdog.join();
+    let _ = reader_handle.join();
     let _ = child.wait();
 
     if panicked {
@@ -1198,6 +1220,40 @@ mod tests {
             data.windows(8).any(|w| w == b"etc/motd"),
             "archive missing etc/motd entry"
         );
+    }
+
+    #[test]
+    fn smoke_markers_satisfied_only_when_every_hard_marker_seen() {
+        // Mirrors the retain+contains loop in `fn smoke`: an accumulated
+        // serial-capture string drives the hard/soft marker sets to empty.
+        // The test keeps the bar honest by feeding a complete real-looking
+        // capture and asserting drain, plus a partial capture that must
+        // still leave at least one marker outstanding.
+        use std::collections::HashSet;
+
+        let full: String = SMOKE_MARKERS
+            .iter()
+            .chain(SMOKE_SOFT_MARKERS.iter())
+            .map(|m| format!("{m}\n"))
+            .collect();
+        let mut hard: HashSet<&'static str> = SMOKE_MARKERS.iter().copied().collect();
+        let mut soft: HashSet<&'static str> = SMOKE_SOFT_MARKERS.iter().copied().collect();
+        hard.retain(|m| !full.contains(m));
+        soft.retain(|m| !full.contains(m));
+        assert!(hard.is_empty() && soft.is_empty());
+
+        // Drop the last hard marker from the capture — drain must leave it.
+        let last = SMOKE_MARKERS.last().copied().unwrap();
+        let partial: String = SMOKE_MARKERS
+            .iter()
+            .filter(|m| **m != last)
+            .chain(SMOKE_SOFT_MARKERS.iter())
+            .map(|m| format!("{m}\n"))
+            .collect();
+        let mut hard: HashSet<&'static str> = SMOKE_MARKERS.iter().copied().collect();
+        hard.retain(|m| !partial.contains(m));
+        assert_eq!(hard.len(), 1);
+        assert!(hard.contains(last));
     }
 
     #[test]


### PR DESCRIPTION
Closes #476

## Summary

- Replaces `xtask::smoke`'s blocking `read_line` main loop with a thread-based reader + `mpsc::recv_timeout(100 ms)` poll so the deadline check runs continuously. Today's green smoke runs return ~600 s after the iso is ready — the exact HARD_CAP — because `read_line` parks inside itself once the kernel quiesces after the last marker. After this change, smoke returns as soon as every marker has appeared (back to the historical ~3 min wall-clock under un-accelerated CI QEMU).
- Emits a new kernel-side serial marker `"init: iretq to ring-3"` from `init_ring3_entry` just before `jump_to_ring3`, and adds it to `SMOKE_MARKERS`. Splits the prior "missing `init: hello from pid 1`" failure mode into two distinguishable ones: ring-3 entry never reached (new marker missing too) vs. ring-3 executed but first userspace `write()` produced no serial output (new marker present, old one missing).

## Why

See #476 for the full finding trail. Short version: #465 kept bumping `HARD_CAP` (90→180→300→600 s) to mask a flake that's actually a logic bug — the poll loop can't notice completion while parked in a blocking read against a kernel that has gone idle. Every recent "passing" smoke run is already butting up against the 600 s cap, and occasionally tipping past it on loaded runners. Moving read I/O onto its own thread with a short-timeout `recv` lets the main loop check `remaining.is_empty()` continuously instead of only on the next line.

The pre-IRETQ marker is orthogonal coverage for the second finding in #476: when the "init: hello from pid 1" marker is missing, we currently cannot tell whether the kernel even reached `IRETQ`. With this marker, the failure mode becomes self-bisecting.

## Test plan

- [x] `cargo xtask build` (local aarch64 host — cross-compiles the kernel to x86_64-unknown-none fine)
- [x] `cargo test -p xtask` — 26 tests pass, including the new `smoke_markers_satisfied_only_when_every_hard_marker_seen` host test
- [ ] CI: host unit tests, integration tests, and smoke green — smoke is the real assertion here (local aarch64 can't run x86-only `cargo xtask test` / `cargo xtask smoke`)
- [ ] Monitor the next ~10 main-branch merges for smoke wall-clock duration: expect ~3 min end-to-end instead of ~10 min, and no more "init: hello from pid 1" missing-marker failures