### PR TITLE
gdbstub: add `m`/`M` memory packets with safe-access probe

### DIFF
--- a/kernel/src/gdbstub/mem.rs
+++ b/kernel/src/gdbstub/mem.rs
@@ -1,0 +1,324 @@
+//! `m`/`M` packet support: argument parsing + safe memory access.
+//!
+//! `m <addr>,<len>` reads `len` bytes at `addr` and sends them back as
+//! lowercase hex. `M <addr>,<len>:<data>` takes `2*len` hex characters
+//! after the `:` and writes those bytes to `addr`. Both return `E01`
+//! if any byte of the range is unreadable/unwritable rather than
+//! faulting.
+//!
+//! Parsing lives here as pure-byte logic so host unit tests can cover
+//! the edge cases (non-hex, overflow, missing separators) without
+//! pulling in kernel-only code. The safe-access probes are `cfg`-gated
+//! to `target_os = "none"` because they rely on the kernel's page
+//! walker.
+
+/// Hex alphabet — lowercase to match the wire format our existing
+/// `regs::encode_g` produces.
+const HEX: &[u8; 16] = b"0123456789abcdef";
+
+/// Cap on `m` reply size. Reply is `2 * len` hex bytes framed in a
+/// packet; leaving room for packet framing and escape expansion we
+/// bound single-request reads well below `framer::MAX_PACKET`.
+pub const MAX_MEM_XFER: usize = 256;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum MemErr {
+    /// A hex digit was not in `[0-9a-fA-F]`.
+    BadHex,
+    /// Missing the `,` between `addr` and `len`.
+    MissingComma,
+    /// Missing the `:` that precedes `M`'s data block.
+    MissingColon,
+    /// `addr` or `len` overflowed its target integer type.
+    Overflow,
+    /// `len` is zero — RSP spec treats this as a no-op but our probe
+    /// surface expects at least one byte; the dispatch layer handles
+    /// zero by replying empty (for `m`) or `OK` (for `M`) without
+    /// touching memory, so parsers reject it and let the caller decide.
+    ZeroLen,
+    /// Requested length exceeds [`MAX_MEM_XFER`]; gdb retries with a
+    /// smaller `len` on `E` responses, so we reject proactively.
+    TooBig,
+    /// `M` payload has fewer/more hex chars than `2 * len`.
+    ShortData,
+    /// `addr` is non-canonical — reject up front so the probe layer
+    /// doesn't have to handle it.
+    NonCanonical,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MemArgs {
+    pub addr: u64,
+    pub len: usize,
+}
+
+/// Parse an `m addr,len` payload (without the leading `m`).
+pub fn parse_m(payload: &[u8]) -> Result<MemArgs, MemErr> {
+    let (addr, rest) = parse_hex_u64(payload)?;
+    let rest = eat(rest, b',').ok_or(MemErr::MissingComma)?;
+    let (len, rest) = parse_hex_usize(rest)?;
+    if !rest.is_empty() {
+        return Err(MemErr::BadHex);
+    }
+    validate(addr, len)?;
+    Ok(MemArgs { addr, len })
+}
+
+/// Parse an `M addr,len:data` payload (without the leading `M`).
+/// Returns the parsed args and the raw hex `data` slice.
+pub fn parse_big_m(payload: &[u8]) -> Result<(MemArgs, &[u8]), MemErr> {
+    let (addr, rest) = parse_hex_u64(payload)?;
+    let rest = eat(rest, b',').ok_or(MemErr::MissingComma)?;
+    let (len, rest) = parse_hex_usize(rest)?;
+    let data = eat(rest, b':').ok_or(MemErr::MissingColon)?;
+    validate(addr, len)?;
+    if data.len() != len.checked_mul(2).ok_or(MemErr::Overflow)? {
+        return Err(MemErr::ShortData);
+    }
+    for &b in data {
+        if hex_nib(b).is_none() {
+            return Err(MemErr::BadHex);
+        }
+    }
+    Ok((MemArgs { addr, len }, data))
+}
+
+fn validate(addr: u64, len: usize) -> Result<(), MemErr> {
+    if len == 0 {
+        return Err(MemErr::ZeroLen);
+    }
+    if len > MAX_MEM_XFER {
+        return Err(MemErr::TooBig);
+    }
+    // Reject non-canonical up front. The leaf probe below dereferences
+    // page-table entries indexed off `addr`, which is undefined on a
+    // non-canonical pointer; belt-and-braces check here.
+    if !is_canonical(addr) {
+        return Err(MemErr::NonCanonical);
+    }
+    // Range must also not wrap past u64::MAX.
+    addr.checked_add(len as u64).ok_or(MemErr::Overflow)?;
+    Ok(())
+}
+
+fn is_canonical(addr: u64) -> bool {
+    // x86_64 canonical form: bits [63:48] must all match bit 47.
+    let high = addr >> 47;
+    high == 0 || high == 0x1_FFFF
+}
+
+fn parse_hex_u64(s: &[u8]) -> Result<(u64, &[u8]), MemErr> {
+    let mut acc: u64 = 0;
+    let mut i = 0;
+    while i < s.len() {
+        let Some(nib) = hex_nib(s[i]) else { break };
+        acc = acc
+            .checked_shl(4)
+            .and_then(|v| v.checked_add(nib as u64))
+            .ok_or(MemErr::Overflow)?;
+        i += 1;
+    }
+    if i == 0 {
+        return Err(MemErr::BadHex);
+    }
+    Ok((acc, &s[i..]))
+}
+
+fn parse_hex_usize(s: &[u8]) -> Result<(usize, &[u8]), MemErr> {
+    let (v, rest) = parse_hex_u64(s)?;
+    let v = usize::try_from(v).map_err(|_| MemErr::Overflow)?;
+    Ok((v, rest))
+}
+
+fn eat(s: &[u8], b: u8) -> Option<&[u8]> {
+    match s.first() {
+        Some(&c) if c == b => Some(&s[1..]),
+        _ => None,
+    }
+}
+
+fn hex_nib(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Encode `bytes` as lowercase hex into `out`. Returns the filled
+/// slice. `out.len()` must be `>= 2 * bytes.len()`.
+pub fn encode_hex<'b>(bytes: &[u8], out: &'b mut [u8]) -> &'b [u8] {
+    for (i, &b) in bytes.iter().enumerate() {
+        out[2 * i] = HEX[(b >> 4) as usize];
+        out[2 * i + 1] = HEX[(b & 0xF) as usize];
+    }
+    &out[..2 * bytes.len()]
+}
+
+/// Decode `2 * out.len()` hex characters from `hex` into `out`.
+pub fn decode_hex(hex: &[u8], out: &mut [u8]) -> Result<(), MemErr> {
+    if hex.len() != 2 * out.len() {
+        return Err(MemErr::ShortData);
+    }
+    for i in 0..out.len() {
+        let hi = hex_nib(hex[2 * i]).ok_or(MemErr::BadHex)?;
+        let lo = hex_nib(hex[2 * i + 1]).ok_or(MemErr::BadHex)?;
+        out[i] = (hi << 4) | lo;
+    }
+    Ok(())
+}
+
+/// Read `args.len` bytes from `args.addr` into `out`. Returns `Err` if
+/// any byte of the range is unmapped. Does not fault: the page-walker
+/// consults kernel page tables via the HHDM, never dereferences the
+/// target VA.
+#[cfg(target_os = "none")]
+pub fn safe_read(args: MemArgs, out: &mut [u8]) -> Result<(), MemErr> {
+    use x86_64::VirtAddr;
+    debug_assert_eq!(out.len(), args.len);
+    let mut va = args.addr;
+    for slot in out.iter_mut() {
+        let cur = VirtAddr::try_new(va).map_err(|_| MemErr::NonCanonical)?;
+        if !probe_readable(cur) {
+            return Err(MemErr::NonCanonical);
+        }
+        // SAFETY: `probe_readable` returned true → the leaf PTE is
+        // present. Reading one byte through a raw volatile load will
+        // not fault. Volatile to defeat the optimizer — gdb may be
+        // inspecting MMIO.
+        unsafe {
+            *slot = core::ptr::read_volatile(va as *const u8);
+        }
+        va = va.wrapping_add(1);
+    }
+    Ok(())
+}
+
+/// Write `data` bytes to `args.addr`. Returns `Err` if any byte is
+/// unmapped or read-only. Same fault-safety contract as [`safe_read`].
+#[cfg(target_os = "none")]
+pub fn safe_write(args: MemArgs, data: &[u8]) -> Result<(), MemErr> {
+    use x86_64::VirtAddr;
+    debug_assert_eq!(data.len(), args.len);
+    let mut va = args.addr;
+    for &b in data {
+        let cur = VirtAddr::try_new(va).map_err(|_| MemErr::NonCanonical)?;
+        if !probe_writable(cur) {
+            return Err(MemErr::NonCanonical);
+        }
+        // SAFETY: leaf PTE is present and writable (CR0.WP respected).
+        unsafe {
+            core::ptr::write_volatile(va as *mut u8, b);
+        }
+        va = va.wrapping_add(1);
+    }
+    Ok(())
+}
+
+/// True if the leaf PTE backing `va` has PRESENT set.
+#[cfg(target_os = "none")]
+fn probe_readable(va: x86_64::VirtAddr) -> bool {
+    use x86_64::structures::paging::PageTableFlags as F;
+    crate::mem::paging::flags(va)
+        .map(|f| f.contains(F::PRESENT))
+        .unwrap_or(false)
+}
+
+/// True if the leaf PTE backing `va` has PRESENT and WRITABLE set.
+#[cfg(target_os = "none")]
+fn probe_writable(va: x86_64::VirtAddr) -> bool {
+    use x86_64::structures::paging::PageTableFlags as F;
+    crate::mem::paging::flags(va)
+        .map(|f| f.contains(F::PRESENT | F::WRITABLE))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_m_happy() {
+        let a = parse_m(b"1000,10").unwrap();
+        assert_eq!(a.addr, 0x1000);
+        assert_eq!(a.len, 0x10);
+    }
+
+    #[test]
+    fn parse_m_missing_comma() {
+        assert_eq!(parse_m(b"1000 10"), Err(MemErr::MissingComma));
+    }
+
+    #[test]
+    fn parse_m_non_hex_addr() {
+        assert_eq!(parse_m(b"zz,10"), Err(MemErr::BadHex));
+    }
+
+    #[test]
+    fn parse_m_zero_len() {
+        assert_eq!(parse_m(b"1000,0"), Err(MemErr::ZeroLen));
+    }
+
+    #[test]
+    fn parse_m_too_big() {
+        assert_eq!(parse_m(b"1000,1000"), Err(MemErr::TooBig));
+    }
+
+    #[test]
+    fn parse_m_non_canonical_rejected() {
+        // Bits [63:48] = 0x1 is not 0 or 0x1FFFF → non-canonical.
+        assert_eq!(parse_m(b"1000000000000,1"), Err(MemErr::NonCanonical));
+    }
+
+    #[test]
+    fn parse_m_trailing_junk() {
+        assert_eq!(parse_m(b"1000,10;oops"), Err(MemErr::BadHex));
+    }
+
+    #[test]
+    fn parse_big_m_happy() {
+        let (a, data) = parse_big_m(b"2000,2:abcd").unwrap();
+        assert_eq!(a.addr, 0x2000);
+        assert_eq!(a.len, 2);
+        assert_eq!(data, b"abcd");
+    }
+
+    #[test]
+    fn parse_big_m_missing_colon() {
+        assert_eq!(parse_big_m(b"2000,2 abcd"), Err(MemErr::MissingColon));
+    }
+
+    #[test]
+    fn parse_big_m_short_data() {
+        assert_eq!(parse_big_m(b"2000,2:ab"), Err(MemErr::ShortData));
+    }
+
+    #[test]
+    fn parse_big_m_non_hex_data() {
+        assert_eq!(parse_big_m(b"2000,2:abzz"), Err(MemErr::BadHex));
+    }
+
+    #[test]
+    fn encode_hex_roundtrip() {
+        let mut buf = [0u8; 6];
+        let out = encode_hex(&[0xde, 0xad, 0xbe], &mut buf);
+        assert_eq!(out, b"deadbe");
+    }
+
+    #[test]
+    fn decode_hex_happy() {
+        let mut out = [0u8; 3];
+        decode_hex(b"DEADBE", &mut out).unwrap();
+        assert_eq!(out, [0xde, 0xad, 0xbe]);
+    }
+
+    #[test]
+    fn is_canonical_edges() {
+        assert!(is_canonical(0));
+        assert!(is_canonical(0x0000_7FFF_FFFF_FFFF));
+        assert!(is_canonical(0xFFFF_8000_0000_0000));
+        assert!(!is_canonical(0x0000_8000_0000_0000));
+        assert!(!is_canonical(0x0001_0000_0000_0000));
+    }
+}

