### PR TITLE
tty: wire N_TTY ldisc into PS/2 + serial rx paths

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -257,6 +257,10 @@ name = "tty_sigttin_read"
 harness = false
 
 [[test]]
+name = "ntty_ldisc_wiring"
+harness = false
+
+[[test]]
 name = "shell_help"
 harness = false
 

--- a/kernel/src/tty/ntty.rs
+++ b/kernel/src/tty/ntty.rs
@@ -375,6 +375,140 @@ impl Default for NTty {
     }
 }
 
+#[cfg(any(target_os = "none", test))]
+impl NTty {
+    /// Drain up to `out.len()` committed bytes from the raw ring into
+    /// `out`, returning the number of bytes written. Canonical-mode
+    /// callers see only bytes past a committed newline / VEOL / VEOF;
+    /// raw-mode callers see every byte as it arrives.
+    pub fn drain_raw(&self, out: &mut [u8]) -> usize {
+        let mut st = self.state.lock();
+        let mut i = 0;
+        while i < out.len() && st.raw.head != st.raw.tail {
+            out[i] = st.raw.buf[st.raw.head & (RAW_RING_CAP - 1)];
+            st.raw.head = st.raw.head.wrapping_add(1);
+            i += 1;
+        }
+        if st.raw.head == st.raw.tail {
+            st.raw.eof_pos = None;
+        }
+        i
+    }
+
+    /// Number of committed bytes currently available in the raw ring.
+    pub fn raw_len(&self) -> usize {
+        self.state.lock().raw.len()
+    }
+}
+
+/// [`LineDiscipline`] wrapper around [`NTty`].
+///
+/// Issue #474 — this is the glue that finally wires the fully-tested
+/// N_TTY pipeline (iflag / ISIG / ICANON / OPOST) into the PS/2 and
+/// serial rx paths. A softirq-context byte arriving through
+/// `tty.ldisc.receive_byte(&tty, b)` flows through:
+///
+/// 1. `NTty::receive_signal_or_byte` — ISIG check against VINTR/VQUIT/
+///    VSUSP. Consumed signal bytes return `None`; others return `Some(b)`
+///    after iflag rewriting.
+/// 2. `NTty::canon_input` — ICANON line editor or raw ring append.
+/// 3. `NTty::queue_echo` — ECHO/ECHOE/ECHONL output, pushed through the
+///    driver's tx path so the user sees what they typed.
+///
+/// The `tty: &Tty` argument gives us access to `termios` (for the
+/// iflag/lflag snapshot) and `ctrl` (for the foreground-pgrp snapshot
+/// consumed by ISIG). `termios` is copied under its IrqLock guard —
+/// [`Termios`] is `Copy` — so no lock is held across the NTty call.
+/// `ctrl`'s `pgrp_snapshot` is a lock-free `AtomicPid`, but
+/// `receive_signal_or_byte` takes a `&JobControl`, so we hold the
+/// `ctrl` guard across the call. The critical section is short (no
+/// allocation, no further locks taken through `dispatch`) and does not
+/// invert lock order: `ctrl` sits below the process TABLE, never above.
+#[cfg(target_os = "none")]
+pub struct NTtyLdisc {
+    ntty: NTty,
+    dispatch: alloc::boxed::Box<dyn SignalDispatch + Send + Sync>,
+}
+
+#[cfg(target_os = "none")]
+impl NTtyLdisc {
+    /// Build an ldisc backed by the production [`KernelSignalDispatch`].
+    pub fn new_kernel() -> Self {
+        Self {
+            ntty: NTty::new(),
+            dispatch: alloc::boxed::Box::new(KernelSignalDispatch),
+        }
+    }
+
+    /// Build an ldisc with a caller-supplied dispatcher. Used by the
+    /// `kernel/tests/ntty_ldisc_wiring.rs` integration test.
+    pub fn with_dispatch(dispatch: alloc::boxed::Box<dyn SignalDispatch + Send + Sync>) -> Self {
+        Self {
+            ntty: NTty::new(),
+            dispatch,
+        }
+    }
+
+    /// Borrow the inner [`NTty`] for read-only observation (e.g. draining
+    /// the committed ring in tests).
+    pub fn ntty(&self) -> &NTty {
+        &self.ntty
+    }
+}
+
+#[cfg(target_os = "none")]
+struct TtyReaderWake(alloc::sync::Arc<crate::poll::WaitQueue>);
+
+#[cfg(target_os = "none")]
+impl ReaderWake for TtyReaderWake {
+    fn wake(&self) {
+        self.0.wake_all();
+    }
+}
+
+/// [`OutSink`] adapter that pushes echo bytes through a [`TtyDriver`]'s
+/// tx path. One byte at a time keeps the interface minimal; `write`
+/// holds the driver's tx lock for each byte, but echo volume is bounded
+/// by human typing rate.
+#[cfg(target_os = "none")]
+struct DriverEchoSink<'a>(&'a dyn super::TtyDriver);
+
+#[cfg(target_os = "none")]
+impl OutSink for DriverEchoSink<'_> {
+    fn push(&mut self, b: u8) {
+        self.0.write(&[b]);
+    }
+}
+
+#[cfg(target_os = "none")]
+impl super::LineDiscipline for NTtyLdisc {
+    fn receive_byte(&self, tty: &super::Tty, byte: u8) {
+        let termios_snap = *tty.termios.lock();
+        // Hold `ctrl` only across the ISIG check. `receive_signal_or_byte`
+        // reads `ctrl.pgrp_snapshot` (lock-free) and dispatches via
+        // `self.dispatch`; the guard drops before `canon_input` acquires
+        // `NTty.state`.
+        let survived = {
+            let ctrl = tty.ctrl.lock();
+            self.ntty
+                .receive_signal_or_byte(&termios_snap, &*ctrl, &*self.dispatch, byte)
+        };
+        let Some(b) = survived else {
+            return;
+        };
+        let wake = TtyReaderWake(tty.read_wait.clone());
+        self.ntty.canon_input(&termios_snap, b, &wake);
+        let mut sink = DriverEchoSink(&*tty.driver);
+        self.ntty.queue_echo(&termios_snap, b, &mut sink);
+    }
+
+    fn open(&self, _tty: &super::Tty) -> Result<(), i64> {
+        Ok(())
+    }
+
+    fn close(&self, _tty: &super::Tty) {}
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/kernel/src/tty/ps2.rs
+++ b/kernel/src/tty/ps2.rs
@@ -9,11 +9,11 @@
 //! forwards every decoded Unicode byte (UTF-8) into
 //! `tty.ldisc.receive_byte(&tty, b)`.
 //!
-//! The default line discipline is [`PassthroughLdisc::new`], which drops
-//! bytes on the floor. This keeps behaviour identical to the pre-#405
-//! world (the shell still reads keystrokes via [`crate::input`]'s
-//! untouched SCANCODES ring) while establishing the pipe that N_TTY
-//! (#375) will hook into once it lands.
+//! The default line discipline is [`NTtyLdisc::new_kernel`], which runs
+//! each decoded byte through the full N_TTY pipeline (ISIG / ICANON /
+//! OPOST / ECHO). The shell still reads keystrokes via [`crate::input`]'s
+//! untouched SCANCODES ring until a second consumer migrates to the
+//! ldisc's raw ring in a follow-up.
 //!
 //! A second `pc_keyboard::Keyboard` instance lives here rather than
 //! sharing the one in [`crate::input`]; the shell-side consumer and the
@@ -27,7 +27,9 @@ use crate::tty::TtyDriver;
 #[cfg(target_os = "none")]
 use crate::task::softirq::{self, SoftIrq};
 #[cfg(target_os = "none")]
-use crate::tty::{LineDiscipline, PassthroughLdisc, Tty};
+use crate::tty::ntty::NTtyLdisc;
+#[cfg(target_os = "none")]
+use crate::tty::{LineDiscipline, Tty};
 #[cfg(target_os = "none")]
 use alloc::sync::Arc;
 #[cfg(target_os = "none")]
@@ -57,7 +59,7 @@ impl TtyDriver for Ps2Driver {
 static PS2_TTY: Lazy<Arc<Tty>> = Lazy::new(|| {
     Arc::new(Tty::with_driver(
         Arc::new(Ps2Driver),
-        Arc::new(PassthroughLdisc::new()) as Arc<dyn LineDiscipline>,
+        Arc::new(NTtyLdisc::new_kernel()) as Arc<dyn LineDiscipline>,
     ))
 });
 

--- a/kernel/src/tty/serial.rs
+++ b/kernel/src/tty/serial.rs
@@ -9,11 +9,11 @@
 //! drains the ring and forwards every byte into
 //! `tty.ldisc.receive_byte(&tty, b)`.
 //!
-//! The default line discipline is [`PassthroughLdisc::new`], which drops
-//! bytes on the floor. This keeps behaviour identical to the pre-#406
-//! world (shell / kernel consumers still read bytes via
-//! [`crate::serial::try_read_byte`]) while establishing the pipe that
-//! N_TTY (#375) will hook into once it lands.
+//! The default line discipline is [`NTtyLdisc::new_kernel`], which runs
+//! each byte through the full N_TTY pipeline (ISIG / ICANON / OPOST /
+//! ECHO). Shell / kernel consumers still read bytes via
+//! [`crate::serial::try_read_byte`] until a follow-up migrates them to
+//! the ldisc's committed raw ring.
 //!
 //! RTS flow control: when the ring first crosses [`WATERMARK_HIGH`] the
 //! ISR-side path clears MCR.RTS to backpressure a peer that honours
@@ -35,7 +35,9 @@ use x86_64::instructions::port::Port;
 #[cfg(target_os = "none")]
 use crate::task::softirq::{self, SoftIrq};
 #[cfg(target_os = "none")]
-use crate::tty::{LineDiscipline, PassthroughLdisc, Tty};
+use crate::tty::ntty::NTtyLdisc;
+#[cfg(target_os = "none")]
+use crate::tty::{LineDiscipline, Tty};
 #[cfg(target_os = "none")]
 use spin::Lazy;
 
@@ -80,7 +82,7 @@ impl TtyDriver for SerialDriver {
 static SERIAL_TTY: Lazy<Arc<Tty>> = Lazy::new(|| {
     Arc::new(Tty::with_driver(
         Arc::new(SerialDriver),
-        Arc::new(PassthroughLdisc::new()) as Arc<dyn LineDiscipline>,
+        Arc::new(NTtyLdisc::new_kernel()) as Arc<dyn LineDiscipline>,
     ))
 });
 

--- a/kernel/tests/ntty_ldisc_wiring.rs
+++ b/kernel/tests/ntty_ldisc_wiring.rs
@@ -1,0 +1,205 @@
+//! Integration test: N_TTY line discipline wired into the Tty rx path (#474).
+//!
+//! Exercises the ldisc glue end-to-end without a live driver ISR:
+//!  - A VINTR byte delivered through `tty.ldisc.receive_byte()` triggers
+//!    a SIGINT on the tty's foreground pgrp (captured via a test
+//!    `SignalDispatch` impl — we don't want to involve the real process
+//!    table here).
+//!  - `abc\n` delivered through `tty.ldisc.receive_byte()` is committed
+//!    into the N_TTY raw ring and observable via `NTty::drain_raw`.
+//!  - `push_scancode_from_isr` / the softirq drain plumb a VINTR code
+//!    all the way through the PS/2 rx path.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicU32, AtomicU8, Ordering};
+
+use vibix::tty::ntty::{NTtyLdisc, SignalDispatch};
+use vibix::tty::ps2::{push_scancode_from_isr, PS2_RX_RING};
+use vibix::tty::serial::{push_byte_from_isr, SERIAL_RX_RING};
+use vibix::tty::{LineDiscipline, NullDriver, Tty};
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    // Needed so the PS/2 / serial softirq drain handlers actually fire
+    // when we raise their bits in the scancode-path smoke test.
+    x86_64::instructions::interrupts::enable();
+    serial_println!("ntty_ldisc_wiring: init ok");
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "vintr_delivers_sigint_to_fg_pgrp",
+            &(vintr_delivers_sigint_to_fg_pgrp as fn()),
+        ),
+        (
+            "canon_line_commits_to_raw_ring",
+            &(canon_line_commits_to_raw_ring as fn()),
+        ),
+        (
+            "ps2_rx_path_routes_through_ntty",
+            &(ps2_rx_path_routes_through_ntty as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+/// Counts `(pgid, sig)` deliveries. `orphaned_pgrp == 0` means "no pgrp
+/// orphaned"; otherwise `is_orphaned` returns true only for that pgid.
+struct RecordingDispatch {
+    orphaned_pgrp: AtomicU32,
+    last_pgid: AtomicU32,
+    last_sig: AtomicU8,
+    count: AtomicU32,
+}
+
+impl RecordingDispatch {
+    const fn new() -> Self {
+        Self {
+            orphaned_pgrp: AtomicU32::new(0),
+            last_pgid: AtomicU32::new(0),
+            last_sig: AtomicU8::new(0),
+            count: AtomicU32::new(0),
+        }
+    }
+}
+
+impl SignalDispatch for RecordingDispatch {
+    fn is_orphaned(&self, pgid: u32) -> bool {
+        let o = self.orphaned_pgrp.load(Ordering::Relaxed);
+        o != 0 && o == pgid
+    }
+
+    fn send_to_pgrp(&self, pgid: u32, sig: u8) {
+        self.last_pgid.store(pgid, Ordering::Relaxed);
+        self.last_sig.store(sig, Ordering::Relaxed);
+        self.count.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Build a fresh [`Tty`] with ISIG-on termios, a test dispatcher, and a
+/// null driver (no tx surface). The dispatcher pointer is leaked into a
+/// `Box::leak` so the test can read its counters after the Arc<Tty> is
+/// gone — the test process exits immediately after, so the leak is
+/// bounded and does not cross test cases.
+fn make_tty_with_dispatch() -> (Arc<Tty>, &'static RecordingDispatch) {
+    let dispatch: &'static RecordingDispatch = Box::leak(Box::new(RecordingDispatch::new()));
+    // NTtyLdisc owns its own dispatcher handle; give it a cloneable
+    // wrapper that forwards into the &'static one so tests observe.
+    struct Forward(&'static RecordingDispatch);
+    impl SignalDispatch for Forward {
+        fn is_orphaned(&self, pgid: u32) -> bool {
+            self.0.is_orphaned(pgid)
+        }
+        fn send_to_pgrp(&self, pgid: u32, sig: u8) {
+            self.0.send_to_pgrp(pgid, sig);
+        }
+    }
+    let ldisc: Arc<dyn LineDiscipline> =
+        Arc::new(NTtyLdisc::with_dispatch(Box::new(Forward(dispatch))));
+    let tty = Arc::new(Tty::with_driver(Arc::new(NullDriver), ldisc));
+    // Enable ISIG + ICANON (already set by Termios::sane, but be explicit)
+    // and plant a foreground pgrp so `pgrp_snapshot.load()` returns 77.
+    {
+        let mut ctrl = tty.ctrl.lock();
+        ctrl.set_pgrp(Some(77));
+    }
+    (tty, dispatch)
+}
+
+/// Ldisc's `NTtyLdisc` isn't directly accessible through `Arc<dyn
+/// LineDiscipline>`. For the raw-ring assertion we keep a second
+/// `NTtyLdisc` reference around by constructing it up front and handing
+/// a clone to the tty.
+fn vintr_delivers_sigint_to_fg_pgrp() {
+    let (tty, dispatch) = make_tty_with_dispatch();
+    // Deliver Ctrl-C (VINTR default = 0x03) through the ldisc entry
+    // point — same call that the softirq drain would make.
+    tty.ldisc.receive_byte(&tty, 0x03);
+    assert_eq!(dispatch.count.load(Ordering::Relaxed), 1);
+    assert_eq!(dispatch.last_pgid.load(Ordering::Relaxed), 77);
+    // SIGINT == 2, matching kernel/src/signal/mod.rs.
+    assert_eq!(dispatch.last_sig.load(Ordering::Relaxed), 2);
+}
+
+fn canon_line_commits_to_raw_ring() {
+    // Build the ldisc directly so we can drain its raw ring after.
+    let ldisc = Arc::new(NTtyLdisc::with_dispatch(Box::new(NullDispatch)));
+    let ldisc_for_tty: Arc<dyn LineDiscipline> = ldisc.clone();
+    let tty = Arc::new(Tty::with_driver(Arc::new(NullDriver), ldisc_for_tty));
+    for &b in b"abc\n" {
+        tty.ldisc.receive_byte(&tty, b);
+    }
+    let mut out = [0u8; 8];
+    let n = ldisc.ntty().drain_raw(&mut out);
+    assert_eq!(
+        &out[..n],
+        b"abc\n",
+        "expected committed line, got {:?}",
+        &out[..n]
+    );
+}
+
+/// Dispatcher that drops every delivery; used when a test doesn't care
+/// about signal observation.
+struct NullDispatch;
+impl SignalDispatch for NullDispatch {
+    fn is_orphaned(&self, _pgid: u32) -> bool {
+        false
+    }
+    fn send_to_pgrp(&self, _pgid: u32, _sig: u8) {}
+}
+
+/// Smoke test: push scancode 0x2e (keyboard 'c') followed by nothing
+/// through `push_scancode_from_isr`, then spin a handful of hlts so the
+/// softirq drain runs on the next PIT tick. The PS/2 tty's default
+/// ldisc is now `NTtyLdisc`, so the fact that the path runs without
+/// panicking — and that the ring is emptied — proves the wiring.
+fn ps2_rx_path_routes_through_ntty() {
+    // Flush any stray codes a prior test may have left.
+    while PS2_RX_RING.pop().is_some() {}
+    while SERIAL_RX_RING.pop().is_some() {}
+    // Scancode 0x2e = 'c' make on set-1; decode is not required for
+    // this assertion — we only prove the path reaches the ldisc.
+    push_scancode_from_isr(0x2e);
+    // Also push a direct serial byte so the serial path is exercised.
+    push_byte_from_isr(b'x');
+    for _ in 0..20 {
+        x86_64::instructions::hlt();
+    }
+    assert!(
+        PS2_RX_RING.pop().is_none(),
+        "ps2 softirq drain didn't consume scancode"
+    );
+    assert!(
+        SERIAL_RX_RING.pop().is_none(),
+        "serial softirq drain didn't consume byte"
+    );
+    // Silence unused-vector warnings.
+    let _ = Vec::<u8>::new();
+}


### PR DESCRIPTION
Closes #474.

## Summary

- Add `NTtyLdisc` in `kernel/src/tty/ntty.rs`: wraps `NTty` + a `SignalDispatch`, implements `LineDiscipline`. `receive_byte` snapshots `termios`, runs the byte through `receive_signal_or_byte` (ISIG + iflag), then hands the surviving byte to `canon_input` (ICANON / raw ring) and `queue_echo` (ECHO / ECHOE / ECHONL, through `OPOST` back to the driver's tx path).
- Swap the default ldisc in `kernel/src/tty/ps2.rs:60` and `kernel/src/tty/serial.rs:83` from `PassthroughLdisc::new()` to `NTtyLdisc::new_kernel()`. `Tty::new()` (the stub container used by PCBs before a driver attaches, per the issue's last bullet) keeps `PassthroughLdisc`.
- Expose `NTty::drain_raw` + `raw_len` so readers (and the new test) can observe the committed ring without reaching into the Mutex.
- Add `kernel/tests/ntty_ldisc_wiring.rs` with three cases: VINTR -> SIGINT on fg pgrp, `abc\n` committed to the raw ring, and PS/2 + serial rx softirq drains consuming pushed bytes without panic.

`Option B` in the issue (pass `&Tty` into `LineDiscipline::receive_byte`) was already in tree (merged via #439), so no trait reshape was needed here.

## Test plan
- [x] `cargo xtask build` — kernel lib + bin build clean.
- [x] `cargo xtask test-integration` — full QEMU suite green, including the new `ntty_ldisc_wiring` (3/3 cases pass).
- [x] `cargo xtask smoke` — 31/31 markers present.
- [x] Existing N_TTY unit tests (`ntty::tests`) still pass unchanged.