### PR TITLE
signal: preserve user syscall arg regs across SA_RESTART+handler sigreturn

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -267,3 +267,7 @@ harness = false
 [[test]]
 name = "gdbstub_loop"
 harness = false
+
+[[test]]
+name = "signal_sarestart_handler_regs"
+harness = false

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -100,6 +100,35 @@ pub static FORK_USER_RSP: AtomicU64 = AtomicU64::new(0);
 #[no_mangle]
 pub static SIGRETURN_PENDING: AtomicU64 = AtomicU64::new(0);
 
+/// Set to 1 by the SIGRETURN dispatch arm when the SigFrame carried saved
+/// user syscall arg regs (i.e. was pushed on the syscall-return path).
+/// Tells `check_and_deliver_signals` to both repopulate ctx's arg-reg
+/// slots from the `SIGRET_USER_*` statics *and* arm `SYSCALL_RESTART_PENDING`.
+/// On a fault-delivered signal's sigreturn, this stays 0 and the arg-reg
+/// slots in ctx are left alone — avoiding a spurious zero-fill of user
+/// GPRs. Cleared after consumption.
+#[no_mangle]
+pub static SIGRET_HAS_SYSCALL_ARGS: AtomicU64 = AtomicU64::new(0);
+
+/// User syscall arg regs (rax/rdi/rsi/rdx/r10/r8/r9) shuttled from
+/// `sys_sigreturn` to `check_and_deliver_signals` so the sigreturn path
+/// can repopulate the kernel-stack `SyscallReturnContext` before SYSRETQ.
+/// Only meaningful when `SIGRET_HAS_SYSCALL_ARGS == 1`.
+#[no_mangle]
+pub static SIGRET_USER_RAX: AtomicU64 = AtomicU64::new(0);
+#[no_mangle]
+pub static SIGRET_USER_RDI: AtomicU64 = AtomicU64::new(0);
+#[no_mangle]
+pub static SIGRET_USER_RSI: AtomicU64 = AtomicU64::new(0);
+#[no_mangle]
+pub static SIGRET_USER_RDX: AtomicU64 = AtomicU64::new(0);
+#[no_mangle]
+pub static SIGRET_USER_R10: AtomicU64 = AtomicU64::new(0);
+#[no_mangle]
+pub static SIGRET_USER_R8: AtomicU64 = AtomicU64::new(0);
+#[no_mangle]
+pub static SIGRET_USER_R9: AtomicU64 = AtomicU64::new(0);
+
 /// Set to 1 by `check_and_deliver_signals` when a bare syscall restart
 /// (no user handler) is about to occur. The syscall trampoline checks
 /// this flag after the signal hook returns: when set, the saved user
@@ -611,6 +640,18 @@ pub unsafe extern "C" fn syscall_dispatch(
             FORK_USER_RIP.store(restored.rip, Ordering::Relaxed);
             FORK_USER_RFLAGS.store(restored.rflags, Ordering::Relaxed);
             FORK_USER_RSP.store(restored.rsp, Ordering::Relaxed);
+            if let Some(args) = restored.syscall_args {
+                SIGRET_USER_RAX.store(args.rax, Ordering::Relaxed);
+                SIGRET_USER_RDI.store(args.rdi, Ordering::Relaxed);
+                SIGRET_USER_RSI.store(args.rsi, Ordering::Relaxed);
+                SIGRET_USER_RDX.store(args.rdx, Ordering::Relaxed);
+                SIGRET_USER_R10.store(args.r10, Ordering::Relaxed);
+                SIGRET_USER_R8.store(args.r8, Ordering::Relaxed);
+                SIGRET_USER_R9.store(args.r9, Ordering::Relaxed);
+                SIGRET_HAS_SYSCALL_ARGS.store(1, Ordering::Relaxed);
+            } else {
+                SIGRET_HAS_SYSCALL_ARGS.store(0, Ordering::Relaxed);
+            }
             SIGRETURN_PENDING.store(1, Ordering::Relaxed);
             0i64
         }

--- a/kernel/src/signal/frame.rs
+++ b/kernel/src/signal/frame.rs
@@ -42,6 +42,13 @@
 use core::mem;
 
 /// Index of key registers in `SigFrame::gregs`.
+const REG_R8: usize = 0;
+const REG_R9: usize = 1;
+const REG_R10: usize = 2;
+const REG_RDI: usize = 8;
+const REG_RSI: usize = 9;
+const REG_RDX: usize = 12;
+const REG_RAX: usize = 13;
 const REG_RSP: usize = 15;
 const REG_RIP: usize = 16;
 const REG_EFLAGS: usize = 17;
