### PR TITLE
task: single choke point for SYSCALL_KERNEL_RSP + TSS.rsp[0] on switch (#505)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -281,3 +281,7 @@ harness = false
 [[test]]
 name = "gdbstub_loop"
 harness = false
+
+[[test]]
+name = "syscall_stack_switch"
+harness = false

--- a/kernel/src/arch/x86_64/gdt.rs
+++ b/kernel/src/arch/x86_64/gdt.rs
@@ -136,3 +136,28 @@ pub fn set_tss_rsp0(stack_top: u64) {
         (*tss_ptr).privilege_stack_table[0] = VirtAddr::new(stack_top);
     }
 }
+
+/// Read the current value of `TSS.rsp[0]` directly from the live TSS
+/// struct that the CPU's TSS descriptor points at.
+///
+/// Used by the post-switch sanity check in
+/// [`crate::task::set_active_syscall_stack`] to confirm the helper's
+/// write landed in the struct the hardware will actually consult on
+/// the next ring-3 → ring-0 transition.
+pub fn tss_rsp0() -> u64 {
+    // SAFETY: same invariants as `set_tss_rsp0`'s writer side. We only
+    // read, and the CPU writes `rsp[0]` only when fetching it on a
+    // privilege change — never mid-execution here.
+    let tss_ptr: *const TaskStateSegment = &*TSS;
+    unsafe { (*tss_ptr).privilege_stack_table[0].as_u64() }
+}
+
+/// Read the atomic shadow of `TSS.rsp[0]` — the last value passed to
+/// [`set_tss_rsp0`]. Cheap; does not dereference the live TSS struct.
+///
+/// Exposed so tests and the sanity check in
+/// [`crate::task::set_active_syscall_stack`] can compare the helper's
+/// last-written value against the live TSS without an unsafe read.
+pub fn tss_rsp0_shadow() -> u64 {
+    TSS_RSP0.load(Ordering::Relaxed)
+}

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -427,6 +427,20 @@ pub fn current_priority() -> u8 {
         .unwrap_or(DEFAULT_PRIORITY)
 }
 