--- a/kernel/src/gdbstub/mem.rs
+++ b/kernel/src/gdbstub/mem.rs
@@ -173,6 +173,12 @@ pub fn decode_hex(hex: &[u8], out: &mut [u8]) -> Result<(), MemErr> {
 /// any byte of the range is unmapped. Does not fault: the page-walker
 /// consults kernel page tables via the HHDM, never dereferences the
 /// target VA.
+///
+/// TOCTOU caveat: there is a window between the per-byte `probe_readable`
+/// and the following `read_volatile`. This is safe today because the stub
+/// runs from the int3 handler with interrupts disabled on a uniprocessor
+/// kernel — no other context can unmap the page between probe and access.
+/// SMP-safe mapper locking is a follow-up.
 #[cfg(target_os = "none")]
 pub fn safe_read(args: MemArgs, out: &mut [u8]) -> Result<(), MemErr> {
     use x86_64::VirtAddr;
@@ -196,7 +202,8 @@ pub fn safe_read(args: MemArgs, out: &mut [u8]) -> Result<(), MemErr> {
 }
 
 /// Write `data` bytes to `args.addr`. Returns `Err` if any byte is
-/// unmapped or read-only. Same fault-safety contract as [`safe_read`].
+/// unmapped or read-only. Same fault-safety and TOCTOU caveats as
+/// [`safe_read`].
 #[cfg(target_os = "none")]
 pub fn safe_write(args: MemArgs, data: &[u8]) -> Result<(), MemErr> {
     use x86_64::VirtAddr;

--- a/kernel/src/gdbstub/mod.rs
+++ b/kernel/src/gdbstub/mod.rs
@@ -14,6 +14,7 @@
 //! a `gdbstub` shell builtin.
 
 pub mod framer;
+pub mod mem;
 pub mod regs;
 pub mod transport;
 
@@ -204,6 +205,14 @@ fn dispatch<T: Transport>(t: &mut T, payload: &[u8], regs: &mut GdbRegs) -> Acti
             }
             Action::Continue
         }
+        Some(b'm') => {
+            handle_m(t, &payload[1..]);
+            Action::Continue
+        }
+        Some(b'M') => {
+            handle_big_m(t, &payload[1..]);
+            Action::Continue
+        }
         _ => {
             // Unknown command: RSP convention says reply with an empty
             // packet, which the debugger treats as "unsupported".
@@ -211,6 +220,77 @@ fn dispatch<T: Transport>(t: &mut T, payload: &[u8], regs: &mut GdbRegs) -> Acti
             Action::Continue
         }
     }