@@ -55,6 +62,19 @@ const SIGRETURN_TRAMPOLINE: [u8; 9] = [
     0x48, 0xC7, 0xC0, 0x0F, 0x00, 0x00, 0x00, // mov rax, 15
     0x0F, 0x05, // syscall
 ];
+
+/// Vibix-local `uc_flags` bit indicating that `gregs[REG_RAX / REG_RDI /
+/// REG_RSI / REG_RDX / REG_R10 / REG_R8 / REG_R9]` carry the user syscall
+/// arg registers saved at delivery time. Set by `push_signal_frame` (the
+/// syscall-return path) and **not** set by `push_fault_signal_frame` (the
+/// fault-return path, which lacks a `SyscallReturnContext` with those
+/// values). The sigreturn path restores syscall arg regs into the kernel-
+/// stack ctx only when this flag is present, avoiding a regression where
+/// fault-delivered signals would zero-fill those user GPRs after return.
+///
+/// Picked from the high half of `uc_flags` so it cannot collide with
+/// Linux's low-numbered `UC_*` flag bits.
+pub const UC_VIBIX_SYSCALL_REGS: u64 = 0x1000_0000_0000_0000;
 
 /// The signal frame pushed on the user stack before entering the handler.
 ///
@@ -92,11 +112,37 @@ pub struct SigFrame {
 const _: () = assert!(mem::size_of::<SigFrame>() % 16 == 0);
 
 /// Recovered register state from a `SigFrame`.
+///
+/// `syscall_args` is `Some` only when the frame was pushed on the syscall-
+/// return path (the `UC_VIBIX_SYSCALL_REGS` flag is set). On an SA_RESTART+
+/// handler delivery the trampoline rewound `rip` to the SYSCALL instruction;
+/// after sigreturn returns to that rewound rip, SYSCALL must see the
+/// original `(nr, a0..a5)` in those GPRs. See #499.
+///
+/// On fault-delivered signals (#PF / SIGSEGV), the flag is absent and
+/// `syscall_args` is `None` — the sigreturn path leaves the kernel-stack
+/// ctx's user GPR slots alone.
 pub struct RestoredRegs {
     pub rip: u64,
     pub rflags: u64,
     pub rsp: u64,
     pub saved_mask: u64,
+    pub syscall_args: Option<SyscallArgRegs>,
+}
+
+/// The 7 user GPRs that the Linux x86_64 syscall ABI uses — `rax` as the
+/// syscall number, `rdi/rsi/rdx/r10/r8/r9` as args 0..5. Preserved through
+/// `SigFrame::gregs` so SA_RESTART+handler restarts can replay the original
+/// syscall after sigreturn.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SyscallArgRegs {
+    pub rax: u64,
+    pub rdi: u64,
+    pub rsi: u64,
+    pub rdx: u64,
+    pub r10: u64,
+    pub r8: u64,
+    pub r9: u64,
 }
 
 /// Push a `SigFrame` onto the user stack at `user_rsp` and return the new
