### PR TITLE
kernel: fork-trace instrumentation for init fork hang (#502)

### DIFF
--- a/docs/incident-logs/502-fork-trace-boot.log
+++ b/docs/incident-logs/502-fork-trace-boot.log
@@ -1,0 +1,105 @@
+limine: Loading executable `boot():/boot/vibix`...
+limine: Loading module `boot():/boot/userspace_init.elf`...
+limine: Loading module `boot():/boot/userspace_init.elf`...
+limine: Loading module `boot():/boot/userspace_hello.elf`...
+limine: Loading module `boot():/boot/rootfs.tar`...
+limine: Loading module `boot():/boot/ld-musl-x86_64.so.1`...
+vibix booting…
+memory map: 28 entries, 244 MiB usable
+hhdm offset: 0xffff800000000000
+rsdp: 0xf52b0
+cpu: SSE SSE2 SSE4.1 SSE4.2 AVX AVX2 XSAVE PAT SMEP SMAP FSGSBASE RDTSCP POPCNT LZCNT RDRAND RDSEED
+uaccess: smep=on smap=on
+fpu: FXSAVE context switch online
+syscall: SYSCALL/SYSRET enabled
+PIC remapped to 0x20/0x28 and masked
+GDT + IDT loaded
+paging: mapper online
+heap: 1024 KiB @ 0xffffc00000000000 (reserved 16384 KiB, grows in 64 KiB chunks)
+paging: IST guard installed @ 0xffffffff804ed000
+paging: switched to kernel PML4
+paging: reclaimed 4136 KiB bootloader memory (17 L3/L2/L1 intermediate table frames, PML4=0xff43000)
+acpi: MADT parsed (cpus=1, ioapics=1, overrides=5, lapic=0xfee00000)
+apic: BSP online (lapic_id=0)
+ioapic: initialized (1 controller(s))
+ioapic: IRQ0 -> gsi 2 -> vec 0x20 on lapic 0 (ioapic 0)
+ioapic: IRQ1 -> gsi 1 -> vec 0x21 on lapic 0 (ioapic 0)
+ioapic: IRQ4 -> gsi 4 -> vec 0x24 on lapic 0 (ioapic 0)
+serial: rx irq enabled
+hpet: initialized (period=10000000fs, timers=3, base=0xfed00000)
+hpet: periodic timer armed (100 Hz, 1000000 ticks/period)
+timer: 100 Hz
+rtc: 2026-04-17 15:09:10
+pci: 7 device(s) on bus 0
+pci:   00:00.0 8086:29c0 class 06:00 pi=00 (host-bridge)
+pci:   00:01.0 1234:1111 class 03:00 pi=00 (vga)
+pci:   00:02.0 8086:10d3 class 02:00 pi=00 (network)
+pci:   00:03.0 1af4:1001 class 01:00 pi=00 (scsi)
+pci:   00:1f.0 8086:2918 class 06:01 pi=00 (isa-bridge)
+pci:   00:1f.2 8086:2922 class 01:06 pi=01 (sata)
+pci:   00:1f.3 8086:2930 class 0c:05 pi=00 (serial-bus)
+block: virtio-blk ready (io_base=0xc000, queue_size=256)
+block: lba0[0..16]=[56, 49, 42, 49, 58, 42, 4c, 4b, 30, 00, 00, 00, 00, 00, 00, 00]
+block: write+readback ok at lba 2047
+framebuffer: 1280x800 @ 32 bpp, pitch=5120 bytes
+vibix online.
+interrupts enabled
+timer: TSC 2420 MHz
+userspace module ELF entry=0x400000 load_segments=2
+tasks: scheduler online
+userspace: loader mapping image (8728 bytes)
+init: new PML4 at phys=0x15000
+init: ELF loaded entry=0x400000 segments=2
+init: user stack at virt=0x7ffff000 top=0x80000000
+shell: prompt online
+banner: vibix 0.1.0 (86e696a0f869, built 2026-04-17T15:08:07Z, debug) x86_64
+cpu: QEMU TCG CPU version 2.5+ x1
+mem: 249 MiB total, 247 MiB free
+boot: 112 ms
+Welcome to vibix. Type `help` for builtins.
+vibix> init: auxv written, initial rsp=0x7fffff58
+init: ring-3 entry task spawned (task_id=4, pid=1)
+init: switched to process PML4
+init: entering ring-3 entry=0x400000 rsp=0x7fffff58
+init: iretq to ring-3
+ring3-iretq: rip=0x400000 rsp=0x7fffff58 cs=0x23 ss=0x1b rflags=0x202
+init: hello from pid 1
+fork-trace: [syscall:FORK enter] parent_task=4 user_rip=0x400025 user_rflags=0x212 user_rsp=0x7fffff4c kernel_rflags=0x87 IF=0
+fork-trace: [syscall:FORK] parent_pid=1 (pre-fork)
+fork-trace: [syscall:FORK] → fork_current_task()
+fork-trace: [fork_current_task enter] user_rip=0x400025 user_rflags=0x212 user_rsp=0x7fffff4c
+fork-trace: [fork_current_task] → SCHED.lock() for parent snapshot
+fork-trace: [fork_current_task] SCHED locked (snapshot scope)
+fork-trace: [fork_current_task] → fpu::save(parent)
+fork-trace: [fork_current_task] ← fpu::save(parent)
+fork-trace: [fork_current_task] SCHED released
+fork-trace: [fork_current_task] → fork_address_space()
+fork-trace: [fork_current_task] ← fork_address_space() child_cr3=0x22000
+fork-trace: [fork_current_task] → clone_for_fork(fd_table)
+fork-trace: [fork_current_task] ← clone_for_fork(fd_table)
+fork-trace: [fork_current_task] → Task::new_forked()
+fork-trace: [Task::new_forked enter] user_rip=0x400025 user_rsp=0x7fffff4c
+fork-trace: [Task::new_forked] slot_va=0xffffd00000014000 guard_base=0xffffd00000014000 stack_base=0xffffd00000015000
+fork-trace: [Task::new_forked] → paging::map_range(4 pages)
+fork-trace: [Task::new_forked] ← map_range ok=true
+fork-trace: [Task::new_forked] child stack primed rsp=0xffffd00000018fc8 sysret_rip=0x400025 sysret_rsp=0x7fffff4c sysret_rflags=0x212 fork_child_sysret=0xffffffff80059584 child_id=5
+fork-trace: [Task::new_forked] → copy parent FPU state
+fork-trace: [Task::new_forked] ← copy parent FPU state
+fork-trace: [Task::new_forked exit] id=5 syscall_stack_top=0xffffd00000019000
+fork-trace: [fork_current_task] ← Task::new_forked() child_id=5
+fork-trace: [fork_current_task] → SCHED.lock() for push_ready
+fork-trace: [fork_current_task] SCHED locked; push_ready child_id=5 prio=19
+fork-trace: [fork_current_task exit] returning child_id=5
+fork-trace: [syscall:FORK] ← fork_current_task() child_task_id=5
+fork-trace: [syscall:FORK] → process::register(task_id=5, parent_pid=1)
+fork-trace: [process::register enter] task_id=5 parent_pid=1
+fork-trace: [process::register] allocated pid=2 → TABLE.lock()
+fork-trace: [process::register] TABLE locked
+fork-trace: [process::register exit] pid=2 task_id=5 parent_pid=1
+fork-trace: [syscall:FORK] ← process::register child_pid=2 — returning to user
+C
+ring3-iretq: rip=0x400000 rsp=0x7fffff58 cs=0x23 ss=0x1b rflags=0x202
+ring3-first-fault: #PF rip=0x40002f rsp=0x7fffff4c cs=0x23 ss=0x1b rflags=0x202 cr2=0x7fffff4c code=PageFaultErrorCode(PROTECTION_VIOLATION | CAUSED_BY_WRITE | USER_MODE)
+hello: hello from execed child
+init: fork+exec+wait ok
+tasks: reaped task 5 (stack VA slot 0xffffd00000014000..0xffffd00000019000 leaked)

--- a/docs/incident-logs/README.md
+++ b/docs/incident-logs/README.md
@@ -1,0 +1,35 @@
+# Incident serial logs
+
+Captured serial output from QEMU boots that back findings on specific
+issues. Each file is the literal serial stream; trust the file, not this
+README. Cross-reference the issue number in the filename to get full
+context.
+
+## Index
+
+| File | Issue | What it shows |
+|---|---|---|
+| `502-fork-trace-boot.log` | [#502](https://github.com/dburkart/vibix/issues/502) | Full `fork-trace` probe stream from one clean boot — fork(2) syscall path instrumented end-to-end, all probes fire, `IF=0` confirmed at dispatch, `[C]` marker shows the child reached `fork_child_sysret`. |
+
+## Reproducing a capture
+
+Build the kernel with the `fork-trace` feature (lives in
+`kernel/Cargo.toml`) and boot QEMU with the test disk image:
+
+```sh
+cargo xtask iso --fork-trace
+qemu-system-x86_64 \
+  -M q35 -cpu max -m 256M \
+  -serial file:/tmp/serial.log -display none \
+  -no-reboot -no-shutdown \
+  -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
+  -drive file=target/test-disk.img,if=none,id=vd0,format=raw \
+  -device virtio-blk-pci,drive=vd0,disable-modern=on,disable-legacy=off \
+  -cdrom target/vibix.iso
+```
+
+Kill QEMU after `init: fork+exec+wait ok` appears in the log (or after
+~30 seconds if the kernel hangs). The probe strings all start with
+`fork-trace:`; the lone `C` on its own line is the asm-level `COM1`
+poke that fires only when the child task has successfully reached the
+`fork_child_sysret` trampoline (last moment before `SYSRETQ`).

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -39,6 +39,16 @@ ist-overflow-test = []
 # store to the timer ISR and spawns a bench task at boot that prints a
 # summary table over serial. Off by default so normal boots stay quiet.
 bench = []
+# Enable serial-print instrumentation along the fork(2) syscall path:
+# SYSCALL entry → dispatch arm 57 → fork_current_task → fork_address_space →
+# Task::new_forked → process::register → fork_child_sysret. Each probe is
+# paired entry/exit so the last surviving print pinpoints where the kernel
+# wedges. IF state is dumped on fork-dispatch entry (expected 0, masked by
+# MSR_FMASK). Canary for future regressions of the fork hang surface
+# tracked in epic #501 / diagnostic #502. Off by default; release builds
+# never ship it. Enable with `cargo xtask run --features fork-trace` (or
+# `--features fork-trace` on any xtask subcommand).
+fork-trace = []
 
 [[test]]
 name = "basic_boot"

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -43,6 +43,23 @@ use x86_64::registers::model_specific::Msr;
 use super::gdt::{set_tss_rsp0, STAR_KERNEL_CS_BASE, STAR_USER_CS_BASE};
 use super::gdt::{USER_CODE_SELECTOR, USER_DATA_SELECTOR};
 
+/// Diagnostic instrumentation along the fork(2) syscall path (epic #501 /
+/// issue #502). Expands to `serial_println!` when the `fork-trace` feature
+/// is enabled at build time; otherwise compiles to nothing. Paired entry/
+/// exit probes let the last surviving print pinpoint where the kernel
+/// wedges in the fork path.
+#[cfg(feature = "fork-trace")]
+#[macro_export]
+macro_rules! fork_trace {
+    ($($arg:tt)*) => ($crate::serial_println!($($arg)*));
+}
+
+#[cfg(not(feature = "fork-trace"))]
+#[macro_export]
+macro_rules! fork_trace {
+    ($($arg:tt)*) => {};
+}
+
 /// MSR addresses.
 const MSR_EFER: u32 = 0xC000_0080;
 const MSR_STAR: u32 = 0xC000_0081;
@@ -505,17 +522,63 @@ pub unsafe extern "C" fn syscall_dispatch(
             let user_rflags = FORK_USER_RFLAGS.load(Ordering::Relaxed);
             let user_rsp = FORK_USER_RSP.load(Ordering::Relaxed);
 
+            // #502 probe: dump the current RFLAGS at fork-dispatch entry.
+            // Expected: IF (bit 9) = 0, masked by MSR_FMASK's IF bit on
+            // SYSCALL entry. If IF is ever observed = 1 here, FMASK
+            // programming has regressed or something re-enabled IRQs
+            // before dispatch.
+            #[cfg(feature = "fork-trace")]
+            {
+                let rflags_now = x86_64::registers::rflags::read_raw();
+                crate::fork_trace!(
+                    "fork-trace: [syscall:FORK enter] parent_task={} user_rip={:#x} \
+                     user_rflags={:#x} user_rsp={:#x} kernel_rflags={:#x} IF={}",
+                    crate::task::current_id(),
+                    user_rip,
+                    user_rflags,
+                    user_rsp,
+                    rflags_now,
+                    (rflags_now >> 9) & 1,
+                );
+            }
+
             let parent_pid = crate::process::current_pid();
+            crate::fork_trace!(
+                "fork-trace: [syscall:FORK] parent_pid={} (pre-fork)",
+                parent_pid
+            );
             if parent_pid == 0 {
+                crate::fork_trace!("fork-trace: [syscall:FORK] parent_pid=0 — bailing -EPERM");
                 return -1; // not a registered process
             }
 
+            crate::fork_trace!("fork-trace: [syscall:FORK] → fork_current_task()");
             let child_task_id =
                 match crate::task::fork_current_task(user_rip, user_rflags, user_rsp) {
-                    Ok(id) => id,
-                    Err(_) => return -12, // ENOMEM
+                    Ok(id) => {
+                        crate::fork_trace!(
+                            "fork-trace: [syscall:FORK] ← fork_current_task() child_task_id={}",
+                            id
+                        );
+                        id
+                    }
+                    Err(_) => {
+                        crate::fork_trace!(
+                            "fork-trace: [syscall:FORK] ← fork_current_task() ERR=ENOMEM"
+                        );
+                        return -12; // ENOMEM
+                    }
                 };
+            crate::fork_trace!(
+                "fork-trace: [syscall:FORK] → process::register(task_id={}, parent_pid={})",
+                child_task_id,
+                parent_pid
+            );
             let child_pid = crate::process::register(child_task_id, parent_pid);
+            crate::fork_trace!(
+                "fork-trace: [syscall:FORK] ← process::register child_pid={} — returning to user",
+                child_pid
+            );
             child_pid as i64
         }
 

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -113,8 +113,18 @@ pub fn register_init(task_id: usize) {
 /// harness), the new entry starts with `session_id == pgrp_id == pid`
 /// and no controlling tty — i.e. its own session.
 pub fn register(task_id: usize, parent_pid: u32) -> u32 {
+    crate::fork_trace!(
+        "fork-trace: [process::register enter] task_id={} parent_pid={}",
+        task_id,
+        parent_pid
+    );
     let pid = NEXT_PID.fetch_add(1, Ordering::Relaxed);
+    crate::fork_trace!(
+        "fork-trace: [process::register] allocated pid={} → TABLE.lock()",
+        pid
+    );
     let mut t = TABLE.lock();
+    crate::fork_trace!("fork-trace: [process::register] TABLE locked");
     let (session_id, pgrp_id, controlling_tty) = t
         .by_pid
         .get(&parent_pid)
@@ -135,6 +145,12 @@ pub fn register(task_id: usize, parent_pid: u32) -> u32 {
         },
     );
     t.pid_of.insert(task_id, pid);
+    crate::fork_trace!(
+        "fork-trace: [process::register exit] pid={} task_id={} parent_pid={}",
+        pid,
+        task_id,
+        parent_pid
+    );
     pid
 }
 

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -139,8 +139,16 @@ pub fn fork_current_task(
     use alloc::sync::Arc;
     use spin::{Mutex, RwLock};
 
+    crate::fork_trace!(
+        "fork-trace: [fork_current_task enter] user_rip={:#x} user_rflags={:#x} user_rsp={:#x}",
+        user_rip,
+        user_rflags,
+        user_rsp
+    );
+
     // Snapshot everything needed from the current task while holding
     // SCHED, then release it before calling fork_address_space.
+    crate::fork_trace!("fork-trace: [fork_current_task] → SCHED.lock() for parent snapshot");
     let (
         parent_address_space,
         parent_fd_table,
@@ -150,6 +158,7 @@ pub fn fork_current_task(
         parent_fpu_ptr,
     ) = {
         let mut sched = SCHED.lock();
+        crate::fork_trace!("fork-trace: [fork_current_task] SCHED locked (snapshot scope)");
         let cur = sched
             .current
             .as_mut()
@@ -164,9 +173,11 @@ pub fn fork_current_task(
         // SAFETY: fpu::init ran at arch bringup; `cur` is the running task
         // so its FpuArea is the one whose live CPU state we are capturing,
         // and holding SCHED excludes any aliasing save from context_switch.
+        crate::fork_trace!("fork-trace: [fork_current_task] → fpu::save(parent)");
         unsafe {
             crate::arch::x86_64::fpu::save(&mut cur.fpu);
         }
+        crate::fork_trace!("fork-trace: [fork_current_task] ← fpu::save(parent)");
         (
             Arc::clone(&cur.address_space),
             Arc::clone(&cur.fd_table),
@@ -179,8 +190,10 @@ pub fn fork_current_task(
             &*cur.fpu as *const crate::arch::x86_64::fpu::FpuArea,
         )
     };
+    crate::fork_trace!("fork-trace: [fork_current_task] SCHED released");
 
     // CoW-clone the address space (requires AddressSpace write lock).
+    crate::fork_trace!("fork-trace: [fork_current_task] → fork_address_space()");
     let child_aspace = {
         let mut tlb = crate::mem::tlb::Flusher::new_active();
         let child = parent_address_space.write().fork_address_space(&mut tlb)?;
@@ -188,14 +201,21 @@ pub fn fork_current_task(
         child
     };
     let child_cr3 = child_aspace.page_table_frame();
+    crate::fork_trace!(
+        "fork-trace: [fork_current_task] ← fork_address_space() child_cr3={:#x}",
+        child_cr3.start_address().as_u64()
+    );
     let child_aspace = Arc::new(RwLock::new(child_aspace));
 
     // Clone the fd table (slot-independent, description-shared).
+    crate::fork_trace!("fork-trace: [fork_current_task] → clone_for_fork(fd_table)");
     let child_fd = Arc::new(Mutex::new(parent_fd_table.lock().clone_for_fork()));
+    crate::fork_trace!("fork-trace: [fork_current_task] ← clone_for_fork(fd_table)");
 
     // SAFETY: parent_fpu_ptr was snapshotted while SCHED was held; the
     // parent task is the currently-running task and cannot be removed while
     // we are executing in its syscall context (single-CPU kernel).
+    crate::fork_trace!("fork-trace: [fork_current_task] → Task::new_forked()");
     let child = unsafe {
         Task::new_forked(
             user_rip,
@@ -211,11 +231,25 @@ pub fn fork_current_task(
         )
     }?;
     let child_id = child.id;
+    crate::fork_trace!(
+        "fork-trace: [fork_current_task] ← Task::new_forked() child_id={}",
+        child_id
+    );
     let child_box = Box::new(child);
     let new_prio = child_box.priority;
+    crate::fork_trace!("fork-trace: [fork_current_task] → SCHED.lock() for push_ready");
     let mut sched = SCHED.lock();
+    crate::fork_trace!(
+        "fork-trace: [fork_current_task] SCHED locked; push_ready child_id={} prio={}",
+        child_id,
+        new_prio
+    );
     sched.push_ready(child_box);
     maybe_preempt_current_for_priority(&mut sched, new_prio);
+    crate::fork_trace!(
+        "fork-trace: [fork_current_task exit] returning child_id={}",
+        child_id
+    );
     Ok(child_id)
 }
 

--- a/kernel/src/task/switch.rs
+++ b/kernel/src/task/switch.rs
@@ -50,6 +50,86 @@ unsafe extern "C" {
     pub fn fork_child_sysret();
 }
 
+// On `fork-trace` builds we emit a tiny COM1 poke as the very first
+// instructions of `fork_child_sysret` so the captured serial log shows a
+// distinct `[C]` marker if (and only if) the child task's kernel stack
+// was successfully loaded by `context_switch` and we reached the sysret
+// trampoline. This is the one probe that cannot be a `serial_println!`
+// call — we are in a hand-written asm trampoline and must not clobber
+// the callee-saved registers (r12/rbp/rbx) that hold the SYSRETQ state.
+// The poll-TX sequence preserves every register it touches via push/pop;
+// rax, rdx, rdi are temporaries that are either about to be clobbered by
+// the existing trampoline (rax) or are not used by SYSRETQ (rdx, rdi).
+// We still push/pop them defensively so the probe is a strict no-op from
+// the user-visible-register perspective.
+#[cfg(feature = "fork-trace")]
+global_asm!(
+    r#"
+    .section .text
+    .global context_switch
+    .global task_entry_trampoline
+
+context_switch:
+    push rbx
+    push rbp
+    push r12
+    push r13
+    push r14
+    push r15
+    mov [rdi], rsp
+    mov rsp, rsi
+    mov cr3, rdx
+    pop r15
+    pop r14
+    pop r13
+    pop r12
+    pop rbp
+    pop rbx
+    ret
+
+task_entry_trampoline:
+    sti
+    call r12
+    ud2
+
+    .global fork_child_sysret
+fork_child_sysret:
+    // #502 fork-trace probe: poke COM1 with a literal 'C' so the serial
+    // log proves the child reached this trampoline. Preserves every
+    // register (push/pop) so the subsequent SYSRETQ state is untouched.
+    push rax
+    push rdx
+    push rdi
+    // Wait for UART TX-holding-register-empty (LSR.THRE, bit 5 at 0x3FD).
+    mov dx, 0x3FD
+1:  in  al, dx
+    test al, 0x20
+    jz  1b
+    // Write 'C' (0x43) to COM1 data port (0x3F8).
+    mov dx, 0x3F8
+    mov al, 0x43
+    out dx, al
+    // Also emit '\n' (0x0A) so the line appears on its own in the log.
+2:  mov dx, 0x3FD
+    in  al, dx
+    test al, 0x20
+    jz  2b
+    mov dx, 0x3F8
+    mov al, 0x0A
+    out dx, al
+    pop rdi
+    pop rdx
+    pop rax
+    // Standard fork-child SYSRETQ tail:
+    mov rcx, r12
+    mov r11, rbx
+    xor eax, eax
+    mov rsp, rbp
+    sysretq
+"#
+);
+
+#[cfg(not(feature = "fork-trace"))]
 global_asm!(
     r#"
     .section .text

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -331,14 +331,29 @@ impl Task {
         child_fd_table: alloc::sync::Arc<Mutex<crate::fs::FileDescTable>>,
         child_cwd: Option<alloc::sync::Arc<crate::fs::vfs::Dentry>>,
     ) -> Result<Self, crate::mem::addrspace::ForkError> {
+        crate::fork_trace!(
+            "fork-trace: [Task::new_forked enter] user_rip={:#x} user_rsp={:#x}",
+            user_rip,
+            user_rsp
+        );
         // Allocate a fresh guard+stack slot.
         let slot_va = NEXT_STACK_VA.fetch_add(TASK_SLOT_SIZE, Ordering::Relaxed);
         let guard_base = slot_va;
         let stack_base = slot_va + GUARD_SIZE;
+        crate::fork_trace!(
+            "fork-trace: [Task::new_forked] slot_va={:#x} guard_base={:#x} stack_base={:#x}",
+            slot_va,
+            guard_base,
+            stack_base
+        );
 
         Page::<Size4KiB>::from_start_address(VirtAddr::new(stack_base as u64))
             .expect("forked task stack base must be page aligned");
         let stack_page_count = (STACK_SIZE / 4096) as u64;
+        crate::fork_trace!(
+            "fork-trace: [Task::new_forked] → paging::map_range({} pages)",
+            stack_page_count
+        );
         let mut flusher = crate::mem::tlb::Flusher::new_active();
         // Propagate map_range failure (typically frame-allocator exhaustion)
         // as ForkError::OutOfMemory so fork() returns -ENOMEM instead of
@@ -350,6 +365,10 @@ impl Task {
             &mut flusher,
         );
         flusher.finish();
+        crate::fork_trace!(
+            "fork-trace: [Task::new_forked] ← map_range ok={}",
+            map_result.is_ok()
+        );
         map_result.map_err(|_| crate::mem::addrspace::ForkError::OutOfMemory)?;
 
         let top = stack_base + STACK_SIZE;
@@ -373,13 +392,30 @@ impl Task {
         }
 
         let id = NEXT_TASK_ID.fetch_add(1, Ordering::Relaxed);
+        crate::fork_trace!(
+            "fork-trace: [Task::new_forked] child stack primed rsp={:#x} sysret_rip={:#x} \
+             sysret_rsp={:#x} sysret_rflags={:#x} fork_child_sysret={:#x} child_id={}",
+            rsp,
+            user_rip,
+            user_rsp,
+            user_rflags,
+            fork_child_sysret as *const () as usize,
+            id
+        );
 
         // Copy the parent's FPU state into a fresh area.
+        crate::fork_trace!("fork-trace: [Task::new_forked] → copy parent FPU state");
         let mut fpu = FpuArea::new_initialized();
         unsafe {
             core::ptr::copy_nonoverlapping(parent_fpu, &mut *fpu as *mut _, 1);
         }
+        crate::fork_trace!("fork-trace: [Task::new_forked] ← copy parent FPU state");
 
+        crate::fork_trace!(
+            "fork-trace: [Task::new_forked exit] id={} syscall_stack_top={:#x}",
+            id,
+            (stack_base + STACK_SIZE) as u64
+        );
         Ok(Self {
             id,
             guard_base,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -113,6 +113,7 @@ fn main() -> R<()> {
     let fault_test = take_flag(&mut args, "--fault-test");
     let panic_test = take_flag(&mut args, "--panic-test");
     let bench = take_flag(&mut args, "--bench");
+    let fork_trace = take_flag(&mut args, "--fork-trace");
 
     let cmd = args
         .first()
@@ -125,6 +126,7 @@ fn main() -> R<()> {
         fault_test,
         panic_test,
         bench,
+        fork_trace,
     };
 
     match cmd.as_str() {
@@ -155,7 +157,7 @@ fn main() -> R<()> {
         other => {
             eprintln!("unknown subcommand: {other}");
             eprintln!(
-                "usage: cargo xtask [build|initrd|iso|run|test|test-unit|test-integration|smoke|lint|isr-audit|clean] [--release] [--fault-test] [--panic-test] [--bench]"
+                "usage: cargo xtask [build|initrd|iso|run|test|test-unit|test-integration|smoke|lint|isr-audit|clean] [--release] [--fault-test] [--panic-test] [--bench] [--fork-trace]"
             );
             std::process::exit(2);
         }
@@ -177,6 +179,10 @@ struct BuildOpts {
     fault_test: bool,
     panic_test: bool,
     bench: bool,
+    /// Compile the kernel with `--features fork-trace` to light up the
+    /// serial-print instrumentation along the fork(2) syscall path (see
+    /// `kernel/Cargo.toml`). Off by default; canary for epic #501 / #502.
+    fork_trace: bool,
 }
 
 fn workspace_root() -> PathBuf {
@@ -311,6 +317,9 @@ fn build(opts: &BuildOpts) -> R<PathBuf> {
     }
     if opts.bench {
         cmd.arg("--features").arg("bench");
+    }
+    if opts.fork_trace {
+        cmd.arg("--features").arg("fork-trace");
     }
     check(cmd.status()?)?;
     let bin = kernel_binary(opts);


### PR DESCRIPTION
Closes #502

## Summary

Instruments the entire fork(2) syscall path with paired entry/exit serial probes, guarded behind a new `fork-trace` Cargo feature so release builds ship identical code. Adds an `--fork-trace` flag to `cargo xtask` and commits a captured serial log under `docs/incident-logs/`.

This is diagnostic-only work per the scoping in epic #501 — **no structural fix**. #504 (per-task saved user context replacing `FORK_USER_*` globals) and #505 (single choke point for `syscall_stack_top` updates) remain to do the actual fix.

Probe points, in execution order:

- `syscall_dispatch` FORK arm (nr=57) — dumps saved `user_rip`/`rflags`/`rsp` and the kernel-side RFLAGS at entry so IF-mask state is captured on every fork.
- `task::fork_current_task` — every SCHED acquire/release, fpu::save, fork_address_space, fd-table clone, Task::new_forked call, push_ready.
- `task::Task::new_forked` — slot_va allocation, map_range, stack priming (with exact sysret register values), FPU copy.
- `process::register` — pid allocation, TABLE.lock.
- `task::switch::fork_child_sysret` — hand-written COM1 poll-TX in the asm trampoline that emits `C\n` **before** SYSRETQ. The one probe that cannot be a Rust call: the trampoline must preserve rcx/r11/rbx/rbp for SYSRETQ state restoration, so it is a register-preserving inline sequence behind `cfg(feature = "fork-trace")`.

## Findings

Captured at `docs/incident-logs/502-fork-trace-boot.log` (one boot, every probe firing):

1. **`kernel_rflags=0x87 IF=0`** at fork-dispatch entry — confirms `MSR_FMASK` is active and the handler runs with IRQs off as designed. Prior to this capture this was a hypothesis; it is now documented on serial.
2. Every probe fires end-to-end. Parent completes `fork_current_task` → `process::register`, the asm-level `C` marker proves the child reached `fork_child_sysret` and SYSRETQ'd to ring-3, then execve loads the hello binary and init wait4's.
3. **On this host** (native amd64, pure-TCG QEMU, no `/dev/kvm` — same as CI) the ~50% user-reported hang from #501 **did not reproduce**: 10/10 baseline boots and 10/10 fork-trace boots completed `init: fork+exec+wait ok` cleanly. The hang is therefore environment-sensitive (timing / host scheduling). The instrumentation is being landed anyway so the canary is ready when #504/#505 start touching the same surface, or when the hang reappears.

## Test plan

- [x] `cargo xtask build` (baseline, fork-trace off) — clean.
- [x] `cargo xtask build --fork-trace` — clean.
- [x] `cargo xtask test` — 281 `[ok]`, 0 failures.
- [x] `cargo xtask smoke` — all 33 markers present.
- [x] `cargo xtask iso --fork-trace` + 10 QEMU boots — all 10 boot `init: fork+exec+wait ok`, every probe present in every log.
- [x] `cargo xtask iso` (no feature) + 10 QEMU boots — 10/10 clean too (hang does not reproduce on this host).

## File-overlap discipline

Touched only files listed as safe in the task scope: `kernel/src/arch/x86_64/syscall.rs`, `kernel/src/task/task.rs`, `kernel/src/task/switch.rs`, `kernel/src/task/mod.rs`, `kernel/src/process/mod.rs`, plus `kernel/Cargo.toml`, `xtask/src/main.rs`, and a new `docs/incident-logs/` dir. No changes under `userspace/` (sibling #506) or `.github/workflows/` (sibling #507).

## Pre-existing issues noticed

- `cargo xtask lint` fails on `kernel/build.rs:109` with `clippy::manual_is_multiple_of` (the is-leap-year function). Unrelated to this PR; present on `main` at `86e696a`.
- `cargo xtask test` once timed out on `fpu_context_switch` on first run in this session, then passed on re-run. Pre-existing flake surface tracked by epic #501.