+/// Top of the currently-running task's dedicated SYSCALL kernel stack,
+/// or `0` for kernel-only tasks. Exposed primarily so the integration
+/// test for [`set_active_syscall_stack`] can compare against
+/// [`crate::arch::x86_64::gdt::tss_rsp0`] and confirm the two agree
+/// after a context switch.
+pub fn current_syscall_stack_top() -> u64 {
+    SCHED
+        .lock()
+        .current
+        .as_ref()
+        .map(|t| t.syscall_stack_top)
+        .unwrap_or(0)
+}
+
 fn find_priority(sched: &Scheduler, id: usize) -> Option<u8> {
     if let Some(cur) = sched.current.as_ref() {
         if cur.id == id {
@@ -646,6 +660,101 @@ pub fn replace_current_address_space(
     old // caller must drop this AFTER switching CR3
 }
 
+/// Single choke point for updating the SYSCALL/IRQ kernel-entry stack
+/// pointers on a context switch: writes both
+/// [`crate::arch::x86_64::syscall::SYSCALL_KERNEL_RSP`] (read by the
+/// `syscall_entry` trampoline on SYSCALL) and `TSS.rsp[0]` (read by the
+/// CPU on ring-3 → ring-0 interrupt or exception) from
+/// `task.syscall_stack_top`.
+///
+/// A `syscall_stack_top` of `0` means the task is kernel-only — it
+/// will never execute SYSCALL from ring-3, and leaving the previous
+/// task's stack pointers in place is harmless because nothing will
+/// consult them until the next ring-3 task is switched in.
+///
+/// # Why a helper
+///
+/// The preempt / block / exit paths each need to perform exactly this
+/// pair of writes after selecting the incoming task. Before this
+/// consolidation (issue #505) the sequence was inlined at three call
+/// sites — drift between them (e.g. a fourth switch path forgetting
+/// the update) would silently route the incoming ring-3 task's
+/// syscalls onto a previous task's kernel stack and corrupt it. Having
+/// a single named helper makes "this is how a switch updates the
+/// syscall stack" searchable and reviewable.
+///
+/// # Debug-only invariants
+///
+/// - When the task carries a non-zero `syscall_stack_top`, it must
+///   point somewhere above the task's own kernel-stack guard page —
+///   a SYSCALL entry would otherwise land on or below the guard and
+///   take a #PF (or, worse, into some other task's allocation if the
+///   value is entirely stale). Ring-3 arming is done once per task by
+///   [`arm_ring3_syscall_stack`] while the task is `current`; every
+///   subsequent switch-in passes the value through unchanged.
+/// - After the pair of writes, confirm the live TSS struct and the
+///   `SYSCALL_KERNEL_RSP` atomic both hold the value we just wrote.
+///   This catches a lost write (e.g. a mis-aimed pointer, or a future
+///   refactor that accidentally breaks the symmetry between the two
+///   writes).
+///
+/// `IA32_KERNEL_GS_BASE` is not used by the current kernel — there is
+/// no `swapgs` on the SYSCALL entry path — so the readback checks the
+/// TSS struct directly against the atomic shadow and
+/// `SYSCALL_KERNEL_RSP`. If a future ring-0 stack-swap mechanism
+/// starts using `IA32_KERNEL_GS_BASE`, add an `rdmsr` check here.
+pub(in crate::task) fn set_active_syscall_stack(task: &Task) {
+    use crate::arch::x86_64::gdt::{set_tss_rsp0, tss_rsp0, tss_rsp0_shadow};
+    use crate::arch::x86_64::syscall::SYSCALL_KERNEL_RSP;
+    use core::sync::atomic::Ordering;
+
+    let top = task.syscall_stack_top;
+
+    if top == 0 {
+        // Kernel-only task (or the bootstrap task before
+        // `arm_ring3_syscall_stack` runs). No SYSCALL stack to arm —
+        // leave the previous ring-3 task's stack pointers in place,
+        // which is harmless because a kernel-only task cannot execute
+        // SYSCALL. The scheduler will call this helper again when a
+        // ring-3 task switches back in.
+        return;
+    }
+
+    // Debug-only sanity on the source of truth: an armed ring-3 task
+    // must have been set up with a top above its own guard page. A
+    // ring-3 task whose `syscall_stack_top` sits inside (or below) its
+    // guard would SYSCALL onto the guard and take a #PF; catch that
+    // in debug rather than letting the first syscall explode.
+    debug_assert!(
+        task.guard_base == 0 || top as usize > task.guard_base,
+        "set_active_syscall_stack: task id={} syscall_stack_top ({:#x}) not above guard_base ({:#x})",
+        task.id,
+        top,
+        task.guard_base,
+    );
+
+    SYSCALL_KERNEL_RSP.store(top, Ordering::Relaxed);
+    set_tss_rsp0(top);
+
+    if cfg!(debug_assertions) {
+        let shadow = tss_rsp0_shadow();
+        let live = tss_rsp0();
+        let syscall_rsp = SYSCALL_KERNEL_RSP.load(Ordering::Relaxed);
+        debug_assert_eq!(
+            shadow, top,
+            "set_active_syscall_stack: TSS_RSP0 atomic shadow ({shadow:#x}) != helper write ({top:#x})",
+        );
+        debug_assert_eq!(
+            live, top,
+            "set_active_syscall_stack: live TSS.rsp[0] ({live:#x}) != helper write ({top:#x})",
+        );
+        debug_assert_eq!(
+            syscall_rsp, top,
+            "set_active_syscall_stack: SYSCALL_KERNEL_RSP ({syscall_rsp:#x}) != helper write ({top:#x})",
+        );
+    }
+}
+
 /// Prepare the current task to run in ring-3: configure TSS.rsp[0] and
 /// `SYSCALL_KERNEL_RSP` to point at the TOP of this task's own kernel stack
 /// so ring-3 syscalls and exceptions land on a per-task stack (not the shared
@@ -655,27 +764,21 @@ pub fn replace_current_address_space(
 /// Must be called from the task's kernel entry function (e.g.
 /// `init_ring3_entry`) *before* jumping to ring-3 with `jump_to_ring3`.
 pub fn arm_ring3_syscall_stack() {
-    use crate::arch::x86_64::gdt::set_tss_rsp0;
-    use crate::arch::x86_64::syscall::SYSCALL_KERNEL_RSP;
-    use core::sync::atomic::Ordering;
     // GUARD_SIZE=4096 and STACK_SIZE=16*1024 from task.rs (private constants;
     // replicated here to avoid visibility issues — must stay in sync with task.rs).
     const GUARD_SIZE: usize = 4096;
     const STACK_SIZE: usize = 16 * 1024;
 
-    let stack_top = {
-        let mut sched = SCHED.lock();
-        let current = sched
-            .current
-            .as_mut()
-            .expect("arm_ring3_syscall_stack: no running task");
-        let top = (current.guard_base + GUARD_SIZE + STACK_SIZE) as u64;
-        current.syscall_stack_top = top;
-        top
-    };
-    // Point the SYSCALL entry and IRQ entry stacks at the task's own stack.
-    SYSCALL_KERNEL_RSP.store(stack_top, Ordering::Relaxed);
-    set_tss_rsp0(stack_top);
+    let mut sched = SCHED.lock();
+    let current = sched
+        .current
+        .as_mut()
+        .expect("arm_ring3_syscall_stack: no running task");
+    let top = (current.guard_base + GUARD_SIZE + STACK_SIZE) as u64;
+    current.syscall_stack_top = top;
+    // Delegate to the single choke point so the switch-path helpers
+    // and the initial-arming path use exactly the same update sequence.
+    set_active_syscall_stack(current);
 }
 
 /// Install a VMA on the currently-running task. The VMA is resolved
@@ -784,7 +887,7 @@ pub fn exit() -> ! {
     // released. IrqLock cannot be used end-to-end here because the
     // guard drop would re-enable IRQs before context_switch.
     interrupts::disable();
-    let (prev_rsp_ptr, next_rsp, next_cr3, next_fpu_ptr, next_syscall_top) = {
+    let (prev_rsp_ptr, next_rsp, next_cr3, next_fpu_ptr) = {
         let mut sched = SCHED.lock();
         // Exiting the bootstrap task would reap the kernel PML4 and
         // the inherited boot stack — neither of which we own. Reject
@@ -808,8 +911,11 @@ pub fn exit() -> ! {
         let next_cr3 = next.cr3.start_address().as_u64();
         sched.current = Some(next);
         sched.current.as_mut().unwrap().slice_remaining_ms = DEFAULT_SLICE_MS;
+        // Arm SYSCALL/TSS for the incoming task's own per-task kernel
+        // stack. Done while still holding SCHED so the Task reference
+        // outlives the write.
+        set_active_syscall_stack(sched.current.as_ref().unwrap());
         let next_fpu_ptr: *const fpu::FpuArea = &*sched.current.as_ref().unwrap().fpu;
-        let next_syscall_top = sched.current.as_ref().unwrap().syscall_stack_top;
         // Enqueue the doomed task for the reaper task to drain in its
         // own context. We drop SCHED before touching REAPER_VICTIMS /
         // REAPER_WQ to keep the lock order SCHED -> REAPER_VICTIMS and
@@ -824,13 +930,7 @@ pub fn exit() -> ! {
         // `context_switch`'s single write to `prev.rsp`.
         let prev_rsp_ptr: *mut usize = &mut prev_ref.rsp as *mut usize;
         drop(victims);
-        (
-            prev_rsp_ptr,
-            next_rsp,
-            next_cr3,
-            next_fpu_ptr,
-            next_syscall_top,
-        )
+        (prev_rsp_ptr, next_rsp, next_cr3, next_fpu_ptr)
     };
     // Poke the reaper before we switch away. `notify_all` takes
     // `WaitQueue.inner` then `SCHED` (via `task::wake`); SCHED was
@@ -842,12 +942,6 @@ pub fn exit() -> ! {
     // We intentionally skip `fpu::save` — the exiting task is doomed.
     unsafe {
         fpu::restore(&*next_fpu_ptr);
-        if next_syscall_top != 0 {
-            use core::sync::atomic::Ordering;
-            crate::arch::x86_64::syscall::SYSCALL_KERNEL_RSP
-                .store(next_syscall_top, Ordering::Relaxed);
-            crate::arch::x86_64::gdt::set_tss_rsp0(next_syscall_top);
-        }
         context_switch(prev_rsp_ptr, next_rsp, next_cr3);
     }
     unreachable!("task::exit returned from context_switch");
@@ -1000,11 +1094,15 @@ pub fn preempt_tick() {
     let prev_prio = prev.priority;
     sched.current = Some(next);
     sched.current.as_mut().unwrap().slice_remaining_ms = DEFAULT_SLICE_MS;
+    // Arm SYSCALL/TSS for the incoming task's own per-task kernel
+    // stack. Done while still holding SCHED so the Task reference is
+    // valid; the helper only performs atomic / live-TSS writes and
+    // does not take any other lock.
+    set_active_syscall_stack(sched.current.as_ref().unwrap());
     // Grab a raw pointer to the incoming task's FPU area while we
     // still hold the mutable borrow; we'll dereference it after the
     // lock is dropped.
     let next_fpu_ptr: *const fpu::FpuArea = &*sched.current.as_ref().unwrap().fpu;
-    let next_syscall_top = sched.current.as_ref().unwrap().syscall_stack_top;
     sched.push_ready(prev);
     // The push above put `prev` at the back of its priority's queue;
     // retrieve the pointer through the bank to keep the Box-stability
@@ -1031,16 +1129,9 @@ pub fn preempt_tick() {
     unsafe {
         fpu::save(&mut *prev_fpu_ptr);
         fpu::restore(&*next_fpu_ptr);
-        // Update the SYSCALL/TSS stack pointer to the incoming task's
-        // own per-task kernel stack, if it has one. This prevents ring-3
-        // syscalls from the incoming task clobbering the shared INIT_KERNEL_STACK
-        // state of other tasks that are blocked mid-syscall.
-        if next_syscall_top != 0 {
-            use core::sync::atomic::Ordering;
-            crate::arch::x86_64::syscall::SYSCALL_KERNEL_RSP
-                .store(next_syscall_top, Ordering::Relaxed);
-            crate::arch::x86_64::gdt::set_tss_rsp0(next_syscall_top);
-        }
+        // Note: SYSCALL/TSS stack pointers were armed above under the
+        // SCHED lock via `set_active_syscall_stack`; see the helper for
+        // why this consolidation exists (#505).
         context_switch(prev_rsp_ptr, next_rsp, next_cr3);
     }
 }
@@ -1087,7 +1178,7 @@ pub fn block_current() {
     let was_on = interrupts::are_enabled();
     interrupts::disable();
 
-    let (prev_rsp_ptr, prev_fpu_ptr, next_fpu_ptr, next_rsp, next_cr3, next_syscall_top) = {
+    let (prev_rsp_ptr, prev_fpu_ptr, next_fpu_ptr, next_rsp, next_cr3) = {
         let mut sched = SCHED.lock();
 
         // Fast path: a prior wake() set wake_pending while we were
@@ -1124,8 +1215,11 @@ pub fn block_current() {
         let next_cr3 = next.cr3.start_address().as_u64();
         sched.current = Some(next);
         sched.current.as_mut().unwrap().slice_remaining_ms = DEFAULT_SLICE_MS;
+        // Arm SYSCALL/TSS for the incoming task's own per-task kernel
+        // stack under the SCHED lock; see `set_active_syscall_stack`
+        // for why this consolidation exists (#505).
+        set_active_syscall_stack(sched.current.as_ref().unwrap());
         let next_fpu_ptr: *const fpu::FpuArea = &*sched.current.as_ref().unwrap().fpu;
-        let next_syscall_top = sched.current.as_ref().unwrap().syscall_stack_top;
         sched.parked.insert(prev_id, prev);
 
         let prev_ref = sched
@@ -1140,14 +1234,7 @@ pub fn block_current() {
         let prev_rsp_ptr: *mut usize = &mut prev_ref.rsp as *mut usize;
         let prev_fpu_ptr: *mut fpu::FpuArea = &mut *prev_ref.fpu;
 
-        (
-            prev_rsp_ptr,
-            prev_fpu_ptr,
-            next_fpu_ptr,
-            next_rsp,
-            next_cr3,
-            next_syscall_top,
-        )
+        (prev_rsp_ptr, prev_fpu_ptr, next_fpu_ptr, next_rsp, next_cr3)
     };
 
     // SAFETY: IRQs are masked, the SCHED lock is dropped so the
@@ -1158,12 +1245,6 @@ pub fn block_current() {
     unsafe {
         fpu::save(&mut *prev_fpu_ptr);
         fpu::restore(&*next_fpu_ptr);
-        if next_syscall_top != 0 {
-            use core::sync::atomic::Ordering;
-            crate::arch::x86_64::syscall::SYSCALL_KERNEL_RSP
-                .store(next_syscall_top, Ordering::Relaxed);
-            crate::arch::x86_64::gdt::set_tss_rsp0(next_syscall_top);
-        }
         context_switch(prev_rsp_ptr, next_rsp, next_cr3);
     }
 

--- a/kernel/tests/syscall_stack_switch.rs
+++ b/kernel/tests/syscall_stack_switch.rs
@@ -1,0 +1,271 @@
+//! Integration test: the context-switch paths all route through
+//! [`task::set_active_syscall_stack`], and after every switch the live
+//! TSS.rsp[0] / `SYSCALL_KERNEL_RSP` agree with the incoming task's
+//! `syscall_stack_top`.
+//!
+//! Regression guard for issue #505 (epic #501): before consolidation
+//! the preempt / block / exit paths each carried their own inlined
+//! pair of writes to `SYSCALL_KERNEL_RSP` and `TSS.rsp[0]`. A future
+//! switch path that forgot the pair would silently land the incoming
+//! ring-3 task's SYSCALL on some other task's kernel stack. The single
+//! helper eliminates that drift risk, and this test is the teeth:
+//! spawn two workers, arm each with a distinct `syscall_stack_top`,
+//! force switches between them, and confirm the live TSS matches the
+//! current task's stack top after each switch.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+
+use vibix::arch::x86_64::gdt;
+use vibix::arch::x86_64::syscall::SYSCALL_KERNEL_RSP;
+use vibix::{
+    exit_qemu, serial_println, task,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "tss_tracks_current_task_after_switch",
+            &(tss_tracks_current_task_after_switch as fn()),
+        ),
+        (
+            "kernel_only_task_leaves_prior_stack_in_place",
+            &(kernel_only_task_leaves_prior_stack_in_place as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+// -------------------------------------------------------------------
+// Test 1: two armed workers rotate, and the live TSS / SYSCALL_KERNEL_RSP
+// always match the current task's syscall_stack_top.
+
+static A_STACK: AtomicU64 = AtomicU64::new(0);
+static B_STACK: AtomicU64 = AtomicU64::new(0);
+static A_MISMATCHES: AtomicUsize = AtomicUsize::new(0);
+static B_MISMATCHES: AtomicUsize = AtomicUsize::new(0);
+static A_SAMPLES: AtomicUsize = AtomicUsize::new(0);
+static B_SAMPLES: AtomicUsize = AtomicUsize::new(0);
+static WORKERS_DONE: AtomicUsize = AtomicUsize::new(0);
+
+const SAMPLES_PER_WORKER: usize = 200;
+
+fn worker_a() -> ! {
+    // Arm this task's dedicated SYSCALL kernel stack exactly as the
+    // init path does before `jump_to_ring3`. That populates
+    // `syscall_stack_top` in the Task struct and flows through the
+    // helper under test.
+    task::arm_ring3_syscall_stack();
+    let my_stack = task::current_syscall_stack_top();
+    A_STACK.store(my_stack, Ordering::SeqCst);
+    assert_ne!(my_stack, 0, "worker_a: arm_ring3_syscall_stack left 0");
+
+    // Hammer the scheduler: each iteration parks briefly on `hlt` so
+    // the PIT rotates us out, then on wake we confirm the live TSS
+    // and SYSCALL_KERNEL_RSP were updated to OUR stack top by the
+    // set_active_syscall_stack call in the preempt/block return path.
+    for _ in 0..SAMPLES_PER_WORKER {
+        x86_64::instructions::hlt();
+        let live = gdt::tss_rsp0();
+        let shadow = gdt::tss_rsp0_shadow();
+        let syscall_rsp = SYSCALL_KERNEL_RSP.load(Ordering::Relaxed);
+        A_SAMPLES.fetch_add(1, Ordering::SeqCst);
+        if live != my_stack || shadow != my_stack || syscall_rsp != my_stack {
+            A_MISMATCHES.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+    WORKERS_DONE.fetch_add(1, Ordering::SeqCst);
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn worker_b() -> ! {
+    task::arm_ring3_syscall_stack();
+    let my_stack = task::current_syscall_stack_top();
+    B_STACK.store(my_stack, Ordering::SeqCst);
+    assert_ne!(my_stack, 0, "worker_b: arm_ring3_syscall_stack left 0");
+
+    for _ in 0..SAMPLES_PER_WORKER {
+        x86_64::instructions::hlt();
+        let live = gdt::tss_rsp0();
+        let shadow = gdt::tss_rsp0_shadow();
+        let syscall_rsp = SYSCALL_KERNEL_RSP.load(Ordering::Relaxed);
+        B_SAMPLES.fetch_add(1, Ordering::SeqCst);
+        if live != my_stack || shadow != my_stack || syscall_rsp != my_stack {
+            B_MISMATCHES.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+    WORKERS_DONE.fetch_add(1, Ordering::SeqCst);
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn tss_tracks_current_task_after_switch() {
+    A_STACK.store(0, Ordering::SeqCst);
+    B_STACK.store(0, Ordering::SeqCst);
+    A_MISMATCHES.store(0, Ordering::SeqCst);
+    B_MISMATCHES.store(0, Ordering::SeqCst);
+    A_SAMPLES.store(0, Ordering::SeqCst);
+    B_SAMPLES.store(0, Ordering::SeqCst);
+    WORKERS_DONE.store(0, Ordering::SeqCst);
+
+    task::spawn(worker_a);
+    task::spawn(worker_b);
+
+    // Park the driver until both workers have sampled to completion
+    // or the deadline passes. Generous slack: at 100 Hz PIT and
+    // SAMPLES_PER_WORKER=200 per task plus rotation overhead, a few
+    // seconds' worth of ticks is the right order of magnitude.
+    for _ in 0..2_000 {
+        if WORKERS_DONE.load(Ordering::SeqCst) == 2 {
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+
+    let a_stack = A_STACK.load(Ordering::SeqCst);
+    let b_stack = B_STACK.load(Ordering::SeqCst);
+    let a_samples = A_SAMPLES.load(Ordering::SeqCst);
+    let b_samples = B_SAMPLES.load(Ordering::SeqCst);
+    let a_mismatches = A_MISMATCHES.load(Ordering::SeqCst);
+    let b_mismatches = B_MISMATCHES.load(Ordering::SeqCst);
+    let done = WORKERS_DONE.load(Ordering::SeqCst);
+
+    assert_eq!(done, 2, "workers did not finish sampling (done={done})");
+    assert_ne!(a_stack, 0, "worker_a never published its stack top");
+    assert_ne!(b_stack, 0, "worker_b never published its stack top");
+    assert_ne!(
+        a_stack, b_stack,
+        "workers ended up with the same syscall_stack_top ({a_stack:#x})"
+    );
+    assert_eq!(
+        a_samples, SAMPLES_PER_WORKER,
+        "worker_a sampled {a_samples} times, expected {SAMPLES_PER_WORKER}"
+    );
+    assert_eq!(
+        b_samples, SAMPLES_PER_WORKER,
+        "worker_b sampled {b_samples} times, expected {SAMPLES_PER_WORKER}"
+    );
+    assert_eq!(
+        a_mismatches, 0,
+        "worker_a saw {a_mismatches}/{a_samples} post-switch TSS/SYSCALL_KERNEL_RSP mismatches against its own stack ({a_stack:#x})"
+    );
+    assert_eq!(
+        b_mismatches, 0,
+        "worker_b saw {b_mismatches}/{b_samples} post-switch TSS/SYSCALL_KERNEL_RSP mismatches against its own stack ({b_stack:#x})"
+    );
+}
+
+// -------------------------------------------------------------------
+// Test 2: a kernel-only task (syscall_stack_top == 0) must NOT clobber
+// the TSS / SYSCALL_KERNEL_RSP with zero when switched in — the helper
+// treats `syscall_stack_top == 0` as "don't touch", keeping the prior
+// ring-3 task's stack pointers live.
+
+static ARMER_STACK: AtomicU64 = AtomicU64::new(0);
+static ARMER_READY: AtomicBool = AtomicBool::new(false);
+static KERNEL_ONLY_RAN: AtomicBool = AtomicBool::new(false);
+static TSS_DURING_KERNEL_ONLY: AtomicU64 = AtomicU64::new(0);
+static SYSCALL_RSP_DURING_KERNEL_ONLY: AtomicU64 = AtomicU64::new(0);
+
+fn armer_task() -> ! {
+    task::arm_ring3_syscall_stack();
+    ARMER_STACK.store(task::current_syscall_stack_top(), Ordering::SeqCst);
+    ARMER_READY.store(true, Ordering::SeqCst);
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn kernel_only_task() -> ! {
+    // This task NEVER calls arm_ring3_syscall_stack — its
+    // syscall_stack_top stays at 0 (kernel-only task). When the
+    // scheduler rotates us in, the helper should skip the write,
+    // leaving whatever the prior ring-3 armer stored.
+    KERNEL_ONLY_RAN.store(true, Ordering::SeqCst);
+    TSS_DURING_KERNEL_ONLY.store(gdt::tss_rsp0(), Ordering::SeqCst);
+    SYSCALL_RSP_DURING_KERNEL_ONLY
+        .store(SYSCALL_KERNEL_RSP.load(Ordering::Relaxed), Ordering::SeqCst);
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn kernel_only_task_leaves_prior_stack_in_place() {
+    ARMER_STACK.store(0, Ordering::SeqCst);
+    ARMER_READY.store(false, Ordering::SeqCst);
+    KERNEL_ONLY_RAN.store(false, Ordering::SeqCst);
+    TSS_DURING_KERNEL_ONLY.store(0, Ordering::SeqCst);
+    SYSCALL_RSP_DURING_KERNEL_ONLY.store(0, Ordering::SeqCst);
+
+    // Spawn the armer first and wait for it to publish its stack top
+    // (and therefore install it on the TSS). Only then spawn the
+    // kernel-only follower, so we know the TSS held a non-zero
+    // armer-specific value at the moment of the kernel-only switch-in.
+    task::spawn(armer_task);
+    for _ in 0..200 {
+        if ARMER_READY.load(Ordering::SeqCst) {
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+    assert!(
+        ARMER_READY.load(Ordering::SeqCst),
+        "armer task never ran / published its stack"
+    );
+    let armer_stack = ARMER_STACK.load(Ordering::SeqCst);
+    assert_ne!(armer_stack, 0, "armer stack top was still 0");
+
+    task::spawn(kernel_only_task);
+    for _ in 0..200 {
+        if KERNEL_ONLY_RAN.load(Ordering::SeqCst) {
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+    assert!(
+        KERNEL_ONLY_RAN.load(Ordering::SeqCst),
+        "kernel-only task never got the CPU"
+    );
+
+    // The kernel-only task observed live TSS/SYSCALL_KERNEL_RSP while
+    // running — both should still be whatever the armer installed,
+    // not zero.
+    let tss = TSS_DURING_KERNEL_ONLY.load(Ordering::SeqCst);
+    let syscall_rsp = SYSCALL_RSP_DURING_KERNEL_ONLY.load(Ordering::SeqCst);
+    assert_ne!(
+        tss, 0,
+        "kernel-only task observed TSS.rsp[0] == 0 after switch-in (armer stack was {armer_stack:#x})"
+    );
+    assert_ne!(
+        syscall_rsp, 0,
+        "kernel-only task observed SYSCALL_KERNEL_RSP == 0 after switch-in (armer stack was {armer_stack:#x})"
+    );
+}


### PR DESCRIPTION
Closes #505

## Summary

- Add `task::set_active_syscall_stack(&Task)` — the single choke point all context-switch paths call to point `SYSCALL_KERNEL_RSP` and `TSS.rsp[0]` at the incoming task's per-task kernel stack.
- Replace the three inlined pairs of writes (`exit`, `preempt_tick`, `block_current`) with calls to the helper. `arm_ring3_syscall_stack` also now delegates, so "first arming" and "every subsequent switch-in" share one code path.
- Debug-only invariants: `debug_assert!` the incoming top is above the task's guard page, and post-write read back TSS (atomic shadow + live struct) and `SYSCALL_KERNEL_RSP` to confirm all three agree with the helper's last write. `IA32_KERNEL_GS_BASE` isn't used by the current kernel (no swapgs on SYSCALL entry) — the readback uses the TSS struct instead, with a comment for the future swapgs case.
- `gdt::tss_rsp0()` / `tss_rsp0_shadow()` exposed for the sanity check and tests.
- New integration test `kernel/tests/syscall_stack_switch.rs`: spawns two armed workers, force-rotates them via preempt/block, and asserts `tss_rsp0 == SYSCALL_KERNEL_RSP == current_task.syscall_stack_top` after every round-trip. A second case confirms a kernel-only task (syscall_stack_top == 0) leaves the prior ring-3 stack pointers in place (the helper's early-return contract).

Per-task `syscall_stack_top` was introduced by #206 / #504; this is the "single choke point" follow-up from the epic #501 work list. The three inlined copies at mod.rs:{exit, preempt_tick, block_current} are gone.

## Test plan

- [x] `cargo xtask build`
- [x] `cargo xtask test` — all host unit tests (377) and integration tests pass; the two new `syscall_stack_switch` cases pass
- [x] `cargo xtask smoke` — all 33 markers present
- [x] `cargo fmt --all -- --check`
- [x] `init_process.rs` already routed through `arm_ring3_syscall_stack`, no change needed
- [x] `setup_ring3_stacks` in `arch/x86_64/syscall.rs` operates on the shared `INIT_KERNEL_STACK`, not per-task, so it's unchanged