@@ -118,6 +164,7 @@ pub unsafe fn push_signal_frame(
     saved_rip: u64,
     saved_rflags: u64,
     saved_mask: u64,
+    syscall_args: Option<SyscallArgRegs>,
 ) -> Result<u64, ()> {
     use crate::arch::x86_64::uaccess;
 
@@ -132,13 +179,23 @@ pub unsafe fn push_signal_frame(
         return Err(());
     }
 
+    // Flag the frame with UC_VIBIX_SYSCALL_REGS only when the caller is
+    // delivering on top of an SA_RESTART-style restart — that's the one
+    // path where rip was rewound to the SYSCALL insn and the saved regs
+    // must replay on sigreturn.
+    let uc_flags = if syscall_args.is_some() {
+        UC_VIBIX_SYSCALL_REGS
+    } else {
+        0
+    };
+
     // Build the frame in kernel memory, then copy it to user space.
     let mut frame = SigFrame {
         pretcode: frame_addr + mem::offset_of!(SigFrame, trampoline_code) as u64,
         sig: sig as u32,
         _pad: 0,
         info: [0u8; 128],
-        uc_flags: 0,
+        uc_flags,
         uc_link: 0,
         uc_stack: [0u64; 3],
         gregs: [0u64; 23],
@@ -156,6 +213,17 @@ pub unsafe fn push_signal_frame(
     frame.gregs[REG_RIP] = saved_rip;
     frame.gregs[REG_EFLAGS] = saved_rflags;
     frame.gregs[REG_RSP] = user_rsp;
+    // Preserve syscall arg regs so SA_RESTART+handler restarts can replay
+    // the original syscall after sigreturn rewinds rip to the SYSCALL insn.
+    if let Some(args) = syscall_args {
+        frame.gregs[REG_RAX] = args.rax;
+        frame.gregs[REG_RDI] = args.rdi;
+        frame.gregs[REG_RSI] = args.rsi;
+        frame.gregs[REG_RDX] = args.rdx;
+        frame.gregs[REG_R10] = args.r10;
+        frame.gregs[REG_R8] = args.r8;
+        frame.gregs[REG_R9] = args.r9;
+    }
 
     // Copy frame to user stack.
     let frame_bytes =
@@ -262,11 +330,26 @@ pub unsafe fn restore_signal_frame(frame_addr: u64) -> Result<RestoredRegs, ()> 
         return Err(());
     }
 
+    let syscall_args = if frame.uc_flags & UC_VIBIX_SYSCALL_REGS != 0 {
+        Some(SyscallArgRegs {
+            rax: frame.gregs[REG_RAX],
+            rdi: frame.gregs[REG_RDI],
+            rsi: frame.gregs[REG_RSI],
+            rdx: frame.gregs[REG_RDX],
+            r10: frame.gregs[REG_R10],
+            r8: frame.gregs[REG_R8],
+            r9: frame.gregs[REG_R9],
+        })
+    } else {
+        None
+    };
+
     Ok(RestoredRegs {
         rip,
         rflags: frame.gregs[REG_EFLAGS],
         rsp,
         saved_mask: frame.uc_sigmask,
+        syscall_args,
     })
 }
 
@@ -314,8 +397,35 @@ mod tests {
 
     #[test]
     fn gregs_indices_are_in_range() {
-        assert!(REG_RSP < 23);
-        assert!(REG_RIP < 23);
-        assert!(REG_EFLAGS < 23);
+        for i in [
+            REG_R8, REG_R9, REG_R10, REG_RDI, REG_RSI, REG_RDX, REG_RAX, REG_RSP, REG_RIP,
+            REG_EFLAGS,
+        ] {
+            assert!(i < 23, "greg index {i} out of range");
+        }
+    }
+
+    #[test]
+    fn syscall_arg_regs_roundtrip_through_gregs() {
+        // Populating `gregs` at the positions dictated by the Linux
+        // mcontext ABI and reading them back through `RestoredRegs` must
+        // recover the exact values. This is the invariant that keeps the
+        // SA_RESTART+handler restart path intact across sigreturn.
+        let mut gregs = [0u64; 23];
+        gregs[REG_RAX] = 0xAA;
+        gregs[REG_RDI] = 0xD1;
+        gregs[REG_RSI] = 0x51;
+        gregs[REG_RDX] = 0xD2;
+        gregs[REG_R10] = 0x10;
+        gregs[REG_R8] = 0x08;
+        gregs[REG_R9] = 0x09;
+        // Indices must all be distinct so they don't alias.
+        assert_eq!(REG_RAX, 13);
+        assert_eq!(REG_RDI, 8);
+        assert_eq!(REG_RSI, 9);
+        assert_eq!(REG_RDX, 12);
+        assert_eq!(REG_R10, 2);
+        assert_eq!(REG_R8, 0);
+        assert_eq!(REG_R9, 1);
     }
 }

--- a/kernel/src/signal/mod.rs
+++ b/kernel/src/signal/mod.rs
@@ -706,10 +706,29 @@ pub unsafe extern "C" fn check_and_deliver_signals(ctx: *mut SyscallReturnContex
 
     // Handle sigreturn: restore saved context from FORK_USER_* statics.
     if crate::arch::x86_64::syscall::SIGRETURN_PENDING.load(Ordering::Relaxed) != 0 {
-        crate::arch::x86_64::syscall::SIGRETURN_PENDING.store(0, Ordering::Relaxed);
-        (*ctx).user_rip = crate::arch::x86_64::syscall::FORK_USER_RIP.load(Ordering::Relaxed);
-        (*ctx).user_rflags = crate::arch::x86_64::syscall::FORK_USER_RFLAGS.load(Ordering::Relaxed);
-        (*ctx).user_rsp = crate::arch::x86_64::syscall::FORK_USER_RSP.load(Ordering::Relaxed);
+        use crate::arch::x86_64::syscall;
+        syscall::SIGRETURN_PENDING.store(0, Ordering::Relaxed);
+        (*ctx).user_rip = syscall::FORK_USER_RIP.load(Ordering::Relaxed);
+        (*ctx).user_rflags = syscall::FORK_USER_RFLAGS.load(Ordering::Relaxed);
+        (*ctx).user_rsp = syscall::FORK_USER_RSP.load(Ordering::Relaxed);
+        // When the SigFrame was pushed on a syscall-return path, the
+        // trampoline rewound rip to the SYSCALL insn before the handler
+        // ran. After sigreturn restores that rewound rip above, the
+        // SYSCALL insn must see the original (nr, a0..a5) in user GPRs
+        // — so repopulate the saved regs in ctx and arm the trampoline's
+        // restart-restore arm so they reach the user GPRs before SYSRETQ.
+        // Fault-delivered signals skip this (the flag stays 0) and leave
+        // ctx's arg-reg slots untouched, matching pre-#499 behavior.
+        if syscall::SIGRET_HAS_SYSCALL_ARGS.swap(0, Ordering::Relaxed) != 0 {
+            (*ctx).user_rax = syscall::SIGRET_USER_RAX.load(Ordering::Relaxed);
+            (*ctx).user_rdi = syscall::SIGRET_USER_RDI.load(Ordering::Relaxed);
+            (*ctx).user_rsi = syscall::SIGRET_USER_RSI.load(Ordering::Relaxed);
+            (*ctx).user_rdx = syscall::SIGRET_USER_RDX.load(Ordering::Relaxed);
+            (*ctx).user_r10 = syscall::SIGRET_USER_R10.load(Ordering::Relaxed);
+            (*ctx).user_r8 = syscall::SIGRET_USER_R8.load(Ordering::Relaxed);
+            (*ctx).user_r9 = syscall::SIGRET_USER_R9.load(Ordering::Relaxed);
+            syscall::SYSCALL_RESTART_PENDING.store(1, Ordering::Relaxed);
+        }
         // After sigreturn still check for any newly-pending signal.
     }
 
@@ -761,8 +780,19 @@ pub unsafe extern "C" fn check_and_deliver_signals(ctx: *mut SyscallReturnContex
     }
     let sig_for_delivery = signal_to_deliver(decision, popped.map(|(s, d, _)| (s, d)));
 
+    // True when the handler we're about to deliver rides on top of an
+    // SA_RESTART-style restart — i.e. rip was just rewound to the SYSCALL
+    // insn and the frame will carry the original syscall arg regs so
+    // sigreturn can replay them. Only this path sets UC_VIBIX_SYSCALL_REGS.
+    let is_restart_handler = matches!(
+        decision,
+        RestartDecision::Restart {
+            deliver_handler: true
+        }
+    );
+
     if let Some(sig) = sig_for_delivery {
-        deliver_signal(sig, &mut *ctx);
+        deliver_signal(sig, &mut *ctx, is_restart_handler);
     }
     rv_out
 }
@@ -772,7 +802,7 @@ pub unsafe extern "C" fn check_and_deliver_signals(ctx: *mut SyscallReturnContex
 ///
 /// # Safety
 /// `ctx` must point to valid kernel-stack-saved user context.
-unsafe fn deliver_signal(sig: u8, ctx: &mut SyscallReturnContext) {
+unsafe fn deliver_signal(sig: u8, ctx: &mut SyscallReturnContext, is_restart_handler: bool) {
     let task_id = crate::task::current_id();
 
     // Capture the pre-delivery mask and block the signal in one lock window.
@@ -816,12 +846,33 @@ unsafe fn deliver_signal(sig: u8, ctx: &mut SyscallReturnContext) {
         }
         Disposition::Handler(handler_va) => {
             // Push signal frame onto the user stack and redirect SYSRETQ.
+            // Carry the syscall arg regs through the frame only on the
+            // SA_RESTART+handler restart path — the caller rewound rip to
+            // the SYSCALL insn, and on sigreturn those regs must replay.
+            // On a non-restart handler delivery, rip points past SYSCALL
+            // and gregs[REG_RAX] would have to hold the syscall rv instead
+            // of the nr for userspace to see the right value — that's a
+            // wider rework, deliberately out of scope.
+            let args = if is_restart_handler {
+                Some(frame::SyscallArgRegs {
+                    rax: ctx.user_rax,
+                    rdi: ctx.user_rdi,
+                    rsi: ctx.user_rsi,
+                    rdx: ctx.user_rdx,
+                    r10: ctx.user_r10,
+                    r8: ctx.user_r8,
+                    r9: ctx.user_r9,
+                })
+            } else {
+                None
+            };
             let new_user_rsp = match frame::push_signal_frame(
                 ctx.user_rsp,
                 sig,
                 ctx.user_rip,
                 ctx.user_rflags,
                 pre_block_mask,
+                args,
             ) {
                 Ok(sp) => sp,
                 Err(_) => {
@@ -870,6 +921,7 @@ pub unsafe fn sys_sigreturn(user_rsp: u64) -> SigReturnRegs {
                 rip: restored.rip,
                 rflags: restored.rflags,
                 rsp: restored.rsp,
+                syscall_args: restored.syscall_args,
             }
         }
         Err(_) => {
@@ -889,6 +941,16 @@ pub struct SigReturnRegs {
     pub rip: u64,
     pub rflags: u64,
     pub rsp: u64,
+    /// Syscall arg regs saved at signal-delivery time — `Some` only when
+    /// the frame was pushed on the syscall-return path (fault-delivered
+    /// signals push through `push_fault_signal_frame`, which doesn't have
+    /// the originating user GPRs available). When `Some`, the sigreturn
+    /// path restores these into the kernel-stack `SyscallReturnContext`
+    /// and arms `SYSCALL_RESTART_PENDING` so the syscall trampoline
+    /// reloads them into user GPRs before SYSRETQ. That's what lets an
+    /// SA_RESTART+handler restart re-execute SYSCALL with the original
+    /// `(nr, a0..a5)`.
+    pub syscall_args: Option<frame::SyscallArgRegs>,
 }
 
 // ── Host-side unit tests ──────────────────────────────────────────────────

--- a/kernel/src/signal/mod.rs
+++ b/kernel/src/signal/mod.rs
@@ -732,6 +732,14 @@ pub unsafe extern "C" fn check_and_deliver_signals(ctx: *mut SyscallReturnContex
         // After sigreturn still check for any newly-pending signal.
     }
 
+    // Snapshot whether a restart is armed right now (set by the sigreturn
+    // block above, or by an earlier restart hop). If we end up delivering a
+    // fresh handler in this same call, the args must ride on the new frame
+    // — otherwise the frame's sigreturn won't re-arm them and the eventual
+    // SYSCALL replay will see handler-clobbered GPRs.
+    let restart_already_pending =
+        crate::arch::x86_64::syscall::SYSCALL_RESTART_PENDING.load(Ordering::Relaxed) != 0;
+
     let task_id = crate::task::current_id();
     // Peek the next deliverable signal and its (disposition, sa_flags) in
     // a single lock window so the restart-decision classifier sees a
@@ -784,14 +792,34 @@ pub unsafe extern "C" fn check_and_deliver_signals(ctx: *mut SyscallReturnContex
     // SA_RESTART-style restart — i.e. rip was just rewound to the SYSCALL
     // insn and the frame will carry the original syscall arg regs so
     // sigreturn can replay them. Only this path sets UC_VIBIX_SYSCALL_REGS.
+    //
+    // Two distinct sources feed this: (a) the current decision is a
+    // handler-restart, (b) a prior sigreturn in this same call just armed
+    // SYSCALL_RESTART_PENDING and we're about to deliver a fresh signal on
+    // top of it. In case (b), ctx.user_rip already points at the rewound
+    // SYSCALL and ctx.user_rax..r9 already hold the original syscall args
+    // — exactly the invariant case (a) sets up.
     let is_restart_handler = matches!(
         decision,
         RestartDecision::Restart {
             deliver_handler: true
         }
-    );
+    ) || (restart_already_pending && sig_for_delivery.is_some());
 
     if let Some(sig) = sig_for_delivery {
+        // Consume any pending restart before pushing the new frame. The
+        // args are now riding on the pushed frame; the eventual sigreturn
+        // of this new frame will re-arm SYSCALL_RESTART_PENDING from the
+        // frame's UC_VIBIX_SYSCALL_REGS. Leaving it armed now would make
+        // the asm epilogue pop ctx.user_rax..r9 into handler entry regs —
+        // cosmetically harmless for a signal handler (which reads its
+        // signum from its own stack-based trampoline) but it also consumes
+        // the flag, which is the real hazard: no one re-arms it until the
+        // nested sigreturn runs, so the eventual SYSCALL replay would see
+        // whatever handler-clobbered rax..r9 are in ctx at that point.
+        if restart_already_pending {
+            crate::arch::x86_64::syscall::SYSCALL_RESTART_PENDING.store(0, Ordering::Relaxed);
+        }
         deliver_signal(sig, &mut *ctx, is_restart_handler);
     }
     rv_out

--- a/kernel/tests/signal_sarestart_handler_regs.rs
+++ b/kernel/tests/signal_sarestart_handler_regs.rs
@@ -1,0 +1,219 @@
+//! Integration test: user syscall arg regs survive the SA_RESTART+handler
+//! sigreturn path (#499).
+//!
+//! Before #499, `push_signal_frame` dropped `(rax, rdi, rsi, rdx, r10, r8,
+//! r9)` on the floor — so after an SA_RESTART-style restart that routed
+//! through a user handler, sigreturn would land on the rewound SYSCALL
+//! instruction with clobbered arg regs and the syscall would re-execute
+//! with garbage. This test pins the roundtrip: push → restore → verify the
+//! recovered `SyscallArgRegs` match, and that fault-pushed frames set no
+//! flag (`syscall_args == None`) so fault-delivered signals don't force a
+//! spurious zero-fill of user GPRs on sigreturn.
+//!
+//! End-to-end verification of an SA_RESTART handler actually replaying a
+//! real syscall with the original args requires ring-3 job-control testing
+//! and lives in the shell-level smoke suite.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+
+use vibix::mem::vmatree::{Share, Vma};
+use vibix::mem::vmobject::AnonObject;
+use vibix::signal::frame::{
+    push_fault_signal_frame, push_signal_frame, restore_signal_frame, SyscallArgRegs,
+};
+use vibix::{
+    exit_qemu, serial_println, task,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+use x86_64::structures::paging::PageTableFlags;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    task::init();
+    x86_64::instructions::interrupts::enable();
+    serial_println!("signal_sarestart_handler_regs: init ok");
+    install_user_stack();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+// A 2-page user-accessible VMA used as a fake user stack. Both
+// `push_signal_frame` and `restore_signal_frame` round-trip through
+// `copy_to_user` / `copy_from_user`, so we need a real user mapping.
+const STACK_BASE: usize = 0x0000_3000_0020_0000;
+const STACK_PAGES: usize = 2;
+const STACK_TOP: u64 = (STACK_BASE + STACK_PAGES * 4096) as u64;
+
+fn install_user_stack() {
+    let pte_flags = (PageTableFlags::PRESENT
+        | PageTableFlags::WRITABLE
+        | PageTableFlags::USER_ACCESSIBLE
+        | PageTableFlags::NO_EXECUTE)
+        .bits();
+    task::install_vma_on_current(Vma::new(
+        STACK_BASE,
+        STACK_BASE + STACK_PAGES * 4096,
+        0x3, // PROT_READ | PROT_WRITE
+        pte_flags,
+        Share::Private,
+        AnonObject::new(Some(STACK_PAGES)),
+        0,
+    ));
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "push_then_restore_preserves_syscall_args",
+            &(push_then_restore_preserves_syscall_args as fn()),
+        ),
+        (
+            "push_preserves_rip_rflags_rsp_alongside_args",
+            &(push_preserves_rip_rflags_rsp_alongside_args as fn()),
+        ),
+        (
+            "fault_frame_yields_no_syscall_args",
+            &(fault_frame_yields_no_syscall_args as fn()),
+        ),
+        (
+            "non_restart_handler_frame_yields_no_syscall_args",
+            &(non_restart_handler_frame_yields_no_syscall_args as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+fn push_then_restore_preserves_syscall_args() {
+    // Plausible `write(fd=7, buf=0x…, count=42)` interrupted by SIGTTOU.
+    // Syscall nr `write = 1` on Linux x86_64.
+    let args = SyscallArgRegs {
+        rax: 1,                     // write
+        rdi: 7,                     // fd
+        rsi: 0x0000_2000_0000_0080, // buf
+        rdx: 42,                    // count
+        r10: 0xdead,                // a3 (unused by write, but must round-trip)
+        r8: 0xbeef,
+        r9: 0xcafe,
+    };
+    let user_rsp = STACK_TOP - 16;
+    let saved_rip = 0x0000_4000_0010_0100;
+    let saved_rflags = 0x202;
+    let saved_mask = 0;
+
+    let frame_addr = unsafe {
+        push_signal_frame(
+            user_rsp,
+            22,
+            saved_rip,
+            saved_rflags,
+            saved_mask,
+            Some(args),
+        )
+        .expect("push_signal_frame ok")
+    };
+    let restored = unsafe { restore_signal_frame(frame_addr).expect("restore ok") };
+    let got = restored
+        .syscall_args
+        .expect("syscall-path frame must carry UC_VIBIX_SYSCALL_REGS");
+    assert_eq!(got, args, "syscall arg regs must round-trip verbatim");
+}
+
+fn non_restart_handler_frame_yields_no_syscall_args() {
+    // Non-restart handler delivery (no SA_RESTART+handler on ERESTARTSYS)
+    // must NOT flag the frame with UC_VIBIX_SYSCALL_REGS, because rip in
+    // that frame points past SYSCALL and gregs[REG_RAX] holds the syscall
+    // nr rather than the rv. Restoring rax from gregs on sigreturn would
+    // clobber the syscall's return value that userspace is about to read.
+    let user_rsp = STACK_TOP - 64;
+    let saved_rip = 0x0000_4000_0040_0400;
+    let saved_rflags = 0x202;
+    let saved_mask = 0;
+
+    let frame_addr = unsafe {
+        push_signal_frame(user_rsp, 22, saved_rip, saved_rflags, saved_mask, None)
+            .expect("push_signal_frame(None) ok")
+    };
+    let restored = unsafe { restore_signal_frame(frame_addr).expect("restore ok") };
+    assert!(
+        restored.syscall_args.is_none(),
+        "non-restart handler frames must not carry syscall arg regs"
+    );
+    assert_eq!(restored.rip, saved_rip);
+}
+
+fn push_preserves_rip_rflags_rsp_alongside_args() {
+    // Adding syscall-arg round-trip must not regress the existing rip /
+    // rflags / rsp / saved_mask path that sigreturn has always restored.
+    let args = SyscallArgRegs {
+        rax: 0x11,
+        rdi: 0x22,
+        rsi: 0x33,
+        rdx: 0x44,
+        r10: 0x55,
+        r8: 0x66,
+        r9: 0x77,
+    };
+    let user_rsp = STACK_TOP - 32;
+    let saved_rip = 0x0000_4000_0020_0200;
+    let saved_rflags = 0x246;
+    let saved_mask = 0xabcd_ef01_2345_6789;
+
+    let frame_addr = unsafe {
+        push_signal_frame(
+            user_rsp,
+            15,
+            saved_rip,
+            saved_rflags,
+            saved_mask,
+            Some(args),
+        )
+        .expect("push ok")
+    };
+    let restored = unsafe { restore_signal_frame(frame_addr).expect("restore ok") };
+    assert_eq!(restored.rip, saved_rip);
+    assert_eq!(restored.rflags, saved_rflags);
+    assert_eq!(restored.rsp, user_rsp);
+    assert_eq!(restored.saved_mask, saved_mask);
+}
+
+fn fault_frame_yields_no_syscall_args() {
+    // Fault-delivered signals (`#PF` → SIGSEGV) push through
+    // `push_fault_signal_frame`, which has no `SyscallReturnContext` with
+    // arg regs. `restore_signal_frame` must report `syscall_args = None`
+    // so the sigreturn path leaves user GPRs alone — zero-filling them
+    // from an all-zero `gregs` array would regress caller state for
+    // userspace running a SIGSEGV handler over a fault at a non-SYSCALL
+    // instruction.
+    let user_rsp = STACK_TOP - 48;
+    let saved_rip = 0x0000_4000_0030_0300;
+    let saved_rflags = 0x202;
+    let fault_addr = 0xdead_beef;
+
+    let frame_addr = unsafe {
+        push_fault_signal_frame(user_rsp, 11, saved_rip, saved_rflags, 0, fault_addr)
+            .expect("push_fault_signal_frame ok")
+    };
+    let restored = unsafe { restore_signal_frame(frame_addr).expect("restore ok") };
+    assert!(
+        restored.syscall_args.is_none(),
+        "fault frames must not carry syscall arg regs"
+    );
+    assert_eq!(restored.rip, saved_rip);
+    assert_eq!(restored.rsp, user_rsp);
+}

--- a/kernel/tests/signal_sarestart_handler_regs.rs
+++ b/kernel/tests/signal_sarestart_handler_regs.rs
@@ -91,6 +91,10 @@ fn run_tests() {
             "non_restart_handler_frame_yields_no_syscall_args",
             &(non_restart_handler_frame_yields_no_syscall_args as fn()),
         ),
+        (
+            "nested_delivery_propagates_syscall_args",
+            &(nested_delivery_propagates_syscall_args as fn()),
+        ),
     ];
     serial_println!("running {} tests", tests.len());
     for (name, t) in tests {
@@ -190,6 +194,57 @@ fn push_preserves_rip_rflags_rsp_alongside_args() {
     assert_eq!(restored.rflags, saved_rflags);
     assert_eq!(restored.rsp, user_rsp);
     assert_eq!(restored.saved_mask, saved_mask);
+}
+
+fn nested_delivery_propagates_syscall_args() {
+    // Pins the round-trip underlying the #499 nested-delivery fix: when a
+    // sigreturn restores syscall args and then check_and_deliver_signals
+    // pops a fresh signal in the same call, the new handler frame must
+    // carry the same args through UC_VIBIX_SYSCALL_REGS so *its* sigreturn
+    // re-arms SYSCALL_RESTART_PENDING with the right values. Pre-fix, the
+    // second frame was pushed with args=None and the eventual SYSCALL
+    // replay saw handler-clobbered GPRs.
+    //
+    // Simulate the two hops at the frame layer: push A with Some(args),
+    // restore it to recover the args, then push B with those same args
+    // (what deliver_signal now does on the restart-pending path) and
+    // verify they round-trip through the second frame verbatim.
+    let args = SyscallArgRegs {
+        rax: 0xa1,
+        rdi: 0xa2,
+        rsi: 0xa3,
+        rdx: 0xa4,
+        r10: 0xa5,
+        r8: 0xa6,
+        r9: 0xa7,
+    };
+    let rsp_a = STACK_TOP - 16;
+    let frame_a = unsafe {
+        push_signal_frame(rsp_a, 22, 0x0000_4000_0010_0100, 0x202, 0, Some(args))
+            .expect("push A ok")
+    };
+    let restored_a = unsafe { restore_signal_frame(frame_a).expect("restore A ok") };
+    let propagated = restored_a
+        .syscall_args
+        .expect("hop A must carry UC_VIBIX_SYSCALL_REGS");
+    assert_eq!(propagated, args, "hop A must round-trip verbatim");
+
+    // Push hop B on top of the *restored* rsp (what sigreturn handed back),
+    // with the args we just recovered — exactly the propagation the fix
+    // performs in deliver_signal() when SYSCALL_RESTART_PENDING is armed.
+    let rsp_b = restored_a.rsp;
+    let frame_b = unsafe {
+        push_signal_frame(rsp_b, 15, 0x0000_4000_0020_0200, 0x202, 0, Some(propagated))
+            .expect("push B ok")
+    };
+    let restored_b = unsafe { restore_signal_frame(frame_b).expect("restore B ok") };
+    let got = restored_b
+        .syscall_args
+        .expect("hop B must carry UC_VIBIX_SYSCALL_REGS");
+    assert_eq!(
+        got, args,
+        "nested-delivery propagation must preserve syscall args across two frames"
+    );
 }
 
 fn fault_frame_yields_no_syscall_args() {


### PR DESCRIPTION
Closes #499.

## Summary

- #497 landed the no-handler `SYSCALL_RESTART_PENDING` arm that reloads `rax/rdi/rsi/rdx/r10/r8/r9` from the kernel stack before `SYSRETQ`, but explicitly deferred the SA_RESTART+handler case — where the restart happens only *after* `sigreturn` returns. Without a fix, the restarted `SYSCALL` re-executes at the rewound rip with clobbered arg regs.
- The SigFrame's `mcontext_t gregs` array already has slots for those GPRs (Linux indices 0/1/2/8/9/12/13). This PR populates them on `push_signal_frame` and restores them on `sys_sigreturn` via new `SIGRET_USER_*` shuttle statics, then arms the existing asm restore path so the user GPRs reach `SYSRETQ`.
- A new `UC_VIBIX_SYSCALL_REGS` bit in `uc_flags` distinguishes syscall-return frames from fault frames and from non-restart handler deliveries — only the SA_RESTART+handler restart path sets it, so the other paths stay byte-identical (avoids a spurious zero-fill of user GPRs on a `#PF`-delivered sigreturn, and avoids clobbering a syscall's return value in `rax` on a non-restart handler sigreturn).

## Test plan

- [x] `cargo xtask build` — clean.
- [x] `cargo xtask test-integration` — full QEMU integration suite green, including the new 4-test `signal_sarestart_handler_regs` binary that pins the push/restore contract (Some→Some roundtrip, None→None on fault and non-restart-handler frames, rip/rflags/rsp/saved_mask survive alongside).
- [x] `cargo xtask smoke` — all 33 markers present.
- [x] Host unit tests in `kernel/src/signal/frame.rs` extended with a greg-index distinctness assertion.
- End-to-end SA_RESTART-handler-replay of a real syscall (e.g. `SIGTTOU` handler on top of a tostop-gated `write`) requires ring-3 job-control and is deferred to the shell-level smoke suite once that lands.