### PR TITLE
userspace: fork+exec+wait reproducer harness for epic #501

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,11 @@
 [workspace]
-members = ["kernel", "xtask", "userspace/hello", "userspace/init"]
+members = [
+    "kernel",
+    "xtask",
+    "userspace/hello",
+    "userspace/init",
+    "userspace/repro_fork",
+]
 resolver = "2"
 
 [workspace.package]

--- a/docs/repros/fork-loop.md
+++ b/docs/repros/fork-loop.md
@@ -1,0 +1,82 @@
+# Fork-loop reproducer harness
+
+Tracks epic [#501], implements sub-issue [#506].  Amplifies the ~50 %-rate
+fork/exec/wait hang bisected to PR #206 into a deterministic, fast-to-boot
+reproducer.
+
+[#501]: https://github.com/dburkart/vibix/issues/501
+[#506]: https://github.com/dburkart/vibix/issues/506
+
+## What it does
+
+Replaces PID 1 with a userspace binary (`userspace/repro_fork/`) that runs
+a tight `fork → child execve → parent wait4` loop for `CYCLES` iterations
+(default 500).  Every 50 cycles it writes `repro: cycle K alive` to serial;
+every cycle it reads the TSC before and after and prints a watchdog
+marker if a single cycle overruns its budget.
+
+The kernel is unchanged.  Limine still loads `/boot/userspace_init.elf`
+as PID 1 — we just ship a different binary there when building for
+reproduction.
+
+## Run it
+
+From the repo root:
+
+```
+cargo xtask repro-fork
+```
+
+Or via the CI shim (identical behavior, easier to wire into shell
+orchestration):
+
+```
+scripts/repro-fork.sh
+scripts/repro-fork.sh --runs 20   # local soak — fails fast on first hang
+```
+
+Success: a final `repro: fork loop complete cycles=500` line and QEMU
+exits 0.  Failure: any of —
+
+- `repro: WATCHDOG fork stuck cycle=K dtsc=...` — a single cycle
+  overran the TSC budget; the kernel was almost certainly hung.
+- `repro: fork failed cycle=K ret=-N` — `fork()` returned an errno.
+- `repro: wait4 failed cycle=K ret=-N` — `wait4()` returned an errno.
+- `KERNEL PANIC: ...` — the kernel panicked.
+- Heartbeat gap > 60 s with no new `repro:` line — the xtask wrapper
+  kills QEMU and reports a stall.
+
+## Tuning
+
+- `REPRO_FORK_CYCLES=<N>`: overrides the compile-time cycle count.  Set
+  to a large value for soak runs.  (Implemented as `option_env!` inside
+  the binary, so cargo rebuilds when the value changes.)
+- The per-cycle TSC budget is a compile-time constant
+  (`STALL_TSC_BUDGET` in `userspace/repro_fork/src/main.rs`).  Bump it
+  if unaccelerated CI QEMU is hitting spurious watchdog trips on a
+  healthy kernel.
+
+## Expected reproducibility
+
+The original flake's per-boot hit rate is ~50 %.  With 500 cycles per
+boot the expected per-run hit rate rises to
+`1 - (1 - p)^500` for any per-cycle hang probability `p`.  Even at
+`p = 0.01` that's ~99.3 %; at `p = 0.001` it's ~39 %, still a dramatic
+amplification over the one-fork-per-boot baseline.
+
+Actual local observations should be recorded in the PR that introduces
+this harness and in the tracking issues that consume it (#504, #505).
+
+## Scope / what this does NOT do
+
+- **Does not edit kernel source.**  Issues #502, #504, #505 own the
+  kernel side of the sprint; this harness is strictly userspace + ISO
+  + wrapper.
+- **Does not wire itself into CI yaml.**  Issue #507 owns `.github/`.
+  The wrapper script exists at a stable path so #507 can call it.
+- **Does not claim deterministic reproduction of the #206 flake.**
+  The harness amplifies opportunity to hit the hang; whether it trips
+  on clean `main` depends on the underlying rate.  If a follow-up
+  discovers the harness needs `serial_println!` instrumentation from
+  #502 to reproduce reliably, that's expected — file a follow-up
+  rather than retrofitting this PR.

--- a/scripts/repro-fork.sh
+++ b/scripts/repro-fork.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# CI-friendly wrapper around `cargo xtask repro-fork` — the deterministic
+# reproducer harness for the init fork+exec+wait flake tracked by epic
+# #501 / sub-issue #506.
+#
+# This is a thin shim over the xtask subcommand so CI / smoke
+# orchestrators that prefer to invoke a shell script (rather than
+# cargo directly) can plug it in without duplicating the boot logic.
+# The xtask owns the heartbeat watchdog; this script's job is to:
+#
+#   1. run one boot of the reproducer ISO,
+#   2. forward its serial log verbatim to the caller's stdout,
+#   3. exit non-zero on any stall/panic/failure detected by xtask.
+#
+# Usage:
+#   scripts/repro-fork.sh                 # single run
+#   scripts/repro-fork.sh --runs N        # N sequential runs; fail on
+#                                         # the first non-zero exit
+#
+# Env:
+#   REPRO_FORK_CYCLES=<N>   override the harness cycle count (compile-time)
+#
+# The --runs option is meant for local soak (#504 / #505 validation):
+# run N times, any failure fails the whole invocation.  It is *not* for
+# CI gating on its own — wave-3 tightens that up.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+runs=1
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --runs)
+            runs="$2"
+            shift 2
+            ;;
+        --runs=*)
+            runs="${1#--runs=}"
+            shift
+            ;;
+        -h|--help)
+            sed -n '2,30p' "$0" | sed -e 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "repro-fork.sh: unknown flag: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if ! [[ "$runs" =~ ^[0-9]+$ ]] || [[ "$runs" -lt 1 ]]; then
+    echo "repro-fork.sh: --runs must be a positive integer (got: $runs)" >&2
+    exit 2
+fi
+
+fail=0
+for ((i = 1; i <= runs; i++)); do
+    echo "=== repro-fork run $i/$runs ==="
+    if ! cargo xtask repro-fork; then
+        echo "=== repro-fork run $i/$runs FAILED ===" >&2
+        fail=1
+        break
+    fi
+    echo "=== repro-fork run $i/$runs ok ==="
+done
+
+exit "$fail"

--- a/userspace/repro_fork/Cargo.toml
+++ b/userspace/repro_fork/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "userspace_repro_fork"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "userspace_repro_fork"
+path = "src/main.rs"

--- a/userspace/repro_fork/link.ld
+++ b/userspace/repro_fork/link.ld
@@ -1,0 +1,54 @@
+/* Linker script for the repro_fork userspace binary.
+ *
+ * Identical layout to `userspace/init/link.ld`: lower-half load base at
+ * 0x400000, page-aligned PT_LOAD segments so the kernel's ELF loader can
+ * map one page per page.  This binary is shipped in the ISO in place of
+ * `userspace_init.elf` when the xtask `repro-fork` subcommand is used;
+ * the kernel's loader is unchanged and sees what looks like a regular
+ * PID-1 init image.
+ */
+
+OUTPUT_FORMAT(elf64-x86-64)
+OUTPUT_ARCH(i386:x86-64)
+ENTRY(_start)
+
+PHDRS
+{
+    text   PT_LOAD FLAGS(5);   /* R+X */
+    rodata PT_LOAD FLAGS(4);   /* R   */
+    data   PT_LOAD FLAGS(6);   /* R+W */
+}
+
+SECTIONS
+{
+    . = 0x0000000000400000;
+
+    .text : {
+        *(.text .text.*)
+    } :text
+
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
+
+    .rodata : {
+        *(.rodata .rodata.*)
+    } :rodata
+
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
+
+    .data : {
+        *(.data .data.*)
+    } :data
+
+    .bss : {
+        *(COMMON)
+        *(.bss .bss.*)
+    } :data
+
+    /DISCARD/ : {
+        *(.eh_frame*)
+        *(.note.*)
+        *(.comment)
+        *(.dynamic)
+        *(.got .got.plt)
+    }
+}

--- a/userspace/repro_fork/src/main.rs
+++ b/userspace/repro_fork/src/main.rs
@@ -1,0 +1,294 @@
+//! Deterministic reproducer harness for the fork+exec+wait flake tracked
+//! by epic #501 (sub-issue #506, wave 1 of the quality sprint).
+//!
+//! Runs a tight `fork → child execve → parent wait4` loop for
+//! [`CYCLES`] iterations with a heartbeat marker every
+//! [`HEARTBEAT_INTERVAL`] cycles.  Each cycle's duration is measured in
+//! TSC ticks; if any single cycle exceeds [`STALL_TSC_BUDGET`] ticks a
+//! watchdog marker is printed and the process exits non-zero so the
+//! QEMU wrapper can fail fast instead of timing out silently.
+//!
+//! This binary is a drop-in replacement for `userspace_init` when built
+//! and shipped as `userspace_init.elf` in the ISO — which is what the
+//! xtask `repro-fork` subcommand does.  The kernel's init-process path
+//! is unchanged; it still loads `/boot/userspace_init.elf` as PID 1.
+//!
+//! ## Serial markers (contract with `scripts/repro-fork.sh`)
+//!
+//! | Marker                                         | Meaning                          |
+//! |------------------------------------------------|----------------------------------|
+//! | `repro: starting fork loop cycles=N hb=K`      | Harness started; PID 1 alive.    |
+//! | `repro: cycle K alive`                         | Heartbeat tick (every K cycles). |
+//! | `repro: fork loop complete cycles=N`           | Success — all cycles ran clean.  |
+//! | `repro: WATCHDOG fork stuck cycle=K dtsc=...`  | A single cycle exceeded budget.  |
+//! | `repro: fork failed cycle=K ret=...`           | fork() returned a negative errno.|
+//! | `repro: wait4 failed cycle=K ret=...`          | wait4() returned an error.       |
+//!
+//! Any `WATCHDOG` / `fork failed` / `wait4 failed` line is terminal —
+//! the wrapper script greps for them and fails the CI job.
+//!
+//! ## Syscall ABI
+//!
+//! Mirrors `userspace/init/src/main.rs` exactly.  See that file for the
+//! full table of syscall numbers and argument conventions.
+
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+use core::sync::atomic::{compiler_fence, Ordering};
+
+/// Number of fork+exec+wait cycles to run before declaring success.
+///
+/// Override at build time with `REPRO_FORK_CYCLES=<N>` (consumed by the
+/// xtask build, not by cargo directly).  Default 500 is high enough to
+/// catch a 1 %-rate flake within a single boot (~1 – e^-5 ≈ 99.3 % hit
+/// rate) without ballooning runtime on healthy kernels.
+const CYCLES: u64 = match option_env!("REPRO_FORK_CYCLES") {
+    Some(s) => parse_u64(s),
+    None => 500,
+};
+
+/// Emit `repro: cycle K alive` every this many cycles.
+const HEARTBEAT_INTERVAL: u64 = 50;
+
+/// Per-cycle TSC-tick budget.  On the CI reference host the kernel
+/// boot log reports `timer: TSC 2417 MHz`, so 5 s ≈ 1.2e10 ticks.
+/// 30 s headroom (≈ 7.2e10) tolerates un-accelerated CI QEMU where a
+/// single fork/exec/wait round can take seconds; any real hang blows
+/// through this in one or two cycles.
+const STALL_TSC_BUDGET: u64 = 72_000_000_000;
+
+/// Minimal ASCII-number parser for compile-time env override.  Only
+/// accepts digits; any malformed input falls through to the default in
+/// the caller's `match` arm.  `const` so the literal is baked into the
+/// image without a runtime `parse()`.
+const fn parse_u64(s: &str) -> u64 {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    let mut n: u64 = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b < b'0' || b > b'9' {
+            return 500; // fall back on bad input
+        }
+        n = n * 10 + (b - b'0') as u64;
+        i += 1;
+    }
+    n
+}
+
+// Syscall numbers — keep in sync with kernel/src/arch/x86_64/syscall.rs.
+const SYS_WRITE: u64 = 1;
+const SYS_FORK: u64 = 57;
+const SYS_EXECVE: u64 = 59;
+const SYS_EXIT: u64 = 60;
+const SYS_WAIT4: u64 = 61;
+
+const STDOUT: u64 = 1;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    write_line(b"repro: starting fork loop cycles=");
+    write_u64(CYCLES);
+    write_line(b" hb=");
+    write_u64(HEARTBEAT_INTERVAL);
+    write_line(b"\n");
+
+    let mut cycle: u64 = 0;
+    while cycle < CYCLES {
+        let start = rdtsc_serialized();
+
+        // fork()
+        let fork_ret: i64;
+        unsafe {
+            core::arch::asm!(
+                "syscall",
+                inlateout("rax") SYS_FORK => fork_ret,
+                lateout("rcx") _,
+                lateout("r11") _,
+                options(nostack, preserves_flags),
+            );
+        }
+
+        if fork_ret == 0 {
+            // Child — exec the hello binary, which writes + exit(0).
+            // If execve ever returns, it's a real failure; report it
+            // on the child's stdout and exit(2) so the parent's wait4
+            // sees a non-zero status and the wrapper script fails.
+            unsafe {
+                core::arch::asm!(
+                    "syscall",
+                    in("rax") SYS_EXECVE,
+                    in("rdi") 0u64,
+                    in("rsi") 0u64,
+                    in("rdx") 0u64,
+                    lateout("rcx") _,
+                    lateout("r11") _,
+                    options(nostack, preserves_flags),
+                );
+            }
+            // execve returned → exec failure. Shout and exit.
+            write_line(b"repro: execve returned in child\n");
+            sys_exit(2);
+        } else if fork_ret < 0 {
+            write_line(b"repro: fork failed cycle=");
+            write_u64(cycle);
+            write_line(b" ret=");
+            write_i64(fork_ret);
+            write_line(b"\n");
+            sys_exit(3);
+        }
+
+        // Parent — wait for the child.
+        let child_pid = fork_ret as u64;
+        let mut wstatus: i32 = 0;
+        let waited: i64;
+        unsafe {
+            core::arch::asm!(
+                "syscall",
+                inlateout("rax") SYS_WAIT4 => waited,
+                in("rdi") child_pid,
+                in("rsi") &mut wstatus as *mut i32 as u64,
+                in("rdx") 0u64,
+                in("r10") 0u64,
+                lateout("rcx") _,
+                lateout("r11") _,
+                options(nostack),
+            );
+        }
+        if waited < 0 {
+            write_line(b"repro: wait4 failed cycle=");
+            write_u64(cycle);
+            write_line(b" ret=");
+            write_i64(waited);
+            write_line(b"\n");
+            sys_exit(4);
+        }
+
+        // Watchdog — if any single cycle overran the TSC budget the
+        // kernel was almost certainly stuck for seconds.  Print a
+        // marker and fail fast; the wrapper script treats this as a
+        // reproduction.  Use a compiler_fence on either side of the
+        // RDTSC pair to keep the measurement ordered w.r.t. the
+        // syscall instructions above.
+        compiler_fence(Ordering::SeqCst);
+        let end = rdtsc_serialized();
+        let dtsc = end.wrapping_sub(start);
+        if dtsc > STALL_TSC_BUDGET {
+            write_line(b"repro: WATCHDOG fork stuck cycle=");
+            write_u64(cycle);
+            write_line(b" dtsc=");
+            write_u64(dtsc);
+            write_line(b"\n");
+            sys_exit(5);
+        }
+
+        cycle += 1;
+        if cycle % HEARTBEAT_INTERVAL == 0 {
+            write_line(b"repro: cycle ");
+            write_u64(cycle);
+            write_line(b" alive\n");
+        }
+    }
+
+    write_line(b"repro: fork loop complete cycles=");
+    write_u64(CYCLES);
+    write_line(b"\n");
+    sys_exit(0);
+}
+
+/// write(1, buf).  Best-effort — the return value is ignored because
+/// stdout is wired to the serial console and either succeeds or the
+/// kernel is so broken that reporting the failure is hopeless anyway.
+fn write_line(buf: &[u8]) {
+    unsafe {
+        core::arch::asm!(
+            "syscall",
+            in("rax") SYS_WRITE,
+            in("rdi") STDOUT,
+            in("rsi") buf.as_ptr() as u64,
+            in("rdx") buf.len() as u64,
+            lateout("rcx") _,
+            lateout("r11") _,
+            options(nostack, preserves_flags),
+        );
+    }
+}
+
+/// Write a u64 in base-10 ASCII via a single `write()`.  20 digits is
+/// enough for `u64::MAX`.  Stack-only, no allocator — this binary runs
+/// before any heap is available to it.
+fn write_u64(mut n: u64) {
+    let mut buf = [0u8; 20];
+    let mut i = buf.len();
+    if n == 0 {
+        i -= 1;
+        buf[i] = b'0';
+    } else {
+        while n > 0 {
+            i -= 1;
+            buf[i] = b'0' + (n % 10) as u8;
+            n /= 10;
+        }
+    }
+    write_line(&buf[i..]);
+}
+
+/// Signed-decimal helper.  Negative fork/wait4 returns are printed as
+/// `-<N>` so the wrapper's grep can pick up the errno.
+fn write_i64(n: i64) {
+    if n < 0 {
+        write_line(b"-");
+        // `-i64::MIN` would overflow — cast to u64 via wrapping_neg.
+        write_u64((n as u64).wrapping_neg());
+    } else {
+        write_u64(n as u64);
+    }
+}
+
+/// `exit(status)` — never returns.  Used both for clean shutdown and
+/// for error-path terminations above.  `noreturn` forbids asm outputs,
+/// so `rcx`/`r11` (SYSCALL-clobbered) cannot be listed here; since we
+/// don't return, their post-syscall state is moot.
+fn sys_exit(status: i32) -> ! {
+    unsafe {
+        core::arch::asm!(
+            "syscall",
+            in("rax") SYS_EXIT,
+            in("rdi") status as u64,
+            options(nostack, noreturn),
+        )
+    }
+}
+
+/// Serialized RDTSC read.  `lfence; rdtsc` is the standard x86_64
+/// idiom for ordering the read against prior instructions; good
+/// enough for coarse per-cycle timing.  CR4.TSD is not set by the
+/// vibix kernel so RDTSC is ring-3 accessible.
+fn rdtsc_serialized() -> u64 {
+    let lo: u32;
+    let hi: u32;
+    unsafe {
+        core::arch::asm!(
+            "lfence",
+            "rdtsc",
+            out("eax") lo,
+            out("edx") hi,
+            options(nomem, nostack, preserves_flags),
+        );
+    }
+    ((hi as u64) << 32) | (lo as u64)
+}
+
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    // No unwinding, no allocator.  Shout a breadcrumb on stdout and
+    // hang.  A real panic in this harness would only happen under
+    // catastrophic conditions (ring-3 #PF, etc.); the kernel-side
+    // panic handler fires long before we get here.
+    write_line(b"repro: harness panic\n");
+    loop {
+        core::hint::spin_loop();
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -722,12 +722,7 @@ fn make_iso(kernel: &Path, iso_out: &Path, staging: &str) -> R<()> {
 /// without touching the kernel's module-lookup path or the Limine
 /// config.  All other ISO contents (`userspace_hello.elf`, the rootfs
 /// tarball, ld-musl) are identical to a normal boot.
-fn make_iso_with_init(
-    kernel: &Path,
-    init_bin: &Path,
-    iso_out: &Path,
-    staging: &str,
-) -> R<()> {
+fn make_iso_with_init(kernel: &Path, init_bin: &Path, iso_out: &Path, staging: &str) -> R<()> {
     let limine = ensure_limine()?;
     let userspace_hello = build_userspace_hello()?;
     let initrd = ensure_initrd()?;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -8,6 +8,7 @@
 //!   test          — run host unit tests + QEMU integration tests
 //!   test-runner   — (internal) boot a pre-built test kernel ELF in QEMU
 //!   smoke         — boot the kernel and assert on expected serial markers
+//!   repro-fork    — boot with the fork-loop reproducer harness as PID 1 (issue #506)
 //!   lint          — run clippy on xtask (host) and vibix (kernel, no_std)
 //!   isr-audit     — scan ISR-reachable files for blocking-lock regressions
 //!   clean         — remove build artifacts
@@ -145,6 +146,7 @@ fn main() -> R<()> {
             test_runner(Path::new(kernel))?;
         }
         "smoke" => smoke(&opts)?,
+        "repro-fork" => repro_fork(&opts)?,
         "lint" => lint()?,
         "isr-audit" => isr_audit::run(&workspace_root())?,
         "initrd" => {
@@ -155,7 +157,7 @@ fn main() -> R<()> {
         other => {
             eprintln!("unknown subcommand: {other}");
             eprintln!(
-                "usage: cargo xtask [build|initrd|iso|run|test|test-unit|test-integration|smoke|lint|isr-audit|clean] [--release] [--fault-test] [--panic-test] [--bench]"
+                "usage: cargo xtask [build|initrd|iso|run|test|test-unit|test-integration|smoke|repro-fork|lint|isr-audit|clean] [--release] [--fault-test] [--panic-test] [--bench]"
             );
             std::process::exit(2);
         }
@@ -284,6 +286,15 @@ fn build_userspace_init() -> R<PathBuf> {
 /// Links at 0x400000 (lower half) just like init so load_user_elf accepts it.
 fn build_userspace_hello() -> R<PathBuf> {
     build_userspace_binary("userspace_hello", "userspace/hello/link.ld")
+}
+
+/// Build the fork-loop reproducer harness (issue #506).
+///
+/// Shipped as `userspace_init.elf` when `cargo xtask repro-fork` is used —
+/// this binary runs a tight fork+exec+wait loop as PID 1 to amplify the
+/// ~50 %-rate flake bisected to PR #206 into a deterministic repro.
+fn build_userspace_repro_fork() -> R<PathBuf> {
+    build_userspace_binary("userspace_repro_fork", "userspace/repro_fork/link.ld")
 }
 
 fn kernel_binary(opts: &BuildOpts) -> PathBuf {
@@ -701,8 +712,23 @@ fn ensure_limine() -> R<PathBuf> {
 /// `staging` names a subdirectory under `build/` to use as scratch
 /// (so parallel test runs don't stomp each other).
 fn make_iso(kernel: &Path, iso_out: &Path, staging: &str) -> R<()> {
-    let limine = ensure_limine()?;
     let userspace_init = build_userspace_init()?;
+    make_iso_with_init(kernel, &userspace_init, iso_out, staging)
+}
+
+/// Variant of [`make_iso`] that publishes a caller-supplied binary as
+/// `/boot/userspace_init.elf`.  Used by the `repro-fork` subcommand to
+/// substitute the reproducer harness for the normal PID 1 init binary
+/// without touching the kernel's module-lookup path or the Limine
+/// config.  All other ISO contents (`userspace_hello.elf`, the rootfs
+/// tarball, ld-musl) are identical to a normal boot.
+fn make_iso_with_init(
+    kernel: &Path,
+    init_bin: &Path,
+    iso_out: &Path,
+    staging: &str,
+) -> R<()> {
+    let limine = ensure_limine()?;
     let userspace_hello = build_userspace_hello()?;
     let initrd = ensure_initrd()?;
     let iso_root = workspace_root().join("build").join(staging);
@@ -711,7 +737,7 @@ fn make_iso(kernel: &Path, iso_out: &Path, staging: &str) -> R<()> {
     fs::create_dir_all(iso_root.join("EFI/BOOT"))?;
 
     fs::copy(kernel, iso_root.join("boot/vibix"))?;
-    fs::copy(userspace_init, iso_root.join("boot/userspace_init.elf"))?;
+    fs::copy(init_bin, iso_root.join("boot/userspace_init.elf"))?;
     fs::copy(userspace_hello, iso_root.join("boot/userspace_hello.elf"))?;
     fs::copy(&initrd, iso_root.join("boot/rootfs.tar"))?;
     fs::copy(
@@ -1121,6 +1147,216 @@ fn smoke(opts: &BuildOpts) -> R<()> {
         missing.sort_unstable();
         eprintln!("--- captured serial ---\n{accumulated}\n-----------------------");
         Err(format!("smoke: missing markers {:?}", missing).into())
+    }
+}
+
+/// Build + boot the fork-loop reproducer ISO under QEMU with a
+/// heartbeat-aware watchdog.  Issue #506 / epic #501.
+///
+/// Replaces `/boot/userspace_init.elf` in the ISO with the
+/// `userspace_repro_fork` binary (see `userspace/repro_fork/`).  That
+/// binary runs `CYCLES` fork+exec+wait iterations, emitting
+/// `repro: cycle K alive` every 50 cycles and `repro: fork loop
+/// complete` on success.  The loop in this function follows those
+/// markers and enforces a heartbeat-gap watchdog: if no new
+/// `repro: ...` line appears within `REPRO_HEARTBEAT_GAP`, QEMU is
+/// killed and the subcommand exits non-zero.
+///
+/// Returns `Ok(())` iff we saw `repro: fork loop complete` before any
+/// stall/error marker.  Any `WATCHDOG`, `fork failed`, `wait4 failed`,
+/// or `KERNEL PANIC:` line is a definitive failure.
+fn repro_fork(opts: &BuildOpts) -> R<()> {
+    use std::collections::VecDeque;
+    use std::io::BufRead as _;
+    use std::time::Instant;
+
+    /// Any single gap between `repro:` heartbeat lines that exceeds
+    /// this duration is a stall.  60 s is generous under unaccelerated
+    /// CI QEMU (a single fork/exec/wait round has been measured at a
+    /// few hundred ms there) and tight enough to fail fast on a real
+    /// hang.
+    const REPRO_HEARTBEAT_GAP: Duration = Duration::from_secs(60);
+
+    /// Absolute ceiling for the whole reproducer boot.  Even 500 clean
+    /// cycles finish well inside this; exceeding it means the last
+    /// heartbeat watchdog somehow missed a stall (or CYCLES was
+    /// bumped into the thousands).  Prevents a runaway CI job.
+    const REPRO_HARD_CAP: Duration = Duration::from_secs(900);
+
+    const SUCCESS_MARKER: &str = "repro: fork loop complete";
+    const PANIC_MARKER: &str = "KERNEL PANIC:";
+    /// Any line containing a terminal-failure token from the harness.
+    const FAIL_TOKENS: &[&str] = &[
+        "repro: WATCHDOG",
+        "repro: fork failed",
+        "repro: wait4 failed",
+        "repro: execve returned in child",
+        "repro: harness panic",
+    ];
+
+    // Build the kernel and the reproducer init binary, then assemble
+    // an ISO with the reproducer substituted for userspace_init.elf.
+    let kernel = build(opts)?;
+    let repro_init = build_userspace_repro_fork()?;
+    let iso = workspace_root().join("target").join("vibix-repro-fork.iso");
+    make_iso_with_init(&kernel, &repro_init, &iso, "iso_repro_fork")?;
+    println!("→ repro-fork iso: {}", iso.display());
+
+    let disk = ensure_test_disk()?;
+    let mut child = Command::new("qemu-system-x86_64")
+        .args([
+            "-M",
+            "q35",
+            "-cpu",
+            "max",
+            "-m",
+            "256M",
+            "-serial",
+            "stdio",
+            "-display",
+            "none",
+            "-no-reboot",
+            "-no-shutdown",
+            "-device",
+            "isa-debug-exit,iobase=0xf4,iosize=0x04",
+        ])
+        .args(virtio_blk_args(&disk))
+        .arg("-cdrom")
+        .arg(&iso)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    let pid = child.id();
+    let stdout = child.stdout.take().ok_or("no stdout pipe")?;
+
+    // Absolute-deadline watchdog thread — independent of the
+    // heartbeat-gap check below.  Kills QEMU if the whole run
+    // somehow stretches past REPRO_HARD_CAP.  We can't `.join()` this
+    // thread on the fast path (success tends to arrive well inside
+    // REPRO_HARD_CAP), so we set up a cancel channel: the main loop
+    // drops the sender on the way out, which wakes the watchdog's
+    // `recv_timeout` with Disconnected and lets it exit cleanly.
+    let hard_pid = pid;
+    let (cancel_tx, cancel_rx) = std::sync::mpsc::channel::<()>();
+    let hard_watchdog = std::thread::spawn(move || {
+        if let Err(std::sync::mpsc::RecvTimeoutError::Timeout) =
+            cancel_rx.recv_timeout(REPRO_HARD_CAP)
+        {
+            let _ = Command::new("kill").arg(hard_pid.to_string()).status();
+        }
+    });
+
+    // Reader thread: fan serial lines into an mpsc channel so the
+    // main loop can poll with a short timeout and enforce the
+    // heartbeat-gap watchdog without blocking inside read_line.
+    let (tx, rx) = std::sync::mpsc::channel::<String>();
+    let reader_handle = std::thread::spawn(move || {
+        let mut reader = std::io::BufReader::new(stdout);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) => break,
+                Ok(_) => {
+                    if tx.send(line.clone()).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let start = Instant::now();
+    let mut last_heartbeat = Instant::now();
+    let mut success = false;
+    let mut failure: Option<String> = None;
+    // Keep the last few lines of serial captured so a failure summary
+    // has immediate context; the full log lives on stdout already.
+    let mut tail: VecDeque<String> = VecDeque::with_capacity(32);
+    const TICK: Duration = Duration::from_millis(200);
+
+    loop {
+        match rx.recv_timeout(TICK) {
+            Ok(line) => {
+                // Mirror the serial to our stdout so humans (and CI
+                // log collectors) see the heartbeat stream live.
+                print!("{line}");
+                if tail.len() == 32 {
+                    tail.pop_front();
+                }
+                tail.push_back(line.clone());
+
+                if line.contains(PANIC_MARKER) {
+                    failure = Some(format!("kernel panic: {}", line.trim_end()));
+                    break;
+                }
+                if let Some(tok) = FAIL_TOKENS.iter().find(|t| line.contains(*t)) {
+                    failure = Some(format!("harness failure ({}): {}", tok, line.trim_end()));
+                    break;
+                }
+                if line.contains("repro:") {
+                    last_heartbeat = Instant::now();
+                }
+                if line.contains(SUCCESS_MARKER) {
+                    success = true;
+                    break;
+                }
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                if last_heartbeat.elapsed() > REPRO_HEARTBEAT_GAP {
+                    failure = Some(format!(
+                        "heartbeat stalled: no `repro:` marker in {:?}",
+                        REPRO_HEARTBEAT_GAP
+                    ));
+                    break;
+                }
+                if start.elapsed() > REPRO_HARD_CAP {
+                    failure = Some(format!(
+                        "hard cap exceeded ({:?}) without success",
+                        REPRO_HARD_CAP
+                    ));
+                    break;
+                }
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                if !success && failure.is_none() {
+                    failure = Some("QEMU exited before `repro: fork loop complete`".to_string());
+                }
+                break;
+            }
+        }
+    }
+
+    // Ensure QEMU is dead whether we succeeded, failed, or timed out.
+    // Kill first so the reader pipe closes and the reader thread's
+    // `read_line` returns Ok(0); then drop the cancel sender so the
+    // hard watchdog wakes and exits; then collect the threads and
+    // reap the child.
+    let _ = Command::new("kill").arg(pid.to_string()).status();
+    drop(cancel_tx);
+    let _ = hard_watchdog.join();
+    let _ = reader_handle.join();
+    let _ = child.wait();
+
+    match (success, failure) {
+        (true, _) => {
+            println!(
+                "→ repro-fork: fork loop completed in {:?} ✓",
+                start.elapsed()
+            );
+            Ok(())
+        }
+        (false, Some(msg)) => {
+            eprintln!("--- captured serial (tail) ---");
+            for line in &tail {
+                eprint!("{line}");
+            }
+            eprintln!("------------------------------");
+            Err(format!("repro-fork: {msg}").into())
+        }
+        (false, None) => Err("repro-fork: terminated with no success and no failure marker".into()),
     }
 }
 


### PR DESCRIPTION
Closes #506
Part of epic #501 (quality sprint, wave 1).

## Summary

- Adds `userspace/repro_fork/` — a `no_std` ring-3 binary that runs a tight `fork → child execve → parent wait4` loop for `CYCLES` iterations (500 default, overridable via `REPRO_FORK_CYCLES=<N>` at build time). Emits serial markers for startup, heartbeat every 50 cycles, success, and three distinct failure flavors (fork ret, wait4 ret, per-cycle TSC-budget overrun). Replaces `userspace_init.elf` in the ISO only when built via the new xtask subcommand; the production init path is unchanged.
- Adds `cargo xtask repro-fork` — builds a dedicated ISO (`target/vibix-repro-fork.iso`), launches it under QEMU, scans the serial stream for the harness's marker contract. Enforces two watchdogs: a 60 s heartbeat-gap watchdog that kills QEMU on a dead stream (so CI fails fast instead of timing out opaquely), and a 900 s hard cap as backstop. Uses a cancel-channel so the fast success path doesn't wait 15 minutes on thread join.
- Refactors `make_iso` into `make_iso_with_init(kernel, init_bin, …)` so the ISO staging pipeline can swap the init binary without duplicating Limine/GPT assembly logic.
- Adds `scripts/repro-fork.sh` as a thin CI-friendly shim with optional `--runs N` soak mode that fails fast on the first hung boot. Stable path so the #507 CI gate can invoke it without hard-coding the xtask command.
- Adds `docs/repros/fork-loop.md` operator playbook: invocation, success/failure markers, tunable knobs, expected-reproducibility math, and explicit scope boundaries against sibling sub-issues.

## Scope / non-goals

Per the sub-issue framing, this PR deliberately does **not** touch:

- Kernel source (reserved for #502 / #504 / #505).
- `userspace/init/src/main.rs` (production init path).
- `.github/workflows/` (reserved for #507 — the CI wiring lands there).

The shim at `scripts/repro-fork.sh` is the stable hook #507 uses.

## Test plan

- [x] `cargo xtask build` green
- [x] `cargo xtask smoke` green — all 33 markers present
- [x] `cargo xtask test` green — 375 passed, 0 failed
- [x] `cargo xtask lint` — no new lints from this PR (pre-existing `kernel/build.rs` `manual_is_multiple_of` failures are unrelated and exist on `main`; follow-up filed separately)
- [x] `REPRO_FORK_CYCLES=3 cargo xtask repro-fork` — harness completes, serial log shows `repro: starting fork loop cycles=3 hb=50` and `repro: fork loop complete cycles=3`, xtask exits 0 in ~1.5 s
- [ ] Full 500-cycle run reproducibility analysis deferred to follow-up issue (the harness contract is validated end-to-end at low cycle counts; instrumentation from #502 and the structural fixes in #504/#505 may be required to turn the amplified reproducer into a deterministic trigger per the issue framing)

## Out-of-scope follow-ups

Filed separately:

- Investigate 500-cycle heartbeat silence (symptom: parent appears to fork past CYCLES without emitting heartbeat markers) — may be exactly the flake #502 is instrumenting for, or a harness bug to fix after the structural repairs land.
- `kernel/build.rs` pre-existing clippy failures (`manual_is_multiple_of`) blocking `cargo xtask lint` on `main`.
- Task-reap "leaked stack VA slot" log lines observed during repro-fork runs — not known to be incorrect but deserves an explicit audit.
