### PR TITLE
ci: add repro-fork-build build-only xtask for smoke-soak pre-build (#526)

### DIFF
--- a/.github/workflows/smoke-soak.yml
+++ b/.github/workflows/smoke-soak.yml
@@ -221,16 +221,21 @@ jobs:
 
       # Pre-build the kernel + reproducer ISO once up front so each
       # per-run iteration only pays the QEMU-boot cost, not the
-      # build cost. `cargo xtask repro-fork` is a no-op rebuild when
-      # the artifacts are already current, but an explicit pre-build
-      # here also surfaces build failures in their own step rather
-      # than charged against run 1's pass/fail accounting.
+      # build cost. `cargo xtask repro-fork-build` is the build-only
+      # variant of `repro-fork` — it compiles the kernel, the
+      # reproducer init binary, and assembles the ISO, then exits
+      # without booting QEMU. Using the full `repro-fork` subcommand
+      # here would also run the harness in the Pre-build step, which
+      # defeats the whole point of having a dedicated 100× soak loop
+      # below — a first-boot flake in Pre-build would skip the loop
+      # entirely (see issue #526, run 24593451935).
       - name: Pre-build reproducer ISO
-        run: cargo xtask repro-fork
-        # One full run costs ~15-60 s on a clean kernel; even with the
-        # flake-hit 60 s heartbeat watchdog it stays under the outer
-        # SOAK_RUN_TIMEOUT_SECS. Done here so the first iteration of
-        # the loop below sees warm artifacts.
+        run: cargo xtask repro-fork-build
+        # The build step finishes well under 10 min on a cold cache
+        # and near-instantly when the cargo + limine caches are warm.
+        # The 20 min cap is belt-and-suspenders headroom for a fully
+        # cold runner; the step does not boot QEMU, so it cannot
+        # stall on a kernel-side flake.
         timeout-minutes: 20
 
       - name: Run smoke soak

--- a/docs/repros/fork-loop.md
+++ b/docs/repros/fork-loop.md
@@ -35,6 +35,26 @@ scripts/repro-fork.sh
 scripts/repro-fork.sh --runs 20   # local soak — fails fast on first hang
 ```
 
+### Build-only variant
+
+```
+cargo xtask repro-fork-build
+```
+
+Compiles the kernel, the `userspace_repro_fork` binary, and the
+reproducer ISO — the same artifacts as `repro-fork` — but exits
+without booting QEMU.  Use this when you want to warm the build
+artifacts and catch compile errors without also exercising the
+harness.
+
+The `smoke-soak` workflow uses `repro-fork-build` for its "Pre-build
+reproducer ISO" step.  Driving `repro-fork` there instead would run
+the full harness during pre-build and, if the first boot flaked,
+would prevent the 100× soak loop below from executing at all
+(see issue #526, workflow run 24593451935).  `repro-fork-build` has
+no QEMU dependency, so it cannot fail for flake reasons — any failure
+is a genuine build error.
+
 Success: a final `repro: fork loop complete cycles=500` line and QEMU
 exits 0.  Failure: any of —
 

--- a/docs/repros/fork-loop.md
+++ b/docs/repros/fork-loop.md
@@ -37,7 +37,7 @@ scripts/repro-fork.sh --runs 20   # local soak — fails fast on first hang
 
 ### Build-only variant
 
-```
+```bash
 cargo xtask repro-fork-build
 ```
 

--- a/scripts/repro-fork.sh
+++ b/scripts/repro-fork.sh
@@ -12,6 +12,14 @@
 #   2. forward its serial log verbatim to the caller's stdout,
 #   3. exit non-zero on any stall/panic/failure detected by xtask.
 #
+# Artifact reuse: the per-run path delegates to `cargo xtask
+# repro-fork`, which internally calls the same build helpers as
+# `cargo xtask repro-fork-build`.  On a warm workspace cargo no-ops
+# the compile step and the ISO is reassembled from already-built
+# inputs — the 100× smoke-soak in CI pre-warms via `repro-fork-build`
+# before this script is called, so the per-iteration cost is dominated
+# by QEMU boot time, not rebuild time (issue #526).
+#
 # Usage:
 #   scripts/repro-fork.sh                 # single run
 #   scripts/repro-fork.sh --runs N        # N sequential runs; fail on

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1760,8 +1760,17 @@ harness = false
             source.contains("\"repro-fork-build\" =>"),
             "main() must dispatch \"repro-fork-build\""
         );
