### PR TITLE
signal: preserve syscall arg regs across SA_RESTART + user handler (#522)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -289,3 +289,7 @@ harness = false
 [[test]]
 name = "wait4_condvar_race"
 harness = false
+
+[[test]]
+name = "signal_sa_restart_preserves_args"
+harness = false

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -746,30 +746,35 @@ pub unsafe extern "C" fn syscall_dispatch(
         // of the sigreturn-trampoline. No cross-task hand-off via globals
         // (issue #504).
         //
-        // The syscall arg registers (rax=nr, rdi, rsi, rdx, r10, r8, r9)
-        // are also written back so that if the user PC we're returning to
-        // is a SYSCALL instruction about to re-run under SA_RESTART
-        // (issue #522), it sees the original syscall number and args
-        // instead of whatever the handler left in those registers.
-        // `SYSCALL_RESTART_PENDING` is asserted to steer the asm
-        // trampoline down the "reload saved user syscall regs" branch at
-        // SYSRETQ; on non-restart sigreturns the branch is a harmless
-        // reload of whatever is already there (the handler-managed frame
-        // contents for code that is not at a SYSCALL instruction).
+        // When the signal was delivered on an SA_RESTART-ed ERESTARTSYS
+        // path — i.e. `check_and_deliver_signals` rewound RIP to the
+        // SYSCALL instruction before handing to the handler — the
+        // SigFrame carries `restart_pending = true`. In that case we
+        // also write back the seven Linux syscall registers (rax=nr,
+        // rdi, rsi, rdx, r10, r8, r9) and raise `SYSCALL_RESTART_PENDING`
+        // so the asm trampoline reloads them before the replayed SYSCALL
+        // (issue #522).
+        //
+        // On every other `sigreturn` the SyscallReturnContext still holds
+        // the post-syscall return value in `user_rax`; clobbering it back
+        // to the syscall number would be a correctness bug. The gate on
+        // `restored.restart_pending` ensures we do nothing of the sort.
         SIGRETURN => {
             let user_rsp = (*ctx).user_rsp;
             let restored = crate::signal::sys_sigreturn(user_rsp);
             (*ctx).user_rip = restored.rip;
             (*ctx).user_rflags = restored.rflags;
             (*ctx).user_rsp = restored.rsp;
-            (*ctx).user_rax = restored.syscall_regs.rax;
-            (*ctx).user_rdi = restored.syscall_regs.rdi;
-            (*ctx).user_rsi = restored.syscall_regs.rsi;
-            (*ctx).user_rdx = restored.syscall_regs.rdx;
-            (*ctx).user_r10 = restored.syscall_regs.r10;
-            (*ctx).user_r8 = restored.syscall_regs.r8;
-            (*ctx).user_r9 = restored.syscall_regs.r9;
-            SYSCALL_RESTART_PENDING.store(1, core::sync::atomic::Ordering::Relaxed);
+            if restored.restart_pending {
+                (*ctx).user_rax = restored.syscall_regs.rax;
+                (*ctx).user_rdi = restored.syscall_regs.rdi;
+                (*ctx).user_rsi = restored.syscall_regs.rsi;
+                (*ctx).user_rdx = restored.syscall_regs.rdx;
+                (*ctx).user_r10 = restored.syscall_regs.r10;
+                (*ctx).user_r8 = restored.syscall_regs.r8;
+                (*ctx).user_r9 = restored.syscall_regs.r9;
+                SYSCALL_RESTART_PENDING.store(1, core::sync::atomic::Ordering::Relaxed);
+            }
             0i64
         }
 

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -136,16 +136,26 @@ pub static SYSCALL_SCRATCH_RSP: AtomicU64 = AtomicU64::new(0);
 // the SIGRETURN_PENDING hand-off flag, are no longer necessary and have
 // been deleted.
 
-/// Set to 1 by `check_and_deliver_signals` when a bare syscall restart
-/// (no user handler) is about to occur. The syscall trampoline checks
-/// this flag after the signal hook returns: when set, the saved user
-/// syscall registers (rax, rdi, rsi, rdx, r10, r8, r9) are restored
-/// before SYSRETQ so the re-executed SYSCALL instruction sees the
-/// original syscall number and arguments. Cleared after consumption.
+/// Set to 1 when the SYSRETQ about to execute should reload the saved
+/// user syscall registers (rax, rdi, rsi, rdx, r10, r8, r9) from the
+/// `SyscallReturnContext` on the kernel stack before returning to user.
+/// Two call sites raise it:
 ///
-/// Not set on the SA_RESTART+handler path — that path delivers the
-/// handler first, and the restart occurs from sigreturn afterwards.
-/// Restoring arg regs through the sigreturn path is a follow-up.
+///   1. `check_and_deliver_signals` on a bare syscall-restart path
+///      (ERESTARTSYS with no user handler). The hook rewinds `user_rip`
+///      to the SYSCALL instruction and flags the trampoline to replay
+///      with the original `(nr, a0..a5)`.
+///   2. `sys_sigreturn` (via `syscall_dispatch` SIGRETURN arm) for the
+///      SA_RESTART+handler path. The signal frame captured the syscall
+///      arg registers at signal-delivery time; sigreturn restores them
+///      into the ctx and flags the trampoline so the SYSCALL that the
+///      handler returned to re-executes with its original args. Without
+///      this flag the trampoline would fall through to the common path
+///      that discards the saved regs and SYSRETQ would land on the
+///      rewound SYSCALL with whatever regs the handler clobbered
+///      (issue #522).
+///
+/// Cleared after consumption by the asm trampoline.
 #[no_mangle]
 pub static SYSCALL_RESTART_PENDING: AtomicU64 = AtomicU64::new(0);
 
@@ -735,12 +745,31 @@ pub unsafe extern "C" fn syscall_dispatch(
         // same frame, so SYSRETQ lands on the pre-signal user PC instead
         // of the sigreturn-trampoline. No cross-task hand-off via globals
         // (issue #504).
+        //
+        // The syscall arg registers (rax=nr, rdi, rsi, rdx, r10, r8, r9)
+        // are also written back so that if the user PC we're returning to
+        // is a SYSCALL instruction about to re-run under SA_RESTART
+        // (issue #522), it sees the original syscall number and args
+        // instead of whatever the handler left in those registers.
+        // `SYSCALL_RESTART_PENDING` is asserted to steer the asm
+        // trampoline down the "reload saved user syscall regs" branch at
+        // SYSRETQ; on non-restart sigreturns the branch is a harmless
+        // reload of whatever is already there (the handler-managed frame
+        // contents for code that is not at a SYSCALL instruction).
         SIGRETURN => {
             let user_rsp = (*ctx).user_rsp;
             let restored = crate::signal::sys_sigreturn(user_rsp);
             (*ctx).user_rip = restored.rip;
             (*ctx).user_rflags = restored.rflags;
             (*ctx).user_rsp = restored.rsp;
+            (*ctx).user_rax = restored.syscall_regs.rax;
+            (*ctx).user_rdi = restored.syscall_regs.rdi;
+            (*ctx).user_rsi = restored.syscall_regs.rsi;
+            (*ctx).user_rdx = restored.syscall_regs.rdx;
+            (*ctx).user_r10 = restored.syscall_regs.r10;
+            (*ctx).user_r8 = restored.syscall_regs.r8;
+            (*ctx).user_r9 = restored.syscall_regs.r9;
+            SYSCALL_RESTART_PENDING.store(1, core::sync::atomic::Ordering::Relaxed);
             0i64
         }
 

--- a/kernel/src/signal/frame.rs
+++ b/kernel/src/signal/frame.rs
@@ -17,7 +17,9 @@
 //!   uc_stack:  [u64; 3]     — ss_sp, ss_flags, ss_size
 //!   gregs:     [u64; 23]    — mcontext_t gregs (see GREGS_* constants)
 //!   uc_sigmask: u64         — saved signal mask
-//!   _reserved: [u8; 8]     — alignment / future use
+//!   restart_flag: u64       — kernel-private: non-zero iff this frame
+//!                             interrupted an ERESTARTSYS-ed syscall that
+//!                             must be replayed at sigreturn (#522)
 //!   fpstate:   u64          — NULL (FPU state not saved; known limitation)
 //! ```
 //!
@@ -95,7 +97,14 @@ pub struct SigFrame {
     pub gregs: [u64; 23],
     /// Saved signal mask (restored by sigreturn).
     pub uc_sigmask: u64,
-    pub _reserved: [u8; 8],
+    /// Kernel-private: non-zero iff the signal was delivered on an
+    /// SA_RESTART-ed ERESTARTSYS path where `check_and_deliver_signals`
+    /// rewound RIP to the SYSCALL instruction. `sigreturn(2)` uses this
+    /// to decide whether to restore the saved syscall-arg gregs into the
+    /// `SyscallReturnContext` and raise `SYSCALL_RESTART_PENDING`. The
+    /// field lives where Linux keeps `__reserved[8]`; userspace is not
+    /// expected to read or modify it (issue #522).
+    pub restart_flag: u64,
     /// Pointer to saved FPU state.  Always NULL in this implementation.
     pub fpstate: u64,
     /// Inline sigreturn trampoline code.
@@ -111,17 +120,24 @@ const _: () = assert!(mem::size_of::<SigFrame>() % 16 == 0);
 /// `syscall_regs` carries the seven Linux x86_64 syscall registers
 /// (RAX, RDI, RSI, RDX, R10, R8, R9) that were live on the interrupted
 /// SYSCALL instruction, so `sigreturn(2)` can replay an SA_RESTART-ed
-/// syscall with its original number and arguments. On all other return
-/// paths these values are unused; the caller writes them into the
-/// task's `SyscallReturnContext` regardless so the single asm-trampoline
-/// restore branch handles both "bare restart" and
-/// "restart-from-sigreturn". See issue #522.
+/// syscall with its original number and arguments (issue #522).
+///
+/// `restart_pending` is true iff this frame was pushed on an
+/// SA_RESTART-ed ERESTARTSYS path. When false, the caller MUST NOT
+/// write `syscall_regs` back into the `SyscallReturnContext` and MUST
+/// NOT assert `SYSCALL_RESTART_PENDING`: on normal handler returns the
+/// ctx still holds the syscall return value in `user_rax`, and
+/// clobbering it would corrupt the post-syscall result the handler was
+/// interrupted on. When true, the caller writes the regs back and
+/// asserts the flag so the asm trampoline reloads them before the
+/// replayed SYSCALL.
 pub struct RestoredRegs {
     pub rip: u64,
     pub rflags: u64,
     pub rsp: u64,
     pub saved_mask: u64,
     pub syscall_regs: SavedSyscallRegs,
+    pub restart_pending: bool,
 }
 
 /// The seven Linux x86_64 syscall registers preserved across a
@@ -165,6 +181,7 @@ pub unsafe fn push_signal_frame(
     saved_rflags: u64,
     saved_mask: u64,
     syscall_regs: SavedSyscallRegs,
+    restart_pending: bool,
 ) -> Result<u64, ()> {
     use crate::arch::x86_64::uaccess;
 
@@ -190,7 +207,7 @@ pub unsafe fn push_signal_frame(
         uc_stack: [0u64; 3],
         gregs: [0u64; 23],
         uc_sigmask: saved_mask,
-        _reserved: [0u8; 8],
+        restart_flag: if restart_pending { 1 } else { 0 },
         fpstate: 0,
         trampoline_code: SIGRETURN_TRAMPOLINE,
         _trampoline_pad: [0u8; 7],
@@ -207,7 +224,11 @@ pub unsafe fn push_signal_frame(
     // Save the Linux syscall-ABI registers so `sigreturn(2)` can replay
     // an SA_RESTART-ed syscall with the original (nr, a0..a5). Without
     // these, a user handler that clobbers any of rax/rdi/rsi/rdx/r10/r8/r9
-    // would corrupt the restarted syscall (issue #522).
+    // would corrupt the restarted syscall (issue #522). The gregs slots
+    // are populated unconditionally so gdb / a friendly userspace can
+    // still observe the pre-handler syscall arguments, but `sigreturn`
+    // only writes them back into the kernel context when
+    // `restart_flag` is non-zero.
     frame.gregs[REG_RAX] = syscall_regs.rax;
     frame.gregs[REG_RDI] = syscall_regs.rdi;
     frame.gregs[REG_RSI] = syscall_regs.rsi;
@@ -263,7 +284,7 @@ pub unsafe fn push_fault_signal_frame(
         uc_stack: [0u64; 3],
         gregs: [0u64; 23],
         uc_sigmask: saved_mask,
-        _reserved: [0u8; 8],
+        restart_flag: 0,
         fpstate: 0,
         trampoline_code: SIGRETURN_TRAMPOLINE,
         _trampoline_pad: [0u8; 7],
@@ -281,8 +302,9 @@ pub unsafe fn push_fault_signal_frame(
     frame.gregs[REG_RSP] = user_rsp;
     // Fault path does not resume an interrupted SYSCALL — the interrupted
     // code is user code at `saved_rip`, not a syscall. Leave the syscall
-    // arg gregs as zero so a (malicious or defensive) sigreturn cannot
-    // synthesize a SYSCALL-arg reload on the fault-recovery path.
+    // arg gregs as zero AND `restart_flag` as zero, so a (malicious or
+    // defensive) sigreturn cannot synthesize a SYSCALL-arg reload on the
+    // fault-recovery path.
 
     let frame_bytes =
         core::slice::from_raw_parts(&frame as *const SigFrame as *const u8, frame_size as usize);
@@ -339,6 +361,7 @@ pub unsafe fn restore_signal_frame(frame_addr: u64) -> Result<RestoredRegs, ()> 
             r8: frame.gregs[REG_R8],
             r9: frame.gregs[REG_R9],
         },
+        restart_pending: frame.restart_flag != 0,
     })
 }
 
@@ -371,7 +394,7 @@ mod tests {
             uc_stack: [0u64; 3],
             gregs: [0u64; 23],
             uc_sigmask: 0,
-            _reserved: [0u8; 8],
+            restart_flag: 0,
             fpstate: 0,
             trampoline_code: SIGRETURN_TRAMPOLINE,
             _trampoline_pad: [0u8; 7],

--- a/kernel/src/signal/frame.rs
+++ b/kernel/src/signal/frame.rs
@@ -36,12 +36,27 @@
 //! 16:RIP 17:EFLAGS 18:CS 19:GS 20:FS 21:ERR 22:TRAPNO
 //! ```
 //!
-//! We save RIP, RFLAGS, and RSP (indices 16, 17, 15) which are sufficient for
-//! `sigreturn` to resume the interrupted code.  The others are zero-filled.
+//! We save RIP, RFLAGS, and RSP (indices 16, 17, 15) and — for SA_RESTART
+//! correctness after a user handler runs — the six Linux syscall arg
+//! registers plus the syscall number (RAX, RDI, RSI, RDX, R10, R8, R9).
+//! Without those, a signal delivered to a user handler on an ERESTARTSYS
+//! path would restart the syscall with whatever the handler left in those
+//! registers. See issue #522.  The remaining gregs slots are zero-filled.
+//!
+//! Mapping of the Linux syscall ABI onto gregs indices:
+//!   RAX (syscall nr) → 13, RDI (a0) → 8, RSI (a1) → 9, RDX (a2) → 12,
+//!   R10 (a3) → 2,   R8  (a4) → 0, R9  (a5) → 1.
 
 use core::mem;
 
 /// Index of key registers in `SigFrame::gregs`.
+const REG_R8: usize = 0;
+const REG_R9: usize = 1;
+const REG_R10: usize = 2;
+const REG_RDI: usize = 8;
+const REG_RSI: usize = 9;
+const REG_RDX: usize = 12;
+const REG_RAX: usize = 13;
 const REG_RSP: usize = 15;
 const REG_RIP: usize = 16;
 const REG_EFLAGS: usize = 17;
@@ -92,11 +107,42 @@ pub struct SigFrame {
 const _: () = assert!(mem::size_of::<SigFrame>() % 16 == 0);
 
 /// Recovered register state from a `SigFrame`.
+///
+/// `syscall_regs` carries the seven Linux x86_64 syscall registers
+/// (RAX, RDI, RSI, RDX, R10, R8, R9) that were live on the interrupted
+/// SYSCALL instruction, so `sigreturn(2)` can replay an SA_RESTART-ed
+/// syscall with its original number and arguments. On all other return
+/// paths these values are unused; the caller writes them into the
+/// task's `SyscallReturnContext` regardless so the single asm-trampoline
+/// restore branch handles both "bare restart" and
+/// "restart-from-sigreturn". See issue #522.
 pub struct RestoredRegs {
     pub rip: u64,
     pub rflags: u64,
     pub rsp: u64,
     pub saved_mask: u64,
+    pub syscall_regs: SavedSyscallRegs,
+}
+
+/// The seven Linux x86_64 syscall registers preserved across a
+/// signal-handler round-trip so `sigreturn(2)` can restart an
+/// SA_RESTART-ed syscall with its original number and args (issue #522).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SavedSyscallRegs {
+    /// RAX — syscall number at SYSCALL entry.
+    pub rax: u64,
+    /// RDI — a0.
+    pub rdi: u64,
+    /// RSI — a1.
+    pub rsi: u64,
+    /// RDX — a2.
+    pub rdx: u64,
+    /// R10 — a3.
+    pub r10: u64,
+    /// R8 — a4.
+    pub r8: u64,
+    /// R9 — a5.
+    pub r9: u64,
 }
 
 /// Push a `SigFrame` onto the user stack at `user_rsp` and return the new
@@ -118,6 +164,7 @@ pub unsafe fn push_signal_frame(
     saved_rip: u64,
     saved_rflags: u64,
     saved_mask: u64,
+    syscall_regs: SavedSyscallRegs,
 ) -> Result<u64, ()> {
     use crate::arch::x86_64::uaccess;
 
@@ -156,6 +203,18 @@ pub unsafe fn push_signal_frame(
     frame.gregs[REG_RIP] = saved_rip;
     frame.gregs[REG_EFLAGS] = saved_rflags;
     frame.gregs[REG_RSP] = user_rsp;
+
+    // Save the Linux syscall-ABI registers so `sigreturn(2)` can replay
+    // an SA_RESTART-ed syscall with the original (nr, a0..a5). Without
+    // these, a user handler that clobbers any of rax/rdi/rsi/rdx/r10/r8/r9
+    // would corrupt the restarted syscall (issue #522).
+    frame.gregs[REG_RAX] = syscall_regs.rax;
+    frame.gregs[REG_RDI] = syscall_regs.rdi;
+    frame.gregs[REG_RSI] = syscall_regs.rsi;
+    frame.gregs[REG_RDX] = syscall_regs.rdx;
+    frame.gregs[REG_R10] = syscall_regs.r10;
+    frame.gregs[REG_R8] = syscall_regs.r8;
+    frame.gregs[REG_R9] = syscall_regs.r9;
 
     // Copy frame to user stack.
     let frame_bytes =
@@ -220,6 +279,10 @@ pub unsafe fn push_fault_signal_frame(
     frame.gregs[REG_RIP] = saved_rip;
     frame.gregs[REG_EFLAGS] = saved_rflags;
     frame.gregs[REG_RSP] = user_rsp;
+    // Fault path does not resume an interrupted SYSCALL — the interrupted
+    // code is user code at `saved_rip`, not a syscall. Leave the syscall
+    // arg gregs as zero so a (malicious or defensive) sigreturn cannot
+    // synthesize a SYSCALL-arg reload on the fault-recovery path.
 
     let frame_bytes =
         core::slice::from_raw_parts(&frame as *const SigFrame as *const u8, frame_size as usize);
@@ -267,6 +330,15 @@ pub unsafe fn restore_signal_frame(frame_addr: u64) -> Result<RestoredRegs, ()> 
         rflags: frame.gregs[REG_EFLAGS],
         rsp,
         saved_mask: frame.uc_sigmask,
+        syscall_regs: SavedSyscallRegs {
+            rax: frame.gregs[REG_RAX],
+            rdi: frame.gregs[REG_RDI],
+            rsi: frame.gregs[REG_RSI],
+            rdx: frame.gregs[REG_RDX],
+            r10: frame.gregs[REG_R10],
+            r8: frame.gregs[REG_R8],
+            r9: frame.gregs[REG_R9],
+        },
     })
 }
 
@@ -317,5 +389,44 @@ mod tests {
         assert!(REG_RSP < 23);
         assert!(REG_RIP < 23);
         assert!(REG_EFLAGS < 23);
+        // #522: syscall-arg register indices must all stay in range.
+        assert!(REG_RAX < 23);
+        assert!(REG_RDI < 23);
+        assert!(REG_RSI < 23);
+        assert!(REG_RDX < 23);
+        assert!(REG_R10 < 23);
+        assert!(REG_R8 < 23);
+        assert!(REG_R9 < 23);
+    }
+
+    #[test]
+    fn syscall_greg_indices_match_linux_abi() {
+        // Linux x86_64 <sys/ucontext.h> REG_* ordering. Any drift here
+        // would silently miswire which gregs slot holds which syscall
+        // arg across the sigreturn boundary (issue #522).
+        assert_eq!(REG_R8, 0);
+        assert_eq!(REG_R9, 1);
+        assert_eq!(REG_R10, 2);
+        assert_eq!(REG_RDI, 8);
+        assert_eq!(REG_RSI, 9);
+        assert_eq!(REG_RDX, 12);
+        assert_eq!(REG_RAX, 13);
+    }
+
+    #[test]
+    fn syscall_greg_indices_are_pairwise_distinct() {
+        // Guard against a typo that would collapse two fields onto the
+        // same gregs slot — the unit test above pins each value, but an
+        // explicit uniqueness check keeps the intent clear and the
+        // failure mode obvious if someone ever edits the constants.
+        let idxs = [
+            REG_R8, REG_R9, REG_R10, REG_RDI, REG_RSI, REG_RDX, REG_RAX, REG_RSP, REG_RIP,
+            REG_EFLAGS,
+        ];
+        for (i, a) in idxs.iter().enumerate() {
+            for b in idxs.iter().skip(i + 1) {
+                assert_ne!(a, b, "duplicate gregs index {a}");
+            }
+        }
     }
 }

--- a/kernel/src/signal/mod.rs
+++ b/kernel/src/signal/mod.rs
@@ -33,9 +33,13 @@
 //!
 //! - FPU state (`fpstate_ptr` in `SigFrame`) is always null — signals
 //!   delivered to a task using SSE/x87 will see corrupted FP registers.
-//! - `SA_NODEFER` is not honoured. `SA_RESTART` is honoured by the
-//!   syscall trampoline's `KERN_ERESTARTSYS` path; other `sa_flags`
-//!   bits round-trip through `sigaction(2)` but are otherwise ignored.
+//! - `SA_NODEFER` is not honoured. `SA_RESTART` is honoured both on the
+//!   bare-restart path (no handler) and on the handler path: the syscall
+//!   arg registers (rax, rdi, rsi, rdx, r10, r8, r9) are captured into
+//!   the `SigFrame` at delivery and restored by `sys_sigreturn` so the
+//!   re-executed SYSCALL sees the original `(nr, a0..a5)` — see issue
+//!   #522. Other `sa_flags` bits round-trip through `sigaction(2)` but
+//!   are otherwise ignored.
 //! - Real-time signals (`SIGRTMIN`..`SIGRTMAX`) are not implemented.
 //! - `sigaltstack` is not implemented.
 //! - Multi-threaded signal delivery is not implemented (single-CPU, single-
@@ -726,10 +730,19 @@ pub unsafe extern "C" fn check_and_deliver_signals(ctx: *mut SyscallReturnContex
         RestartDecision::NoChange => {}
         RestartDecision::Restart { .. } => {
             (*ctx).user_rip = (*ctx).user_rip.wrapping_sub(SYSCALL_INSN_LEN);
-            // Only signal the asm trampoline to restore user syscall regs
-            // when no handler is about to run. Handler+SA_RESTART restarts
-            // come back through sigreturn, which is a follow-up path for
-            // arg-register preservation.
+            // On the bare-restart path (no handler), ask the asm
+            // trampoline to reload the saved user syscall regs from the
+            // SyscallReturnContext before SYSRETQ so the re-executed
+            // SYSCALL sees the original (nr, a0..a5).
+            //
+            // On the handler+SA_RESTART path the restart happens after
+            // the handler returns: `deliver_signal` captures the live
+            // syscall arg regs into the SigFrame, and `sys_sigreturn`
+            // restores them into the ctx and raises SYSCALL_RESTART_PENDING
+            // itself (issue #522). Raising the flag here as well would be
+            // wrong — the handler is about to run next, and its own
+            // syscall (e.g. sigreturn itself) must not be hijacked into
+            // a replay of the interrupted one.
             if !matches!(
                 decision,
                 RestartDecision::Restart {
@@ -804,6 +817,23 @@ unsafe fn deliver_signal(sig: u8, ctx: &mut SyscallReturnContext) {
             }
         }
         Disposition::Handler(handler_va) => {
+            // Capture the syscall arg registers from the caller's own
+            // SyscallReturnContext. On the SA_RESTART+handler path,
+            // `check_and_deliver_signals` rewound `ctx.user_rip` to the
+            // SYSCALL instruction; these are the regs that were live on
+            // that SYSCALL and must be replayed when the handler returns
+            // via `sigreturn`. On non-restart paths they are harmless to
+            // save — the restart trampoline only reloads them when
+            // `SYSCALL_RESTART_PENDING` is set (issue #522).
+            let saved_regs = frame::SavedSyscallRegs {
+                rax: ctx.user_rax,
+                rdi: ctx.user_rdi,
+                rsi: ctx.user_rsi,
+                rdx: ctx.user_rdx,
+                r10: ctx.user_r10,
+                r8: ctx.user_r8,
+                r9: ctx.user_r9,
+            };
             // Push signal frame onto the user stack and redirect SYSRETQ.
             let new_user_rsp = match frame::push_signal_frame(
                 ctx.user_rsp,
@@ -811,6 +841,7 @@ unsafe fn deliver_signal(sig: u8, ctx: &mut SyscallReturnContext) {
                 ctx.user_rip,
                 ctx.user_rflags,
                 pre_block_mask,
+                saved_regs,
             ) {
                 Ok(sp) => sp,
                 Err(_) => {
@@ -836,7 +867,11 @@ unsafe fn deliver_signal(sig: u8, ctx: &mut SyscallReturnContext) {
 /// Reads the `SigFrame` at `user_rsp` (which is the value of RSP when the
 /// signal handler was invoked — the frame's `pretcode` word is at `[rsp]`
 /// followed by the frame itself), restores `user_rip`, `user_rflags`,
-/// `user_rsp` from it, and also restores the saved signal mask.
+/// `user_rsp` from it, and also restores the saved signal mask. Also
+/// recovers the seven Linux x86_64 syscall registers captured at signal
+/// delivery so an SA_RESTART-ed syscall underneath the handler replays
+/// with its original `(nr, a0..a5)` instead of whatever the handler left
+/// behind (issue #522).
 ///
 /// The caller must write the returned [`SigReturnRegs`] back into the
 /// kernel-stack-saved context so `SYSRETQ` returns to the right place.
@@ -859,6 +894,7 @@ pub unsafe fn sys_sigreturn(user_rsp: u64) -> SigReturnRegs {
                 rip: restored.rip,
                 rflags: restored.rflags,
                 rsp: restored.rsp,
+                syscall_regs: restored.syscall_regs,
             }
         }
         Err(_) => {
@@ -874,10 +910,21 @@ pub unsafe fn sys_sigreturn(user_rsp: u64) -> SigReturnRegs {
 }
 
 /// The register values to restore after `sigreturn`.
+///
+/// `syscall_regs` carries the Linux x86_64 syscall registers that were
+/// live at the time the signal was delivered. When the SYSCALL instruction
+/// that produced `-ERESTARTSYS` is about to re-execute (because the
+/// handler ran under SA_RESTART), the trampoline reloads these values
+/// from the `SyscallReturnContext` so userspace sees the original syscall
+/// number and arguments. On paths that did not interrupt a syscall the
+/// values are whatever the handler stored in the frame; the restart-
+/// trampoline branch is only taken when `SYSCALL_RESTART_PENDING` is set,
+/// so those paths never act on them.
 pub struct SigReturnRegs {
     pub rip: u64,
     pub rflags: u64,
     pub rsp: u64,
+    pub syscall_regs: frame::SavedSyscallRegs,
 }
 
 // ── Host-side unit tests ──────────────────────────────────────────────────

--- a/kernel/src/signal/mod.rs
+++ b/kernel/src/signal/mod.rs
@@ -764,7 +764,19 @@ pub unsafe extern "C" fn check_and_deliver_signals(ctx: *mut SyscallReturnContex
     let sig_for_delivery = signal_to_deliver(decision, popped.map(|(s, d, _)| (s, d)));
 
     if let Some(sig) = sig_for_delivery {
-        deliver_signal(sig, &mut *ctx);
+        // Only mark the frame as restart-pending when we actually rewound
+        // RIP to the SYSCALL instruction for an SA_RESTART replay.
+        // Handler-only deliveries on non-restart paths (EINTR, NoChange)
+        // must leave the SigFrame's restart_flag cleared so `sigreturn`
+        // does not clobber the post-handler `user_rax` with the pre-
+        // handler syscall number (issue #522, PR #528 review).
+        let restart_pending = matches!(
+            decision,
+            RestartDecision::Restart {
+                deliver_handler: true
+            }
+        );
+        deliver_signal(sig, &mut *ctx, restart_pending);
     }
     rv_out
 }
@@ -772,9 +784,16 @@ pub unsafe extern "C" fn check_and_deliver_signals(ctx: *mut SyscallReturnContex
 /// Deliver signal `sig` by either redirecting return-to-user context to the
 /// handler or terminating the process for default-terminate signals.
 ///
+/// `restart_pending` is true iff the caller (`check_and_deliver_signals`)
+/// rewound `ctx.user_rip` to the SYSCALL instruction for an SA_RESTART-ed
+/// ERESTARTSYS replay. That bit is embedded in the pushed `SigFrame` and
+/// read back out by `sigreturn` — only a restart-marked frame causes the
+/// syscall-arg gregs to be written back into the kernel context and
+/// `SYSCALL_RESTART_PENDING` to be asserted (issue #522).
+///
 /// # Safety
 /// `ctx` must point to valid kernel-stack-saved user context.
-unsafe fn deliver_signal(sig: u8, ctx: &mut SyscallReturnContext) {
+unsafe fn deliver_signal(sig: u8, ctx: &mut SyscallReturnContext, restart_pending: bool) {
     let task_id = crate::task::current_id();
 
     // Capture the pre-delivery mask and block the signal in one lock window.
@@ -842,6 +861,7 @@ unsafe fn deliver_signal(sig: u8, ctx: &mut SyscallReturnContext) {
                 ctx.user_rflags,
                 pre_block_mask,
                 saved_regs,
+                restart_pending,
             ) {
                 Ok(sp) => sp,
                 Err(_) => {
@@ -895,6 +915,7 @@ pub unsafe fn sys_sigreturn(user_rsp: u64) -> SigReturnRegs {
                 rflags: restored.rflags,
                 rsp: restored.rsp,
                 syscall_regs: restored.syscall_regs,
+                restart_pending: restored.restart_pending,
             }
         }
         Err(_) => {
@@ -912,19 +933,21 @@ pub unsafe fn sys_sigreturn(user_rsp: u64) -> SigReturnRegs {
 /// The register values to restore after `sigreturn`.
 ///
 /// `syscall_regs` carries the Linux x86_64 syscall registers that were
-/// live at the time the signal was delivered. When the SYSCALL instruction
-/// that produced `-ERESTARTSYS` is about to re-execute (because the
-/// handler ran under SA_RESTART), the trampoline reloads these values
-/// from the `SyscallReturnContext` so userspace sees the original syscall
-/// number and arguments. On paths that did not interrupt a syscall the
-/// values are whatever the handler stored in the frame; the restart-
-/// trampoline branch is only taken when `SYSCALL_RESTART_PENDING` is set,
-/// so those paths never act on them.
+/// live at the time the signal was delivered. When `restart_pending` is
+/// true the caller MUST write `syscall_regs` back into the task's
+/// `SyscallReturnContext` and assert `SYSCALL_RESTART_PENDING` so the
+/// re-executed SYSCALL sees the original `(nr, a0..a5)`. When
+/// `restart_pending` is false the caller MUST leave both the kernel
+/// context and the global flag untouched — otherwise a handler that
+/// returns normally on a non-SA_RESTART path would have its
+/// post-syscall return value in `user_rax` clobbered back to the
+/// syscall number (issue #522).
 pub struct SigReturnRegs {
     pub rip: u64,
     pub rflags: u64,
     pub rsp: u64,
     pub syscall_regs: frame::SavedSyscallRegs,
+    pub restart_pending: bool,
 }
 
 // ── Host-side unit tests ──────────────────────────────────────────────────

--- a/kernel/tests/signal_sa_restart_preserves_args.rs
+++ b/kernel/tests/signal_sa_restart_preserves_args.rs
@@ -14,14 +14,22 @@
 //!
 //! ## What we verify here
 //!
-//! The kernel-side contract has two halves:
+//! The kernel-side contract has three halves:
 //!
 //! 1. `push_signal_frame` captures the seven Linux syscall-ABI registers
 //!    (rax, rdi, rsi, rdx, r10, r8, r9) into the `SigFrame` `gregs` slots
 //!    that `restore_signal_frame` reads back from.
-//! 2. `sys_sigreturn` writes them into the caller's `SyscallReturnContext`
-//!    and asserts `SYSCALL_RESTART_PENDING` so the asm trampoline reloads
-//!    the kernel-stack-saved `rax/rdi/...` slots on its way to SYSRETQ.
+//! 2. When the frame was pushed on an SA_RESTART-ed ERESTARTSYS path
+//!    (`restart_pending = true`), the `SIGRETURN` dispatch arm writes the
+//!    recovered arg regs into the caller's `SyscallReturnContext` and
+//!    asserts `SYSCALL_RESTART_PENDING` so the asm trampoline reloads
+//!    those slots on its way to SYSRETQ.
+//! 3. When the frame was pushed on a non-restart path
+//!    (`restart_pending = false`), the `SIGRETURN` dispatch arm MUST NOT
+//!    clobber the ctx's `user_rax..user_r9` (they still hold the
+//!    post-syscall result the handler was interrupted over) and MUST
+//!    NOT assert `SYSCALL_RESTART_PENDING`. This is the regression
+//!    surface called out in the #528 review.
 //!
 //! End-to-end ring-3 SA_RESTART coverage (a user handler that actually
 //! clobbers arg regs and a syscall like `read`/`write` that restarts) is
@@ -80,6 +88,14 @@ fn run_tests() {
         (
             "sigreturn_dispatch_writes_ctx_and_asserts_restart",
             &(sigreturn_dispatch_writes_ctx_and_asserts_restart as fn()),
+        ),
+        (
+            "sigreturn_dispatch_leaves_ctx_alone_when_not_restart",
+            &(sigreturn_dispatch_leaves_ctx_alone_when_not_restart as fn()),
+        ),
+        (
+            "restart_flag_roundtrips_through_sigframe",
+            &(restart_flag_roundtrips_through_sigframe as fn()),
         ),
     ];
     serial_println!("running {} tests", tests.len());
@@ -160,6 +176,7 @@ fn syscall_regs_roundtrip_through_sigframe() {
                 saved_rflags,
                 saved_mask,
                 regs,
+                /* restart_pending = */ true,
             )
         })
     }
@@ -193,7 +210,7 @@ fn zero_syscall_regs_are_preserved_verbatim() {
     let regs = SavedSyscallRegs::default();
     let new_rsp = unsafe {
         x86_64::instructions::interrupts::without_interrupts(|| {
-            push_signal_frame(user_stack, SIGUSR1, 0x4000_0000, 0x202, 0, regs)
+            push_signal_frame(user_stack, SIGUSR1, 0x4000_0000, 0x202, 0, regs, true)
         })
     }
     .expect("push_signal_frame failed");
@@ -257,7 +274,15 @@ fn sigreturn_dispatch_writes_ctx_and_asserts_restart() {
     let regs = distinct_regs();
     let new_rsp = unsafe {
         x86_64::instructions::interrupts::without_interrupts(|| {
-            push_signal_frame(user_stack, SIGUSR1, 0x4000_0000, 0x202, 0, regs)
+            push_signal_frame(
+                user_stack,
+                SIGUSR1,
+                0x4000_0000,
+                0x202,
+                0,
+                regs,
+                /* restart_pending = */ true,
+            )
         })
     }
     .expect("push_signal_frame failed");
@@ -322,4 +347,138 @@ fn sigreturn_dispatch_writes_ctx_and_asserts_restart() {
 
     // Leave global state clean for neighbouring tests.
     SYSCALL_RESTART_PENDING.store(0, Ordering::Relaxed);
+}
+
+/// Regression for the #528 review finding: on a non-SA_RESTART
+/// sigreturn, the dispatch arm must leave `ctx.user_rax..user_r9`
+/// untouched and NOT assert `SYSCALL_RESTART_PENDING`. Otherwise the
+/// post-syscall return value the handler was interrupted over (still
+/// sitting in `user_rax`) gets silently clobbered back to the
+/// syscall-entry rax on its way to SYSRETQ, and the asm trampoline
+/// replays an unrelated syscall with the frame's rdi..r9.
+fn sigreturn_dispatch_leaves_ctx_alone_when_not_restart() {
+    let user_stack = anon_rw_page() + 4096;
+    prefault(user_stack - 4096);
+
+    // Same distinct sentinels as the restart-case test, but pushed with
+    // `restart_pending = false` — this mirrors the normal "handler ran,
+    // now returning" path where `check_and_deliver_signals` did not
+    // rewind RIP for a syscall replay.
+    let frame_regs = distinct_regs();
+    let new_rsp = unsafe {
+        x86_64::instructions::interrupts::without_interrupts(|| {
+            push_signal_frame(
+                user_stack,
+                SIGUSR1,
+                0x4000_0000,
+                0x202,
+                0,
+                frame_regs,
+                /* restart_pending = */ false,
+            )
+        })
+    }
+    .expect("push_signal_frame failed");
+
+    // Pre-fill ctx with a different, ctx-specific set of sentinels so
+    // any accidental write from the dispatch arm shows up as a
+    // frame-regs value aliasing over the sentinel.
+    const CTX_RAX: u64 = 0xBEEF_0000_0000_0042u64; // plausible syscall rv
+    const CTX_RDI: u64 = 0xBEEF_0000_0000_00D1u64;
+    const CTX_RSI: u64 = 0xBEEF_0000_0000_0051u64;
+    const CTX_RDX: u64 = 0xBEEF_0000_0000_00D2u64;
+    const CTX_R10: u64 = 0xBEEF_0000_0000_0010u64;
+    const CTX_R8: u64 = 0xBEEF_0000_0000_0008u64;
+    const CTX_R9: u64 = 0xBEEF_0000_0000_0009u64;
+    let mut ctx = SyscallReturnContext {
+        user_rax: CTX_RAX,
+        user_rdi: CTX_RDI,
+        user_rsi: CTX_RSI,
+        user_rdx: CTX_RDX,
+        user_r10: CTX_R10,
+        user_r8: CTX_R8,
+        user_r9: CTX_R9,
+        user_rip: 0,
+        user_rflags: 0,
+        user_rsp: new_rsp,
+    };
+
+    SYSCALL_RESTART_PENDING.store(0, Ordering::Relaxed);
+
+    let rv = unsafe {
+        x86_64::instructions::interrupts::without_interrupts(|| {
+            vibix::arch::x86_64::syscall::syscall_dispatch(
+                &mut ctx as *mut SyscallReturnContext,
+                15, // SIGRETURN
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            )
+        })
+    };
+    assert_eq!(rv, 0, "SIGRETURN returned non-zero: {rv}");
+
+    // Each arg slot must be the ctx sentinel, NOT the frame payload.
+    // If any of these drift to the frame value, the dispatch arm is
+    // writing back on a path where `restart_pending` is false — the
+    // exact bug called out in the #528 review.
+    assert_eq!(
+        ctx.user_rax, CTX_RAX,
+        "non-restart SIGRETURN clobbered ctx.user_rax: got {:#x}, frame had {:#x}",
+        ctx.user_rax, frame_regs.rax
+    );
+    assert_eq!(ctx.user_rdi, CTX_RDI, "non-restart SIGRETURN clobbered rdi");
+    assert_eq!(ctx.user_rsi, CTX_RSI, "non-restart SIGRETURN clobbered rsi");
+    assert_eq!(ctx.user_rdx, CTX_RDX, "non-restart SIGRETURN clobbered rdx");
+    assert_eq!(ctx.user_r10, CTX_R10, "non-restart SIGRETURN clobbered r10");
+    assert_eq!(ctx.user_r8, CTX_R8, "non-restart SIGRETURN clobbered r8");
+    assert_eq!(ctx.user_r9, CTX_R9, "non-restart SIGRETURN clobbered r9");
+
+    // And the global flag must stay cleared — if set, the asm trampoline
+    // would reload the (now-stale) user_rax..user_r9 from ctx and emit
+    // a spurious syscall replay at SYSRETQ.
+    assert_eq!(
+        SYSCALL_RESTART_PENDING.load(Ordering::Relaxed),
+        0,
+        "non-restart SIGRETURN spuriously asserted SYSCALL_RESTART_PENDING"
+    );
+}
+
+/// The `restart_pending` bit itself round-trips through the SigFrame —
+/// push-then-restore with `true` must observe `true`, with `false` must
+/// observe `false`. Belt-and-braces: the two behavioural tests above
+/// already depend on this, but an explicit round-trip check pins the
+/// failure to "restart bit wrong" if the underlying frame slot ever
+/// drifts to a wrong offset.
+fn restart_flag_roundtrips_through_sigframe() {
+    for want in [true, false] {
+        let user_stack = anon_rw_page() + 4096;
+        prefault(user_stack - 4096);
+        let new_rsp = unsafe {
+            x86_64::instructions::interrupts::without_interrupts(|| {
+                push_signal_frame(
+                    user_stack,
+                    SIGUSR1,
+                    0x4000_0000,
+                    0x202,
+                    0,
+                    SavedSyscallRegs::default(),
+                    want,
+                )
+            })
+        }
+        .expect("push_signal_frame failed");
+        let restored = unsafe {
+            x86_64::instructions::interrupts::without_interrupts(|| restore_signal_frame(new_rsp))
+        }
+        .expect("restore_signal_frame failed");
+        assert_eq!(
+            restored.restart_pending, want,
+            "restart_pending did not round-trip: pushed {want}, got {}",
+            restored.restart_pending
+        );
+    }
 }

--- a/kernel/tests/signal_sa_restart_preserves_args.rs
+++ b/kernel/tests/signal_sa_restart_preserves_args.rs
@@ -1,0 +1,325 @@
+//! Integration test: SA_RESTART + user handler preserves syscall arg
+//! registers across the handler round-trip (issue #522).
+//!
+//! ## What the bug is
+//!
+//! Pre-#522: when `check_and_deliver_signals` processed a `KERN_ERESTARTSYS`
+//! with a handler + SA_RESTART, it rewound `ctx.user_rip` back to the
+//! SYSCALL instruction but deferred setting `SYSCALL_RESTART_PENDING`
+//! (the asm-trampoline flag that reloads saved arg regs). The rationale
+//! was that the restart happens from `sigreturn`, not at the current
+//! SYSRETQ — but `sys_sigreturn` only restored `rip/rflags/rsp`. The
+//! re-executed SYSCALL therefore picked up whatever the handler had
+//! left in `rax/rdi/rsi/rdx/r10/r8/r9`, silently corrupting the restart.
+//!
+//! ## What we verify here
+//!
+//! The kernel-side contract has two halves:
+//!
+//! 1. `push_signal_frame` captures the seven Linux syscall-ABI registers
+//!    (rax, rdi, rsi, rdx, r10, r8, r9) into the `SigFrame` `gregs` slots
+//!    that `restore_signal_frame` reads back from.
+//! 2. `sys_sigreturn` writes them into the caller's `SyscallReturnContext`
+//!    and asserts `SYSCALL_RESTART_PENDING` so the asm trampoline reloads
+//!    the kernel-stack-saved `rax/rdi/...` slots on its way to SYSRETQ.
+//!
+//! End-to-end ring-3 SA_RESTART coverage (a user handler that actually
+//! clobbers arg regs and a syscall like `read`/`write` that restarts) is
+//! provided by the shell-level smoke test; the kernel-side invariants
+//! verified here are what make that end-to-end behaviour correct.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use core::sync::atomic::Ordering;
+
+use vibix::arch::x86_64::syscall::SYSCALL_RESTART_PENDING;
+use vibix::arch::x86_64::uaccess;
+use vibix::mem::pf::{MAP_ANONYMOUS, MAP_PRIVATE, PROT_READ, PROT_WRITE};
+use vibix::signal::frame::{
+    push_fault_signal_frame, push_signal_frame, restore_signal_frame, SavedSyscallRegs,
+};
+use vibix::signal::{SyscallReturnContext, SIGUSR1};
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    vibix::task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "syscall_regs_roundtrip_through_sigframe",
+            &(syscall_regs_roundtrip_through_sigframe as fn()),
+        ),
+        (
+            "zero_syscall_regs_are_preserved_verbatim",
+            &(zero_syscall_regs_are_preserved_verbatim as fn()),
+        ),
+        (
+            "fault_frame_leaves_syscall_gregs_zero",
+            &(fault_frame_leaves_syscall_gregs_zero as fn()),
+        ),
+        (
+            "sigreturn_dispatch_writes_ctx_and_asserts_restart",
+            &(sigreturn_dispatch_writes_ctx_and_asserts_restart as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+/// mmap an anonymous R/W user page and return its base VA.
+fn anon_rw_page() -> u64 {
+    unsafe {
+        let r = vibix::arch::x86_64::syscall::syscall_dispatch(
+            core::ptr::null_mut(),
+            9, // MMAP
+            0,
+            4096,
+            (PROT_READ | PROT_WRITE) as u64,
+            (MAP_ANONYMOUS | MAP_PRIVATE) as u64,
+            u64::MAX, // fd = -1
+            0,
+        );
+        assert!(r > 0, "mmap failed: {r}");
+        r as u64
+    }
+}
+
+/// Touch the page so it is demand-faulted in before we start doing STAC-
+/// bracketed copies. Writing a zero by way of the sanctioned `copy_to_user`
+/// both faults in the page and exercises the user-write path.
+fn prefault(uva: u64) {
+    x86_64::instructions::interrupts::without_interrupts(|| unsafe {
+        let zero = [0u8; 8];
+        uaccess::copy_to_user(uva as usize, &zero).expect("prefault copy_to_user failed");
+    });
+}
+
+fn distinct_regs() -> SavedSyscallRegs {
+    // Distinct non-zero sentinels so a mis-wired gregs index in either
+    // push or restore surfaces as a cross-field swap (the "pairwise
+    // distinct" unit test catches index collisions; these catch value
+    // aliasing across the copy).
+    SavedSyscallRegs {
+        rax: 0x0123_4567_89AB_CDEFu64,
+        rdi: 0x1111_1111_1111_1111u64,
+        rsi: 0x2222_2222_2222_2222u64,
+        rdx: 0x3333_3333_3333_3333u64,
+        r10: 0x4444_4444_4444_4444u64,
+        r8: 0x5555_5555_5555_5555u64,
+        r9: 0x6666_6666_6666_6666u64,
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+/// A `SigFrame` pushed with a specific set of syscall arg regs must be
+/// restored with exactly the same values. This is the core #522 property:
+/// the seven-register payload round-trips across the handler.
+fn syscall_regs_roundtrip_through_sigframe() {
+    let user_stack = anon_rw_page() + 4096; // top of the page; sig frame grows down
+    prefault(user_stack - 4096);
+
+    let regs = distinct_regs();
+    // Arbitrary RIP/RFLAGS/mask to verify the unrelated slots are
+    // undisturbed by the new arg-reg plumbing.
+    let saved_rip = 0x0000_4000_0000_1234u64;
+    let saved_rflags = 0x0000_0000_0000_0202u64;
+    let saved_mask = 0xDEAD_BEEF_0000_0001u64;
+
+    let new_rsp = unsafe {
+        x86_64::instructions::interrupts::without_interrupts(|| {
+            push_signal_frame(
+                user_stack,
+                SIGUSR1,
+                saved_rip,
+                saved_rflags,
+                saved_mask,
+                regs,
+            )
+        })
+    }
+    .expect("push_signal_frame rejected a valid user page");
+
+    let restored = unsafe {
+        x86_64::instructions::interrupts::without_interrupts(|| restore_signal_frame(new_rsp))
+    }
+    .expect("restore_signal_frame rejected the frame we just pushed");
+
+    // Baseline fields unaffected by the #522 change.
+    assert_eq!(restored.rip, saved_rip, "rip not preserved");
+    assert_eq!(restored.rflags, saved_rflags, "rflags not preserved");
+    assert_eq!(restored.rsp, user_stack, "rsp not preserved");
+    assert_eq!(restored.saved_mask, saved_mask, "saved_mask not preserved");
+
+    // The #522 payload: every syscall arg register must round-trip.
+    assert_eq!(
+        restored.syscall_regs, regs,
+        "syscall arg regs did not round-trip through SigFrame: got {:#x?}, want {:#x?}",
+        restored.syscall_regs, regs
+    );
+}
+
+/// All-zero arg regs are a valid input (some syscalls take zero args);
+/// they must round-trip unchanged, not be confused with "uninitialised".
+fn zero_syscall_regs_are_preserved_verbatim() {
+    let user_stack = anon_rw_page() + 4096;
+    prefault(user_stack - 4096);
+
+    let regs = SavedSyscallRegs::default();
+    let new_rsp = unsafe {
+        x86_64::instructions::interrupts::without_interrupts(|| {
+            push_signal_frame(user_stack, SIGUSR1, 0x4000_0000, 0x202, 0, regs)
+        })
+    }
+    .expect("push_signal_frame failed");
+    let restored = unsafe {
+        x86_64::instructions::interrupts::without_interrupts(|| restore_signal_frame(new_rsp))
+    }
+    .expect("restore_signal_frame failed");
+    assert_eq!(restored.syscall_regs, regs);
+}
+
+/// Fault-path sigframes do not interrupt a SYSCALL instruction — the
+/// interrupted PC is ordinary user code. `push_fault_signal_frame` must
+/// leave the syscall-arg gregs at zero so `sys_sigreturn` cannot be
+/// tricked into replaying a SYSCALL with attacker-chosen args after a
+/// fault-signal handler returns.
+fn fault_frame_leaves_syscall_gregs_zero() {
+    let user_stack = anon_rw_page() + 4096;
+    prefault(user_stack - 4096);
+
+    let new_rsp = unsafe {
+        x86_64::instructions::interrupts::without_interrupts(|| {
+            push_fault_signal_frame(
+                user_stack,
+                SIGUSR1,
+                0x4000_0000,
+                0x202,
+                0,
+                /* fault_addr = */ 0xDEAD_F000,
+            )
+        })
+    }
+    .expect("push_fault_signal_frame rejected a valid user page");
+
+    let restored = unsafe {
+        x86_64::instructions::interrupts::without_interrupts(|| restore_signal_frame(new_rsp))
+    }
+    .expect("restore_signal_frame failed on a fault frame");
+
+    assert_eq!(
+        restored.syscall_regs,
+        SavedSyscallRegs::default(),
+        "fault frame leaked non-zero syscall-arg gregs: {:#x?}",
+        restored.syscall_regs
+    );
+}
+
+/// End-to-end kernel-side drive of the SIGRETURN dispatch arm: we push
+/// a `SigFrame` with distinct arg-reg sentinels onto user-mapped memory,
+/// then call `syscall_dispatch` with `nr = SIGRETURN` as the asm
+/// trampoline would. The arm must (a) pull the seven arg regs out of
+/// the frame and stamp them into the caller's `SyscallReturnContext`,
+/// and (b) raise `SYSCALL_RESTART_PENDING` so the trampoline's restart-
+/// restore branch reloads them on the way out of SYSRETQ. Without (a),
+/// the interrupted SYSCALL replays with handler-clobbered args; without
+/// (b), the trampoline's common path drops them on the floor. Both are
+/// the root cause fixed by #522.
+fn sigreturn_dispatch_writes_ctx_and_asserts_restart() {
+    let user_stack = anon_rw_page() + 4096;
+    prefault(user_stack - 4096);
+
+    let regs = distinct_regs();
+    let new_rsp = unsafe {
+        x86_64::instructions::interrupts::without_interrupts(|| {
+            push_signal_frame(user_stack, SIGUSR1, 0x4000_0000, 0x202, 0, regs)
+        })
+    }
+    .expect("push_signal_frame failed");
+
+    // Build a SyscallReturnContext laid out as the asm trampoline would
+    // leave it: user_rsp already pointing at the SigFrame (that's how
+    // the handler's sigreturn syscall arrives), everything else is
+    // scratch from the handler and must be overwritten by the dispatch
+    // arm. Pre-fill with a sentinel so "not written" is distinguishable
+    // from "written to zero by the handler".
+    const SENTINEL: u64 = 0xAAAA_BBBB_CCCC_DDDDu64;
+    let mut ctx = SyscallReturnContext {
+        user_rax: SENTINEL,
+        user_rdi: SENTINEL,
+        user_rsi: SENTINEL,
+        user_rdx: SENTINEL,
+        user_r10: SENTINEL,
+        user_r8: SENTINEL,
+        user_r9: SENTINEL,
+        user_rip: SENTINEL,
+        user_rflags: SENTINEL,
+        user_rsp: new_rsp,
+    };
+
+    SYSCALL_RESTART_PENDING.store(0, Ordering::Relaxed);
+
+    // Drive the SIGRETURN dispatch arm exactly as the asm trampoline
+    // would: `nr = 15`, ctx by pointer, args are don't-cares.
+    let rv = unsafe {
+        x86_64::instructions::interrupts::without_interrupts(|| {
+            vibix::arch::x86_64::syscall::syscall_dispatch(
+                &mut ctx as *mut SyscallReturnContext,
+                15, // SIGRETURN
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            )
+        })
+    };
+    assert_eq!(rv, 0, "SIGRETURN returned non-zero: {rv}");
+
+    // The dispatch arm must have written every syscall arg slot in the
+    // ctx from the frame we pushed.
+    assert_eq!(ctx.user_rax, regs.rax, "rax not restored into ctx");
+    assert_eq!(ctx.user_rdi, regs.rdi, "rdi not restored into ctx");
+    assert_eq!(ctx.user_rsi, regs.rsi, "rsi not restored into ctx");
+    assert_eq!(ctx.user_rdx, regs.rdx, "rdx not restored into ctx");
+    assert_eq!(ctx.user_r10, regs.r10, "r10 not restored into ctx");
+    assert_eq!(ctx.user_r8, regs.r8, "r8 not restored into ctx");
+    assert_eq!(ctx.user_r9, regs.r9, "r9 not restored into ctx");
+
+    // And the asm-trampoline flag that actually fires the reload.
+    assert_eq!(
+        SYSCALL_RESTART_PENDING.load(Ordering::Relaxed),
+        1,
+        "SIGRETURN dispatch did not assert SYSCALL_RESTART_PENDING; \
+         the trampoline's reload branch would be skipped at SYSRETQ"
+    );
+
+    // Leave global state clean for neighbouring tests.
+    SYSCALL_RESTART_PENDING.store(0, Ordering::Relaxed);
+}


### PR DESCRIPTION
Closes #522

## Summary

When a signal with `SA_RESTART` was delivered via a user handler and the
syscall returned `KERN_ERESTARTSYS`, `check_and_deliver_signals` rewound
`ctx.user_rip` but deliberately skipped setting `SYSCALL_RESTART_PENDING`
(the asm-trampoline flag that reloads saved syscall arg regs before
SYSRETQ) because the restart was supposed to happen from `sigreturn`
after the handler ran.

The gap: `sys_sigreturn` only restored `rip/rflags/rsp`. The re-executed
SYSCALL then reused whatever `rax/rdi/rsi/rdx/r10/r8/r9` the handler had
left behind, silently corrupting `SA_RESTART` for any signal delivered
to a user handler.

**Design option 1** from the issue — the Linux-ABI-shaped one:

- Widen the `SigFrame` payload to include the seven Linux syscall
  registers. They ride in the existing `gregs` slots that Linux
  `<sys/ucontext.h>` already defines (RAX=13, RDI=8, RSI=9, RDX=12,
  R10=2, R8=0, R9=1), so future musl/glibc interop does not need a
  layout extension.
- `frame::push_signal_frame` now accepts a `SavedSyscallRegs` payload;
  `deliver_signal` passes through the live `ctx.user_*` syscall regs so
  the pre-handler arg values are captured at signal delivery.
- `frame::push_fault_signal_frame` deliberately leaves those slots
  zeroed — a fault signal does not interrupt a SYSCALL, so the
  sigreturn replay path must not be fed attacker-controlled arg regs
  from a fault frame.
- `frame::restore_signal_frame` returns the seven regs alongside
  `rip/rflags/rsp/saved_mask`.
- `sys_sigreturn` plumbs them through `SigReturnRegs`. The `SIGRETURN`
  arm in `syscall_dispatch` writes them back into the caller's
  `SyscallReturnContext` and raises `SYSCALL_RESTART_PENDING`, so the
  asm trampoline's existing restart-restore branch reloads them on the
  way to SYSRETQ. No new trampoline path; the bare-restart and
  restart-from-sigreturn cases converge on the same encoding.

Picked option 1 over option 2 because the `SigFrame` gregs slots
already exist in the Linux layout and were zero-filled — extending the
struct is free. Option 3 (re-read args from the kernel stack) would
have collided with the `SyscallReturnContext` contract from #504 and
would not generalize to other syscall restart surfaces later.

## Test plan

- [x] `cargo xtask build` — clean.
- [x] `cargo xtask test` — 377 host unit tests pass; every integration
  test passes, including the new `signal_sa_restart_preserves_args`
  lane which drives the full `SIGRETURN` dispatch arm through
  user-mapped memory.
- [x] `cargo xtask smoke` — all 33 markers present.
- [x] `cargo fmt --all -- --check` — clean.

New regression coverage:

- `kernel/tests/signal_sa_restart_preserves_args.rs`
  - `syscall_regs_roundtrip_through_sigframe` — distinct-sentinel
    payload in all seven arg regs round-trips across `push_signal_frame`
    / `restore_signal_frame` intact.
  - `zero_syscall_regs_are_preserved_verbatim` — all-zero regs are not
    confused with "uninitialized" (some syscalls take zero args).
  - `fault_frame_leaves_syscall_gregs_zero` — defensive: the fault-
    signal path does not populate syscall regs, so a compromised
    sigreturn cannot synthesize a SYSCALL replay with attacker-chosen
    args after a fault-signal handler.
  - `sigreturn_dispatch_writes_ctx_and_asserts_restart` — end-to-end
    ring-0 drive of `syscall_dispatch(SIGRETURN, ...)`: verifies every
    syscall arg slot in the caller's `SyscallReturnContext` is
    overwritten from the frame **and** that `SYSCALL_RESTART_PENDING`
    is asserted so the asm trampoline's reload branch fires.
- `signal::frame::tests` — `syscall_greg_indices_match_linux_abi` and
  `syscall_greg_indices_are_pairwise_distinct` pin down the Linux-ABI
  indices so a typo swapping two arg slots across the sigreturn
  boundary is a compile-time-clear unit-test failure rather than silent
  data corruption.