### PR TITLE
signal: honor SA_RESTART for KERN_ERESTARTSYS at syscall return

### DIFF
--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -1089,15 +1089,25 @@ syscall_entry:
     add rsp, 8
     // rax = return value
 
-    // 5b. Check for pending signals before returning to user.
-    //     Pass a pointer to the saved [user_rip, user_rflags, user_rsp]
-    //     on the kernel stack so check_and_deliver_signals can redirect
-    //     the return to a signal handler if needed.
-    //     Save rax across the call (it holds the syscall return value).
+    // 5b. Check for pending signals and ERESTARTSYS before returning to
+    //     user. Pass a pointer to the saved [user_rip, user_rflags,
+    //     user_rsp] on the kernel stack as arg0 so the handler can
+    //     redirect to a signal frame or rewind rip; pass the dispatcher's
+    //     return value in rax as arg1 (rsi). The handler returns the
+    //     (possibly rewritten) return value in rax, which becomes the
+    //     value SYSRETQ delivers.
+    //
+    //     `push rax` serves two purposes: 16-byte alignment for the CALL
+    //     (the preceding 3 pushes + dispatcher's matching sub/add leaves
+    //     rsp at top-24, i.e. 8 mod 16; one more push brings it to 0 mod
+    //     16), and it harmlessly stashes a copy of rax that we discard.
+    //     The handler returns the new rv in rax directly; we just drop
+    //     the alignment slot.
     push rax
-    lea rdi, [rsp + 8]   // pointer to saved [rip, rflags, rsp]
+    lea rdi, [rsp + 8]  // pointer to saved [rip, rflags, rsp]
+    mov rsi, rax        // rv → arg1
     call check_and_deliver_signals
-    pop rax
+    add rsp, 8          // drop the alignment slot; rax is the new rv
 
     // 6. Restore return-to-user context.
     pop rcx           // user RIP  → rcx  (for SYSRETQ)

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -100,6 +100,19 @@ pub static FORK_USER_RSP: AtomicU64 = AtomicU64::new(0);
 #[no_mangle]
 pub static SIGRETURN_PENDING: AtomicU64 = AtomicU64::new(0);
 
