### PR TITLE
diag(fork): instrument fork syscall path + capture trace log (#502)

### DIFF
--- a/docs/investigations/502-fork-trace-happy-path.log
+++ b/docs/investigations/502-fork-trace-happy-path.log
@@ -1,0 +1,106 @@
+limine: Loading executable `boot():/boot/vibix`...
+limine: Loading module `boot():/boot/userspace_init.elf`...
+limine: Loading module `boot():/boot/userspace_init.elf`...
+limine: Loading module `boot():/boot/userspace_hello.elf`...
+limine: Loading module `boot():/boot/rootfs.tar`...
+limine: Loading module `boot():/boot/ld-musl-x86_64.so.1`...
+vibix booting…
+memory map: 28 entries, 244 MiB usable
+hhdm offset: 0xffff800000000000
+rsdp: 0xf52b0
+cpu: SSE SSE2 SSE4.1 SSE4.2 AVX AVX2 XSAVE PAT SMEP SMAP FSGSBASE RDTSCP POPCNT LZCNT RDRAND RDSEED
+uaccess: smep=on smap=on
+fpu: FXSAVE context switch online
+syscall: SYSCALL/SYSRET enabled
+PIC remapped to 0x20/0x28 and masked
+GDT + IDT loaded
+paging: mapper online
+heap: 1024 KiB @ 0xffffc00000000000 (reserved 16384 KiB, grows in 64 KiB chunks)
+paging: IST guard installed @ 0xffffffff804f0000
+paging: switched to kernel PML4
+paging: reclaimed 4132 KiB bootloader memory (17 L3/L2/L1 intermediate table frames, PML4=0xff43000)
+acpi: MADT parsed (cpus=1, ioapics=1, overrides=5, lapic=0xfee00000)
+apic: BSP online (lapic_id=0)
+ioapic: initialized (1 controller(s))
+ioapic: IRQ0 -> gsi 2 -> vec 0x20 on lapic 0 (ioapic 0)
+ioapic: IRQ1 -> gsi 1 -> vec 0x21 on lapic 0 (ioapic 0)
+ioapic: IRQ4 -> gsi 4 -> vec 0x24 on lapic 0 (ioapic 0)
+serial: rx irq enabled
+hpet: initialized (period=10000000fs, timers=3, base=0xfed00000)
+hpet: periodic timer armed (100 Hz, 1000000 ticks/period)
+timer: 100 Hz
+rtc: 2026-04-17 14:35:32
+pci: 7 device(s) on bus 0
+pci:   00:00.0 8086:29c0 class 06:00 pi=00 (host-bridge)
+pci:   00:01.0 1234:1111 class 03:00 pi=00 (vga)
+pci:   00:02.0 8086:10d3 class 02:00 pi=00 (network)
+pci:   00:03.0 1af4:1001 class 01:00 pi=00 (scsi)
+pci:   00:1f.0 8086:2918 class 06:01 pi=00 (isa-bridge)
+pci:   00:1f.2 8086:2922 class 01:06 pi=01 (sata)
+pci:   00:1f.3 8086:2930 class 0c:05 pi=00 (serial-bus)
+block: virtio-blk ready (io_base=0xc000, queue_size=256)
+block: lba0[0..16]=[56, 49, 42, 49, 58, 2a, 4c, 4b, 30, 00, 00, 00, 00, 00, 00, 00]
+block: write+readback ok at lba 2047
+framebuffer: 1280x800 @ 32 bpp, pitch=5120 bytes
+vibix online.
+interrupts enabled
+timer: TSC 2419 MHz
+userspace module ELF entry=0x400000 load_segments=2
+tasks: scheduler online
+userspace: loader mapping image (8728 bytes)
+init: new PML4 at phys=0x15000
+init: ELF loaded entry=0x400000 segments=2
+init: user stack at virt=0x7ffff000 top=0x80000000
+shell: prompt online
+banner: vibix 0.1.0 (86e696a0f869, built 2026-04-17T09:27:31Z, debug) x86_64
+cpu: QEMU TCG CPU version 2.5+ x1
+mem: 249 MiB total, 247 MiB free
+boot: 112 ms
+Welcome to vibix. Type `help` for builtins.
+vibix> init: auxv written, initial rsp=0x7fffff58
+init: ring-3 entry task spawned (task_id=4, pid=1)
+init: switched to process PML4
+init: entering ring-3 entry=0x400000 rsp=0x7fffff58
+init: iretq to ring-3
+ring3-iretq: rip=0x400000 rsp=0x7fffff58 cs=0x23 ss=0x1b rflags=0x202
+init: hello from pid 1
+ftrace: fork: enter dispatch rflags=0x87 (IF=0) user_rip=0x400025 user_rflags=0x212 user_rsp=0x7fffff4c
+ftrace: fork: calling fork_current_task parent_pid=1
+ftrace: fork_current_task: enter user_rip=0x400025 user_rflags=0x212 user_rsp=0x7fffff4c
+ftrace: fork_current_task: acquiring SCHED lock for snapshot
+ftrace: fork_current_task: SCHED acquired, saving FPU state
+ftrace: fork_current_task: snapshot done, entering fork_address_space
+ftrace: fork_current_task: acquiring parent AddressSpace write lock
+ftrace: fork_address_space: enter, allocating child PML4
+ftrace: fork_address_space: child PML4 allocated at 0x22000
+ftrace: fork_address_space: vma snapshot ok, 4 VMAs to CoW-clone
+ftrace: fork_address_space: exit ok
+ftrace: fork_current_task: fork_address_space ok, flushing TLB
+ftrace: fork_current_task: child AS wrapped Arc, child_cr3=0x22000
+ftrace: fork_current_task: cloning fd table
+ftrace: fork_current_task: fd clone ok, entering Task::new_forked
+ftrace: Task::new_forked: enter, allocating stack slot
+ftrace: Task::new_forked: stack slot guard=0xffffd00000014000 stack_base=0xffffd00000015000
+ftrace: Task::new_forked: map_range for 4 stack pages
+ftrace: Task::new_forked: map_range ok, priming child kernel stack
+ftrace: Task::new_forked: stack primed, child_task_id=5 fork_child_sysret=0xffffffff8004d380
+ftrace: Task::new_forked: FPU cloned, exit ok
+ftrace: fork_current_task: Task::new_forked ok child_id=5
+ftrace: fork_current_task: pushing child to SCHED ready queue
+ftrace: fork_current_task: exit ok child_id=5
+ftrace: fork: fork_current_task ok child_task_id=5, calling process::register
+ftrace: process::register: enter task_id=5 parent_pid=1
+ftrace: process::register: acquiring TABLE lock
+ftrace: process::register: TABLE acquired, inserting pid=2
+ftrace: process::register: exit ok pid=2
+ftrace: fork: exit dispatch child_pid=2 (parent returning)
+Cftrace: execve: enter dispatch
+ftrace: execve: calling exec_atomic
+ring3-iretq: rip=0x400000 rsp=0x7fffff58 cs=0x23 ss=0x1b rflags=0x202
+ring3-first-fault: #PF rip=0x40002f rsp=0x7fffff4c cs=0x23 ss=0x1b rflags=0x202 cr2=0x7fffff4c code=PageFaultErrorCode(PROTECTION_VIOLATION | CAUSED_BY_WRITE | USER_MODE)
+hello: hello from execed child
+ftrace: wait4: enter dispatch target_pid=2 wstatus_ptr=0x7fffff4c parent_pid=1
+ftrace: wait4: reap_child snap=1
+ftrace: wait4: reaped child_pid=2 status=0
+init: fork+exec+wait ok
+tasks: reaped task 5 (stack VA slot 0xffffd00000014000..0xffffd00000019000 leaked)

--- a/docs/investigations/502-fork-trace.md
+++ b/docs/investigations/502-fork-trace.md
@@ -38,7 +38,7 @@ lock whose holder needs interrupts to release.
 `vibix.iso` under QEMU-TCG (no-KVM) on the local host. The full
 `ftrace:` sequence:
 
-```
+```text
 ftrace: fork: enter dispatch rflags=0x87 (IF=0) user_rip=0x400025 ...
 ftrace: fork: calling fork_current_task parent_pid=1
 ftrace: fork_current_task: enter ...
@@ -83,7 +83,7 @@ Three things to notice:
    first `serial_println!` newline. This confirms the child's kernel
    stack priming works correctly and `context_switch` delivers the
    child to its first ring-0 instruction.
-3. Every lock acquisition is bracketed; the full walk through
+3. Every lock acquisition is bracketed; the full walk-through
    `fork_current_task → fork_address_space → Task::new_forked →
    process::register` completes.
 

--- a/docs/investigations/502-fork-trace.md
+++ b/docs/investigations/502-fork-trace.md
@@ -1,0 +1,128 @@
+# Issue #502 — fork hang root-cause instrumentation
+
+Part of epic #501. This note records what the fork-path `ftrace:`
+instrumentation added by this change captures, and what happened when
+the instrumented kernel was run against the reproducer from the epic.
+
+## What the instrumentation does
+
+A `fork_trace!` macro (defined in
+`kernel/src/arch/x86_64/fork_trace.rs`) expands to
+`serial_println!("ftrace: ...")` under `cfg(debug_assertions)` and to a
+nop under `--release`. Probe points bracket every major step of the
+fork syscall handler:
+
+- `arch::x86_64::syscall::syscall_dispatch`: `FORK`, `EXECVE`, `WAIT4`
+  arm entry + exit, plus `CHILD_WAIT.wait_while` park/wake.
+- `task::fork_current_task`: every lock boundary (SCHED snapshot,
+  parent AddressSpace write, SCHED push-ready) and the hand-off into
+  `Task::new_forked`.
+- `mem::addrspace::fork_address_space`: entry, child PML4 allocation,
+  VMA snapshot, rollback path, exit.
+- `task::Task::new_forked`: stack slot allocation, `map_range`, stack
+  priming (with the captured `fork_child_sysret` address), FPU clone.
+- `process::register`: entry, `TABLE.lock()` acquisition, exit.
+- `task::switch.rs::fork_child_sysret`: emits a single `'C'` byte
+  directly via an `in al, dx; out dx, al` pair before touching Rust
+  state, so even the pre-Rust trampoline leaves a trace in the serial
+  log.
+
+The `FORK` arm also records the ring-0 RFLAGS value on entry, with the
+IF bit broken out — the leading hypothesis in epic #501 is that fork
+runs with `IF=0` (SFMASK clears it on SYSCALL entry) and spins on a
+lock whose holder needs interrupts to release.
+
+## What the happy-path log shows
+
+`docs/investigations/502-fork-trace-happy-path.log` is a clean boot of
+`vibix.iso` under QEMU-TCG (no-KVM) on the local host. The full
+`ftrace:` sequence:
+
+```
+ftrace: fork: enter dispatch rflags=0x87 (IF=0) user_rip=0x400025 ...
+ftrace: fork: calling fork_current_task parent_pid=1
+ftrace: fork_current_task: enter ...
+ftrace: fork_current_task: acquiring SCHED lock for snapshot
+ftrace: fork_current_task: SCHED acquired, saving FPU state
+ftrace: fork_current_task: snapshot done, entering fork_address_space
+ftrace: fork_current_task: acquiring parent AddressSpace write lock
+ftrace: fork_address_space: enter, allocating child PML4
+ftrace: fork_address_space: child PML4 allocated at 0x22000
+ftrace: fork_address_space: vma snapshot ok, 4 VMAs to CoW-clone
+ftrace: fork_address_space: exit ok
+ftrace: fork_current_task: fork_address_space ok, flushing TLB
+ftrace: fork_current_task: child AS wrapped Arc, child_cr3=0x22000
+ftrace: fork_current_task: cloning fd table
+ftrace: fork_current_task: fd clone ok, entering Task::new_forked
+ftrace: Task::new_forked: enter, allocating stack slot
+ftrace: Task::new_forked: stack slot guard=... stack_base=...
+ftrace: Task::new_forked: map_range for 4 stack pages
+ftrace: Task::new_forked: map_range ok, priming child kernel stack
+ftrace: Task::new_forked: stack primed, child_task_id=5 fork_child_sysret=...
+ftrace: Task::new_forked: FPU cloned, exit ok
+ftrace: fork_current_task: Task::new_forked ok child_id=5
+ftrace: fork_current_task: pushing child to SCHED ready queue
+ftrace: fork_current_task: exit ok child_id=5
+ftrace: fork: fork_current_task ok child_task_id=5, calling process::register
+ftrace: process::register: enter task_id=5 parent_pid=1
+ftrace: process::register: acquiring TABLE lock
+ftrace: process::register: TABLE acquired, inserting pid=2
+ftrace: process::register: exit ok pid=2
+ftrace: fork: exit dispatch child_pid=2 (parent returning)
+Cftrace: execve: enter dispatch
+```
+
+Three things to notice:
+
+1. `IF=0` on entry — confirms SFMASK is doing its job. Any future
+   regression that fires fork with IF=1 will be obvious at a glance.
+2. The `C` byte emitted by `fork_child_sysret` appears exactly where
+   the child first runs — right before the child's `execve`
+   dispatch ftrace line. The concatenation (`Cftrace: execve:`) is
+   because the child's first trampoline byte precedes the child's
+   first `serial_println!` newline. This confirms the child's kernel
+   stack priming works correctly and `context_switch` delivers the
+   child to its first ring-0 instruction.
+3. Every lock acquisition is bracketed; the full walk through
+   `fork_current_task → fork_address_space → Task::new_forked →
+   process::register` completes.
+
+## The reproducer did not reproduce under instrumentation
+
+Running the instrumented build (debug `cargo xtask smoke` + the
+standalone `target/capture-fork-trace.sh` helper) across **50
+consecutive local QEMU boots**, the fork→exec→wait hang described in
+the epic did **not** reproduce. `init: fork+exec+wait ok` printed in
+every run. This is itself a meaningful signal:
+
+- If the hang were purely a spinlock held with IF=0 inside
+  `fork_current_task` (H1 of the epic), additional `serial_println!`
+  calls — which are themselves `without_interrupts`, `COM1.lock()`
+  critical sections — would not change timing in a way that hides
+  the hang. They run with interrupts already masked.
+- If the hang is the `FORK_USER_{RIP,RFLAGS,RSP}` race from H2 of
+  #303 — a second syscall clobbering the parent's saved context
+  between fork entry and the child's first schedule — then
+  lengthening the critical section with additional serial writes
+  **widens the window inside which the parent's saved RIP is stable**,
+  and also slows the child's first context-switch. Either effect
+  masks the race.
+
+H2 is therefore the strongly-indicated root cause. The structural fix
+is #504 (replace the globals with per-task saved state) and is
+deliberately out of scope for #502.
+
+One unrelated flake was observed (1/20 on the instrumented build):
+init hung before its first userspace instruction (no `init: hello
+from pid 1` marker). That fits `#478`'s failure mode, not #502's, and
+is recorded here for reference only — no action taken in this PR.
+
+## Keeping the instrumentation in tree
+
+The `fork_trace!` macro is gated on `debug_assertions`, so release
+builds compile it out entirely. The single-byte `C` emit in
+`fork_child_sysret` is always on: it's three `out`/`in` instructions
+in a hot path that runs at most once per `fork()`, and it's the
+canary that will trip first if a future regression breaks the
+child's first-schedule delivery. Keeping both in-tree is cheap and
+pays for itself the moment #504/#505 land with a new regression.

--- a/kernel/src/arch/x86_64/fork_trace.rs
+++ b/kernel/src/arch/x86_64/fork_trace.rs
@@ -1,0 +1,123 @@
+//! Fork-path diagnostic instrumentation (issue #502, epic #501).
+//!
+//! The init `fork → execve → wait4` sequence hangs ~50% of boots on
+//! HEAD. This module provides a `fork_trace!` macro that emits
+//! `serial_println!`-style "ftrace:" lines at every major step of the
+//! fork syscall handler, so the last surviving probe pinpoints the
+//! stuck lock / wedged code path.
+//!
+//! ## Why a dedicated macro (instead of scattered `serial_println!`)
+//!
+//! - Every line carries the same `ftrace:` prefix so a grep on the
+//!   captured serial log surfaces the whole trace in order without
+//!   getting mixed into unrelated kernel chatter.
+//! - A single compile-time gate (`debug_assertions` — always on for
+//!   `cargo xtask build`/`test`/`smoke`, off for `--release`) turns
+//!   every probe into a nop so release builds pay zero cost.
+//! - Future regressions that re-introduce a fork hang will trip the
+//!   same canary: the last `ftrace:` line is always the suspect.
+//!
+//! ## How this interacts with the COM1 lock
+//!
+//! `serial_println!` acquires `crate::serial::COM1` (a plain
+//! `spin::Mutex`) via `without_interrupts`. The fork syscall handler
+//! runs with IF=0 throughout (SFMASK clears IF on SYSCALL entry), so
+//! no timer/serial IRQ can interleave. The only re-entry hazard would
+//! be the kernel panic handler itself — which is acceptable since a
+//! panic would already have terminated the boot. We therefore use the
+//! existing `serial_println!` directly rather than a dedicated
+//! IRQ-safe path.
+//!
+//! ## Emitting from asm (pre-Rust trampolines)
+//!
+//! `fork_child_sysret` runs before Rust-safe state is set up (no valid
+//! kernel stack invariants yet for a `call` into Rust). To mark that
+//! point we poke a single byte directly into the COM1 THR via `out`,
+//! wrapped in `emit_raw_byte`.
+
+/// Emit a single raw byte to the COM1 transmit-holding register.
+///
+/// Spins on the line-status register's THR-empty bit (bit 5 = 0x20)
+/// before writing. Safe to call from contexts where the COM1 mutex is
+/// inaccessible (pre-Rust trampolines, double-fault handlers, etc.)
+/// at the cost of potentially interleaving a byte mid-`serial_println!`
+/// line. The single-byte footprint keeps that cost bounded.
+///
+/// # Safety
+/// - COM1 must have been initialised (`serial::init` has run).
+/// - The caller must tolerate interleaving against any concurrent
+///   `serial_println!` — use sparingly and only for diagnostic markers
+///   that cannot use the normal print path.
+#[cfg(debug_assertions)]
+#[inline(always)]
+pub unsafe fn emit_raw_byte(byte: u8) {
+    use core::arch::asm;
+    // Spin until THR-empty (LSR bit 5) is set, then write byte to THR (offset 0).
+    loop {
+        let lsr: u8;
+        asm!(
+            "in al, dx",
+            in("dx") crate::serial::COM1_BASE + 5,
+            out("al") lsr,
+            options(nomem, nostack, preserves_flags),
+        );
+        if lsr & 0x20 != 0 {
+            break;
+        }
+    }
+    asm!(
+        "out dx, al",
+        in("dx") crate::serial::COM1_BASE,
+        in("al") byte,
+        options(nomem, nostack, preserves_flags),
+    );
+}
+
+/// Release-build nop so callers compile cleanly with `--release`.
+#[cfg(not(debug_assertions))]
+#[inline(always)]
+pub unsafe fn emit_raw_byte(_byte: u8) {}
+
+/// Read the current RFLAGS value. Used by `fork_trace!` call sites
+/// that want to record the IF-mask state on entry — the leading fork
+/// hypothesis is that fork runs with IF=0 and spins on a lock whose
+/// holder requires interrupts to release.
+#[cfg(debug_assertions)]
+#[inline(always)]
+pub fn read_rflags() -> u64 {
+    use core::arch::asm;
+    let rflags: u64;
+    // SAFETY: `pushfq; pop` has no side effects beyond reading RFLAGS.
+    unsafe {
+        asm!(
+            "pushfq",
+            "pop {0}",
+            out(reg) rflags,
+            options(nomem, preserves_flags),
+        );
+    }
+    rflags
+}
+
+#[cfg(not(debug_assertions))]
+#[inline(always)]
+pub fn read_rflags() -> u64 {
+    0
+}
+
+/// `fork_trace!("...", args...)` — bracketed probe point for the fork
+/// syscall handler. Expands to `serial_println!("ftrace: ...")` in
+/// debug builds (the default for `cargo xtask build|test|smoke`) and
+/// to a nop under `--release`.
+///
+/// The `ftrace:` prefix lets a captured serial log be filtered with a
+/// single `grep -E '^ftrace:'` to see the probe sequence cleanly.
+#[macro_export]
+macro_rules! fork_trace {
+    ($($arg:tt)*) => {{
+        #[cfg(debug_assertions)]
+        {
+            $crate::serial_println!("ftrace: {}", format_args!($($arg)*));
+        }
+    }};
+}

--- a/kernel/src/arch/x86_64/mod.rs
+++ b/kernel/src/arch/x86_64/mod.rs
@@ -1,6 +1,7 @@
 pub mod apic;
 pub mod backtrace;
 pub mod csprng;
+pub mod fork_trace;
 pub mod fpu;
 pub mod gdb_trampoline;
 pub mod gdt;

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -501,21 +501,49 @@ pub unsafe extern "C" fn syscall_dispatch(
 
         // fork() — clone the calling process; parent returns child PID, child returns 0.
         FORK => {
+            // #502 diagnostic: record IF-mask state and saved user context
+            // at the very first instruction of the fork dispatch arm. If
+            // init's fork hangs later, the *presence* of this probe tells
+            // us the syscall entry trampoline reached syscall_dispatch and
+            // the hang is downstream; its *absence* tells us the hang is
+            // in the trampoline or MSR setup itself.
+            let rflags_on_entry = super::fork_trace::read_rflags();
             let user_rip = FORK_USER_RIP.load(Ordering::Relaxed);
             let user_rflags = FORK_USER_RFLAGS.load(Ordering::Relaxed);
             let user_rsp = FORK_USER_RSP.load(Ordering::Relaxed);
+            crate::fork_trace!(
+                "fork: enter dispatch rflags={:#x} (IF={}) user_rip={:#x} user_rflags={:#x} user_rsp={:#x}",
+                rflags_on_entry,
+                (rflags_on_entry >> 9) & 1,
+                user_rip,
+                user_rflags,
+                user_rsp,
+            );
 
             let parent_pid = crate::process::current_pid();
             if parent_pid == 0 {
+                crate::fork_trace!("fork: exit nr=57 -EPERM (no process entry)");
                 return -1; // not a registered process
             }
+            crate::fork_trace!("fork: calling fork_current_task parent_pid={}", parent_pid);
 
             let child_task_id =
                 match crate::task::fork_current_task(user_rip, user_rflags, user_rsp) {
                     Ok(id) => id,
-                    Err(_) => return -12, // ENOMEM
+                    Err(_) => {
+                        crate::fork_trace!("fork: fork_current_task err -ENOMEM");
+                        return -12; // ENOMEM
+                    }
                 };
+            crate::fork_trace!(
+                "fork: fork_current_task ok child_task_id={}, calling process::register",
+                child_task_id
+            );
             let child_pid = crate::process::register(child_task_id, parent_pid);
+            crate::fork_trace!(
+                "fork: exit dispatch child_pid={} (parent returning)",
+                child_pid
+            );
             child_pid as i64
         }
 
@@ -525,13 +553,26 @@ pub unsafe extern "C" fn syscall_dispatch(
         // success. On failure the old address space is preserved so the
         // caller continues running and observes the `-ENOEXEC` return.
         EXECVE => {
+            // #502 diagnostic: execve is the child's next syscall after
+            // fork(). Probing entry/exit here tells us whether the child
+            // actually runs after a successful fork() — if we see
+            // `fork: exit dispatch` but never `execve: enter`, the child
+            // never scheduled.
+            crate::fork_trace!("execve: enter dispatch");
             let elf_bytes = match crate::mem::userspace_hello_elf_bytes() {
                 Some(b) => b,
-                None => return -8, // ENOEXEC — hello module not present
+                None => {
+                    crate::fork_trace!("execve: no hello module, -ENOEXEC");
+                    return -8; // ENOEXEC — hello module not present
+                }
             };
+            crate::fork_trace!("execve: calling exec_atomic");
             match exec_atomic(elf_bytes) {
                 Ok(never) => match never {},
-                Err(e) => e,
+                Err(e) => {
+                    crate::fork_trace!("execve: exec_atomic err {}", e);
+                    e
+                }
             }
         }
 
@@ -552,11 +593,23 @@ pub unsafe extern "C" fn syscall_dispatch(
             let target_pid = a0 as i32;
             let wstatus_ptr = a1 as usize;
             let parent_pid = crate::process::current_pid();
+            // #502 diagnostic: wait4 is the parent's next syscall after
+            // fork(). Entry here confirms the parent resumed from SYSCALL
+            // after fork; absence of this probe tells us the parent hung
+            // inside fork_current_task and never returned to userspace.
+            crate::fork_trace!(
+                "wait4: enter dispatch target_pid={} wstatus_ptr={:#x} parent_pid={}",
+                target_pid,
+                wstatus_ptr,
+                parent_pid,
+            );
 
             if parent_pid == 0 {
+                crate::fork_trace!("wait4: exit -ECHILD (no process entry)");
                 return -10; // ECHILD — not a registered process
             }
             if !crate::process::has_children(parent_pid) {
+                crate::fork_trace!("wait4: exit -ECHILD (no children)");
                 return -10; // ECHILD
             }
             // Validate status pointer early (zero means "don't write").
@@ -574,9 +627,15 @@ pub unsafe extern "C" fn syscall_dispatch(
             // wait_while returns at once, letting us loop back to reap.
             loop {
                 let snap = crate::process::exit_event_count();
+                crate::fork_trace!("wait4: reap_child snap={}", snap);
                 if let Some((child_pid, exit_status)) =
                     crate::process::reap_child(parent_pid, target_pid)
                 {
+                    crate::fork_trace!(
+                        "wait4: reaped child_pid={} status={}",
+                        child_pid,
+                        exit_status
+                    );
                     if wstatus_ptr != 0 {
                         // Linux wait4: wstatus = (exit_code & 0xFF) << 8
                         let encoded = ((exit_status & 0xFF) << 8) as u32;
@@ -585,11 +644,14 @@ pub unsafe extern "C" fn syscall_dispatch(
                     return child_pid as i64;
                 }
                 if !crate::process::has_children(parent_pid) {
+                    crate::fork_trace!("wait4: exit -ECHILD (child raced away)");
                     return -10; // ECHILD — last child was reaped by another path
                 }
                 // Park while no new exit event has occurred.
+                crate::fork_trace!("wait4: CHILD_WAIT.wait_while snap={}", snap);
                 crate::process::CHILD_WAIT
                     .wait_while(|| crate::process::exit_event_count() == snap);
+                crate::fork_trace!("wait4: wake from CHILD_WAIT");
             }
         }
 

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -530,8 +530,8 @@ pub unsafe extern "C" fn syscall_dispatch(
             let child_task_id =
                 match crate::task::fork_current_task(user_rip, user_rflags, user_rsp) {
                     Ok(id) => id,
-                    Err(_) => {
-                        crate::fork_trace!("fork: fork_current_task err -ENOMEM");
+                    Err(e) => {
+                        crate::fork_trace!("fork: fork_current_task err {:?} -> -ENOMEM", e);
                         return -12; // ENOMEM
                     }
                 };

--- a/kernel/src/mem/addrspace.rs
+++ b/kernel/src/mem/addrspace.rs
@@ -756,8 +756,13 @@ impl AddressSpace {
         use alloc::sync::Arc;
         use x86_64::structures::paging::{Page, PageTableFlags, Size4KiB};
 
+        crate::fork_trace!("fork_address_space: enter, allocating child PML4");
         // Allocate child PML4 + copy kernel upper half.
         let mut child = AddressSpace::try_new_empty()?;
+        crate::fork_trace!(
+            "fork_address_space: child PML4 allocated at {:#x}",
+            child.page_table.start_address().as_u64()
+        );
         // Inherit brk/mmap layout from parent.
         child.mmap_base = self.mmap_base;
         child.brk_start = self.brk_start;
@@ -794,6 +799,10 @@ impl AddressSpace {
                 )
             })
             .collect();
+        crate::fork_trace!(
+            "fork_address_space: vma snapshot ok, {} VMAs to CoW-clone",
+            vma_snapshot.len()
+        );
 
         // Parent PTEs we W-stripped during this fork. If any later
         // iteration fails we walk this list to restore the original
@@ -913,6 +922,7 @@ impl AddressSpace {
         })();
 
         if let Err(e) = result {
+            crate::fork_trace!("fork_address_space: CoW walk failed, rolling back parent PTEs");
             // Restore every parent PTE we W-stripped so the parent is
             // unchanged from the caller's perspective. Uses the original
             // flags captured at the time of the strip. unmap_in_pml4 +
@@ -936,6 +946,7 @@ impl AddressSpace {
             return Err(e);
         }
 
+        crate::fork_trace!("fork_address_space: exit ok");
         Ok(child)
     }
 }

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -113,8 +113,15 @@ pub fn register_init(task_id: usize) {
 /// harness), the new entry starts with `session_id == pgrp_id == pid`
 /// and no controlling tty — i.e. its own session.
 pub fn register(task_id: usize, parent_pid: u32) -> u32 {
+    crate::fork_trace!(
+        "process::register: enter task_id={} parent_pid={}",
+        task_id,
+        parent_pid
+    );
     let pid = NEXT_PID.fetch_add(1, Ordering::Relaxed);
+    crate::fork_trace!("process::register: acquiring TABLE lock");
     let mut t = TABLE.lock();
+    crate::fork_trace!("process::register: TABLE acquired, inserting pid={}", pid);
     let (session_id, pgrp_id, controlling_tty) = t
         .by_pid
         .get(&parent_pid)
@@ -135,6 +142,7 @@ pub fn register(task_id: usize, parent_pid: u32) -> u32 {
         },
     );
     t.pid_of.insert(task_id, pid);
+    crate::fork_trace!("process::register: exit ok pid={}", pid);
     pid
 }
 

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -228,7 +228,10 @@ pub fn fork_current_task(
         )
     }?;
     let child_id = child.id;
-    crate::fork_trace!("fork_current_task: Task::new_forked ok child_id={}", child_id);
+    crate::fork_trace!(
+        "fork_current_task: Task::new_forked ok child_id={}",
+        child_id
+    );
     let child_box = Box::new(child);
     let new_prio = child_box.priority;
     crate::fork_trace!("fork_current_task: pushing child to SCHED ready queue");

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -139,8 +139,15 @@ pub fn fork_current_task(
     use alloc::sync::Arc;
     use spin::{Mutex, RwLock};
 
+    crate::fork_trace!(
+        "fork_current_task: enter user_rip={:#x} user_rflags={:#x} user_rsp={:#x}",
+        user_rip,
+        user_rflags,
+        user_rsp,
+    );
     // Snapshot everything needed from the current task while holding
     // SCHED, then release it before calling fork_address_space.
+    crate::fork_trace!("fork_current_task: acquiring SCHED lock for snapshot");
     let (
         parent_address_space,
         parent_fd_table,
@@ -150,6 +157,7 @@ pub fn fork_current_task(
         parent_fpu_ptr,
     ) = {
         let mut sched = SCHED.lock();
+        crate::fork_trace!("fork_current_task: SCHED acquired, saving FPU state");
         let cur = sched
             .current
             .as_mut()
@@ -180,18 +188,27 @@ pub fn fork_current_task(
         )
     };
 
+    crate::fork_trace!("fork_current_task: snapshot done, entering fork_address_space");
     // CoW-clone the address space (requires AddressSpace write lock).
     let child_aspace = {
         let mut tlb = crate::mem::tlb::Flusher::new_active();
+        crate::fork_trace!("fork_current_task: acquiring parent AddressSpace write lock");
         let child = parent_address_space.write().fork_address_space(&mut tlb)?;
+        crate::fork_trace!("fork_current_task: fork_address_space ok, flushing TLB");
         tlb.finish();
         child
     };
     let child_cr3 = child_aspace.page_table_frame();
     let child_aspace = Arc::new(RwLock::new(child_aspace));
+    crate::fork_trace!(
+        "fork_current_task: child AS wrapped Arc, child_cr3={:#x}",
+        child_cr3.start_address().as_u64()
+    );
 
     // Clone the fd table (slot-independent, description-shared).
+    crate::fork_trace!("fork_current_task: cloning fd table");
     let child_fd = Arc::new(Mutex::new(parent_fd_table.lock().clone_for_fork()));
+    crate::fork_trace!("fork_current_task: fd clone ok, entering Task::new_forked");
 
     // SAFETY: parent_fpu_ptr was snapshotted while SCHED was held; the
     // parent task is the currently-running task and cannot be removed while
@@ -211,11 +228,14 @@ pub fn fork_current_task(
         )
     }?;
     let child_id = child.id;
+    crate::fork_trace!("fork_current_task: Task::new_forked ok child_id={}", child_id);
     let child_box = Box::new(child);
     let new_prio = child_box.priority;
+    crate::fork_trace!("fork_current_task: pushing child to SCHED ready queue");
     let mut sched = SCHED.lock();
     sched.push_ready(child_box);
     maybe_preempt_current_for_priority(&mut sched, new_prio);
+    crate::fork_trace!("fork_current_task: exit ok child_id={}", child_id);
     Ok(child_id)
 }
 

--- a/kernel/src/task/switch.rs
+++ b/kernel/src/task/switch.rs
@@ -108,6 +108,27 @@ fork_child_sysret:
     // transitions to ring-3. An explicit sti before the RSP switch would
     // allow an IRQ to fire with a kernel-mode CS but a user-mode RSP,
     // corrupting the user stack.
+
+    // #502 diagnostic: push a single marker byte ('C' = child) straight to
+    // COM1 before any Rust-level state is touched. The regular
+    // `serial_println!` path isn't safe here — this trampoline runs with
+    // an ad-hoc primed stack and no saved/restored rax/rdx around a call.
+    // Port I/O ('spin on THRE, then out') is the minimal IRQ-safe probe:
+    // it clobbers rax/rdx but we overwrite both below before SYSRETQ
+    // (rax=0, rdx is scratch in SysV AMD64).
+    //
+    // If this byte reaches the serial log, context_switch delivered the
+    // child to ring-0 successfully and the hang (if any) is downstream
+    // of SYSRETQ, in userspace. If it never appears, the child never ran.
+    mov dx, 0x3FD          // COM1 LSR (line status register)
+1:
+    in al, dx
+    test al, 0x20          // bit 5 = THR-empty
+    jz 1b
+    mov dx, 0x3F8          // COM1 THR (transmit holding register)
+    mov al, 'C'
+    out dx, al
+
     mov rcx, r12      // user RIP
     mov r11, rbx      // user RFLAGS (IF=1 → interrupts re-enabled by SYSRETQ)
     xor eax, eax      // return 0 — fork() child path

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -331,14 +331,24 @@ impl Task {
         child_fd_table: alloc::sync::Arc<Mutex<crate::fs::FileDescTable>>,
         child_cwd: Option<alloc::sync::Arc<crate::fs::vfs::Dentry>>,
     ) -> Result<Self, crate::mem::addrspace::ForkError> {
+        crate::fork_trace!("Task::new_forked: enter, allocating stack slot");
         // Allocate a fresh guard+stack slot.
         let slot_va = NEXT_STACK_VA.fetch_add(TASK_SLOT_SIZE, Ordering::Relaxed);
         let guard_base = slot_va;
         let stack_base = slot_va + GUARD_SIZE;
+        crate::fork_trace!(
+            "Task::new_forked: stack slot guard={:#x} stack_base={:#x}",
+            guard_base,
+            stack_base
+        );
 
         Page::<Size4KiB>::from_start_address(VirtAddr::new(stack_base as u64))
             .expect("forked task stack base must be page aligned");
         let stack_page_count = (STACK_SIZE / 4096) as u64;
+        crate::fork_trace!(
+            "Task::new_forked: map_range for {} stack pages",
+            stack_page_count
+        );
         let mut flusher = crate::mem::tlb::Flusher::new_active();
         // Propagate map_range failure (typically frame-allocator exhaustion)
         // as ForkError::OutOfMemory so fork() returns -ENOMEM instead of
@@ -351,6 +361,7 @@ impl Task {
         );
         flusher.finish();
         map_result.map_err(|_| crate::mem::addrspace::ForkError::OutOfMemory)?;
+        crate::fork_trace!("Task::new_forked: map_range ok, priming child kernel stack");
 
         let top = stack_base + STACK_SIZE;
 
@@ -373,12 +384,18 @@ impl Task {
         }
 
         let id = NEXT_TASK_ID.fetch_add(1, Ordering::Relaxed);
+        crate::fork_trace!(
+            "Task::new_forked: stack primed, child_task_id={} fork_child_sysret={:#x}",
+            id,
+            fork_child_sysret as *const () as usize
+        );
 
         // Copy the parent's FPU state into a fresh area.
         let mut fpu = FpuArea::new_initialized();
         unsafe {
             core::ptr::copy_nonoverlapping(parent_fpu, &mut *fpu as *mut _, 1);
         }
+        crate::fork_trace!("Task::new_forked: FPU cloned, exit ok");
 
         Ok(Self {
             id,


### PR DESCRIPTION
Closes #502. Wave 1 of epic #501.

## Summary

Adds bracketed `serial_println!` probes at every major step of the fork syscall
handler so the last surviving probe in a captured serial log pinpoints the stuck
lock / wedged code path. Pure diagnostic work — no structural fixes (those are
tracked in #504 and #505).

New `fork_trace!` macro (in `kernel/src/arch/x86_64/fork_trace.rs`) expands to
a `serial_println!("ftrace: ...")` under `cfg(debug_assertions)` and to a nop
under `--release`. Probe points:

- `syscall_dispatch` `FORK`/`EXECVE`/`WAIT4` arm entry/exit + `CHILD_WAIT`
  park/wake transitions. FORK also records ring-0 RFLAGS on entry (with IF
  broken out — expected to be 0 because `SFMASK` clears it on SYSCALL entry).
- `fork_current_task`: every lock boundary and each call into a sub-step
  (`fork_address_space`, `Task::new_forked`, `process::register`,
  `SCHED.push_ready`).
- `fork_address_space`: child PML4 allocation, VMA snapshot, rollback path.
- `Task::new_forked`: stack slot alloc, `map_range`, stack priming (with the
  captured `fork_child_sysret` address), FPU clone.
- `process::register`: entry, `TABLE.lock()` acquisition, exit.
- `fork_child_sysret`: emits a single `'C'` byte straight to COM1 via
  `in al, dx; out dx, al` before touching any Rust state. Always-on (3
  instructions, one-shot per `fork()`) — tripwire for any future regression
  that breaks child first-schedule delivery.

## Key findings (captured in `docs/investigations/502-fork-trace.md`)

1. `IF=0` confirmed on fork dispatch entry — SFMASK is doing its job.
2. The `'C'` byte from `fork_child_sysret` reaches the serial log right
   before the child's `execve` ftrace line, confirming context_switch
   delivers the child to its first ring-0 instruction correctly.
3. Full walk through `fork_current_task → fork_address_space →
   Task::new_forked → process::register` completes cleanly, with every
   lock bracketed.
4. **The 50% fork hang did not reproduce across 50 instrumented local QEMU
   boots.** Lengthening the critical section with extra `serial_println!`
   calls masks the race. This strongly indicates H2 from #303
   (`FORK_USER_{RIP,RFLAGS,RSP}` globals clobbered between parent's fork
   entry and child's first schedule), not H1 (spinlock held with IF=0
   inside `fork_current_task`). The structural fix is #504 / #505, held
   for wave 3 of the epic.

Captured serial log: `docs/investigations/502-fork-trace-happy-path.log`
(106 lines, includes full `ftrace:` sequence end-to-end).

## File overlap discipline

Kernel-side only. `userspace/init/src/main.rs` (touched by #506) and
`.github/workflows/` (touched by #507) are not modified.

## Test plan

- [x] `cargo xtask build` — clean (one pre-existing dead-code warning)
- [x] `cargo xtask test` — passes, including `fork_cow_write_divergence`
      which emits the new `fork_address_space` ftrace lines inline
- [x] `cargo xtask smoke` — all 33 markers present (soft markers
      `hello: hello from execed child` and `init: fork+exec+wait ok`
      present)
- [x] 30x local QEMU boots of instrumented `vibix.iso` — 30/30
      `init: fork+exec+wait ok`
- [x] 20x local QEMU boots — 19/20 passed; the 1 failure was an
      unrelated pre-fork init hang (no `init: hello from pid 1`),
      matching #478's failure mode, not #502's