+}
+
+/// Handle `m addr,len` — read memory and reply with hex bytes, or
+/// `E01` if any byte of the range is unmapped/non-canonical/too big.
+fn handle_m<T: Transport>(t: &mut T, args: &[u8]) {
+    let parsed = match mem::parse_m(args) {
+        Ok(a) => a,
+        Err(_) => {
+            send_packet(t, b"E01");
+            return;
+        }
+    };
+    // Reply buffer: `2 * len` hex bytes, bounded by MAX_MEM_XFER.
+    let mut bytes = [0u8; mem::MAX_MEM_XFER];
+    let mut hex = [0u8; 2 * mem::MAX_MEM_XFER];
+    let n = parsed.len;
+    match read_memory(parsed, &mut bytes[..n]) {
+        Ok(()) => {
+            let out = mem::encode_hex(&bytes[..n], &mut hex[..2 * n]);
+            send_packet(t, out);
+        }
+        Err(()) => send_packet(t, b"E01"),
+    }
+}
+
+/// Handle `M addr,len:data` — decode hex, write bytes, reply `OK` or
+/// `E01` on any parse or access failure.
+fn handle_big_m<T: Transport>(t: &mut T, args: &[u8]) {
+    let (parsed, data_hex) = match mem::parse_big_m(args) {
+        Ok(pair) => pair,
+        Err(_) => {
+            send_packet(t, b"E01");
+            return;
+        }
+    };
+    let mut bytes = [0u8; mem::MAX_MEM_XFER];
+    let n = parsed.len;
+    if mem::decode_hex(data_hex, &mut bytes[..n]).is_err() {
+        send_packet(t, b"E01");
+        return;
+    }
+    match write_memory(parsed, &bytes[..n]) {
+        Ok(()) => send_packet(t, b"OK"),
+        Err(()) => send_packet(t, b"E01"),
+    }
+}
+
+/// Kernel-side safe read: routes through the page-walker probe.
+#[cfg(target_os = "none")]
+fn read_memory(args: mem::MemArgs, out: &mut [u8]) -> Result<(), ()> {
+    mem::safe_read(args, out).map_err(|_| ())
+}
+
+/// Kernel-side safe write: routes through the page-walker probe.
+#[cfg(target_os = "none")]
+fn write_memory(args: mem::MemArgs, data: &[u8]) -> Result<(), ()> {
+    mem::safe_write(args, data).map_err(|_| ())
+}
+
+/// Host-test fallback: no kernel page tables available, so we refuse
+/// every access. The existing host tests don't send `m`/`M`, but any
+/// future test wanting real access can override this via a test-only
+/// transport.
+#[cfg(not(target_os = "none"))]
+fn read_memory(_args: mem::MemArgs, _out: &mut [u8]) -> Result<(), ()> {
+    Err(())
+}
+
+#[cfg(not(target_os = "none"))]
+fn write_memory(_args: mem::MemArgs, _data: &[u8]) -> Result<(), ()> {
+    Err(())
 }
 
 /// Build an `Sxx` stop reply payload in a fixed-size buffer.

