### PR TITLE
userspace/init: pre/post-write diagnostic markers around first write(1)

### DIFF
--- a/userspace/init/src/main.rs
+++ b/userspace/init/src/main.rs
@@ -61,9 +61,33 @@ const HELLO_MSG: &[u8] = b"init: hello from pid 1\n";
 /// Emitted after the parent collects the child's exit status.
 const DONE_MSG: &[u8] = b"init: fork+exec+wait ok\n";
 
+/// Diagnostic marker for #484 / #527. Emitted on fd=2 as the very first
+/// userspace action — i.e. after `iretq` into ring 3 but before the first
+/// `write(1, HELLO_MSG)`. If the kernel-side `ring3-iretq:` marker fires but
+/// this one doesn't, the first SYSCALL instruction or the entry trampoline
+/// silently faulted before the handler ran. If this fires but
+/// `init: hello from pid 1` doesn't, the failure is specific to the fd=1
+/// write path, not ring-3 entry.
+const PRE_WRITE_MSG: &[u8] = b"init: pre-write marker\n";
+
+/// Diagnostic marker for #484 / #527. Emitted on fd=1 immediately after the
+/// first `write(1, HELLO_MSG)` returns. If `init: hello from pid 1` fires
+/// but this marker doesn't, the write syscall return path (SYSRET / restore
+/// of user context) is the culprit, not the write itself.
+const POST_WRITE_MSG: &[u8] = b"init: post-write marker\n";
+
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
+    // Pre-write diagnostic marker — see #484 / #527. Emitted on fd=2 so it
+    // exercises the syscall path but writes to a distinct stream from
+    // HELLO_MSG, making it easy to grep from the serial log.
+    write(2, PRE_WRITE_MSG);
+
     write(1, HELLO_MSG);
+
+    // Post-write diagnostic marker — see #484 / #527. Emitted immediately
+    // after the first `write(1, HELLO_MSG)` returns, before any further work.
+    write(1, POST_WRITE_MSG);
 
     // fork() — child PID returned to parent; 0 returned to child.
     let fork_ret: i64;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -101,7 +101,17 @@ const SMOKE_MARKERS: &[&str] = &[
     // `ring3-first-fault:` diagnostic line emitted by the IDT fault
     // handlers in that case).
     "ring3-iretq: rip=",
+    // #484 diagnostic: emitted from `_start` before the first
+    // `write(1, HELLO_MSG)`. If `ring3-iretq:` fires but this doesn't, the
+    // first SYSCALL instruction or the entry trampoline silently faulted
+    // before the syscall handler ran — not a fd=1 write bug.
+    "init: pre-write marker",
     "init: hello from pid 1",
+    // #484 diagnostic: emitted immediately after the first
+    // `write(1, HELLO_MSG)` returns. If `init: hello from pid 1` fires but
+    // this doesn't, the write syscall return path (SYSRET / user-context
+    // restore) is the culprit, not the write itself.
+    "init: post-write marker",
 ];
 
 /// Markers for the fork+exec+wait flow. These are flakey under un-accelerated


### PR DESCRIPTION
Closes #484

## Summary

Bracket `init::_start`'s first `write(1, HELLO_MSG)` with two new diagnostic markers, both routed through the existing direct-syscall `write()` helper so they exercise the identical syscall path:

- `init: pre-write marker` — emitted on fd=2 as the very first userspace action, before the first `write(1, HELLO_MSG)`.
- `init: post-write marker` — emitted on fd=1 immediately after the first HELLO_MSG write returns, before any further work.

Both markers are registered in `xtask::SMOKE_MARKERS` so a CI run that loses any of them fails smoke.

Together with the existing kernel-side `init: iretq to ring-3` / `ring3-iretq: rip=...` markers and the userspace `init: hello from pid 1`, the four-marker bracket localises a failure to a specific step on the ring-3 entry + first-syscall path:

| Present | Absent | What's broken |
|---|---|---|
| `ring3-iretq:` | `init: pre-write marker` | First SYSCALL instruction or entry trampoline silently faulted before the syscall handler ran. |
| `init: pre-write marker` | `init: hello from pid 1` | Specific to the fd=1 write path (or the state between the two writes), not ring-3 entry. |
| `init: hello from pid 1` | `init: post-write marker` | Write syscall return path (SYSRET / user-context restore) is the culprit, not the write itself. |

This is split 1/2 of the #478 P0 smoke flake triage, and directly useful for narrowing the residual epic-#501 flake tracked in #527 (`ring3-first-fault: #PF rip=0x4002c6 cr2=0x7fffff0c`).

No behavioral change beyond the two extra `write()` calls.

## Test plan

- [x] `cargo xtask build` — succeeds.
- [x] `cargo test -p xtask` — 28/28 passing; `smoke_markers_satisfied_only_when_every_hard_marker_seen` still green with the two new entries.
- [x] `cargo xtask test` — full host + QEMU integration lane passing.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo xtask smoke` locally — `init: pre-write marker` fires as expected; local run trips #527 on the subsequent `write(1, HELLO_MSG)` (which is exactly what the new markers are designed to localise). On CI with KVM the flake rate is far lower; retry via `gh run rerun <id> --failed` if the run trips the known #527 flake.
- [ ] CI green on `fmt + build`, `host unit tests`, `integration tests (QEMU)`, `smoke test`.
- [ ] `100× smoke soak` reports SKIPPED on `pull_request` (#519 gate).