+        // CodeRabbit on PR #529: a bare `contains("repro-fork-build")`
+        // check always passes because the dispatcher arm, comments,
+        // and this very test all contain that substring.  Pin the
+        // assertion to the literal usage banner so a future edit that
+        // drops the token from the `eprintln!` arm actually fails.
         assert!(
-            source.contains("repro-fork-build"),
+            source.contains(
+                "usage: cargo xtask [build|initrd|iso|run|test|test-unit|\
+                 test-integration|smoke|repro-fork|repro-fork-build|lint|\
+                 isr-audit|clean]"
+            ),
             "usage string must list repro-fork-build"
         );
     }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -9,6 +9,8 @@
 //!   test-runner   — (internal) boot a pre-built test kernel ELF in QEMU
 //!   smoke         — boot the kernel and assert on expected serial markers
 //!   repro-fork    — boot with the fork-loop reproducer harness as PID 1 (issue #506)
+//!   repro-fork-build — build-only variant of `repro-fork`: warm kernel + ISO
+//!                      without booting QEMU (issue #526, for CI pre-build)
 //!   lint          — run clippy on xtask (host) and vibix (kernel, no_std)
 //!   isr-audit     — scan ISR-reachable files for blocking-lock regressions
 //!   clean         — remove build artifacts
@@ -149,6 +151,9 @@ fn main() -> R<()> {
         }
         "smoke" => smoke(&opts)?,
         "repro-fork" => repro_fork(&opts)?,
+        "repro-fork-build" => {
+            repro_fork_build(&opts)?;
+        }
         "lint" => lint()?,
         "isr-audit" => isr_audit::run(&workspace_root())?,
         "initrd" => {
@@ -159,7 +164,7 @@ fn main() -> R<()> {
         other => {
             eprintln!("unknown subcommand: {other}");
             eprintln!(
-                "usage: cargo xtask [build|initrd|iso|run|test|test-unit|test-integration|smoke|repro-fork|lint|isr-audit|clean] [--release] [--fault-test] [--panic-test] [--bench] [--fork-trace]"
+                "usage: cargo xtask [build|initrd|iso|run|test|test-unit|test-integration|smoke|repro-fork|repro-fork-build|lint|isr-audit|clean] [--release] [--fault-test] [--panic-test] [--bench] [--fork-trace]"
             );
             std::process::exit(2);
         }
@@ -1170,6 +1175,39 @@ fn smoke(opts: &BuildOpts) -> R<()> {
     }
 }
 
+/// Warm the reproducer ISO without booting QEMU.  Issue #526.
+///
+/// Builds the kernel, the `userspace_repro_fork` binary, and the ISO
+/// that ships the reproducer as `/boot/userspace_init.elf`.  Returns
+/// the path to the completed ISO.
+///
+/// This is the build-only half of `repro_fork`.  It exists so that CI
+/// can warm the artifacts (and catch build-step failures) in a distinct
+/// workflow step, without also paying for a full QEMU run.  The 100×
+/// smoke-soak workflow drives one `scripts/repro-fork.sh` boot per
+/// iteration; without this split, the "Pre-build" step ended up running
+/// the full harness and any first-boot flake prevented the soak loop
+/// from executing (run 24593451935).
+///
+/// After this returns successfully, a subsequent `cargo xtask
+/// repro-fork` (or `scripts/repro-fork.sh`) on the same workspace will
+/// find every upstream artifact warm — cargo no-ops, the ISO staging
+/// directory is re-assembled from already-built inputs, and the run
+/// cost collapses to QEMU boot time.
+fn repro_fork_build(opts: &BuildOpts) -> R<PathBuf> {
+    // Build the kernel and the reproducer init binary, then assemble
+    // an ISO with the reproducer substituted for userspace_init.elf.
+    let kernel = build(opts)?;
+    let repro_init = build_userspace_repro_fork()?;
+    let iso = workspace_root().join("target").join("vibix-repro-fork.iso");
+    make_iso_with_init(&kernel, &repro_init, &iso, "iso_repro_fork")?;
+    // Also ensure the test disk is present so the per-run boot path
+    // doesn't need to regenerate it.  `ensure_test_disk` is idempotent.
+    ensure_test_disk()?;
+    println!("→ repro-fork iso: {}", iso.display());
+    Ok(iso)
+}
+
 /// Build + boot the fork-loop reproducer ISO under QEMU with a
 /// heartbeat-aware watchdog.  Issue #506 / epic #501.
 ///
@@ -1214,13 +1252,11 @@ fn repro_fork(opts: &BuildOpts) -> R<()> {
         "repro: harness panic",
     ];
 
-    // Build the kernel and the reproducer init binary, then assemble
-    // an ISO with the reproducer substituted for userspace_init.elf.
-    let kernel = build(opts)?;
-    let repro_init = build_userspace_repro_fork()?;
-    let iso = workspace_root().join("target").join("vibix-repro-fork.iso");
-    make_iso_with_init(&kernel, &repro_init, &iso, "iso_repro_fork")?;
-    println!("→ repro-fork iso: {}", iso.display());
+    // Build the kernel, the reproducer init binary, and the ISO.
+    // Delegating to `repro_fork_build` keeps the build-only subcommand
+    // and the full-harness subcommand on the exact same build path —
+    // no drift risk between them.
+    let iso = repro_fork_build(opts)?;
 
     let disk = ensure_test_disk()?;
     let mut child = Command::new("qemu-system-x86_64")
@@ -1630,5 +1666,103 @@ harness = false
                 "skiplist entry {skipped} must not appear in runner list"
             );
         }
