### PR TITLE
syscall: dup/dup2 return EBADF on negative fds

### DIFF
--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -327,9 +327,12 @@ pub unsafe extern "C" fn syscall_dispatch(
 
         // dup(oldfd)
         DUP => {
-            let oldfd = a0 as u32;
+            let oldfd = a0 as i32;
+            if oldfd < 0 {
+                return crate::fs::EBADF;
+            }
             let tbl = crate::task::current_fd_table();
-            let result = tbl.lock().dup(oldfd);
+            let result = tbl.lock().dup(oldfd as u32);
             match result {
                 Ok(newfd) => newfd as i64,
                 Err(e) => e,
@@ -434,10 +437,13 @@ pub unsafe extern "C" fn syscall_dispatch(
 
         // dup2(oldfd, newfd)
         DUP2 => {
-            let oldfd = a0 as u32;
-            let newfd = a1 as u32;
+            let oldfd = a0 as i32;
+            let newfd = a1 as i32;
+            if oldfd < 0 || newfd < 0 {
+                return crate::fs::EBADF;
+            }
             let tbl = crate::task::current_fd_table();
-            let result = tbl.lock().dup2(oldfd, newfd);
+            let result = tbl.lock().dup2(oldfd as u32, newfd as u32);
             match result {
                 Ok(fd) => fd as i64,
                 Err(e) => e,

--- a/kernel/tests/syscall_dup_family.rs
+++ b/kernel/tests/syscall_dup_family.rs
@@ -10,6 +10,7 @@
 //!   touching the source fd's per-fd flags.
 //! - `dup3(_, _, unknown_flag)` returns `EINVAL`.
 //! - `dup`/`dup2`/`dup3` on a closed `oldfd` return `EBADF`.
+//! - `dup`/`dup2`/`dup3` on a negative fd return `EBADF` (not EINVAL).
 
 #![no_std]
 #![no_main]
@@ -297,7 +298,10 @@ fn dup_family_ebadf_on_closed() {
     assert_eq!(dup(9999), EBADF);
     assert_eq!(dup2(9999, 5), EBADF);
     assert_eq!(dup3(9999, 5, 0), EBADF);
-    // Linux returns EBADF (not EINVAL) for negative fds on dup3.
+    // Linux returns EBADF (not EINVAL) for negative fds across the dup family.
+    assert_eq!(dup(-1), EBADF);
+    assert_eq!(dup2(-1, 5), EBADF);
+    assert_eq!(dup2(3, -1), EBADF);
     assert_eq!(dup3(-1, 5, 0), EBADF);
     assert_eq!(dup3(3, -1, 0), EBADF);
 }


### PR DESCRIPTION
Closes #470

## Summary

- `DUP` and `DUP2` dispatcher arms now parse `a0` / `a1` as `i32` and return `EBADF` before casting to `u32`, mirroring the pattern `DUP3` already uses (precedent: commit 615445c from #466).
- Previously `dup(-1)` / `dup2(-1, 5)` relied on `-1 as u32 = 0xffff_ffff` being rejected by a downstream `FileDescTable::get` slot lookup — correct by coincidence. A future refactor that widens the slot lookup could silently accept the wrapped fd; the explicit negative check nails the semantics to Linux's on-the-wire behavior.

## Test plan

- [x] Extend `dup_family_ebadf_on_closed` (kernel/tests/syscall_dup_family.rs) with `dup(-1)`, `dup2(-1, 5)`, and `dup2(3, -1)` assertions — parallel to the existing `dup3(-1, _)` / `dup3(_, -1)` cases.
- [x] `cargo xtask build` clean.
- [x] `cargo test --test syscall_dup_family --target x86_64-unknown-none --no-run` compiles clean.
- [ ] Full `cargo xtask test` + `cargo xtask smoke` via CI.