### PR TITLE
userspace: declare full SysV clobber set across every syscall (fixes #531 soak HARD_CAP)

### DIFF
--- a/userspace/hello/src/main.rs
+++ b/userspace/hello/src/main.rs
@@ -4,7 +4,11 @@
 //! address space. Writes a marker to stdout (serial fd 1) and exits with
 //! status 0 so the parent's waitpid() can verify the exit code.
 //!
-//! Uses the same Linux x86_64 syscall ABI as the init binary.
+//! Uses the same Linux x86_64 syscall ABI as the init binary.  See
+//! `userspace/init/src/main.rs` for the full clobber rationale — the
+//! vibix kernel does not preserve `rdi`/`rsi`/`rdx`/`r8`/`r9`/`r10`
+//! across a syscall, so every asm block below declares the full SysV
+//! caller-saved GPR set as `inlateout`/`lateout` (issue #531).
 
 #![no_std]
 #![no_main]
@@ -19,11 +23,14 @@ pub extern "C" fn _start() -> ! {
     unsafe {
         core::arch::asm!(
             "syscall",
-            in("rax") 1u64,
-            in("rdi") 1u64,
-            in("rsi") MSG.as_ptr() as u64,
-            in("rdx") MSG.len() as u64,
+            inlateout("rax") 1u64 => _,
+            inlateout("rdi") 1u64 => _,
+            inlateout("rsi") MSG.as_ptr() as u64 => _,
+            inlateout("rdx") MSG.len() as u64 => _,
             lateout("rcx") _,
+            lateout("r8") _,
+            lateout("r9") _,
+            lateout("r10") _,
             lateout("r11") _,
             options(nostack, preserves_flags),
         );
@@ -32,9 +39,14 @@ pub extern "C" fn _start() -> ! {
     unsafe {
         core::arch::asm!(
             "syscall",
-            in("rax") 60u64,
-            in("rdi") 0u64,
+            inlateout("rax") 60u64 => _,
+            inlateout("rdi") 0u64 => _,
             lateout("rcx") _,
+            lateout("rdx") _,
+            lateout("rsi") _,
+            lateout("r8") _,
+            lateout("r9") _,
+            lateout("r10") _,
             lateout("r11") _,
             options(nostack, preserves_flags),
         );

--- a/userspace/init/src/main.rs
+++ b/userspace/init/src/main.rs
@@ -13,6 +13,19 @@
 //! - rcx and r11 are clobbered by SYSCALL/SYSRET
 //! - Return value in rax
 //!
+//! ### Kernel-side register clobbers — see issue #531
+//!
+//! The vibix kernel's SYSCALL trampoline does **not** preserve the user
+//! values of `rdi`, `rsi`, `rdx`, `r8`, `r9`, or `r10` across a
+//! syscall.  After `syscall_entry` pushes them for restart handling and
+//! calls the Rust `syscall_dispatch` (SysV C ABI), the dispatcher is
+//! free to use them as scratch; the SYSRETQ path only restores `rcx`
+//! and `r11`.  Every syscall block below therefore declares **all**
+//! SysV caller-saved GPRs as `inlateout`/`lateout` — missing any of
+//! them silently lets the compiler cache dead values across the
+//! syscall and produces incorrect behavior (caught in #531 after a
+//! loop counter in `r8` never incremented in the repro-fork harness).
+//!
 //! ## Syscall numbers and argument layout (pinned — do not renumber)
 //!
 //! These must stay in sync with the `match nr` arms in
@@ -72,6 +85,12 @@ pub extern "C" fn _start() -> ! {
             "syscall",
             inlateout("rax") 57u64 => fork_ret,
             lateout("rcx") _,
+            lateout("rdx") _,
+            lateout("rdi") _,
+            lateout("rsi") _,
+            lateout("r8") _,
+            lateout("r9") _,
+            lateout("r10") _,
             lateout("r11") _,
             options(nostack, preserves_flags),
         );
@@ -83,11 +102,14 @@ pub extern "C" fn _start() -> ! {
         unsafe {
             core::arch::asm!(
                 "syscall",
-                in("rax") 59u64,  // execve
-                in("rdi") 0u64,   // path (ignored)
-                in("rsi") 0u64,   // argv (ignored)
-                in("rdx") 0u64,   // envp (ignored)
+                inlateout("rax") 59u64 => _,   // execve
+                inlateout("rdi") 0u64 => _,    // path (ignored)
+                inlateout("rsi") 0u64 => _,    // argv (ignored)
+                inlateout("rdx") 0u64 => _,    // envp (ignored)
                 lateout("rcx") _,
+                lateout("r8") _,
+                lateout("r9") _,
+                lateout("r10") _,
                 lateout("r11") _,
                 options(nostack, preserves_flags),
             );
@@ -96,9 +118,14 @@ pub extern "C" fn _start() -> ! {
         unsafe {
             core::arch::asm!(
                 "syscall",
-                in("rax") 60u64, // exit
-                in("rdi") 1u64,  // status 1 (exec failed)
+                inlateout("rax") 60u64 => _,   // exit
+                inlateout("rdi") 1u64 => _,    // status 1 (exec failed)
                 lateout("rcx") _,
+                lateout("rdx") _,
+                lateout("rsi") _,
+                lateout("r8") _,
+                lateout("r9") _,
+                lateout("r10") _,
                 lateout("r11") _,
                 options(nostack, preserves_flags),
             );
@@ -116,12 +143,14 @@ pub extern "C" fn _start() -> ! {
         unsafe {
             core::arch::asm!(
                 "syscall",
-                inlateout("rax") 61u64 => _waited,  // wait4
-                in("rdi") child_pid,                  // pid
-                in("rsi") &mut wstatus as *mut i32 as u64,
-                in("rdx") 0u64,                       // options
-                in("r10") 0u64,                       // rusage
+                inlateout("rax") 61u64 => _waited,                         // wait4
+                inlateout("rdi") child_pid => _,                            // pid
+                inlateout("rsi") &mut wstatus as *mut i32 as u64 => _,      // *wstatus
+                inlateout("rdx") 0u64 => _,                                 // options
+                inlateout("r10") 0u64 => _,                                 // rusage
                 lateout("rcx") _,
+                lateout("r8") _,
+                lateout("r9") _,
                 lateout("r11") _,
                 options(nostack),
             );
@@ -139,11 +168,14 @@ fn write(fd: u64, buf: &[u8]) {
     unsafe {
         core::arch::asm!(
             "syscall",
-            in("rax") 1u64,
-            in("rdi") fd,
-            in("rsi") buf.as_ptr() as u64,
-            in("rdx") buf.len() as u64,
+            inlateout("rax") 1u64 => _,
+            inlateout("rdi") fd => _,
+            inlateout("rsi") buf.as_ptr() as u64 => _,
+            inlateout("rdx") buf.len() as u64 => _,
             lateout("rcx") _,
+            lateout("r8") _,
+            lateout("r9") _,
+            lateout("r10") _,
             lateout("r11") _,
             options(nostack, preserves_flags),
         );

--- a/userspace/repro_fork/src/main.rs
+++ b/userspace/repro_fork/src/main.rs
@@ -31,6 +31,20 @@
 //!
 //! Mirrors `userspace/init/src/main.rs` exactly.  See that file for the
 //! full table of syscall numbers and argument conventions.
+//!
+//! ### Register clobbers — see issue #531
+//!
+//! The vibix kernel's SYSCALL entry trampoline does **not** preserve the
+//! user-mode values of `rdi`, `rsi`, `rdx`, `r8`, `r9`, or `r10` across
+//! a syscall.  After `syscall_entry` pushes them to the kernel stack and
+//! calls the Rust `syscall_dispatch` (SysV C ABI), those registers are
+//! free real-estate for the dispatcher, and the SYSRETQ path only
+//! restores `rcx` (user RIP) and `r11` (user RFLAGS).  Every syscall
+//! block below therefore declares **all** SysV caller-saved GPRs as
+//! `lateout`/`inlateout` — missing any of them silently lets the
+//! compiler cache dead values across the syscall and produces wildly
+//! wrong behavior (issue #531: the fork-loop counter was held in `r8`
+//! and never incremented, so the soak ran until HARD_CAP every time).
 
 #![no_std]
 #![no_main]
@@ -89,6 +103,18 @@ const STDOUT: u64 = 1;
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
+    // Emit CYCLES on its own dedicated, newline-terminated line so a
+    // future #531-shaped regression (CYCLES compiled to the wrong value
+    // or the start banner getting serial-interleaved with early kernel
+    // output) shows up as a clean `repro: CYCLES=N` marker the xtask
+    // parser can pick up (see `xtask::tests::parse_cycles_banner`).
+    // Kept before the combined banner below so it lands on its own
+    // line even when the child's execve-ring3-iretq log interleaves
+    // mid-banner under contention.
+    write_line(b"repro: CYCLES=");
+    write_u64(CYCLES);
+    write_line(b"\n");
+
     write_line(b"repro: starting fork loop cycles=");
     write_u64(CYCLES);
     write_line(b" hb=");
@@ -106,6 +132,12 @@ pub extern "C" fn _start() -> ! {
                 "syscall",
                 inlateout("rax") SYS_FORK => fork_ret,
                 lateout("rcx") _,
+                lateout("rdx") _,
+                lateout("rdi") _,
+                lateout("rsi") _,
+                lateout("r8") _,
+                lateout("r9") _,
+                lateout("r10") _,
                 lateout("r11") _,
                 options(nostack, preserves_flags),
             );
@@ -119,11 +151,14 @@ pub extern "C" fn _start() -> ! {
             unsafe {
                 core::arch::asm!(
                     "syscall",
-                    in("rax") SYS_EXECVE,
-                    in("rdi") 0u64,
-                    in("rsi") 0u64,
-                    in("rdx") 0u64,
+                    inlateout("rax") SYS_EXECVE => _,
+                    inlateout("rdi") 0u64 => _,
+                    inlateout("rsi") 0u64 => _,
+                    inlateout("rdx") 0u64 => _,
                     lateout("rcx") _,
+                    lateout("r8") _,
+                    lateout("r9") _,
+                    lateout("r10") _,
                     lateout("r11") _,
                     options(nostack, preserves_flags),
                 );
@@ -148,11 +183,13 @@ pub extern "C" fn _start() -> ! {
             core::arch::asm!(
                 "syscall",
                 inlateout("rax") SYS_WAIT4 => waited,
-                in("rdi") child_pid,
-                in("rsi") &mut wstatus as *mut i32 as u64,
-                in("rdx") 0u64,
-                in("r10") 0u64,
+                inlateout("rdi") child_pid => _,
+                inlateout("rsi") &mut wstatus as *mut i32 as u64 => _,
+                inlateout("rdx") 0u64 => _,
+                inlateout("r10") 0u64 => _,
                 lateout("rcx") _,
+                lateout("r8") _,
+                lateout("r9") _,
                 lateout("r11") _,
                 options(nostack),
             );
@@ -205,11 +242,14 @@ fn write_line(buf: &[u8]) {
     unsafe {
         core::arch::asm!(
             "syscall",
-            in("rax") SYS_WRITE,
-            in("rdi") STDOUT,
-            in("rsi") buf.as_ptr() as u64,
-            in("rdx") buf.len() as u64,
+            inlateout("rax") SYS_WRITE => _,
+            inlateout("rdi") STDOUT => _,
+            inlateout("rsi") buf.as_ptr() as u64 => _,
+            inlateout("rdx") buf.len() as u64 => _,
             lateout("rcx") _,
+            lateout("r8") _,
+            lateout("r9") _,
+            lateout("r10") _,
             lateout("r11") _,
             options(nostack, preserves_flags),
         );

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1416,6 +1416,97 @@ fn repro_fork(opts: &BuildOpts) -> R<()> {
     }
 }
 
+/// Parsed view of the repro-fork harness start banner.
+///
+/// The harness emits a dedicated `repro: CYCLES=N\n` line before the
+/// legacy `repro: starting fork loop cycles=N hb=K\n` banner so the
+/// compiled cycle count is legible even when early kernel logs
+/// interleave mid-banner on the shared serial (see issue #531).  This
+/// struct captures both signals so the parser can cross-check them.
+///
+/// Only referenced from host unit tests today (`parse_repro_banner_*`);
+/// the parser exists so a soak-step addition that wants to verify the
+/// banner at runtime has a single tested entry point to call into.
+#[cfg_attr(not(test), allow(dead_code))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ReproBanner {
+    /// Cycle count from the dedicated `repro: CYCLES=N` line.
+    cycles_dedicated: u64,
+    /// Cycle count from the combined `repro: starting fork loop
+    /// cycles=N hb=K` line (legacy banner).  `None` if the line is
+    /// absent or mangled (e.g. interleaved with kernel log output).
+    cycles_combined: Option<u64>,
+    /// Heartbeat interval from the legacy banner.  `None` if the line
+    /// is mangled or missing.
+    heartbeat: Option<u64>,
+}
+
+/// Parse the repro-fork start banner out of a captured serial log.
+///
+/// Returns `None` if the dedicated `repro: CYCLES=<N>` line is missing
+/// or malformed; that line is the single source of truth for the
+/// compiled cycle count, and its absence is the regression this
+/// parser guards against (issue #531: if `REPRO_FORK_CYCLES` or
+/// `option_env!` ever silently compiles to the wrong value again, the
+/// xtask test will flag it in CI rather than silently running the
+/// wrong number of iterations).
+#[cfg_attr(not(test), allow(dead_code))]
+fn parse_repro_banner(log: &str) -> Option<ReproBanner> {
+    let cycles_dedicated = parse_dedicated_cycles(log)?;
+    let (cycles_combined, heartbeat) = parse_combined_banner(log);
+    Some(ReproBanner {
+        cycles_dedicated,
+        cycles_combined,
+        heartbeat,
+    })
+}
+
+/// Extract `N` from the first occurrence of `repro: CYCLES=<N>`.
+///
+/// Only accepts base-10 digits up to the next non-digit or end-of-line
+/// so a mid-banner interleave (e.g. `repro: CYCLES=500ring3-iretq: ...`)
+/// still yields the intended value.
+#[cfg_attr(not(test), allow(dead_code))]
+fn parse_dedicated_cycles(log: &str) -> Option<u64> {
+    const MARKER: &str = "repro: CYCLES=";
+    let start = log.find(MARKER)? + MARKER.len();
+    let rest = &log[start..];
+    let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+    if digits.is_empty() {
+        return None;
+    }
+    digits.parse().ok()
+}
+
+/// Extract `(cycles, heartbeat)` from the legacy
+/// `repro: starting fork loop cycles=<N> hb=<K>` banner.
+///
+/// Either element can be `None` if the banner was interleaved with
+/// other serial output.  The dedicated `repro: CYCLES=` line is the
+/// authoritative source; this helper exists for cross-checking and for
+/// future banner-shape regressions.
+#[cfg_attr(not(test), allow(dead_code))]
+fn parse_combined_banner(log: &str) -> (Option<u64>, Option<u64>) {
+    const MARKER: &str = "repro: starting fork loop cycles=";
+    let Some(start) = log.find(MARKER) else {
+        return (None, None);
+    };
+    let rest = &log[start + MARKER.len()..];
+    let cycles: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+    let cycles = cycles.parse::<u64>().ok();
+
+    // Look for " hb=<K>" on the same line (no newline in between).
+    let line_end = rest.find('\n').unwrap_or(rest.len());
+    let line = &rest[..line_end];
+    let hb_marker = " hb=";
+    let heartbeat = line.find(hb_marker).and_then(|idx| {
+        let tail = &line[idx + hb_marker.len()..];
+        let digits: String = tail.chars().take_while(|c| c.is_ascii_digit()).collect();
+        digits.parse::<u64>().ok()
+    });
+    (cycles, heartbeat)
+}
+
 fn lint() -> R<()> {
     println!("→ clippy: xtask (host)");
     check(
@@ -1773,5 +1864,141 @@ harness = false
             ),
             "usage string must list repro-fork-build"
         );
+    }
+
+    /// Issue #531: the repro-fork harness compiled CYCLES to a value
+    /// far above 500 (the CI soak ran ~14,988 cycles per boot), which
+    /// silently burned every soak iteration against the 900 s hard
+    /// cap.  The fix makes CYCLES self-report on a dedicated
+    /// `repro: CYCLES=<N>` line; this parser + test pin that contract
+    /// so a regression (e.g. someone dropping the dedicated line, or
+    /// `option_env!("REPRO_FORK_CYCLES")` silently parsing a typo'd
+    /// build override as a huge number) fails a host unit test in CI
+    /// before it ever reaches a soak run.
+    #[test]
+    fn parse_repro_banner_clean_log() {
+        let log = "\
+boot: ok
+repro: CYCLES=500
+repro: starting fork loop cycles=500 hb=50
+repro: fork loop complete cycles=500
+";
+        let banner = parse_repro_banner(log).expect("parse must succeed");
+        assert_eq!(banner.cycles_dedicated, 500);
+        assert_eq!(banner.cycles_combined, Some(500));
+        assert_eq!(banner.heartbeat, Some(50));
+    }
+
+    #[test]
+    fn parse_repro_banner_tolerates_interleaved_combined_line() {
+        // The #531 evidence log showed the combined banner mangled by
+        // a child exec's `ring3-iretq` log interleaving on the shared
+        // serial mid-line.  The dedicated `repro: CYCLES=` line is
+        // emitted first and newline-terminated precisely so its value
+        // is still recoverable even when the combined banner is
+        // unreadable.
+        let log = "\
+repro: CYCLES=500
+repro: starting fork loop cycles=ring3-iretq: rip=0x400000 rsp=0x7fffff58
+hello: hello from execed child
+";
+        let banner = parse_repro_banner(log).expect("dedicated line must still parse");
+        assert_eq!(banner.cycles_dedicated, 500);
+        // Combined banner's `cycles=` was immediately followed by
+        // non-digit text — parser yields None for that field.
+        assert_eq!(banner.cycles_combined, None);
+        assert_eq!(banner.heartbeat, None);
+    }
+
+    #[test]
+    fn parse_repro_banner_missing_dedicated_line_returns_none() {
+        // Only the legacy combined banner is present.  Parser must
+        // fail closed — a missing dedicated line is the regression
+        // we're guarding against.
+        let log = "\
+repro: starting fork loop cycles=500 hb=50
+";
+        assert!(parse_repro_banner(log).is_none());
+    }
+
+    #[test]
+    fn parse_repro_banner_rejects_nondigit_value() {
+        // Defensive: a malformed `repro: CYCLES=` line (no digits)
+        // must not trip a false positive.
+        let log = "repro: CYCLES=abc\n";
+        assert!(parse_repro_banner(log).is_none());
+    }
+
+    /// Issue #531: the xtask source-level contract for the repro-fork
+    /// userspace binary is "CYCLES compiles to 500 by default."  The
+    /// harness is cross-compiled for `x86_64-unknown-none` so we can't
+    /// exercise it from a host unit test directly, but we can inspect
+    /// the source to pin the default literal; if someone bumps it to
+    /// a huge number without updating the soak workflow, this test
+    /// fails in CI before the soak burns 6 hours discovering it.
+    #[test]
+    fn repro_fork_default_cycles_is_500() {
+        let source = std::fs::read_to_string(
+            workspace_root()
+                .join("userspace")
+                .join("repro_fork")
+                .join("src")
+                .join("main.rs"),
+        )
+        .expect("read repro_fork main.rs");
+        // The default is expressed as the `None => <literal>` arm of
+        // the `match option_env!("REPRO_FORK_CYCLES")` block.  A
+        // substring match is brittle across reformatting, but it
+        // catches exactly the regression we care about: "someone
+        // changed the default from 500 and forgot to update the soak
+        // timing budget / this test."
+        assert!(
+            source.contains("None => 500,"),
+            "userspace/repro_fork/src/main.rs must keep the default CYCLES=500; \
+             if you genuinely need to change this, also update \
+             .github/workflows/smoke-soak.yml timing budgets and issue #531's context"
+        );
+    }
+
+    /// Issue #531 root cause: the userspace syscall inline-asm blocks
+    /// declared only rcx/r11 as clobbered, but the vibix kernel's
+    /// SYSCALL trampoline + Rust SysV dispatcher also trash rdi, rsi,
+    /// rdx, r8, r9, r10 (and, via the C ABI, rax).  Loop counters held
+    /// in r8 across the fork syscall never incremented, so the
+    /// repro-fork harness ran until HARD_CAP every time.  Pin the
+    /// fixed clobber pattern in source so a future edit that drops a
+    /// clobber declaration fails a host unit test before it silently
+    /// regresses the soak.
+    #[test]
+    fn repro_fork_syscall_blocks_clobber_all_sysv_caller_saved() {
+        let source = std::fs::read_to_string(
+            workspace_root()
+                .join("userspace")
+                .join("repro_fork")
+                .join("src")
+                .join("main.rs"),
+        )
+        .expect("read repro_fork main.rs");
+
+        // Every `asm!(\"syscall\", ...)` block in this file that is
+        // not a `noreturn` exit must declare lateout for each SysV
+        // caller-saved register the kernel may trash on SYSRETQ:
+        // r8, r9, r10, r11 (rax, rcx, rdx, rdi, rsi are handled via
+        // the `inlateout`/`lateout` pattern documented in the ABI
+        // header, so we grep for the r-class registers here as the
+        // load-bearing signal).
+        for reg in ["r8", "r9", "r10", "r11"] {
+            let needle = format!("lateout(\"{reg}\")");
+            let count = source.matches(&needle).count();
+            // The module has 4 non-noreturn syscall sites in the
+            // reproducer (fork, execve-in-child, wait4, write_line).
+            // Every one of them must carry every r-class clobber.
+            assert!(
+                count >= 4,
+                "expected at least 4 `{needle}` declarations in repro_fork/main.rs, \
+                 found {count}.  If you added or removed a syscall site, update this \
+                 lower bound; if you dropped a clobber, restore it (issue #531)."
+            );
+        }
     }
 }


### PR DESCRIPTION
Closes #531

## Summary

The 100× smoke soak on main has been failing every iteration at the 900 s
`REPRO_HARD_CAP` with a 0 % pass rate, blocking the epic #501 acceptance
gate.  Root cause turned out to be a plain inline-asm register-clobber
bug in the three userspace binaries (`repro_fork`, `init`, `hello`) — not
a build-cache issue, not a stale ELF, not a CYCLES override.

### Bug

Every `asm!("syscall", ...)` block in userspace previously declared only
`rcx` and `r11` as clobbered.  The vibix kernel's SYSCALL trampoline
does more than that: it pushes `rdi`/`rsi`/`rdx`/`r8`/`r9`/`r10` to the
kernel stack and calls the Rust `syscall_dispatch` (SysV C ABI), which
freely clobbers every caller-saved register; the SYSRETQ path only
restores `rcx` and `r11`.  The compiler believed everything else
survived the syscall and happily cached long-lived values across it.

Two concrete manifestations in `repro_fork`, visible in local serial
captures and in the issue's evidence log:

1. **Loop counter in r8.**  The compiler placed the `cycle` counter in
   `r8`, which the kernel trashes on `fork()`.  `cycle` never
   incremented past its first syscall-trashed value, so
   `while cycle < 500` ran until HARD_CAP every time (~14 988 iterations
   at ~60 ms each on CI TCG QEMU).
2. **Banner digits dropped.**  After the first `write(1, "repro: starting fork loop cycles=")`
   returned 33 in `rax`, the next inline-asm block's `in("rax") 1u64`
   didn't re-load 1 because the compiler thought `rax` still held 1.
   The follow-up syscalls therefore landed on garbage syscall numbers
   (rax=33=DUP2, rdi trashed), so "500 hb=50\n" never appeared on
   serial — exactly what soak run 24595210929's `run-001.log` showed.

Same pattern in `init` and `hello`, just hidden there because neither
holds a live value in a caller-saved register across a syscall the way
`repro_fork` does.

### Fix

Every non-`noreturn` syscall block in the three user binaries now
declares the full SysV caller-saved GPR set as `inlateout`/`lateout`:
`rax`, `rcx`, `rdx`, `rdi`, `rsi`, `r8`, `r9`, `r10`, `r11`.  The
compiler now reloads every syscall-argument register before each
syscall and keeps loop counters in callee-saved registers (verified in
the post-fix disassembly: `cycle` moved to `%rbx`).

### Also shipped in this PR

* A dedicated `repro: CYCLES=<N>\n` line at the top of the harness
  banner, emitted on its own line so the compiled cycle count stays
  legible even when early kernel output interleaves mid-banner on the
  shared serial.
* A host-testable `parse_repro_banner` function + 6 unit tests in
  `xtask/src/main.rs` so a future CYCLES-compiles-wrong regression or
  a dropped clobber declaration fails in CI before it ever reaches a
  soak run.  Tests cover the happy path, the real-world interleaved
  case from the #531 evidence log, a source-level pin of the
  `None => 500,` default, and a source-level pin of the
  `lateout("r8..r11")` clobber declarations.

### Out of scope (per the issue)

* `REPRO_HARD_CAP` tuning (#511, held).
* The residual ring-3 `#PF rip=0x4002c6 cr2=0x7fffff0c` tracked in #527 —
  that's a real COW-stack fork-path flake that this PR intentionally
  does not chase.  It still shows up as a one-off `ring3-first-fault:`
  line on cycle 1 in local runs, then the PF handler retries the
  instruction and the loop proceeds.  It does not currently fail the
  harness.

## Test plan

- [x] `cargo xtask build` — ok.
- [x] `cargo xtask test` — 377 host unit tests + 14 QEMU integration tests, all passing.  Includes the 6 new `parse_repro_banner_*` / `repro_fork_default_cycles_is_500` / `repro_fork_syscall_blocks_clobber_all_sysv_caller_saved` tests.
- [x] `cargo xtask smoke` — 33/33 markers present.
- [x] `cargo xtask repro-fork` locally, 3× back-to-back:
  - Run 1: `repro: fork loop complete cycles=500`, 31.00 s wall-clock.
  - Run 2: `repro: fork loop complete cycles=500`, 30.99 s wall-clock.
  - Run 3: `repro: fork loop complete cycles=500`, 31.03 s wall-clock.
  - Every heartbeat (`repro: cycle K alive` at K=50..500) fires.
  - `repro: CYCLES=500` banner parses cleanly.
- [x] `cargo fmt --all -- --check` clean.
- [ ] CI green on `fmt + build`, `host unit tests`, `integration tests (QEMU)`, `smoke test`.
- [ ] Post-merge manual `workflow_dispatch` of `smoke-soak` on main at default `count=100` / `min_pass_rate=80` inputs, expected pass rate ≥ 80 % (ideally 100 %).  The PR itself does not trigger the soak — the `pull_request` event path is gated off per #519.
