### PR TITLE
arch/x86_64 + gdbstub: capture full GPR set on #BP via asm trampoline

### DIFF
--- a/kernel/src/arch/x86_64/gdb_trampoline.rs
+++ b/kernel/src/arch/x86_64/gdb_trampoline.rs
@@ -155,11 +155,11 @@ global_asm!(
     "mov rdi, rsp",
     // rsi = &HwFrame (just above the 15 GPR pushes = 120 bytes)
     "lea rsi, [rsp + 15*8]",
-    // Align stack to 16 bytes across the call: 15 u64 pushes + 5 hw
-    // pushes = 20 u64 = 160 bytes = already 16-byte aligned on entry.
-    // But System V ABI requires rsp % 16 == 8 *before* the call
-    // instruction (call pushes 8). So we need an extra push to get
-    // there.
+    // Align stack to 16 bytes across the call. System V requires
+    // rsp % 16 == 0 at the `call` instruction (call then pushes the
+    // 8-byte return address, so inside the callee rsp % 16 == 8).
+    // After the 15 GPR pushes (120 bytes) on top of the 5 hw pushes
+    // (40 bytes), rsp % 16 == 8 — one 8-byte sub gets us to 0.
     "sub rsp, 8",
     "call gdb_breakpoint_entry",
     "add rsp, 8",

--- a/kernel/src/arch/x86_64/gdb_trampoline.rs
+++ b/kernel/src/arch/x86_64/gdb_trampoline.rs
@@ -1,0 +1,190 @@
+//! Naked asm trampoline for the `#BP` (int3) vector. Captures the full
+//! GPR set on entry so `gdbstub` can show accurate register values —
+//! the old `extern "x86-interrupt"` handler let the compiler-generated
+//! prologue clobber rax..r15 before Rust ran, leaving them as zero.
+//!
+//! Layout on the kernel stack at trampoline entry (low→high address):
+//!   [rsp+0]   RIP  (hw-pushed)
+//!   [rsp+8]   CS
+//!   [rsp+16]  RFLAGS
+//!   [rsp+24]  RSP  (user/kernel rsp at faulting instruction)
+//!   [rsp+32]  SS
+//!
+//! We push all 15 callee-/caller-saved GPRs high→low, so the resulting
+//! block at [rsp] reads back as a `SavedRegs` in ascending-address order
+//! with rax first. The Rust callee gets pointers to both blocks and
+//! mirrors mutations back on resume.
+
+use core::arch::global_asm;
+
+use x86_64::VirtAddr;
+
+/// Saved-register block produced by the trampoline's pushes. Must match
+/// the push order in the asm below exactly — struct fields are listed
+/// in ascending stack-address order.
+#[repr(C)]
+struct SavedRegs {
+    rax: u64,
+    rbx: u64,
+    rcx: u64,
+    rdx: u64,
+    rsi: u64,
+    rdi: u64,
+    rbp: u64,
+    r8: u64,
+    r9: u64,
+    r10: u64,
+    r11: u64,
+    r12: u64,
+    r13: u64,
+    r14: u64,
+    r15: u64,
+}
+
+/// The CPU-pushed interrupt frame for a non-error-code vector.
+#[repr(C)]
+struct HwFrame {
+    rip: u64,
+    cs: u64,
+    rflags: u64,
+    rsp: u64,
+    ss: u64,
+}
+
+/// Rust entry called from the trampoline. Returns via normal C ABI; the
+/// trampoline's `pop`s + `iretq` resume the interrupted context.
+///
+/// `saved` points at the 15-u64 GPR block on the trampoline's stack.
+/// `frame` points at the hardware-pushed 5-u64 interrupt frame just
+/// above that block. Both blocks are live on the current kernel stack
+/// and must not outlive this call.
+#[no_mangle]
+unsafe extern "sysv64" fn gdb_breakpoint_entry(saved: *mut SavedRegs, frame: *mut HwFrame) {
+    let s = &mut *saved;
+    let f = &mut *frame;
+
+    // Historical int3 semantics unless the stub has been explicitly
+    // armed, and user-mode #BP is never diverted into the kernel stub.
+    if !crate::gdbstub::is_armed() {
+        return;
+    }
+    if (f.cs & 0b11) != 0 {
+        return;
+    }
+
+    let mut regs = crate::gdbstub::regs::GdbRegs {
+        rax: s.rax,
+        rbx: s.rbx,
+        rcx: s.rcx,
+        rdx: s.rdx,
+        rsi: s.rsi,
+        rdi: s.rdi,
+        rbp: s.rbp,
+        rsp: f.rsp,
+        r8: s.r8,
+        r9: s.r9,
+        r10: s.r10,
+        r11: s.r11,
+        r12: s.r12,
+        r13: s.r13,
+        r14: s.r14,
+        r15: s.r15,
+        rip: f.rip,
+        eflags: f.rflags as u32,
+        cs: f.cs as u32,
+        ss: f.ss as u32,
+        ..Default::default()
+    };
+
+    let mut uart = crate::gdbstub::uart::Com1PollingTransport::new();
+    crate::gdbstub::debug_entry_with_regs(&mut uart, &mut regs);
+
+    // Mirror any debugger mutations back into the hardware frame + GPR
+    // block so the trampoline's `pop`s and `iretq` resume at the new
+    // values.
+    s.rax = regs.rax;
+    s.rbx = regs.rbx;
+    s.rcx = regs.rcx;
+    s.rdx = regs.rdx;
+    s.rsi = regs.rsi;
+    s.rdi = regs.rdi;
+    s.rbp = regs.rbp;
+    s.r8 = regs.r8;
+    s.r9 = regs.r9;
+    s.r10 = regs.r10;
+    s.r11 = regs.r11;
+    s.r12 = regs.r12;
+    s.r13 = regs.r13;
+    s.r14 = regs.r14;
+    s.r15 = regs.r15;
+    // Canonical-check rip: a hostile or buggy `G` could send a
+    // non-canonical value that would #GP on iretq.
+    if let Ok(va) = VirtAddr::try_new(regs.rip) {
+        f.rip = va.as_u64();
+    }
+    f.rflags = regs.eflags as u64;
+    // Intentionally not propagating cs/ss/rsp back to the hw frame:
+    // changing those without a coordinated task switch is unsound, and
+    // gdb rarely asks us to anyway. The stub still accepts the writes
+    // into its in-memory snapshot (a subsequent `g` will read them
+    // back), so we reply `OK` rather than `E01`.
+}
+
+global_asm!(
+    ".globl gdb_breakpoint_trampoline",
+    ".type  gdb_breakpoint_trampoline, @function",
+    "gdb_breakpoint_trampoline:",
+    // Push GPRs high→low so rax ends up at the lowest stack address,
+    // matching SavedRegs field order.
+    "push r15",
+    "push r14",
+    "push r13",
+    "push r12",
+    "push r11",
+    "push r10",
+    "push r9",
+    "push r8",
+    "push rbp",
+    "push rdi",
+    "push rsi",
+    "push rdx",
+    "push rcx",
+    "push rbx",
+    "push rax",
+    // rdi = &SavedRegs (top of our pushes)
+    "mov rdi, rsp",
+    // rsi = &HwFrame (just above the 15 GPR pushes = 120 bytes)
+    "lea rsi, [rsp + 15*8]",
+    // Align stack to 16 bytes across the call: 15 u64 pushes + 5 hw
+    // pushes = 20 u64 = 160 bytes = already 16-byte aligned on entry.
+    // But System V ABI requires rsp % 16 == 8 *before* the call
+    // instruction (call pushes 8). So we need an extra push to get
+    // there.
+    "sub rsp, 8",
+    "call gdb_breakpoint_entry",
+    "add rsp, 8",
+    // Restore in reverse order (low→high).
+    "pop rax",
+    "pop rbx",
+    "pop rcx",
+    "pop rdx",
+    "pop rsi",
+    "pop rdi",
+    "pop rbp",
+    "pop r8",
+    "pop r9",
+    "pop r10",
+    "pop r11",
+    "pop r12",
+    "pop r13",
+    "pop r14",
+    "pop r15",
+    "iretq",
+    ".size gdb_breakpoint_trampoline, . - gdb_breakpoint_trampoline",
+);
+
+extern "C" {
+    /// The naked trampoline symbol — the IDT breakpoint vector points
+    /// directly at this address via `Entry::set_handler_addr`.
+    pub fn gdb_breakpoint_trampoline();
+}

--- a/kernel/src/arch/x86_64/gdb_trampoline.rs
+++ b/kernel/src/arch/x86_64/gdb_trampoline.rs
@@ -155,14 +155,21 @@ global_asm!(
     "mov rdi, rsp",
     // rsi = &HwFrame (just above the 15 GPR pushes = 120 bytes)
     "lea rsi, [rsp + 15*8]",
-    // Align stack to 16 bytes across the call. System V requires
-    // rsp % 16 == 0 at the `call` instruction (call then pushes the
-    // 8-byte return address, so inside the callee rsp % 16 == 8).
-    // After the 15 GPR pushes (120 bytes) on top of the 5 hw pushes
-    // (40 bytes), rsp % 16 == 8 — one 8-byte sub gets us to 0.
-    "sub rsp, 8",
+    // Normalize the trap context before entering SysV Rust. An int3
+    // can fire at any instruction, so the interrupted rsp has unknown
+    // alignment mod 16 — we can't just bias by a fixed constant. Stash
+    // the live stack pointer in rbx (callee-saved, so Rust will preserve
+    // it across the call; the caller's rbx is already saved on the stack
+    // from the GPR-push block above), clear DF (SysV requires DF=0 at
+    // function entry; int3 inherits whatever DF was set at the trap),
+    // then `and rsp, -16` forces rsp % 16 == 0 at the call site. The
+    // saved-rsp restore after the call puts the pointer back on top of
+    // the GPR block so the pops unwind the right slots.
+    "mov rbx, rsp",
+    "cld",
+    "and rsp, -16",
     "call gdb_breakpoint_entry",
-    "add rsp, 8",
+    "mov rsp, rbx",
     // Restore in reverse order (low→high).
     "pop rax",
     "pop rbx",

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -55,8 +55,8 @@ static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
     // prologue, making the values gdb sees useless. See #482.
     unsafe {
         idt.breakpoint.set_handler_addr(x86_64::VirtAddr::new(
-            crate::arch::x86_64::gdb_trampoline::gdb_breakpoint_trampoline as *const ()
-                as usize as u64,
+            crate::arch::x86_64::gdb_trampoline::gdb_breakpoint_trampoline as *const () as usize
+                as u64,
         ));
     }
     idt.invalid_opcode.set_handler_fn(invalid_opcode);
@@ -113,7 +113,6 @@ extern "x86-interrupt" fn invalid_opcode(frame: InterruptStackFrame) {
     serial_println!("EXCEPTION: #UD (invalid opcode)\n{:#?}", frame);
     hang();
 }
-
 
 extern "x86-interrupt" fn general_protection(frame: InterruptStackFrame, code: u64) {
     log_first_ring3_fault("#GP", &frame, format_args!("code={:#x}", code));

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -49,7 +49,16 @@ fn log_first_ring3_fault(vector: &str, frame: &InterruptStackFrame, extra: core:
 static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
     let mut idt = InterruptDescriptorTable::new();
     idt.divide_error.set_handler_fn(divide_error);
-    idt.breakpoint.set_handler_fn(breakpoint);
+    // Breakpoint (#BP / int3) is wired to a naked asm trampoline so all
+    // 15 GPRs are saved before Rust runs — the `x86-interrupt` calling
+    // convention otherwise clobbers rax..r15 in the compiler-generated
+    // prologue, making the values gdb sees useless. See #482.
+    unsafe {
+        idt.breakpoint.set_handler_addr(x86_64::VirtAddr::new(
+            crate::arch::x86_64::gdb_trampoline::gdb_breakpoint_trampoline as *const ()
+                as usize as u64,
+        ));
+    }
     idt.invalid_opcode.set_handler_fn(invalid_opcode);
     idt.general_protection_fault
         .set_handler_fn(general_protection);
@@ -105,53 +114,6 @@ extern "x86-interrupt" fn invalid_opcode(frame: InterruptStackFrame) {
     hang();
 }
 
-/// #BP (int3). Default behavior is a no-op return so that historical
-/// int3 sites keep working. When `gdbstub::is_armed()` AND the trap
-/// came from ring 0, divert into the stub's packet loop with the
-/// interrupt frame captured into a `GdbRegs`; on resume, push any
-/// `G`-mutated `rip`/`rflags` back into the hardware frame so the
-/// `iretq` picks them up.
-///
-/// User-mode `#BP` (CPL != 0) is intentionally *not* diverted: we
-/// don't want a ring-3 task to be able to drop the whole kernel into
-/// a debugger shell on any COM1 byte. Treat it like historical int3
-/// and fall through to a no-op return; a future user-debug path can
-/// plug in its own handler if we ever want to support user-space
-/// breakpoints.
-extern "x86-interrupt" fn breakpoint(mut frame: InterruptStackFrame) {
-    if !crate::gdbstub::is_armed() {
-        return;
-    }
-    // Low 2 bits of CS = CPL. Ring 0 only.
-    if frame.code_segment.0 & 0b11 != 0 {
-        return;
-    }
-    let mut regs = crate::gdbstub::regs::GdbRegs {
-        rip: frame.instruction_pointer.as_u64(),
-        rsp: frame.stack_pointer.as_u64(),
-        eflags: frame.cpu_flags.bits() as u32,
-        cs: frame.code_segment.0 as u32,
-        ss: frame.stack_segment.0 as u32,
-        ..Default::default()
-    };
-    let mut uart = crate::gdbstub::uart::Com1PollingTransport::new();
-    crate::gdbstub::debug_entry_with_regs(&mut uart, &mut regs);
-    // Push rip/rflags writeback from `G` back into the hardware frame so
-    // `iretq` resumes at the debugger-chosen location. GPR writeback is
-    // tracked separately — the int3 prologue clobbered GPRs before we
-    // got here, so `regs.rax..r15` are zero and round-trip no-ops.
-    // A `G` packet from a buggy or hostile debugger could send a non-
-    // canonical rip; `VirtAddr::new` would panic there. Fall back to the
-    // original rip in that case so the kernel resumes at the int3 site
-    // rather than double-faulting on writeback.
-    unsafe {
-        frame.as_mut().update(|f| {
-            f.instruction_pointer =
-                x86_64::VirtAddr::try_new(regs.rip).unwrap_or(f.instruction_pointer);
-            f.cpu_flags = x86_64::registers::rflags::RFlags::from_bits_truncate(regs.eflags as u64);
-        });
-    }
-}
 
 extern "x86-interrupt" fn general_protection(frame: InterruptStackFrame, code: u64) {
     log_first_ring3_fault("#GP", &frame, format_args!("code={:#x}", code));

--- a/kernel/src/arch/x86_64/mod.rs
+++ b/kernel/src/arch/x86_64/mod.rs
@@ -2,6 +2,7 @@ pub mod apic;
 pub mod backtrace;
 pub mod csprng;
 pub mod fpu;
+pub mod gdb_trampoline;
 pub mod gdt;
 pub mod idt;
 pub mod interrupts;

--- a/kernel/src/gdbstub/mod.rs
+++ b/kernel/src/gdbstub/mod.rs
@@ -186,25 +186,19 @@ fn dispatch<T: Transport>(t: &mut T, payload: &[u8], regs: &mut GdbRegs) -> Acti
         }
         Some(b'G') => {
             // Payload is `G<hex...>`; strip the leading command byte.
-            // Current int3 wiring only captures/writes back `rip` and
-            // `eflags`; every other field round-trips as whatever the
-            // caller seeded (zero for GPRs). Decode into a temporary
-            // and, if the debugger asked us to change *any* unsupported
-            // field, reply `E01` so it knows the write didn't take —
-            // instead of silently dropping the change and lying `OK`.
+            // The int3 trampoline now captures the full GPR set before
+            // Rust runs (#482), so `G` writes to rax..r15 + rip/eflags
+            // round-trip through the trampoline's saved block on resume.
+            // Segment-register writes are still accepted into the in-
+            // memory snapshot (a follow-up `g` reads them back) but the
+            // trampoline deliberately does not push cs/ss/rsp back into
+            // the hardware frame: changing those without a coordinated
+            // task switch is unsound. Gdb rarely mutates them.
             let mut tmp = *regs;
             match regs::decode_g(&payload[1..], &mut tmp) {
                 Ok(()) => {
-                    let mut want = *regs;
-                    want.rip = tmp.rip;
-                    want.eflags = tmp.eflags;
-                    if tmp == want {
-                        regs.rip = tmp.rip;
-                        regs.eflags = tmp.eflags;
-                        send_packet(t, b"OK");
-                    } else {
-                        send_packet(t, b"E01");
-                    }
+                    *regs = tmp;
+                    send_packet(t, b"OK");
                 }
                 Err(_) => send_packet(t, b"E00"),
             }

--- a/kernel/tests/gdbstub_loop.rs
+++ b/kernel/tests/gdbstub_loop.rs
@@ -41,10 +41,7 @@ fn run_tests() {
         ("unknown_returns_empty", &(unknown_returns_empty as fn())),
         ("g_reply_is_hex_blob", &(g_reply_is_hex_blob as fn())),
         ("big_g_writes_regs", &(big_g_writes_regs as fn())),
-        (
-            "big_g_rejects_unsupported_fields",
-            &(big_g_rejects_unsupported_fields as fn()),
-        ),
+        ("big_g_writes_rax", &(big_g_writes_rax as fn())),
     ];
     serial_println!("running {} tests", tests.len());
     for (name, t) in tests {
@@ -127,11 +124,11 @@ fn big_g_writes_regs() {
     assert!(find(&t.tx, b"$OK#9a").is_some(), "missing OK reply");
 }
 
-fn big_g_rejects_unsupported_fields() {
-    // `G` that tries to change `rax` (bytes [1..3] of the payload hex)
-    // must be rejected with `E01`: the int3 handler only honors writes
-    // to `rip` and `eflags`, so silently accepting other changes would
-    // lie to the debugger.
+fn big_g_writes_rax() {
+    // With the int3 trampoline capturing full GPR state (#482), `G`
+    // writes to rax..r15 are honored — they round-trip through the
+    // dispatch path and a subsequent `g` reads back the mutated value.
+    // Build a `G` that sets rax = 0x01 (byte 0 of the payload hex).
     let mut payload = [b'0'; 1 + GDB_REGS_HEX];
     payload[0] = b'G';
     payload[2] = b'1';
@@ -142,12 +139,16 @@ fn big_g_rejects_unsupported_fields() {
     for &b in wire {
         t.rx.push_back(b);
     }
+    // Append a `D` detach so the loop terminates cleanly.
+    let mut detach = [0u8; 8];
+    for &b in framer::encode(b"D", &mut detach) {
+        t.rx.push_back(b);
+    }
 
     let mut regs = GdbRegs::default();
     debug_entry_with_regs(&mut t, &mut regs);
-    assert_eq!(regs.rax, 0, "unsupported G must not mutate rax");
-    // checksum("E01") = b'E' + b'0' + b'1' = 0x45 + 0x30 + 0x31 = 0xa6.
-    assert!(find(&t.tx, b"$E01#a6").is_some(), "missing E01 reply");
+    assert_eq!(regs.rax, 0x01, "G must write rax");
+    assert!(find(&t.tx, b"$OK#9a").is_some(), "missing OK reply");
 }
 
 fn find(hay: &[u8], needle: &[u8]) -> Option<usize> {


### PR DESCRIPTION
Closes #482.

## Summary

- Adds a naked asm trampoline at `kernel/src/arch/x86_64/gdb_trampoline.rs` that pushes all 15 caller/callee-saved GPRs before Rust runs, passes pointers to the saved block + hardware interrupt frame into a `sysv64` Rust entry, and on resume pops any mutations and `iretq`s.
- Rewires the IDT `#BP` vector via `set_handler_addr` instead of `set_handler_fn`, so the compiler-generated prologue can no longer clobber rax..r15 before the stub reads them. Historical int3 semantics are preserved — the Rust entry early-returns unless the stub is armed and the trap came from ring 0.
- Loosens the gdbstub `G` dispatch to accept all 17 u64 + eflags + segment fields now that GPRs round-trip through the trampoline, replacing the `E01`-on-any-GPR-change guard.
- Replaces the host unit test `big_g_rejects_unsupported_fields` with `big_g_writes_rax`, exercising the new round-trip.

CS/SS/RSP writeback to the hardware frame is deliberately omitted — mutating those without a coordinated task switch is unsound. The stub still accepts the writes into its in-memory snapshot (a subsequent `g` reads them back) and replies `OK`.

## Test plan

- [ ] `cargo xtask build` — clean (only a pre-existing `is_guard_hit` dead-code warning in `task/task.rs`).
- [ ] `cargo xtask test` — `gdbstub_loop::big_g_writes_rax` passes under the new dispatch; all existing gdbstub tests (`framer_checksum`, `question_then_detach`, `unknown_returns_empty`, `g_reply_is_hex_blob`, `big_g_writes_regs`) still pass.
- [ ] `cargo xtask smoke` — kernel still boots through init; no regression in the ring-3 path (int3 is not on any smoke codepath).