+    }
+
+    /// Issue #526: `repro-fork-build` must be a pure build subcommand.
+    /// If it ever grows a QEMU invocation, the smoke-soak Pre-build
+    /// step would regress to the full-harness behavior that prompted
+    /// this split in the first place.  We can't execute the subcommand
+    /// from a host unit test (it drives cargo against a custom
+    /// target), so we enforce the contract by inspecting its source.
+    #[test]
+    fn repro_fork_build_does_not_invoke_qemu() {
+        let source =
+            std::fs::read_to_string(workspace_root().join("xtask").join("src").join("main.rs"))
+                .expect("read xtask main.rs");
+
+        // Locate the `fn repro_fork_build` body.  The function opens
+        // with `fn repro_fork_build(` and its body runs until the
+        // next top-level `fn ` declaration.  This is brittle against
+        // drastic reformatting but catches the bug we care about —
+        // "someone added a qemu-system-x86_64 call" — with zero
+        // false positives on the current source.
+        let start = source
+            .find("fn repro_fork_build(")
+            .expect("repro_fork_build must exist");
+        let after_start = &source[start..];
+        let body_start = after_start
+            .find('{')
+            .expect("repro_fork_build must have a body");
+        let search_region = &after_start[body_start..];
+        // Find the matching close brace by brace-counting.
+        let mut depth = 0i32;
+        let mut end = None;
+        for (i, ch) in search_region.char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        end = Some(i + 1);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        let body = &search_region[..end.expect("balanced braces")];
+
+        for forbidden in &["qemu-system-x86_64", "qemu_system_x86_64"] {
+            assert!(
+                !body.contains(forbidden),
+                "repro_fork_build body must not contain `{forbidden}` \
+                 (build-only contract, issue #526)"
+            );
+        }
+
+        // The repro-fork full-harness path is the one thing this
+        // helper must never reach into — that path is what boots
+        // QEMU.  Calling it would undo the whole split.  Check for
+        // a call to `repro_fork(` at an identifier boundary so we
+        // don't false-positive on `build_userspace_repro_fork()`.
+        let mut prev: Option<char> = None;
+        let mut hit = false;
+        for (i, ch) in body.char_indices() {
+            if body[i..].starts_with("repro_fork(") {
+                let is_boundary = match prev {
+                    None => true,
+                    Some(c) => !(c.is_alphanumeric() || c == '_'),
+                };
+                if is_boundary {
+                    hit = true;
+                    break;
+                }
+            }
+            prev = Some(ch);
+        }
+        assert!(
+            !hit,
+            "repro_fork_build body must not call `repro_fork(` \
+             (build-only contract, issue #526)"
+        );
+    }
+
+    /// Issue #526: the `repro-fork-build` subcommand must be wired
+    /// into both the dispatcher and the usage string, otherwise CI's
+    /// `cargo xtask repro-fork-build` call would hit the "unknown
+    /// subcommand" arm.
+    #[test]
+    fn repro_fork_build_subcommand_is_registered() {
+        let source =
+            std::fs::read_to_string(workspace_root().join("xtask").join("src").join("main.rs"))
+                .expect("read xtask main.rs");
+        assert!(
+            source.contains("\"repro-fork-build\" =>"),
+            "main() must dispatch \"repro-fork-build\""
+        );
+        assert!(
+            source.contains("repro-fork-build"),
+            "usage string must list repro-fork-build"
+        );
     }
 }