+/// Set to 1 by `check_and_deliver_signals` when a bare syscall restart
+/// (no user handler) is about to occur. The syscall trampoline checks
+/// this flag after the signal hook returns: when set, the saved user
+/// syscall registers (rax, rdi, rsi, rdx, r10, r8, r9) are restored
+/// before SYSRETQ so the re-executed SYSCALL instruction sees the
+/// original syscall number and arguments. Cleared after consumption.
+///
+/// Not set on the SA_RESTART+handler path — that path delivers the
+/// handler first, and the restart occurs from sigreturn afterwards.
+/// Restoring arg regs through the sigreturn path is a follow-up.
+#[no_mangle]
+pub static SYSCALL_RESTART_PENDING: AtomicU64 = AtomicU64::new(0);
+
 /// Enable SYSCALL/SYSRET and point LSTAR at the entry trampoline.
 /// Must be called after GDT is live.
 pub fn init() {
@@ -1048,6 +1061,23 @@ syscall_entry:
     push r11                  // user RFLAGS (SYSRETQ restores from r11)
     push rcx                  // user RIP    (SYSRETQ jumps to rcx)
 
+    // 3a. Save the user syscall registers so a restart (rip rewound to
+    //     the SYSCALL instruction) can replay with the original syscall
+    //     number and argument registers. Pushed high→low so the struct
+    //     laid out at rsp ends up as:
+    //       [rsp+0]=rax [+8]=rdi [+16]=rsi [+24]=rdx
+    //       [+32]=r10 [+40]=r8 [+48]=r9
+    //       [+56]=user_rip [+64]=user_rflags [+72]=user_rsp
+    //     These slots are adjacent to the rip/rflags/rsp frame above so a
+    //     single pointer (rsp) addresses the whole `SyscallReturnContext`.
+    push r9
+    push r8
+    push r10
+    push rdx
+    push rsi
+    push rdi
+    push rax
+
     // 3b. Finish priming the FORK_USER_* statics so fork() can seed the
     //     child's kernel stack. fork_rsp was already written in step 1.
     mov [rip + {fork_rip}], rcx
@@ -1071,11 +1101,11 @@ syscall_entry:
     //
     //    Save r9 (a5) into the arg6 slot before the remap clobbers it.
     //    SysV requires rsp to be 16-byte aligned immediately before the
-    //    CALL instruction. The 3 preceding pushes (user RSP, RFLAGS, RIP)
-    //    leave rsp at (top-24), i.e. 8 mod 16. Reserving one 8-byte slot
-    //    for arg6 brings rsp to (top-32) — 0 mod 16, exactly what CALL
-    //    needs.
-    sub rsp, 8
+    //    CALL instruction. The 3+7 preceding pushes leave rsp at
+    //    (top-80) — already 0 mod 16. Reserving one 8-byte slot for arg6
+    //    brings rsp to (top-88), which is 8 mod 16; so we compensate with
+    //    one more 8-byte sub to land on 0 mod 16 before CALL.
+    sub rsp, 16
     mov [rsp], r9     // a5 → stack slot for arg6
     mov r9, r8        // a4 → r9 (arg5)
     mov r8, r10       // a3 → r8 (arg4)
@@ -1086,42 +1116,59 @@ syscall_entry:
 
     // 5. Call the Rust dispatcher.
     call syscall_dispatch
-    add rsp, 8
+    add rsp, 16
     // rax = return value
 
     // 5b. Check for pending signals and ERESTARTSYS before returning to
-    //     user. Pass a pointer to the saved [user_rip, user_rflags,
-    //     user_rsp] on the kernel stack as arg0 so the handler can
-    //     redirect to a signal frame or rewind rip; pass the dispatcher's
-    //     return value in rax as arg1 (rsi). The handler returns the
-    //     (possibly rewritten) return value in rax, which becomes the
-    //     value SYSRETQ delivers.
+    //     user. Pass a pointer to the saved `SyscallReturnContext` (the
+    //     10-qword block at rsp) as arg0 so the handler can redirect to a
+    //     signal frame or rewind rip; pass the dispatcher's return value
+    //     in rax as arg1 (rsi). The handler returns the (possibly
+    //     rewritten) return value in rax, which becomes the value
+    //     SYSRETQ delivers.
     //
-    //     `push rax` serves two purposes: 16-byte alignment for the CALL
-    //     (the preceding 3 pushes + dispatcher's matching sub/add leaves
-    //     rsp at top-24, i.e. 8 mod 16; one more push brings it to 0 mod
-    //     16), and it harmlessly stashes a copy of rax that we discard.
-    //     The handler returns the new rv in rax directly; we just drop
-    //     the alignment slot.
-    push rax
-    lea rdi, [rsp + 8]  // pointer to saved [rip, rflags, rsp]
+    //     Stack is at top-80 (3+7 = 10 pushes), already 0 mod 16 — no
+    //     extra alignment is needed for this CALL.
+    mov rdi, rsp        // ctx → arg0
     mov rsi, rax        // rv → arg1
     call check_and_deliver_signals
-    add rsp, 8          // drop the alignment slot; rax is the new rv
 
     // 6. Restore return-to-user context.
+    //
+    //    On the common path, the 7 saved user syscall regs are discarded
+    //    (userspace doesn't rely on them surviving a syscall, per SysV).
+    //    On a bare-restart path (SYSCALL_RESTART_PENDING set by the signal
+    //    hook when rip was rewound to the SYSCALL insn and no user
+    //    handler is about to run), reload them so the re-executed SYSCALL
+    //    sees the original (nr, a0..a5).
+    cmp qword ptr [rip + {restart_pending}], 0
+    jne 2f
+    // Normal path: drop the 7 saved-reg slots; rax already holds rv.
+    add rsp, 56
+    jmp 3f
+2:
+    // Restart path: consume flag and restore saved user syscall regs.
+    mov qword ptr [rip + {restart_pending}], 0
+    pop rax           // saved user rax (syscall nr)
+    pop rdi
+    pop rsi
+    pop rdx
+    pop r10
+    pop r8
+    pop r9
+3:
     pop rcx           // user RIP  → rcx  (for SYSRETQ)
     pop r11           // user RFLAGS → r11 (for SYSRETQ)
-    pop r10           // user RSP  → r10
+    pop rsp           // user RSP  → rsp  (return to user stack)
 
-    // 7. Restore user RSP and return to ring-3.
-    mov rsp, r10
+    // 7. Return to ring-3.
     sysretq
     "#,
     kernel_rsp = sym SYSCALL_KERNEL_RSP,
     fork_rip = sym FORK_USER_RIP,
     fork_rflags = sym FORK_USER_RFLAGS,
     fork_rsp = sym FORK_USER_RSP,
+    restart_pending = sym SYSCALL_RESTART_PENDING,
 );
 
 /// Pinned Linux x86_64 syscall numbers used by `userspace/init`.

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -625,9 +625,9 @@ impl FileBackend for SerialBackend {
         let caller = crate::process::current_pid();
         let tty = crate::tty::console_tty();
         if let Some(rc) = crate::tty::tty_check_sigttin(&tty, caller) {
-            if rc == crate::tty::KERN_ERESTARTSYS {
-                return Err(EINTR);
-            }
+            // KERN_ERESTARTSYS is honoured by the syscall trampoline
+            // (see `signal::check_and_deliver_signals`): restart on
+            // SA_RESTART, otherwise -EINTR.
             return Err(rc);
         }
         for (i, byte) in buf.iter_mut().enumerate() {
@@ -646,18 +646,14 @@ impl FileBackend for SerialBackend {
     /// never calls `serial_println!` or re-enters the COM1 mutex.
     ///
     /// Job-control gate: if the caller's pgrp is not the console tty's
-    /// foreground pgrp and `TOSTOP` is set, raise `SIGTTOU` and fail the
-    /// write with `EINTR`. Real `ERESTARTSYS` semantics (SA_RESTART-aware
-    /// transparent restart) arrive with the syscall trampoline follow-up.
+    /// foreground pgrp and `TOSTOP` is set, raise `SIGTTOU` and return
+    /// `KERN_ERESTARTSYS`. The syscall trampoline then either rewinds
+    /// `rip` to restart the write (SA_RESTART) or converts the return
+    /// to `-EINTR`.
     fn write(&self, buf: &[u8]) -> Result<usize, i64> {
         let caller = crate::process::current_pid();
         let tty = crate::tty::console_tty();
         if let Some(rc) = crate::tty::tty_check_tostop(&tty, caller) {
-            // KERN_ERESTARTSYS → EINTR at the syscall boundary until the
-            // trampoline honours restart semantics.
-            if rc == crate::tty::KERN_ERESTARTSYS {
-                return Err(EINTR);
-            }
             return Err(rc);
         }
         crate::serial::write_bytes(buf);

--- a/kernel/src/signal/mod.rs
+++ b/kernel/src/signal/mod.rs
@@ -524,16 +524,32 @@ fn deliver_fault_terminate(sig: u8) -> ! {
 /// Kernel-stack layout pushed by the `syscall_entry` asm trampoline
 /// immediately before calling `syscall_dispatch`.
 ///
-/// The trampoline pushes (in order, so lowest address is last pushed):
-///   `[rsp+0]`  = user RIP  (rcx at entry)
-///   `[rsp+8]`  = user RFLAGS (r11 at entry)
-///   `[rsp+16]` = user RSP
+/// The trampoline pushes the syscall-arg registers so a syscall restart
+/// (rip rewound to the SYSCALL instruction) can re-execute the syscall
+/// with the original `rax` (syscall number) and argument registers. Push
+/// order is high→low address; `check_and_deliver_signals` receives `rsp`
+/// as the pointer to the start of this struct (the last-pushed field).
 ///
-/// `check_and_deliver_signals` receives `rsp` as the pointer to this layout
-/// and may rewrite any of these fields to redirect the return to a signal
-/// handler.
+/// Layout (low address → high):
+///   `[rsp+0]`   = saved user `rax` (syscall nr)
+///   `[rsp+8]`   = saved user `rdi` (a0)
+///   `[rsp+16]`  = saved user `rsi` (a1)
+///   `[rsp+24]`  = saved user `rdx` (a2)
+///   `[rsp+32]`  = saved user `r10` (a3)
+///   `[rsp+40]`  = saved user `r8`  (a4)
+///   `[rsp+48]`  = saved user `r9`  (a5)
+///   `[rsp+56]`  = user RIP   (rcx at entry)
+///   `[rsp+64]`  = user RFLAGS (r11 at entry)
+///   `[rsp+72]`  = user RSP
 #[repr(C)]
 pub struct SyscallReturnContext {
+    pub user_rax: u64,
+    pub user_rdi: u64,
+    pub user_rsi: u64,
+    pub user_rdx: u64,
+    pub user_r10: u64,
+    pub user_r8: u64,
+    pub user_r9: u64,
     pub user_rip: u64,
     pub user_rflags: u64,
     pub user_rsp: u64,
@@ -626,6 +642,40 @@ pub fn restart_decision(
     }
 }
 
+/// Pure classifier: given a restart decision and the (signal, disposition)
+/// popped from the pending mask, return `Some(sig)` if `deliver_signal`
+/// should be called, or `None` if the syscall return path should skip
+/// delivery.
+///
+/// The distinction matters on the `RestartDecision::Restart` path: a bare
+/// restart must still dispatch default-action signals (SIGTERM → task
+/// exit; SIGTTOU/TSTP/TTIN → stop — currently a no-op). Only
+/// `Disposition::Ignore` and "no signal popped" skip delivery outright.
+/// On `Eintr` and `NoChange`, delivery always occurs if a signal was
+/// popped.
+pub fn signal_to_deliver(
+    decision: RestartDecision,
+    popped: Option<(u8, Disposition)>,
+) -> Option<u8> {
+    match decision {
+        RestartDecision::NoChange => popped.map(|(s, _)| s),
+        RestartDecision::Eintr => popped.map(|(s, _)| s),
+        RestartDecision::Restart { deliver_handler } => match popped {
+            None => None,
+            Some((s, disp)) => {
+                if deliver_handler {
+                    Some(s)
+                } else {
+                    match disp {
+                        Disposition::Ignore => None,
+                        _ => Some(s),
+                    }
+                }
+            }
+        },
+    }
+}
+
 /// Called from the `syscall_entry` asm trampoline between steps 5 and 6
 /// (after `syscall_dispatch` returns, before `pop rcx / sysretq`).
 ///
@@ -676,31 +726,40 @@ pub unsafe extern "C" fn check_and_deliver_signals(ctx: *mut SyscallReturnContex
         })
         .flatten();
 
-    let mut rv_out = rv;
-    let sig_for_delivery: Option<u8> = match restart_decision(
+    let decision = restart_decision(
         rv,
         popped.map(|(s, _, _)| s),
         popped.map(|(_, d, _)| d).unwrap_or(Disposition::Default),
         popped.map(|(_, _, f)| f).unwrap_or(0),
-    ) {
-        RestartDecision::NoChange => popped.map(|(s, _, _)| s),
-        RestartDecision::Restart { deliver_handler } => {
+    );
+    let mut rv_out = rv;
+    match decision {
+        RestartDecision::NoChange => {}
+        RestartDecision::Restart { .. } => {
             (*ctx).user_rip = (*ctx).user_rip.wrapping_sub(SYSCALL_INSN_LEN);
+            // Only signal the asm trampoline to restore user syscall regs
+            // when no handler is about to run. Handler+SA_RESTART restarts
+            // come back through sigreturn, which is a follow-up path for
+            // arg-register preservation.
+            if !matches!(
+                decision,
+                RestartDecision::Restart {
+                    deliver_handler: true
+                }
+            ) {
+                crate::arch::x86_64::syscall::SYSCALL_RESTART_PENDING
+                    .store(1, core::sync::atomic::Ordering::Relaxed);
+            }
             // Clobber rv: after restart, userspace will get the result of
             // the re-executed syscall; the stale -ERESTARTSYS must not
             // leak in case something later skips the restart.
             rv_out = 0;
-            if deliver_handler {
-                popped.map(|(s, _, _)| s)
-            } else {
-                None
-            }
         }
         RestartDecision::Eintr => {
             rv_out = crate::fs::EINTR;
-            popped.map(|(s, _, _)| s)
         }
-    };
+    }
+    let sig_for_delivery = signal_to_deliver(decision, popped.map(|(s, d, _)| (s, d)));
 
     if let Some(sig) = sig_for_delivery {
         deliver_signal(sig, &mut *ctx);

--- a/kernel/src/signal/mod.rs
+++ b/kernel/src/signal/mod.rs
@@ -33,7 +33,9 @@
 //!
 //! - FPU state (`fpstate_ptr` in `SigFrame`) is always null — signals
 //!   delivered to a task using SSE/x87 will see corrupted FP registers.
-//! - `SA_NODEFER` and `SA_RESTART` flags are not honoured.
+//! - `SA_NODEFER` is not honoured. `SA_RESTART` is honoured by the
+//!   syscall trampoline's `KERN_ERESTARTSYS` path; other `sa_flags`
+//!   bits round-trip through `sigaction(2)` but are otherwise ignored.
 //! - Real-time signals (`SIGRTMIN`..`SIGRTMAX`) are not implemented.
 //! - `sigaltstack` is not implemented.
 //! - Multi-threaded signal delivery is not implemented (single-CPU, single-
@@ -78,6 +80,13 @@ pub const NSIG: u8 = 64;
 pub const SIG_DFL: u64 = 0;
 /// `SIG_IGN` — ignore the signal.
 pub const SIG_IGN: u64 = 1;
+
+// ── Sigaction flags (Linux values) ────────────────────────────────────────
+
+/// `SA_RESTART` — restart syscalls that return `KERN_ERESTARTSYS` when this
+/// signal is delivered via a user handler. Without this flag, the syscall
+/// is converted to `-EINTR` instead.
+pub const SA_RESTART: u64 = 0x1000_0000;
 
 /// Per-signal disposition.
 #[derive(Clone, Copy, Debug)]
@@ -171,6 +180,10 @@ pub struct SignalState {
     pub blocked: u64,
     /// Per-signal disposition table (indexed 0 = signal 1).
     pub dispositions: [Disposition; NSIG as usize],
+    /// Per-signal `sa_flags` (Linux `struct sigaction.sa_flags`). Only
+    /// `SA_RESTART` is honoured today; other bits round-trip through
+    /// `sigaction(2)` but are otherwise ignored.
+    pub sa_flags: [u64; NSIG as usize],
 }
 
 impl SignalState {
@@ -183,6 +196,7 @@ impl SignalState {
             pending: 0,
             blocked: 0,
             dispositions,
+            sa_flags: [0; NSIG as usize],
         }
     }
 
@@ -294,8 +308,10 @@ pub fn send_to_pgrp(pgid: u32, sig: u8) -> i64 {
 ///
 /// `act_uva` and `oldact_uva` are user pointers to `struct sigaction`
 /// (Linux x86_64 layout: `sa_handler: u64, sa_flags: u64, sa_restorer: u64,
-/// sa_mask: u64`).  Only `sa_handler` is read / written; the rest are stored
-/// as zero for now (no SA_RESTART / SA_SIGINFO support).
+/// sa_mask: u64`).  `sa_handler` and `sa_flags` round-trip through the
+/// kernel; `sa_restorer` and `sa_mask` are read/written as zero. Of the
+/// flag bits only `SA_RESTART` is honoured (by the syscall trampoline's
+/// `KERN_ERESTARTSYS` path).
 ///
 /// # Safety
 /// `act_uva` and `oldact_uva` are user VA pointers validated via
@@ -309,12 +325,14 @@ pub unsafe fn sys_sigaction(sig: u64, act_uva: u64, oldact_uva: u64) -> i64 {
     let task_id = crate::task::current_id();
     let result = crate::process::with_signal_state_for_task(task_id, |state| {
         let old_disp = state.dispositions[(sig - 1) as usize];
+        let old_flags = state.sa_flags[(sig - 1) as usize];
 
         // Write old disposition to userspace if requested.
         if oldact_uva != 0 {
             let mut sa: [u8; 32] = [0u8; 32];
             let handler_ptr = old_disp.to_handler_ptr();
             sa[..8].copy_from_slice(&handler_ptr.to_ne_bytes());
+            sa[8..16].copy_from_slice(&old_flags.to_ne_bytes());
             if uaccess::copy_to_user(oldact_uva as usize, &sa).is_err() {
                 return -14i64; // EFAULT
             }
@@ -327,7 +345,9 @@ pub unsafe fn sys_sigaction(sig: u64, act_uva: u64, oldact_uva: u64) -> i64 {
                 return -14i64; // EFAULT
             }
             let handler_ptr = u64::from_ne_bytes(sa[..8].try_into().unwrap());
+            let flags = u64::from_ne_bytes(sa[8..16].try_into().unwrap());
             state.dispositions[(sig - 1) as usize] = Disposition::from_handler_ptr(handler_ptr);
+            state.sa_flags[(sig - 1) as usize] = flags;
         }
 
         0i64
@@ -519,25 +539,119 @@ pub struct SyscallReturnContext {
     pub user_rsp: u64,
 }
 
+/// Length of the `SYSCALL` opcode (0x0F 0x05) in bytes. Rewinding
+/// `user_rip` by this amount re-enters the syscall on SYSRETQ.
+pub const SYSCALL_INSN_LEN: u64 = 2;
+
+/// Decision returned by [`restart_decision`] — a pure classifier over
+/// `(rv, sig_opt, disp, sa_flags)` that the trampoline executes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RestartDecision {
+    /// Leave `rv` and `rip` alone. Continue with normal signal delivery.
+    NoChange,
+    /// Rewind `rip` by the syscall insn length and clobber `rv` so
+    /// userspace sees the restarted syscall's fresh return value. Still
+    /// deliver the signal handler afterwards when `deliver_handler` is
+    /// true (handler + SA_RESTART case).
+    Restart { deliver_handler: bool },
+    /// Replace `rv` with `-EINTR`. Still deliver the signal handler.
+    Eintr,
+}
+
+/// Classify what the syscall-return path should do given the dispatcher's
+/// return value, the signal (if any) that was just popped, its disposition,
+/// and its `sa_flags`.
+///
+/// Mirrors the Linux `get_signal` / `do_signal` interaction for
+/// `ERESTARTSYS`:
+/// - If `rv` is not `KERN_ERESTARTSYS`, nothing to do.
+/// - No signal consumed this tick (caller returned `ERESTARTSYS` but the
+///   pending mask was empty — e.g. a spurious wake or a race where the
+///   signal had already been consumed): **unconditional restart**. Matches
+///   Linux's behaviour when an interruptible sleep is unwound with no
+///   signal actually raised.
+/// - Signal whose disposition is `Default` with `DefaultAction::Stop` or
+///   `Ignore`: restart unconditionally (no handler will run, so EINTR
+///   would strand the syscall and the task would never make progress on
+///   the job-control condition the caller just hit).
+/// - Signal with `Disposition::Ignore` or a default-Terminate: restart
+///   (Linux restarts for `ERESTARTSYS` + no handler).
+/// - Signal with `Disposition::Handler` + `SA_RESTART`: restart **and**
+///   deliver the handler on top of the restarted syscall.
+/// - Signal with `Disposition::Handler` and no `SA_RESTART`: convert to
+///   `-EINTR` and deliver the handler.
+pub fn restart_decision(
+    rv: i64,
+    sig: Option<u8>,
+    disp: Disposition,
+    sa_flags: u64,
+) -> RestartDecision {
+    if rv != crate::tty::KERN_ERESTARTSYS {
+        return RestartDecision::NoChange;
+    }
+    match sig {
+        None => RestartDecision::Restart {
+            deliver_handler: false,
+        },
+        Some(s) => match disp {
+            Disposition::Handler(_) => {
+                if sa_flags & SA_RESTART != 0 {
+                    RestartDecision::Restart {
+                        deliver_handler: true,
+                    }
+                } else {
+                    RestartDecision::Eintr
+                }
+            }
+            Disposition::Ignore => RestartDecision::Restart {
+                deliver_handler: false,
+            },
+            Disposition::Default => match default_action(s) {
+                // Stop/Ignore/Continue with no handler: restart the
+                // syscall. Once the task is stopped/woken, re-entering
+                // the syscall will re-check the gate condition.
+                DefaultAction::Stop | DefaultAction::Ignore | DefaultAction::Continue => {
+                    RestartDecision::Restart {
+                        deliver_handler: false,
+                    }
+                }
+                // Default-terminate: the task is about to be killed by
+                // `deliver_signal`. Restart is academic — pick it to
+                // match Linux rather than leaving a dangling -512 in rax.
+                DefaultAction::Terminate => RestartDecision::Restart {
+                    deliver_handler: false,
+                },
+            },
+        },
+    }
+}
+
 /// Called from the `syscall_entry` asm trampoline between steps 5 and 6
 /// (after `syscall_dispatch` returns, before `pop rcx / sysretq`).
 ///
-/// Two responsibilities:
+/// Three responsibilities:
 ///
 /// 1. **sigreturn**: if `SIGRETURN_PENDING` is set (syscall 15 just ran),
 ///    overwrite `ctx` with the restored user context from `FORK_USER_*`
 ///    statics and clear the flag.
 ///
-/// 2. **signal delivery**: if a signal is pending for the current process,
-///    pop the lowest pending signal, look up its disposition, and either
-///    push a `SigFrame` + redirect `ctx->user_rip` (user handler), exit the
-///    process (default terminate), or do nothing (ignored).
+/// 2. **ERESTARTSYS handling**: if the dispatcher returned
+///    `KERN_ERESTARTSYS`, consult [`restart_decision`]. On restart, rewind
+///    `ctx.user_rip` by the syscall insn length and clobber `rv` so the
+///    caller sees the freshly-restarted syscall's result.
+///
+/// 3. **signal delivery**: if a signal was popped (either by step 2's
+///    lookup or a fresh pop after sigreturn), look up its disposition and
+///    either push a `SigFrame` + redirect `ctx->user_rip` (user handler),
+///    exit the process (default terminate), or do nothing (ignored).
+///
+/// The returned value replaces `rax` for SYSRETQ.
 ///
 /// # Safety
 /// `ctx` must point to the [`SyscallReturnContext`] fields on the current
 /// task's kernel stack.  Called only from `syscall_entry` with IF disabled.
 #[no_mangle]
-pub unsafe extern "C" fn check_and_deliver_signals(ctx: *mut SyscallReturnContext) {
+pub unsafe extern "C" fn check_and_deliver_signals(ctx: *mut SyscallReturnContext, rv: i64) -> i64 {
     use core::sync::atomic::Ordering;
 
     // Handle sigreturn: restore saved context from FORK_USER_* statics.
@@ -550,13 +664,48 @@ pub unsafe extern "C" fn check_and_deliver_signals(ctx: *mut SyscallReturnContex
     }
 
     let task_id = crate::task::current_id();
-    let sig =
-        match crate::process::with_signal_state_for_task(task_id, |state| state.pop_next_pending())
-        {
-            Some(Some(sig)) => sig,
-            _ => return, // no pending signal or no process entry
-        };
-    deliver_signal(sig, &mut *ctx);
+    // Peek the next deliverable signal and its (disposition, sa_flags) in
+    // a single lock window so the restart-decision classifier sees a
+    // consistent snapshot.
+    let popped: Option<(u8, Disposition, u64)> =
+        crate::process::with_signal_state_for_task(task_id, |state| {
+            state.pop_next_pending().map(|s| {
+                let i = (s - 1) as usize;
+                (s, state.dispositions[i], state.sa_flags[i])
+            })
+        })
+        .flatten();
+
+    let mut rv_out = rv;
+    let sig_for_delivery: Option<u8> = match restart_decision(
+        rv,
+        popped.map(|(s, _, _)| s),
+        popped.map(|(_, d, _)| d).unwrap_or(Disposition::Default),
+        popped.map(|(_, _, f)| f).unwrap_or(0),
+    ) {
+        RestartDecision::NoChange => popped.map(|(s, _, _)| s),
+        RestartDecision::Restart { deliver_handler } => {
+            (*ctx).user_rip = (*ctx).user_rip.wrapping_sub(SYSCALL_INSN_LEN);
+            // Clobber rv: after restart, userspace will get the result of
+            // the re-executed syscall; the stale -ERESTARTSYS must not
+            // leak in case something later skips the restart.
+            rv_out = 0;
+            if deliver_handler {
+                popped.map(|(s, _, _)| s)
+            } else {
+                None
+            }
+        }
+        RestartDecision::Eintr => {
+            rv_out = crate::fs::EINTR;
+            popped.map(|(s, _, _)| s)
+        }
+    };
+
+    if let Some(sig) = sig_for_delivery {
+        deliver_signal(sig, &mut *ctx);
+    }
+    rv_out
 }
 
 /// Deliver signal `sig` by either redirecting return-to-user context to the
@@ -795,5 +944,139 @@ mod tests {
             s.dispositions[(SIGCHLD - 1) as usize],
             Disposition::Ignore
         ));
+    }
+
+    // ── restart_decision classifier ───────────────────────────────────
+
+    #[test]
+    fn restart_noop_when_rv_is_not_erestartsys() {
+        // Any non-ERESTARTSYS rv is passed through untouched even if a
+        // signal is queued with SA_RESTART clear.
+        assert_eq!(
+            restart_decision(-4, Some(SIGTTOU), Disposition::Handler(0x1000), 0),
+            RestartDecision::NoChange
+        );
+        assert_eq!(
+            restart_decision(0, None, Disposition::Default, 0),
+            RestartDecision::NoChange
+        );
+    }
+
+    #[test]
+    fn restart_without_signal_rewinds_unconditionally() {
+        // ERESTARTSYS with no pending signal (e.g. spurious wake) must
+        // rewind rip so the syscall re-runs; no handler to deliver.
+        assert_eq!(
+            restart_decision(crate::tty::KERN_ERESTARTSYS, None, Disposition::Default, 0),
+            RestartDecision::Restart {
+                deliver_handler: false
+            }
+        );
+    }
+
+    #[test]
+    fn restart_handler_with_sa_restart_rewinds_and_delivers() {
+        assert_eq!(
+            restart_decision(
+                crate::tty::KERN_ERESTARTSYS,
+                Some(SIGTTOU),
+                Disposition::Handler(0x4000_0000),
+                SA_RESTART
+            ),
+            RestartDecision::Restart {
+                deliver_handler: true
+            }
+        );
+    }
+
+    #[test]
+    fn restart_handler_without_sa_restart_returns_eintr() {
+        assert_eq!(
+            restart_decision(
+                crate::tty::KERN_ERESTARTSYS,
+                Some(SIGTTOU),
+                Disposition::Handler(0x4000_0000),
+                0
+            ),
+            RestartDecision::Eintr
+        );
+    }
+
+    #[test]
+    fn restart_handler_with_other_flags_still_needs_sa_restart() {
+        // SA_NODEFER alone doesn't enable restart.
+        let sa_nodefer: u64 = 0x4000_0000;
+        assert_eq!(
+            restart_decision(
+                crate::tty::KERN_ERESTARTSYS,
+                Some(SIGTTOU),
+                Disposition::Handler(0x4000_0000),
+                sa_nodefer
+            ),
+            RestartDecision::Eintr
+        );
+    }
+
+    #[test]
+    fn restart_ignored_signal_rewinds() {
+        // SIG_IGN on an ERESTARTSYS-returning syscall: restart (no
+        // handler to run, nothing for userspace to see).
+        assert_eq!(
+            restart_decision(
+                crate::tty::KERN_ERESTARTSYS,
+                Some(SIGTTOU),
+                Disposition::Ignore,
+                0
+            ),
+            RestartDecision::Restart {
+                deliver_handler: false
+            }
+        );
+    }
+
+    #[test]
+    fn restart_default_stop_rewinds_no_handler() {
+        // Default SIGTTOU/SIGTTIN/SIGTSTP is Stop — the caller will
+        // re-enter the syscall after wake; don't convert to EINTR.
+        assert_eq!(
+            restart_decision(
+                crate::tty::KERN_ERESTARTSYS,
+                Some(SIGTTOU),
+                Disposition::Default,
+                0
+            ),
+            RestartDecision::Restart {
+                deliver_handler: false
+            }
+        );
+    }
+
+    #[test]
+    fn restart_default_terminate_rewinds_no_handler() {
+        // Default-terminate (e.g. SIGTERM): the task is about to die
+        // via deliver_signal → task::exit. Picking Restart (rather than
+        // NoChange) ensures -512 never leaks into userspace if the
+        // terminate path is ever made non-fatal.
+        assert_eq!(
+            restart_decision(
+                crate::tty::KERN_ERESTARTSYS,
+                Some(SIGTERM),
+                Disposition::Default,
+                0
+            ),
+            RestartDecision::Restart {
+                deliver_handler: false
+            }
+        );
+    }
+
+    #[test]
+    fn sigaction_flags_roundtrip_in_state() {
+        // The SignalState machinery itself (not sys_sigaction, which
+        // requires a live process entry) stores sa_flags per signal.
+        let mut s = SignalState::new();
+        s.sa_flags[(SIGTTOU - 1) as usize] = SA_RESTART;
+        assert_eq!(s.sa_flags[(SIGTTOU - 1) as usize], SA_RESTART);
+        assert_eq!(s.sa_flags[(SIGTERM - 1) as usize], 0);
     }
 }

--- a/kernel/src/tty/mod.rs
+++ b/kernel/src/tty/mod.rs
@@ -284,9 +284,9 @@ const ENOTTY: i64 = -25;
 pub const EIO: i64 = -5;
 
 /// Linux-internal "restart this syscall" sentinel. Not user-visible: the
-/// syscall trampoline either restarts the call transparently (SA_RESTART)
-/// or converts it to `EINTR` (-4). Until the trampoline lands (tracked as
-/// a follow-up to #434), callers translate this to `EINTR` directly.
+/// syscall trampoline (`signal::check_and_deliver_signals`) either
+/// restarts the call transparently (when the delivered signal has
+/// `SA_RESTART`) or converts it to `EINTR` (-4).
 pub const KERN_ERESTARTSYS: i64 = -512;
 
 /// `TIOCSCTTY(force)` — acquire `tty` as the caller session's controlling

--- a/kernel/tests/tty_tostop_sigttou.rs
+++ b/kernel/tests/tty_tostop_sigttou.rs
@@ -14,7 +14,8 @@ use core::panic::PanicInfo;
 
 use vibix::process::{self, test_helpers as h};
 use vibix::signal::{
-    restart_decision, sig_bit, Disposition, RestartDecision, SA_RESTART, SIGTERM, SIGTTOU,
+    restart_decision, sig_bit, signal_to_deliver, Disposition, RestartDecision, SA_RESTART,
+    SIGTERM, SIGTTOU,
 };
 use vibix::tty::{termios, tty_check_tostop, Tty, KERN_ERESTARTSYS};
 use vibix::{
@@ -77,6 +78,26 @@ fn run_tests() {
         (
             "erestartsys_no_pending_signal_unconditionally_rewinds",
             &(erestartsys_no_pending_signal_unconditionally_rewinds as fn()),
+        ),
+        (
+            "signal_to_deliver_restart_default_terminate_delivers",
+            &(signal_to_deliver_restart_default_terminate_delivers as fn()),
+        ),
+        (
+            "signal_to_deliver_restart_default_stop_delivers",
+            &(signal_to_deliver_restart_default_stop_delivers as fn()),
+        ),
+        (
+            "signal_to_deliver_restart_ignore_skips",
+            &(signal_to_deliver_restart_ignore_skips as fn()),
+        ),
+        (
+            "signal_to_deliver_restart_handler_delivers",
+            &(signal_to_deliver_restart_handler_delivers as fn()),
+        ),
+        (
+            "signal_to_deliver_eintr_and_nochange_always_deliver",
+            &(signal_to_deliver_eintr_and_nochange_always_deliver as fn()),
         ),
     ];
     serial_println!("running {} tests", tests.len());
@@ -259,4 +280,100 @@ fn erestartsys_no_pending_signal_unconditionally_rewinds() {
             deliver_handler: false
         }
     );
+}
+
+// ── signal_to_deliver: delivery-on-restart classifier ──────────────────
+//
+// Regression: prior to this series, `Restart{deliver_handler:false}`
+// swallowed the popped signal entirely — SIGTERM's default Terminate
+// action never fired on the restart path, and job-control Stop never
+// dispatched either. `signal_to_deliver` now separates "rewind rip" from
+// "deliver the signal".
+
+fn signal_to_deliver_restart_default_terminate_delivers() {
+    // Restart + SIGTERM + Default disposition must still dispatch the
+    // signal so `deliver_signal` can terminate the task. Swallowing it
+    // here would leave the process spinning on the restarted syscall.
+    assert_eq!(
+        signal_to_deliver(
+            RestartDecision::Restart {
+                deliver_handler: false,
+            },
+            Some((SIGTERM, Disposition::Default)),
+        ),
+        Some(SIGTERM)
+    );
+}
+
+fn signal_to_deliver_restart_default_stop_delivers() {
+    // Restart + SIGTTOU + Default disposition must also dispatch — the
+    // default Stop action is a no-op today but will become a real
+    // task-stop once job control lands, and at that point skipping
+    // delivery would break SIGTSTP/SIGTTOU/SIGTTIN.
+    assert_eq!(
+        signal_to_deliver(
+            RestartDecision::Restart {
+                deliver_handler: false,
+            },
+            Some((SIGTTOU, Disposition::Default)),
+        ),
+        Some(SIGTTOU)
+    );
+}
+
+fn signal_to_deliver_restart_ignore_skips() {
+    // Explicit Ignore is the one restart path that legitimately skips
+    // delivery — no handler to run, and default wouldn't fire either.
+    assert_eq!(
+        signal_to_deliver(
+            RestartDecision::Restart {
+                deliver_handler: false,
+            },
+            Some((SIGTTOU, Disposition::Ignore)),
+        ),
+        None
+    );
+    // None popped → None delivered on restart (spurious-wake case).
+    assert_eq!(
+        signal_to_deliver(
+            RestartDecision::Restart {
+                deliver_handler: false,
+            },
+            None,
+        ),
+        None
+    );
+}
+
+fn signal_to_deliver_restart_handler_delivers() {
+    // Restart + handler → deliver the handler on top of the rewound rip.
+    assert_eq!(
+        signal_to_deliver(
+            RestartDecision::Restart {
+                deliver_handler: true,
+            },
+            Some((SIGTTOU, Disposition::Handler(0x4000_0000))),
+        ),
+        Some(SIGTTOU)
+    );
+}
+
+fn signal_to_deliver_eintr_and_nochange_always_deliver() {
+    // Eintr and NoChange never mask delivery — if a signal was popped,
+    // it runs.
+    assert_eq!(
+        signal_to_deliver(
+            RestartDecision::Eintr,
+            Some((SIGTTOU, Disposition::Handler(0x4000_0000))),
+        ),
+        Some(SIGTTOU)
+    );
+    assert_eq!(
+        signal_to_deliver(
+            RestartDecision::NoChange,
+            Some((SIGTERM, Disposition::Default))
+        ),
+        Some(SIGTERM)
+    );
+    assert_eq!(signal_to_deliver(RestartDecision::NoChange, None), None);
 }

--- a/kernel/tests/tty_tostop_sigttou.rs
+++ b/kernel/tests/tty_tostop_sigttou.rs
@@ -243,12 +243,7 @@ fn erestartsys_default_stop_rewinds() {
     // Default-Terminate (e.g. SIGTERM) also rewinds; the task is about
     // to die via deliver_signal but -512 must not leak into userspace.
     assert_eq!(
-        restart_decision(
-            KERN_ERESTARTSYS,
-            Some(SIGTERM),
-            Disposition::Default,
-            0,
-        ),
+        restart_decision(KERN_ERESTARTSYS, Some(SIGTERM), Disposition::Default, 0,),
         RestartDecision::Restart {
             deliver_handler: false
         }

--- a/kernel/tests/tty_tostop_sigttou.rs
+++ b/kernel/tests/tty_tostop_sigttou.rs
@@ -13,7 +13,9 @@ use alloc::sync::Arc;
 use core::panic::PanicInfo;
 
 use vibix::process::{self, test_helpers as h};
-use vibix::signal::{sig_bit, SIGTTOU};
+use vibix::signal::{
+    restart_decision, sig_bit, Disposition, RestartDecision, SA_RESTART, SIGTERM, SIGTTOU,
+};
 use vibix::tty::{termios, tty_check_tostop, Tty, KERN_ERESTARTSYS};
 use vibix::{
     exit_qemu, serial_println,
@@ -59,6 +61,22 @@ fn run_tests() {
         (
             "sigttou_delivered_to_every_pgrp_member",
             &(sigttou_delivered_to_every_pgrp_member as fn()),
+        ),
+        (
+            "erestartsys_sa_restart_rewinds_syscall",
+            &(erestartsys_sa_restart_rewinds_syscall as fn()),
+        ),
+        (
+            "erestartsys_without_sa_restart_yields_eintr",
+            &(erestartsys_without_sa_restart_yields_eintr as fn()),
+        ),
+        (
+            "erestartsys_default_stop_rewinds",
+            &(erestartsys_default_stop_rewinds as fn()),
+        ),
+        (
+            "erestartsys_no_pending_signal_unconditionally_rewinds",
+            &(erestartsys_no_pending_signal_unconditionally_rewinds as fn()),
         ),
     ];
     serial_println!("running {} tests", tests.len());
@@ -158,4 +176,92 @@ fn sigttou_delivered_to_every_pgrp_member() {
         );
     }
     assert_eq!(pending_bits_for_pid(30) & sig_bit(SIGTTOU), 0);
+}
+
+// ── ERESTARTSYS / SA_RESTART trampoline classifier ──────────────────────
+//
+// The syscall trampoline (`check_and_deliver_signals`) reacts to
+// `tty_check_tostop`'s KERN_ERESTARTSYS by consulting `restart_decision`.
+// These cases drive the classifier directly — the trampoline path itself
+// needs a live kernel-stack-backed `SyscallReturnContext` and signal
+// frame push, which is covered by the shell-level end-to-end tests.
+
+fn erestartsys_sa_restart_rewinds_syscall() {
+    // Handler installed with SA_RESTART: rv=-ERESTARTSYS must restart
+    // the syscall *and* deliver the handler on top of the restart.
+    assert_eq!(
+        restart_decision(
+            KERN_ERESTARTSYS,
+            Some(SIGTTOU),
+            Disposition::Handler(0x0000_4000_0000_0000),
+            SA_RESTART,
+        ),
+        RestartDecision::Restart {
+            deliver_handler: true
+        }
+    );
+}
+
+fn erestartsys_without_sa_restart_yields_eintr() {
+    // Handler installed without SA_RESTART: convert to -EINTR.
+    assert_eq!(
+        restart_decision(
+            KERN_ERESTARTSYS,
+            Some(SIGTTOU),
+            Disposition::Handler(0x0000_4000_0000_0000),
+            0,
+        ),
+        RestartDecision::Eintr
+    );
+    // Non-ERESTARTSYS rv is passed through untouched.
+    assert_eq!(
+        restart_decision(
+            -4, // EINTR
+            Some(SIGTTOU),
+            Disposition::Handler(0x0000_4000_0000_0000),
+            0,
+        ),
+        RestartDecision::NoChange
+    );
+}
+
+fn erestartsys_default_stop_rewinds() {
+    // Default SIGTTOU action is Stop (job-control). Restart so that when
+    // the task is resumed it re-evaluates the tostop gate and either
+    // proceeds or re-enters the wait.
+    assert_eq!(
+        restart_decision(
+            KERN_ERESTARTSYS,
+            Some(SIGTTOU),
+            Disposition::Default,
+            0, // flags irrelevant for default disposition
+        ),
+        RestartDecision::Restart {
+            deliver_handler: false
+        }
+    );
+    // Default-Terminate (e.g. SIGTERM) also rewinds; the task is about
+    // to die via deliver_signal but -512 must not leak into userspace.
+    assert_eq!(
+        restart_decision(
+            KERN_ERESTARTSYS,
+            Some(SIGTERM),
+            Disposition::Default,
+            0,
+        ),
+        RestartDecision::Restart {
+            deliver_handler: false
+        }
+    );
+}
+
+fn erestartsys_no_pending_signal_unconditionally_rewinds() {
+    // A caller that returned ERESTARTSYS but no pending signal was
+    // actually consumed (e.g. spurious wake) restarts unconditionally.
+    assert_eq!(
+        restart_decision(KERN_ERESTARTSYS, None, Disposition::Default, 0),
+        RestartDecision::Restart {
+            deliver_handler: false
+        }
+    );
 }


### PR DESCRIPTION
Closes #451

## Summary
- `check_and_deliver_signals` now receives the dispatcher's return value as a second arg and returns the (possibly rewritten) value for SYSRETQ. New `restart_decision` classifier picks `NoChange` / `Restart {deliver_handler}` / `Eintr`.
- `sys_sigaction` round-trips `sa_flags` through bytes 8..16 of `struct sigaction`; `SignalState` gains a parallel `sa_flags: [u64; NSIG]`. Only `SA_RESTART` is honoured today.
- Asm trampoline (`syscall_entry` in `arch::x86_64::syscall`) pushes one alignment slot before the call, passes `rv` in `rsi`, drops the slot after return; `rax` carries the new `rv` into SYSRETQ.
- `SerialBackend::read` / `SerialBackend::write` drop their local `KERN_ERESTARTSYS → -EINTR` shim and propagate the sentinel; the trampoline does the right thing.

## Restart policy (matches Linux `do_signal`'s ERESTARTSYS arm)
| `rv`              | popped signal                        | outcome       |
|-------------------|---------------------------------------|---------------|
| non-ERESTARTSYS   | any                                   | NoChange      |
| ERESTARTSYS       | None (spurious wake)                  | Restart (no handler) |
| ERESTARTSYS       | `Handler(_) + SA_RESTART`             | Restart + deliver handler |
| ERESTARTSYS       | `Handler(_)` without SA_RESTART       | -EINTR + deliver handler |
| ERESTARTSYS       | `Ignore`                              | Restart (no handler) |
| ERESTARTSYS       | `Default` (Stop/Ignore/Continue/Terminate) | Restart (no handler) |

## Test plan
- [x] `cargo xtask build` — clean (only pre-existing `is_guard_hit` dead_code warning)
- [x] `cargo test --test tty_tostop_sigttou` — 10/10 pass (6 existing + 4 new classifier cases)
- [x] `cargo test --test tty_sigttin_read` — 8/8 pass
- [x] `cargo test --test tty_jobctl_ioctls` — 10/10 pass
- [x] Host-unit tests for `restart_decision` — 8 cases covering every arm (ERESTARTSYS vs not, every disposition × SA_RESTART on/off × default-action kind, sigaction flag round-trip in `SignalState`)
- [x] `cargo xtask smoke` — all 33 markers present ✓