### PR TITLE
arch/x86_64: ring-3 entry + first-fault diagnostics for #478

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -2,6 +2,8 @@
 //! during early boot. Each handler logs to serial then halts — we don't
 //! have a panic-unwind story yet, so there's nothing to return to.
 
+use core::sync::atomic::{AtomicBool, Ordering};
+
 use spin::Lazy;
 use x86_64::structures::idt::{InterruptDescriptorTable, InterruptStackFrame, PageFaultErrorCode};
 use x86_64::structures::paging::PageTableFlags;
@@ -11,6 +13,38 @@ use crate::arch::x86_64::interrupts::{
     keyboard_interrupt, serial_interrupt, timer_interrupt, InterruptIndex,
 };
 use crate::serial_println;
+
+/// #478 diagnostic latch: the first CPL=3 fault of the session logs a
+/// `ring3-first-fault:` line with full frame state before the handler
+/// runs its normal path. Subsequent ring-3 faults are common (SIGSEGV
+/// delivery etc.) and must not flood the log. One-shot by design.
+static FIRST_RING3_FAULT_LOGGED: AtomicBool = AtomicBool::new(false);
+
+/// Emit one `ring3-first-fault:` line on the first CPL=3 fault ever
+/// observed. `extra` is vector-specific trailer (e.g. `code=0x0` for #GP,
+/// `cr2=0x400000 code=PROTECTION` for #PF) — no user memory is touched
+/// while formatting, only scalars copied out of the hardware frame.
+fn log_first_ring3_fault(vector: &str, frame: &InterruptStackFrame, extra: core::fmt::Arguments) {
+    if (frame.code_segment.0 & 0b11) == 0 {
+        return;
+    }
+    if FIRST_RING3_FAULT_LOGGED
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return;
+    }
+    serial_println!(
+        "ring3-first-fault: {} rip={:#x} rsp={:#x} cs={:#x} ss={:#x} rflags={:#x} {}",
+        vector,
+        frame.instruction_pointer.as_u64(),
+        frame.stack_pointer.as_u64(),
+        frame.code_segment.0,
+        frame.stack_segment.0,
+        frame.cpu_flags.bits(),
+        extra,
+    );
+}
 
 static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
     let mut idt = InterruptDescriptorTable::new();
@@ -66,6 +100,7 @@ extern "x86-interrupt" fn divide_error(frame: InterruptStackFrame) {
 }
 
 extern "x86-interrupt" fn invalid_opcode(frame: InterruptStackFrame) {
+    log_first_ring3_fault("#UD", &frame, format_args!(""));
     serial_println!("EXCEPTION: #UD (invalid opcode)\n{:#?}", frame);
     hang();
 }
@@ -119,6 +154,7 @@ extern "x86-interrupt" fn breakpoint(mut frame: InterruptStackFrame) {
 }
 
 extern "x86-interrupt" fn general_protection(frame: InterruptStackFrame, code: u64) {
+    log_first_ring3_fault("#GP", &frame, format_args!("code={:#x}", code));
     serial_println!("EXCEPTION: #GP code={:#x}\n{:#?}", code, frame);
     hang();
 }
@@ -138,6 +174,12 @@ extern "x86-interrupt" fn page_fault(mut frame: InterruptStackFrame, code: PageF
         unsafe { core::arch::asm!("clac", options(nomem, nostack)) };
     }
     let addr_u64 = x86_64::registers::control::Cr2::read_raw();
+
+    log_first_ring3_fault(
+        "#PF",
+        &frame,
+        format_args!("cr2={:#x} code={:?}", addr_u64, code),
+    );
 
     if let Some(expected) = crate::test_hook::take_page_fault_expectation() {
         use crate::test_harness::{exit_qemu, QemuExitCode};

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -155,6 +155,18 @@ fn stack_top() -> u64 {
 /// - `stack_top` must point to a mapped, writable user-space page.
 /// - `setup_ring3_stacks` must have been called so TSS.rsp[0] is valid.
 pub unsafe fn jump_to_ring3(entry: u64, stack_top: u64) -> ! {
+    // #478 diagnostic: log the exact IRETQ frame values at the last
+    // kernel-side instruction before the ring-0→ring-3 transition, so
+    // smoke can tell a silent #GP/#PF from a pre-IRETQ failure when the
+    // userspace "init: hello from pid 1" marker goes missing.
+    crate::serial_println!(
+        "ring3-iretq: rip={:#x} rsp={:#x} cs={:#x} ss={:#x} rflags={:#x}",
+        entry,
+        stack_top,
+        USER_CODE_SELECTOR,
+        USER_DATA_SELECTOR,
+        0x202u64,
+    );
     core::arch::asm!(
         "push {ss}",      // SS  = user data selector (stack segment)
         "push {sp}",      // RSP = user stack top

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -88,6 +88,16 @@ const SMOKE_MARKERS: &[&str] = &[
     // "init: hello from pid 1" doesn't, the regression is in the ring-3
     // return path or the first userspace write, not kernel init.
     "init: iretq to ring-3",
+    // #478 diagnostic: printed from `jump_to_ring3` just before the
+    // `iretq` instruction with the full IRETQ frame (RIP/RSP/CS/SS/
+    // RFLAGS). If this is absent in a failing run, the kernel never
+    // reached the ring-3 return path at all — the regression is on
+    // the scheduling/init-process side. If present but
+    // `init: hello from pid 1` is missing, either the `iretq` itself
+    // or the first userspace instruction faulted (see the
+    // `ring3-first-fault:` diagnostic line emitted by the IDT fault
+    // handlers in that case).
+    "ring3-iretq: rip=",
     "init: hello from pid 1",
 ];
 


### PR DESCRIPTION
Closes #485

## Summary

Split 2/2 of #478 — kernel-side diagnostics so the next reproduction of the P0 smoke flake leaves enough trace in the serial capture to tell IRETQ failure modes apart.

- New `ring3-iretq: rip=... rsp=... cs=... ss=... rflags=...` line emitted from `jump_to_ring3` at the last instruction before the `iretq` opcode. Registered as a hard `SMOKE_MARKER` so a regression that skips ring-3 entry fails smoke directly, instead of hiding behind a missing userspace marker.
- New `ring3-first-fault: <VECTOR> rip=... rsp=... cs=... ss=... rflags=... <extra>` line emitted from a one-shot `AtomicBool` latch inside the `#UD`, `#GP`, and `#PF` IDT handlers. Fires only when `CPL=3`, and only on the first ring-3 fault of the session, so legitimate SIGSEGV delivery later in the run does not flood the log. Formatting reads only scalars out of the hardware `InterruptStackFrame` and `CR2` — no user memory is touched, so this is safe to call from inside a page-fault handler.

Complements split 1/2 (userspace-side pre/post-write markers) which is in flight as PR #486.

## Decoding a failing run

- `ring3-iretq:` present + `ring3-first-fault:` absent + init marker absent → IRETQ executed, first ring-3 instruction executed without faulting, then something later went missing (scheduling / stdout path).
- `ring3-iretq:` present + `ring3-first-fault:` present → ring-3 entry faulted immediately; the vector + CR2 tell us which mapping is wrong.
- `ring3-iretq:` absent → kernel never called `jump_to_ring3` — the regression is on the init-process / scheduler side.

## Test plan

- [x] \`cargo xtask build\` clean (only pre-existing \`is_guard_hit\` dead-code warning).
- [ ] Full \`cargo xtask test\` + \`cargo xtask smoke\` via CI (local host is aarch64).
- [ ] Next occurrence of the #478 flake exercises the new diagnostic and its capture tells us which branch fired.