### PR DESCRIPTION
Closes #526

## Summary

- Add `cargo xtask repro-fork-build`: the build-only half of `repro-fork` that warms the kernel, the reproducer init binary, and the ISO but does not boot QEMU.
- Point the `smoke-soak` workflow's "Pre-build reproducer ISO" step at the new subcommand so the 100× soak loop is no longer skipped when a Pre-build boot flakes (run `24593451935`).
- Refactor `repro_fork` to delegate to the new `repro_fork_build` helper so the build-only and full-harness paths stay in lockstep.
- Update `docs/repros/fork-loop.md` and `scripts/repro-fork.sh` header comment to document the two invocations.

## Why

`cargo xtask repro-fork` boots QEMU and runs the full fork+exec+wait harness. That is the right thing for one soak iteration; it is the wrong thing for a "warm the build cache" step. The first manual `workflow_dispatch` run on `main` hit the residual fork flake in Pre-build, the step failed at ~14983 cycles, and the 100× soak loop never executed. After this PR the Pre-build step cannot fail for flake reasons — it has no QEMU dependency.

## Test plan

- [x] `cargo test --package xtask` — 28 passed (27 pre-existing + 2 new).
- [x] `cargo xtask build` — clean.
- [x] `cargo xtask smoke` — all 33 markers present.
- [x] `cargo xtask test` — passes on retry (`wait4_condvar_race` tripped the 30 s host timeout once on this busy workstation; kernel side not touched by this PR; CI's timing is steadier).
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --package xtask --all-targets -- -D warnings` — clean.
- [x] `time cargo xtask repro-fork-build` — cold: 81 s on this host; warm: 1.8 s. Regression budget is <60 s warm.
- [x] Static check `repro_fork_build_does_not_invoke_qemu` asserts the helper body never contains `qemu-system-x86_64` and never calls `repro_fork(` at an identifier boundary.
- [x] Static check `repro_fork_build_subcommand_is_registered` asserts the dispatcher arm and the usage string both list `repro-fork-build`.

## Out-of-scope / deferred

- Residual fork/exec/wait flake (tracked in #527) is unchanged.
- `scripts/repro-fork.sh` still delegates to `cargo xtask repro-fork` per iteration — the rebuild portion is a cargo no-op when the workspace was pre-warmed by `repro-fork-build`, so the per-run cost is dominated by QEMU boot. Leaving this as-is is intentional to keep the script a thin shim (see inline header comment).

## Bonus validation plan

After merge: trigger `smoke-soak` with `count=3` via `workflow_dispatch` on `main` and confirm Pre-build completes quickly and all 3 soak runs execute. If Pre-build still runs the harness, the fix didn't take and needs investigation.