### PR TITLE
userspace/init: add pre/post-write markers for #478 smoke flake

### DIFF
--- a/userspace/init/src/main.rs
+++ b/userspace/init/src/main.rs
@@ -54,12 +54,26 @@ use core::panic::PanicInfo;
 /// Smoke-test marker — asserted by `cargo xtask smoke`.
 const HELLO_MSG: &[u8] = b"init: hello from pid 1\n";
 
+/// Emitted immediately on ring-3 entry, before the first `write(1, ...)`.
+/// Localises the #478 flake: if `init: iretq to ring-3` fires but this
+/// marker doesn't, the first `SYSCALL` instruction or entry trampoline
+/// never ran. fd=2 is used so it's separable from HELLO_MSG on fd=1 and
+/// rules out an fd-1-specific bug.
+const PRE_WRITE_MSG: &[u8] = b"init: pre-write marker\n";
+
+/// Emitted right after the first `write(1, HELLO_MSG)` returns.
+/// If PRE_WRITE fires and HELLO_MSG fires but this doesn't, the write
+/// syscall return path is the culprit.
+const POST_WRITE_MSG: &[u8] = b"init: post-write marker\n";
+
 /// Emitted after the parent collects the child's exit status.
 const DONE_MSG: &[u8] = b"init: fork+exec+wait ok\n";
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
+    write(2, PRE_WRITE_MSG);
     write(1, HELLO_MSG);
+    write(1, POST_WRITE_MSG);
 
     // fork() — child PID returned to parent; 0 returned to child.
     let fork_ret: i64;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -98,7 +98,13 @@ const SMOKE_MARKERS: &[&str] = &[
     // `ring3-first-fault:` diagnostic line emitted by the IDT fault
     // handlers in that case).
     "ring3-iretq: rip=",
+    // Fine-grained userspace markers bracketing the first `write`
+    // syscall. See userspace/init/src/main.rs — together with
+    // `ring3-iretq:` and "init: hello from pid 1" these localise the
+    // #478 flake to the exact step that failed.
+    "init: pre-write marker",
     "init: hello from pid 1",
+    "init: post-write marker",
 ];
 
 /// Markers for the fork+exec+wait flow. These are flakey under un-accelerated


### PR DESCRIPTION
Closes #484

## Summary
- Adds two new smoke markers to userspace init — `"init: pre-write marker"` (fd=2) emitted on ring-3 entry before the first `write(1, HELLO_MSG)`, and `"init: post-write marker"` (fd=1) emitted immediately after HELLO_MSG returns.
- Registers both markers in `SMOKE_MARKERS` (xtask) so the smoke harness fails a CI run that loses any of the four bracket markers.
- Purpose: split 1/2 of the #478 P0 flake ("init: hello from pid 1" missing after IRETQ). Together with the existing kernel-side `"init: iretq to ring-3"` and the userspace `"init: hello from pid 1"`, these localise where the ring-3 entry path breaks when it breaks:
  - `iretq to ring-3` fires, `pre-write` doesn't → first `SYSCALL` instruction or entry trampoline silently faulted.
  - `pre-write` fires, `hello from pid 1` doesn't → fd=1 specific bug.
  - `hello from pid 1` fires, `post-write` doesn't → write syscall return path is the culprit.

Both markers reuse the existing `write()` helper so they exercise the identical syscall path as HELLO_MSG; a separate minimal-syscall path would add a second regression surface without a diagnostic payoff.

## Test plan
- [x] `cargo xtask build` — succeeds locally.
- [x] `cargo test -p xtask` — 26/26 passing, SMOKE_MARKERS satisfaction tests still green with the two new entries.
- [ ] CI green on `fmt + build`, `host unit tests`, `integration tests (QEMU)`, `smoke test`.
- [ ] Follow-up (#485): kernel-side `jump_to_ring3` register / fault diagnostics for the other half of the diagnostic picture.