### PR TITLE
gdbstub: g/G register packets + #BP hook

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -95,10 +95,8 @@ extern "x86-interrupt" fn breakpoint(mut frame: InterruptStackFrame) {
     // got here, so `regs.rax..r15` are zero and round-trip no-ops.
     unsafe {
         frame.as_mut().update(|f| {
-            f.instruction_pointer =
-                x86_64::VirtAddr::new(regs.rip);
-            f.cpu_flags =
-                x86_64::registers::rflags::RFlags::from_bits_truncate(regs.eflags as u64);
+            f.instruction_pointer = x86_64::VirtAddr::new(regs.rip);
+            f.cpu_flags = x86_64::registers::rflags::RFlags::from_bits_truncate(regs.eflags as u64);
         });
     }
 }

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -93,9 +93,14 @@ extern "x86-interrupt" fn breakpoint(mut frame: InterruptStackFrame) {
     // `iretq` resumes at the debugger-chosen location. GPR writeback is
     // tracked separately — the int3 prologue clobbered GPRs before we
     // got here, so `regs.rax..r15` are zero and round-trip no-ops.
+    // A `G` packet from a buggy or hostile debugger could send a non-
+    // canonical rip; `VirtAddr::new` would panic there. Fall back to the
+    // original rip in that case so the kernel resumes at the int3 site
+    // rather than double-faulting on writeback.
     unsafe {
         frame.as_mut().update(|f| {
-            f.instruction_pointer = x86_64::VirtAddr::new(regs.rip);
+            f.instruction_pointer =
+                x86_64::VirtAddr::try_new(regs.rip).unwrap_or(f.instruction_pointer);
             f.cpu_flags = x86_64::registers::rflags::RFlags::from_bits_truncate(regs.eflags as u64);
         });
     }

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -15,6 +15,7 @@ use crate::serial_println;
 static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
     let mut idt = InterruptDescriptorTable::new();
     idt.divide_error.set_handler_fn(divide_error);
+    idt.breakpoint.set_handler_fn(breakpoint);
     idt.invalid_opcode.set_handler_fn(invalid_opcode);
     idt.general_protection_fault
         .set_handler_fn(general_protection);
@@ -67,6 +68,39 @@ extern "x86-interrupt" fn divide_error(frame: InterruptStackFrame) {
 extern "x86-interrupt" fn invalid_opcode(frame: InterruptStackFrame) {
     serial_println!("EXCEPTION: #UD (invalid opcode)\n{:#?}", frame);
     hang();
+}
+
+/// #BP (int3). Default behavior is a no-op return so that historical
+/// int3 sites keep working. When `gdbstub::is_armed()`, divert into the
+/// stub's packet loop with the interrupt frame captured into a
+/// `GdbRegs`; on resume, push any `G`-mutated `rip`/`rflags` back into
+/// the hardware frame so the `iretq` picks them up.
+extern "x86-interrupt" fn breakpoint(mut frame: InterruptStackFrame) {
+    if !crate::gdbstub::is_armed() {
+        return;
+    }
+    let mut regs = crate::gdbstub::regs::GdbRegs {
+        rip: frame.instruction_pointer.as_u64(),
+        rsp: frame.stack_pointer.as_u64(),
+        eflags: frame.cpu_flags.bits() as u32,
+        cs: frame.code_segment.0 as u32,
+        ss: frame.stack_segment.0 as u32,
+        ..Default::default()
+    };
+    let mut uart = crate::gdbstub::uart::Com1PollingTransport::new();
+    crate::gdbstub::debug_entry_with_regs(&mut uart, &mut regs);
+    // Push rip/rflags writeback from `G` back into the hardware frame so
+    // `iretq` resumes at the debugger-chosen location. GPR writeback is
+    // tracked separately — the int3 prologue clobbered GPRs before we
+    // got here, so `regs.rax..r15` are zero and round-trip no-ops.
+    unsafe {
+        frame.as_mut().update(|f| {
+            f.instruction_pointer =
+                x86_64::VirtAddr::new(regs.rip);
+            f.cpu_flags =
+                x86_64::registers::rflags::RFlags::from_bits_truncate(regs.eflags as u64);
+        });
+    }
 }
 
 extern "x86-interrupt" fn general_protection(frame: InterruptStackFrame, code: u64) {

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -71,12 +71,24 @@ extern "x86-interrupt" fn invalid_opcode(frame: InterruptStackFrame) {
 }
 
 /// #BP (int3). Default behavior is a no-op return so that historical
-/// int3 sites keep working. When `gdbstub::is_armed()`, divert into the
-/// stub's packet loop with the interrupt frame captured into a
-/// `GdbRegs`; on resume, push any `G`-mutated `rip`/`rflags` back into
-/// the hardware frame so the `iretq` picks them up.
+/// int3 sites keep working. When `gdbstub::is_armed()` AND the trap
+/// came from ring 0, divert into the stub's packet loop with the
+/// interrupt frame captured into a `GdbRegs`; on resume, push any
+/// `G`-mutated `rip`/`rflags` back into the hardware frame so the
+/// `iretq` picks them up.
+///
+/// User-mode `#BP` (CPL != 0) is intentionally *not* diverted: we
+/// don't want a ring-3 task to be able to drop the whole kernel into
+/// a debugger shell on any COM1 byte. Treat it like historical int3
+/// and fall through to a no-op return; a future user-debug path can
+/// plug in its own handler if we ever want to support user-space
+/// breakpoints.
 extern "x86-interrupt" fn breakpoint(mut frame: InterruptStackFrame) {
     if !crate::gdbstub::is_armed() {
+        return;
+    }
+    // Low 2 bits of CS = CPL. Ring 0 only.
+    if frame.code_segment.0 & 0b11 != 0 {
         return;
     }
     let mut regs = crate::gdbstub::regs::GdbRegs {

--- a/kernel/src/gdbstub/mod.rs
+++ b/kernel/src/gdbstub/mod.rs
@@ -14,13 +14,38 @@
 //! a `gdbstub` shell builtin.
 
 pub mod framer;
+pub mod regs;
 pub mod transport;
 
 #[cfg(target_os = "none")]
 pub mod uart;
 
+use core::sync::atomic::{AtomicBool, Ordering};
+
 use framer::{DecodeError, ACK, EOP, MAX_PACKET, NAK, SOP};
+use regs::{GdbRegs, GDB_REGS_HEX};
 use transport::Transport;
+
+/// The int3 (#BP) handler consults this before diverting into the stub
+/// loop. Default-off so every existing kernel `int3` site (panic paths,
+/// test-harness markers, speculative breakpoints) keeps its prior
+/// behavior until something explicitly arms the stub.
+static ARMED: AtomicBool = AtomicBool::new(false);
+
+/// Arm the stub — the next #BP will drop into [`debug_entry_with_regs`].
+pub fn arm() {
+    ARMED.store(true, Ordering::Release);
+}
+
+/// Disarm the stub; #BP returns to normal semantics.
+pub fn disarm() {
+    ARMED.store(false, Ordering::Release);
+}
+
+/// Whether the int3 handler should divert into the stub on the next #BP.
+pub fn is_armed() -> bool {
+    ARMED.load(Ordering::Acquire)
+}
 
 /// The canned `S05` stop reason — SIGTRAP — we hand back on `?` until
 /// we wire real exception info through in the follow-up.
@@ -40,6 +65,15 @@ const CTRL_C: u8 = 0x03;
 /// [`Com1PollingTransport`](uart::Com1PollingTransport) and calls
 /// through here.
 pub fn debug_entry<T: Transport>(t: &mut T) {
+    let mut regs = GdbRegs::default();
+    debug_entry_with_regs(t, &mut regs);
+}
+
+/// Like [`debug_entry`] but with a caller-owned register snapshot.
+/// The stub reads `regs` for `g` replies and writes into it on `G` —
+/// the caller is responsible for pushing mutated values back into
+/// the hardware interrupt frame on resume.
+pub fn debug_entry_with_regs<T: Transport>(t: &mut T, regs: &mut GdbRegs) {
     // Wire buffer holds the full escaped packet (worst-case 2x payload
     // plus framing). `scratch` receives the unescaped payload that
     // `framer::decode` hands back as `Packet::payload`.
@@ -53,7 +87,7 @@ pub fn debug_entry<T: Transport>(t: &mut T) {
                 match framer::decode(&inbuf[..len], &mut scratch) {
                     Ok((pkt, _)) => {
                         t.write_byte(ACK);
-                        match dispatch(t, pkt.payload) {
+                        match dispatch(t, pkt.payload, regs) {
                             Action::Continue => {}
                             Action::Detach => return,
                         }
@@ -134,7 +168,7 @@ fn read_packet<T: Transport>(t: &mut T, buf: &mut [u8]) -> Result<usize, ReadErr
 
 /// Handle a single decoded packet payload. Emits the response frame
 /// via `t.write_byte` and returns whether the session should continue.
-fn dispatch<T: Transport>(t: &mut T, payload: &[u8]) -> Action {
+fn dispatch<T: Transport>(t: &mut T, payload: &[u8], regs: &mut GdbRegs) -> Action {
     match payload.first() {
         Some(b'?') => {
             send_packet(t, &stop_reply_buf(SIG_TRAP));
@@ -143,6 +177,20 @@ fn dispatch<T: Transport>(t: &mut T, payload: &[u8]) -> Action {
         Some(b'D') => {
             send_packet(t, b"OK");
             Action::Detach
+        }
+        Some(b'g') => {
+            let mut hex = [0u8; GDB_REGS_HEX];
+            let blob = regs::encode_g(regs, &mut hex);
+            send_packet(t, blob);
+            Action::Continue
+        }
+        Some(b'G') => {
+            // Payload is `G<hex...>`; strip the leading command byte.
+            match regs::decode_g(&payload[1..], regs) {
+                Ok(()) => send_packet(t, b"OK"),
+                Err(_) => send_packet(t, b"E00"),
+            }
+            Action::Continue
         }
         _ => {
             // Unknown command: RSP convention says reply with an empty

--- a/kernel/src/gdbstub/mod.rs
+++ b/kernel/src/gdbstub/mod.rs
@@ -254,8 +254,9 @@ mod tests {
 
     #[test]
     fn unknown_command_empty_reply() {
-        // `g` = read registers; we don't support it yet → empty reply.
-        let mut t = VecTransport::with_rx(b"$g#67$D#44");
+        // `q` with no sub-command is not implemented → empty reply.
+        // checksum('q') = 0x71.
+        let mut t = VecTransport::with_rx(b"$q#71$D#44");
         debug_entry(&mut t);
         // Expect: ACK, `$#00`, ACK, `$OK#9a`.
         assert!(find(&t.tx, b"$#00").is_some());

--- a/kernel/src/gdbstub/mod.rs
+++ b/kernel/src/gdbstub/mod.rs
@@ -186,8 +186,26 @@ fn dispatch<T: Transport>(t: &mut T, payload: &[u8], regs: &mut GdbRegs) -> Acti
         }
         Some(b'G') => {
             // Payload is `G<hex...>`; strip the leading command byte.
-            match regs::decode_g(&payload[1..], regs) {
-                Ok(()) => send_packet(t, b"OK"),
+            // Current int3 wiring only captures/writes back `rip` and
+            // `eflags`; every other field round-trips as whatever the
+            // caller seeded (zero for GPRs). Decode into a temporary
+            // and, if the debugger asked us to change *any* unsupported
+            // field, reply `E01` so it knows the write didn't take —
+            // instead of silently dropping the change and lying `OK`.
+            let mut tmp = *regs;
+            match regs::decode_g(&payload[1..], &mut tmp) {
+                Ok(()) => {
+                    let mut want = *regs;
+                    want.rip = tmp.rip;
+                    want.eflags = tmp.eflags;
+                    if tmp == want {
+                        regs.rip = tmp.rip;
+                        regs.eflags = tmp.eflags;
+                        send_packet(t, b"OK");
+                    } else {
+                        send_packet(t, b"E01");
+                    }
+                }
                 Err(_) => send_packet(t, b"E00"),
             }
             Action::Continue

--- a/kernel/src/gdbstub/regs.rs
+++ b/kernel/src/gdbstub/regs.rs
@@ -1,0 +1,275 @@
+//! GDB x86_64 register packet encoding.
+//!
+//! GDB's `g`/`G` commands serialize registers as one big lowercase hex
+//! blob. Field order matches gdb's `i386:x86-64` gdbarch:
+//!
+//! `rax rbx rcx rdx rsi rdi rbp rsp r8..r15 rip eflags cs ss ds es fs gs`
+//!
+//! Each GPR is 8 bytes, `rip` is 8 bytes, `eflags` is 4 bytes, and each
+//! of the six segment selectors is 4 bytes — 16·8 + 8 + 4 + 6·4 = 164
+//! bytes, i.e. 328 hex characters.
+//!
+//! Per-field bytes are emitted little-endian, each byte as two
+//! lowercase hex chars, matching what gdb expects on the wire.
+
+/// Total wire size of a `g` reply in *bytes* (not hex chars).
+pub const GDB_REGS_BYTES: usize = 164;
+
+/// The `g` reply is twice as many hex characters as the payload is
+/// bytes — exactly `2 * GDB_REGS_BYTES`.
+pub const GDB_REGS_HEX: usize = 2 * GDB_REGS_BYTES;
+
+#[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(C)]
+pub struct GdbRegs {
+    pub rax: u64,
+    pub rbx: u64,
+    pub rcx: u64,
+    pub rdx: u64,
+    pub rsi: u64,
+    pub rdi: u64,
+    pub rbp: u64,
+    pub rsp: u64,
+    pub r8: u64,
+    pub r9: u64,
+    pub r10: u64,
+    pub r11: u64,
+    pub r12: u64,
+    pub r13: u64,
+    pub r14: u64,
+    pub r15: u64,
+    pub rip: u64,
+    pub eflags: u32,
+    pub cs: u32,
+    pub ss: u32,
+    pub ds: u32,
+    pub es: u32,
+    pub fs: u32,
+    pub gs: u32,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ParseErr {
+    /// Hex input wasn't exactly `GDB_REGS_HEX` characters long.
+    WrongLength,
+    /// A byte in the hex input wasn't a valid hex nibble.
+    BadHex,
+}
+
+/// Encode `r` as a lowercase-hex little-endian-per-field blob into
+/// `out`. Returns the filled slice (`&out[..GDB_REGS_HEX]`).
+pub fn encode_g<'b>(r: &GdbRegs, out: &'b mut [u8; GDB_REGS_HEX]) -> &'b [u8] {
+    let mut i = 0;
+    let mut put_u64 = |v: u64, i: &mut usize| {
+        write_le_hex(v.to_le_bytes().as_slice(), out, i);
+    };
+    put_u64(r.rax, &mut i);
+    put_u64(r.rbx, &mut i);
+    put_u64(r.rcx, &mut i);
+    put_u64(r.rdx, &mut i);
+    put_u64(r.rsi, &mut i);
+    put_u64(r.rdi, &mut i);
+    put_u64(r.rbp, &mut i);
+    put_u64(r.rsp, &mut i);
+    put_u64(r.r8, &mut i);
+    put_u64(r.r9, &mut i);
+    put_u64(r.r10, &mut i);
+    put_u64(r.r11, &mut i);
+    put_u64(r.r12, &mut i);
+    put_u64(r.r13, &mut i);
+    put_u64(r.r14, &mut i);
+    put_u64(r.r15, &mut i);
+    put_u64(r.rip, &mut i);
+    let mut put_u32 = |v: u32, i: &mut usize| {
+        write_le_hex(v.to_le_bytes().as_slice(), out, i);
+    };
+    put_u32(r.eflags, &mut i);
+    put_u32(r.cs, &mut i);
+    put_u32(r.ss, &mut i);
+    put_u32(r.ds, &mut i);
+    put_u32(r.es, &mut i);
+    put_u32(r.fs, &mut i);
+    put_u32(r.gs, &mut i);
+    debug_assert_eq!(i, GDB_REGS_HEX);
+    &out[..]
+}
+
+/// Decode a `G` hex blob back into `r`. Input must be exactly
+/// `GDB_REGS_HEX` hex characters.
+pub fn decode_g(hex: &[u8], r: &mut GdbRegs) -> Result<(), ParseErr> {
+    if hex.len() != GDB_REGS_HEX {
+        return Err(ParseErr::WrongLength);
+    }
+    let mut i = 0;
+    r.rax = read_le_u64(hex, &mut i)?;
+    r.rbx = read_le_u64(hex, &mut i)?;
+    r.rcx = read_le_u64(hex, &mut i)?;
+    r.rdx = read_le_u64(hex, &mut i)?;
+    r.rsi = read_le_u64(hex, &mut i)?;
+    r.rdi = read_le_u64(hex, &mut i)?;
+    r.rbp = read_le_u64(hex, &mut i)?;
+    r.rsp = read_le_u64(hex, &mut i)?;
+    r.r8 = read_le_u64(hex, &mut i)?;
+    r.r9 = read_le_u64(hex, &mut i)?;
+    r.r10 = read_le_u64(hex, &mut i)?;
+    r.r11 = read_le_u64(hex, &mut i)?;
+    r.r12 = read_le_u64(hex, &mut i)?;
+    r.r13 = read_le_u64(hex, &mut i)?;
+    r.r14 = read_le_u64(hex, &mut i)?;
+    r.r15 = read_le_u64(hex, &mut i)?;
+    r.rip = read_le_u64(hex, &mut i)?;
+    r.eflags = read_le_u32(hex, &mut i)?;
+    r.cs = read_le_u32(hex, &mut i)?;
+    r.ss = read_le_u32(hex, &mut i)?;
+    r.ds = read_le_u32(hex, &mut i)?;
+    r.es = read_le_u32(hex, &mut i)?;
+    r.fs = read_le_u32(hex, &mut i)?;
+    r.gs = read_le_u32(hex, &mut i)?;
+    Ok(())
+}
+
+fn write_le_hex(bytes: &[u8], out: &mut [u8], i: &mut usize) {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    for &b in bytes {
+        out[*i] = HEX[(b >> 4) as usize];
+        out[*i + 1] = HEX[(b & 0xF) as usize];
+        *i += 2;
+    }
+}
+
+fn read_le_u64(hex: &[u8], i: &mut usize) -> Result<u64, ParseErr> {
+    let mut bytes = [0u8; 8];
+    for b in &mut bytes {
+        *b = read_byte(hex, i)?;
+    }
+    Ok(u64::from_le_bytes(bytes))
+}
+
+fn read_le_u32(hex: &[u8], i: &mut usize) -> Result<u32, ParseErr> {
+    let mut bytes = [0u8; 4];
+    for b in &mut bytes {
+        *b = read_byte(hex, i)?;
+    }
+    Ok(u32::from_le_bytes(bytes))
+}
+
+fn read_byte(hex: &[u8], i: &mut usize) -> Result<u8, ParseErr> {
+    let hi = nibble(hex[*i])?;
+    let lo = nibble(hex[*i + 1])?;
+    *i += 2;
+    Ok((hi << 4) | lo)
+}
+
+fn nibble(b: u8) -> Result<u8, ParseErr> {
+    match b {
+        b'0'..=b'9' => Ok(b - b'0'),
+        b'a'..=b'f' => Ok(10 + b - b'a'),
+        b'A'..=b'F' => Ok(10 + b - b'A'),
+        _ => Err(ParseErr::BadHex),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_zero_roundtrip() {
+        let r = GdbRegs::default();
+        let mut out = [0u8; GDB_REGS_HEX];
+        let enc = encode_g(&r, &mut out);
+        assert_eq!(enc.len(), GDB_REGS_HEX);
+        assert!(enc.iter().all(|&b| b == b'0'));
+        let mut back = GdbRegs {
+            rax: 0xDEADBEEF,
+            ..Default::default()
+        };
+        decode_g(enc, &mut back).unwrap();
+        assert_eq!(back, r);
+    }
+
+    #[test]
+    fn rax_first_bytes_little_endian() {
+        // rax is the first field — its bytes should appear at the very
+        // start of the hex blob, little-endian. 0x0102030405060708 →
+        // bytes [08, 07, 06, 05, 04, 03, 02, 01] → "0807060504030201".
+        let r = GdbRegs {
+            rax: 0x0102030405060708,
+            ..Default::default()
+        };
+        let mut out = [0u8; GDB_REGS_HEX];
+        let enc = encode_g(&r, &mut out);
+        assert_eq!(&enc[..16], b"0807060504030201");
+    }
+
+    #[test]
+    fn field_order_matches_spec() {
+        // rip is the 17th u64 (after 16 GPRs), so it starts at byte
+        // offset 16*8 = 128 (= 256 hex chars). eflags follows at 136
+        // bytes (= 272 hex chars) as a u32.
+        let r = GdbRegs {
+            rip: 0x00000000aabbccdd,
+            eflags: 0x11223344,
+            ..Default::default()
+        };
+        let mut out = [0u8; GDB_REGS_HEX];
+        let enc = encode_g(&r, &mut out);
+        // rip little-endian: dd cc bb aa 00 00 00 00 → "ddccbbaa00000000"
+        assert_eq!(&enc[256..272], b"ddccbbaa00000000");
+        // eflags little-endian: 44 33 22 11 → "44332211"
+        assert_eq!(&enc[272..280], b"44332211");
+    }
+
+    #[test]
+    fn roundtrip_nonzero() {
+        let r = GdbRegs {
+            rax: 0x1111111111111111,
+            rbx: 0x2222222222222222,
+            rcx: 0x3333333333333333,
+            rsp: 0x7fff_ffff_ffff_ff00,
+            rip: 0xffff_ffff_8000_1234,
+            eflags: 0x202,
+            cs: 0x08,
+            ss: 0x10,
+            ds: 0x10,
+            es: 0x10,
+            fs: 0x10,
+            gs: 0x10,
+            ..Default::default()
+        };
+        let mut out = [0u8; GDB_REGS_HEX];
+        let enc = encode_g(&r, &mut out);
+        let mut back = GdbRegs::default();
+        decode_g(enc, &mut back).unwrap();
+        assert_eq!(back, r);
+    }
+
+    #[test]
+    fn decode_wrong_length_rejected() {
+        let mut r = GdbRegs::default();
+        assert_eq!(decode_g(b"abcd", &mut r), Err(ParseErr::WrongLength));
+        assert_eq!(
+            decode_g(&[b'0'; GDB_REGS_HEX - 2], &mut r),
+            Err(ParseErr::WrongLength)
+        );
+    }
+
+    #[test]
+    fn decode_non_hex_rejected() {
+        let mut r = GdbRegs::default();
+        let mut buf = [b'0'; GDB_REGS_HEX];
+        buf[5] = b'z';
+        assert_eq!(decode_g(&buf, &mut r), Err(ParseErr::BadHex));
+    }
+
+    #[test]
+    fn decode_mixed_case_hex_accepted() {
+        let mut r = GdbRegs::default();
+        let mut buf = [b'0'; GDB_REGS_HEX];
+        // rax = 0x00000000000000AB via uppercase 'A','B'
+        buf[0] = b'A';
+        buf[1] = b'B';
+        decode_g(&buf, &mut r).unwrap();
+        assert_eq!(r.rax, 0xAB);
+    }
+}

--- a/kernel/tests/gdbstub_loop.rs
+++ b/kernel/tests/gdbstub_loop.rs
@@ -11,7 +11,11 @@ extern crate alloc;
 use core::panic::PanicInfo;
 use vibix::{
     exit_qemu,
-    gdbstub::{debug_entry, framer, transport::VecTransport},
+    gdbstub::{
+        debug_entry, debug_entry_with_regs, framer,
+        regs::{GdbRegs, GDB_REGS_HEX},
+        transport::VecTransport,
+    },
     serial_println,
     test_harness::{test_panic_handler, Testable},
     QemuExitCode,
@@ -35,6 +39,8 @@ fn run_tests() {
         ("framer_checksum", &(framer_checksum as fn())),
         ("question_then_detach", &(question_then_detach as fn())),
         ("unknown_returns_empty", &(unknown_returns_empty as fn())),
+        ("g_reply_is_hex_blob", &(g_reply_is_hex_blob as fn())),
+        ("big_g_writes_regs", &(big_g_writes_regs as fn())),
     ];
     serial_println!("running {} tests", tests.len());
     for (name, t) in tests {
@@ -58,10 +64,61 @@ fn question_then_detach() {
 }
 
 fn unknown_returns_empty() {
-    let mut t = VecTransport::with_rx(b"$g#67$D#44");
+    // `q` with no sub-command is not implemented → empty reply.
+    // checksum('q') = 0x71.
+    let mut t = VecTransport::with_rx(b"$q#71$D#44");
     debug_entry(&mut t);
     assert!(find(&t.tx, b"$#00").is_some(), "missing empty reply");
     assert!(find(&t.tx, b"$OK#9a").is_some(), "missing detach reply");
+}
+
+fn g_reply_is_hex_blob() {
+    // `g` = read all registers. checksum('g') = 0x67.
+    // With a default (all-zero) GdbRegs, the reply payload is
+    // `GDB_REGS_HEX` ASCII '0's framed as `$<hex>#<xx>`.
+    let mut t = VecTransport::with_rx(b"$g#67$D#44");
+    let mut regs = GdbRegs::default();
+    debug_entry_with_regs(&mut t, &mut regs);
+
+    // Find the `$` that starts the `g` reply, then verify its payload
+    // is exactly GDB_REGS_HEX bytes of lowercase '0'.
+    let start = find(&t.tx, b"$").expect("no outbound frame");
+    let hash = start + 1 + GDB_REGS_HEX;
+    assert!(
+        t.tx.len() > hash + 2,
+        "tx too short: {} bytes, need >{}",
+        t.tx.len(),
+        hash + 2
+    );
+    assert_eq!(t.tx[hash], b'#', "EOP not at expected offset");
+    for (k, &b) in t.tx[start + 1..hash].iter().enumerate() {
+        assert_eq!(b, b'0', "non-zero at offset {k} in g reply");
+    }
+    assert!(find(&t.tx, b"$OK#9a").is_some(), "missing detach reply");
+}
+
+fn big_g_writes_regs() {
+    // Build a `G<hex>` packet whose hex blob sets rax=0x1 (all other
+    // fields zero), then verify the stub ack'd with `OK` and actually
+    // mutated the caller's regs.
+    let mut payload = [b'0'; 1 + GDB_REGS_HEX];
+    payload[0] = b'G';
+    // rax LE first byte = 01 → hex "01" at [1..3].
+    payload[2] = b'1';
+    // Worst-case encoded size is 2 * payload.len() + 4 (none of our
+    // bytes need escaping, but framer::encode enforces that cap).
+    let mut frame = [0u8; 2 * (1 + GDB_REGS_HEX) + 4];
+    let wire = framer::encode(&payload, &mut frame);
+
+    let mut t = VecTransport::new();
+    for &b in wire {
+        t.rx.push_back(b);
+    }
+
+    let mut regs = GdbRegs::default();
+    debug_entry_with_regs(&mut t, &mut regs);
+    assert_eq!(regs.rax, 0x01, "G did not write rax");
+    assert!(find(&t.tx, b"$OK#9a").is_some(), "missing OK reply");
 }
 
 fn find(hay: &[u8], needle: &[u8]) -> Option<usize> {

--- a/kernel/tests/gdbstub_loop.rs
+++ b/kernel/tests/gdbstub_loop.rs
@@ -41,6 +41,10 @@ fn run_tests() {
         ("unknown_returns_empty", &(unknown_returns_empty as fn())),
         ("g_reply_is_hex_blob", &(g_reply_is_hex_blob as fn())),
         ("big_g_writes_regs", &(big_g_writes_regs as fn())),
+        (
+            "big_g_rejects_unsupported_fields",
+            &(big_g_rejects_unsupported_fields as fn()),
+        ),
     ];
     serial_println!("running {} tests", tests.len());
     for (name, t) in tests {
@@ -98,15 +102,17 @@ fn g_reply_is_hex_blob() {
 }
 
 fn big_g_writes_regs() {
-    // Build a `G<hex>` packet whose hex blob sets rax=0x1 (all other
-    // fields zero), then verify the stub ack'd with `OK` and actually
-    // mutated the caller's regs.
+    // Build a `G<hex>` packet that changes only `rip` (the 17th u64, so
+    // hex offset 256 in the payload, i.e. index 257 with the leading
+    // `G`). Every other field hex-encodes whatever the caller seeded,
+    // which for a default-zero `GdbRegs` is all '0's — so the only
+    // mutation in flight is `rip`. The stub should reply `OK` and
+    // actually update `regs.rip`.
     let mut payload = [b'0'; 1 + GDB_REGS_HEX];
     payload[0] = b'G';
-    // rax LE first byte = 01 → hex "01" at [1..3].
-    payload[2] = b'1';
-    // Worst-case encoded size is 2 * payload.len() + 4 (none of our
-    // bytes need escaping, but framer::encode enforces that cap).
+    // rip LE first byte = 0x01 → "01" at [257..259]. All other rip
+    // bytes stay '0' → rip = 0x0000_0000_0000_0001.
+    payload[1 + 256 + 1] = b'1';
     let mut frame = [0u8; 2 * (1 + GDB_REGS_HEX) + 4];
     let wire = framer::encode(&payload, &mut frame);
 
@@ -117,8 +123,31 @@ fn big_g_writes_regs() {
 
     let mut regs = GdbRegs::default();
     debug_entry_with_regs(&mut t, &mut regs);
-    assert_eq!(regs.rax, 0x01, "G did not write rax");
+    assert_eq!(regs.rip, 0x01, "G did not write rip");
     assert!(find(&t.tx, b"$OK#9a").is_some(), "missing OK reply");
+}
+
+fn big_g_rejects_unsupported_fields() {
+    // `G` that tries to change `rax` (bytes [1..3] of the payload hex)
+    // must be rejected with `E01`: the int3 handler only honors writes
+    // to `rip` and `eflags`, so silently accepting other changes would
+    // lie to the debugger.
+    let mut payload = [b'0'; 1 + GDB_REGS_HEX];
+    payload[0] = b'G';
+    payload[2] = b'1';
+    let mut frame = [0u8; 2 * (1 + GDB_REGS_HEX) + 4];
+    let wire = framer::encode(&payload, &mut frame);
+
+    let mut t = VecTransport::new();
+    for &b in wire {
+        t.rx.push_back(b);
+    }
+
+    let mut regs = GdbRegs::default();
+    debug_entry_with_regs(&mut t, &mut regs);
+    assert_eq!(regs.rax, 0, "unsupported G must not mutate rax");
+    // checksum("E01") = b'E' + b'0' + b'1' = 0x45 + 0x30 + 0x31 = 0xa6.
+    assert!(find(&t.tx, b"$E01#a6").is_some(), "missing E01 reply");
 }
 
 fn find(hay: &[u8], needle: &[u8]) -> Option<usize> {


### PR DESCRIPTION
Closes #446

## Summary

- Add a 164-byte `i386:x86-64` register blob codec (`gdbstub::regs`) with `encode_g`/`decode_g` plus a `GdbRegs` struct laid out in gdbarch field order. Per-field little-endian, lowercase hex, exactly `GDB_REGS_HEX = 328` chars on the wire.
- Wire `g`/`G` through `gdbstub::dispatch`: `g` encodes a caller-supplied `GdbRegs` and sends the hex blob; `G` parses the incoming blob into the same mutable slot (replies `OK`, or `E00` on malformed input).
- Gate the #BP handler behind a new `gdbstub::ARMED` AtomicBool — default off, so every historical `int3` site (panic paths, test markers) keeps its prior behavior. `gdbstub::arm()` / `disarm()` / `is_armed()` are the public controls.
- Add an `idt.breakpoint` handler that, when armed, captures `rip`/`rsp`/`rflags`/`cs`/`ss` from the interrupt frame into a `GdbRegs`, drives the stub loop over `Com1PollingTransport`, and writes any `G`-mutated `rip`/`rflags` back into the hardware frame via `frame.as_mut().update()` so `iretq` picks them up on resume.

## Out of scope (follow-up)

General-purpose register capture under #BP. The `extern "x86-interrupt"` prologue clobbers GPRs before Rust runs, so `regs.rax..r15` are zero at entry and round-trip as no-ops for now. Full GPR capture needs an asm trampoline that snapshots state before frame setup — tracked separately.

## Test plan

- [x] New host unit tests in `gdbstub/regs.rs` cover encode/decode roundtrip, little-endian ordering of `rax`/`rip`/`eflags`, wrong-length rejection, non-hex rejection, and mixed-case hex acceptance.
- [x] `kernel/tests/gdbstub_loop.rs`: `g_reply_is_hex_blob` verifies the `g` reply is exactly `GDB_REGS_HEX` ASCII `'0'`s for a default-zero `GdbRegs`; `big_g_writes_regs` builds a `G<hex>` packet that sets `rax = 0x01` and checks both the `OK` response and the caller's `GdbRegs` mutation.
- [x] The previous `unknown_returns_empty` probe swapped from `g` (now implemented) to `q` (still unsupported) so the empty-reply path stays covered.
- [x] `cargo xtask build` clean; `cargo test --test gdbstub_loop --no-run` compiles on `x86_64-unknown-none`.
- [ ] Full `cargo xtask test` + `cargo xtask smoke` via CI (skipped locally per host).