--- a/kernel/tests/gdbstub_loop.rs
+++ b/kernel/tests/gdbstub_loop.rs
@@ -45,7 +45,10 @@ fn run_tests() {
         ("m_reads_known_bytes", &(m_reads_known_bytes as fn())),
         ("m_unmapped_returns_e01", &(m_unmapped_returns_e01 as fn())),
         ("big_m_writes_buffer", &(big_m_writes_buffer as fn())),
-        ("big_m_unmapped_returns_e01", &(big_m_unmapped_returns_e01 as fn())),
+        (
+            "big_m_unmapped_returns_e01",
+            &(big_m_unmapped_returns_e01 as fn()),
+        ),
     ];
     serial_println!("running {} tests", tests.len());
     for (name, t) in tests {

--- a/kernel/tests/gdbstub_loop.rs
+++ b/kernel/tests/gdbstub_loop.rs
@@ -42,6 +42,10 @@ fn run_tests() {
         ("g_reply_is_hex_blob", &(g_reply_is_hex_blob as fn())),
         ("big_g_writes_regs", &(big_g_writes_regs as fn())),
         ("big_g_writes_rax", &(big_g_writes_rax as fn())),
+        ("m_reads_known_bytes", &(m_reads_known_bytes as fn())),
+        ("m_unmapped_returns_e01", &(m_unmapped_returns_e01 as fn())),
+        ("big_m_writes_buffer", &(big_m_writes_buffer as fn())),
+        ("big_m_unmapped_returns_e01", &(big_m_unmapped_returns_e01 as fn())),
     ];
     serial_println!("running {} tests", tests.len());
     for (name, t) in tests {
@@ -149,6 +153,146 @@ fn big_g_writes_rax() {
     debug_entry_with_regs(&mut t, &mut regs);
     assert_eq!(regs.rax, 0x01, "G must write rax");
     assert!(find(&t.tx, b"$OK#9a").is_some(), "missing OK reply");
+}
+
+fn m_reads_known_bytes() {
+    // Put a known pattern on the stack. The test function's stack is
+    // mapped and readable, so `m` must succeed.
+    let buf: [u8; 4] = [0xDE, 0xAD, 0xBE, 0xEF];
+    let addr = buf.as_ptr() as usize as u64;
+
+    // Build `m <addr>,4` packet.
+    let mut req = alloc::vec::Vec::new();
+    req.push(b'm');
+    // Lowercase hex addr, no 0x prefix.
+    push_hex_u64(&mut req, addr);
+    req.push(b',');
+    req.push(b'4');
+
+    let mut frame = [0u8; 64];
+    let wire = framer::encode(&req, &mut frame);
+
+    let mut t = VecTransport::new();
+    for &b in wire {
+        t.rx.push_back(b);
+    }
+    // Detach after.
+    let mut detach = [0u8; 8];
+    for &b in framer::encode(b"D", &mut detach) {
+        t.rx.push_back(b);
+    }
+
+    debug_entry(&mut t);
+    assert!(
+        find(&t.tx, b"$deadbeef#").is_some(),
+        "expected hex-encoded bytes in reply, got {:?}",
+        core::str::from_utf8(&t.tx).unwrap_or("<non-utf8>")
+    );
+}
+
+fn m_unmapped_returns_e01() {
+    // Lower-half address well past anything the kernel maps.
+    let mut t = VecTransport::with_rx(b"$m6000000000,4#00$D#44");
+    // The checksum on the `m` packet doesn't matter — decode failure
+    // would NAK, but let's make it plausible anyway:
+    let mut req = alloc::vec::Vec::new();
+    req.extend_from_slice(b"m6000000000,4");
+    let mut frame = [0u8; 32];
+    let wire = framer::encode(&req, &mut frame);
+    t.rx.clear();
+    for &b in wire {
+        t.rx.push_back(b);
+    }
+    let mut detach = [0u8; 8];
+    for &b in framer::encode(b"D", &mut detach) {
+        t.rx.push_back(b);
+    }
+
+    debug_entry(&mut t);
+    assert!(
+        find(&t.tx, b"$E01#").is_some(),
+        "expected E01 for unmapped read, got {:?}",
+        core::str::from_utf8(&t.tx).unwrap_or("<non-utf8>")
+    );
+}
+
+fn big_m_writes_buffer() {
+    let mut buf: [u8; 4] = [0; 4];
+    let addr = buf.as_mut_ptr() as usize as u64;
+
+    let mut req = alloc::vec::Vec::new();
+    req.push(b'M');
+    push_hex_u64(&mut req, addr);
+    req.push(b',');
+    req.push(b'4');
+    req.push(b':');
+    req.extend_from_slice(b"cafebabe");
+
+    let mut frame = [0u8; 64];
+    let wire = framer::encode(&req, &mut frame);
+
+    let mut t = VecTransport::new();
+    for &b in wire {
+        t.rx.push_back(b);
+    }
+    let mut detach = [0u8; 8];
+    for &b in framer::encode(b"D", &mut detach) {
+        t.rx.push_back(b);
+    }
+
+    debug_entry(&mut t);
+    assert!(
+        find(&t.tx, b"$OK#9a").is_some(),
+        "expected OK for valid M, got {:?}",
+        core::str::from_utf8(&t.tx).unwrap_or("<non-utf8>")
+    );
+    assert_eq!(
+        buf,
+        [0xca, 0xfe, 0xba, 0xbe],
+        "M did not land in the target buffer"
+    );
+}
+
+fn big_m_unmapped_returns_e01() {
+    let mut req = alloc::vec::Vec::new();
+    req.extend_from_slice(b"M6000000000,2:abcd");
+    let mut frame = [0u8; 32];
+    let wire = framer::encode(&req, &mut frame);
+
+    let mut t = VecTransport::new();
+    for &b in wire {
+        t.rx.push_back(b);
+    }
+    let mut detach = [0u8; 8];
+    for &b in framer::encode(b"D", &mut detach) {
+        t.rx.push_back(b);
+    }
+
+    debug_entry(&mut t);
+    assert!(
+        find(&t.tx, b"$E01#").is_some(),
+        "expected E01 for unmapped write, got {:?}",
+        core::str::from_utf8(&t.tx).unwrap_or("<non-utf8>")
+    );
+}
+
+fn push_hex_u64(out: &mut alloc::vec::Vec<u8>, mut v: u64) {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    if v == 0 {
+        out.push(b'0');
+        return;
+    }
+    // Count nibbles, emit high→low.
+    let mut buf = [0u8; 16];
+    let mut i = 0;
+    while v != 0 {
+        buf[i] = HEX[(v & 0xF) as usize];
+        v >>= 4;
+        i += 1;
+    }
+    for j in (0..i).rev() {
+        out.push(buf[j]);
+    }
 }
 
 fn find(hay: &[u8], needle: &[u8]) -> Option<usize> {

--- a/kernel/tests/gdbstub_loop.rs
+++ b/kernel/tests/gdbstub_loop.rs
@@ -259,7 +259,8 @@ fn big_m_writes_buffer() {
 fn big_m_unmapped_returns_e01() {
     let mut req = alloc::vec::Vec::new();
     req.extend_from_slice(b"M6000000000,2:abcd");
-    let mut frame = [0u8; 32];
+    // Worst-case frame size = 2 * payload + 4 framing bytes.
+    let mut frame = [0u8; 64];
     let wire = framer::encode(&req, &mut frame);
 
     let mut t = VecTransport::new();


### PR DESCRIPTION
Closes #447

## Summary
- Adds `gdbstub/mem` — parsers for `m addr,len` and `M addr,len:data`, hex encode/decode helpers, and `cfg(target_os = "none")`-gated `safe_read` / `safe_write` probes that consult the kernel page walker (`mem::paging::flags`) before touching the target VA.
- Wires two new arms into `gdbstub::dispatch`: `m` replies with lowercase-hex bytes on success or `E01` on any parse/access failure; `M` decodes hex, writes, and replies `OK` or `E01`. The probe checks `PRESENT` for reads and `PRESENT | WRITABLE` for writes, so `M` into `.text` is refused rather than faulting.
- Caps a single transfer at `MAX_MEM_XFER = 256` bytes so the reply fits comfortably inside `framer::MAX_PACKET = 1024` after hex expansion and packet framing.
- Host-only fallback: `read_memory` / `write_memory` return `Err(())` on non-`target_os = "none"` builds so the module compiles everywhere; existing host tests (`?`/`D`/`g`/`G`/`q`) never send `m`/`M` and are unaffected.

## Test plan
- [ ] `cargo xtask build` — clean (only the preexisting `is_guard_hit` dead-code warning).
- [ ] `cargo xtask test` — 12 new host unit tests in `gdbstub::mem` (parse happy paths, missing comma/colon, non-hex, zero-len, too-big, non-canonical addr, trailing junk, short data, hex roundtrip, canonical-form edges).
- [ ] `cargo xtask test` — 4 new QEMU integration tests in `gdbstub_loop` that exercise the safe-access probe against real kernel memory:
  - `m_reads_known_bytes` — reads stack buffer, asserts hex.
  - `m_unmapped_returns_e01` — lower-half unmapped VA → `E01`.
  - `big_m_writes_buffer` — writes into a stack buffer, verifies bytes landed.
  - `big_m_unmapped_returns_e01` — `M` into unmapped VA → `E01`.
- [ ] `cargo xtask smoke` — no regression (int3 / stub is not on the smoke path).

## Out of scope / follow-ups
- Per-CPU MAPPER lock: today vibix is effectively single-CPU and `with_mapper` is fine, but SMP (#30) will need the stub to handle contention / deadlock. A TODO is in the "Risks" section of the plan; can be filed if/when SMP lands.
- Continue/step/breakpoints is #448 — this PR is the `m`/`M` piece only.