### PR TITLE
auto-manager: add "Think creatively" license to phase 4

### DIFF
--- a/.claude/skills/auto-manager/SKILL.md
+++ b/.claude/skills/auto-manager/SKILL.md
@@ -163,6 +163,26 @@ Goal: drive every filed issue to merge without further user input.
 
 Default posture: **full autonomy**. Spawn wave 1 immediately, respawn as deps unblock, until every issue is merged or externally blocked. User is informed via status messages; they are not gated.
 
+### Think creatively — break process when it helps
+
+As an auto-manager, your job is creative orchestration, not mechanical process execution. The defaults in this skill — prioritization labels, one-issue-per-PR, green main, independent workstreams, spawn-from-main — optimize for the common case. Your value is in the edges: recognizing when following the default throws away something hard-won by an agent already in flight (a parked repro, a clean bisect, a harness that cost days to build) and composing around it instead. SDLC, phase-4 spawn rules, label taxonomy, whatever — if the rule is making you discard a hard-won artifact, break the rule and compose. The rest of this skill is the default path; this section is the license to deviate when the default would waste work.
+
+**For example — stack spawns on in-flight work when it helps.** When one agent's open PR deterministically reproduces a bug that another issue tracks (i.e., the PR is a diagnostic or harness that's working-as-intended but can't merge because it trips the bug), spawn the bug's fix agent with the parked PR's branch as base, not main. The fix PR subsumes the diagnostic PR; CI green proves both directions at once.
+
+Do not:
+
+- Land the diagnostic first — poisons main's CI until the bug is fixed, blocks unrelated PRs.
+- Cherry-pick the repro into a fresh branch off main — loses attribution and re-establishes the repro the parked PR already proved.
+
+**Worked example — epic #501, 2026-04-18:**
+
+PR #530 (`m484-init-write-markers`) added diagnostic markers to init that turned the #527 ring3 user-stack #PF flake from ~1% under CI into deterministic 4/4 under TCG. The PR got parked because smoke went red — working as intended; the markers were exposing a real bug. Two tempting-but-wrong moves surfaced:
+
+- *Merge #530 first:* turns main's smoke red until #527 is fixed, blocking every unrelated PR for days.
+- *Drop the markers, rewrite them as part of the #527 fix:* throws away the deterministic repro the parked PR just proved out, and the #527 fix agent has to re-establish the repro before it can verify its own work.
+
+The composed move: spawn the #527 fix agent with `m484-init-write-markers@<head>` as its base, not main. The fix PR subsumes #530 — when CI goes green, that simultaneously proves the markers fire where expected *and* the stack fault is resolved. One merge, composed signal, no sacrificed main.
+
 ### Spawn rules
 
 Every auto-engineer subagent call uses:


### PR DESCRIPTION
## Summary

- Adds a new subsection at the top of phase 4 of the `/auto-manager` skill that frames the documented rules as the *common-case default* and explicitly licenses deviation when following them would throw away work-in-flight.
- Leads with a general creative-orchestration paragraph, then uses the stacking pattern (spawn a fix agent on a parked diagnostic PR's branch, not main) as a worked example drawn from epic #501 on 2026-04-18 (PR #530 + #527).

## Motivation

During the epic #501 sprint, PR #530 added diagnostic markers to init that turned a ~1% flake into a deterministic repro and got parked because smoke went red. The orchestrator's default instinct would be to branch the fix agent from main; instead we branched from the parked PR so a single merge composed both signals (diagnostic + fix) without poisoning main's CI.

That move was decided ad hoc. With a second team about to onboard on another OS subsystem, the creative-license framing is the part most likely to get lost if only the mechanical phase-4 rules are read — so encoding it explicitly, with a concrete worked example, is cheaper now than re-deriving it per-sprint.

## Scope

- Documentation-only change to `.claude/skills/auto-manager/SKILL.md`.
- No code, tests, CI, or runtime behavior affected.
- The new subsection is placed *first* under phase 4 (before `### Spawn rules`) so the creative-license framing contextualizes the mechanical rules that follow rather than being buried after them.

## Test plan

- [ ] Read the diff end-to-end; confirm the tone matches the rest of the skill.
- [ ] Confirm the worked example references (#530, #527, #501) point at real issues so a future reader can follow the breadcrumbs.
- [ ] No CI impact expected — file is a skill doc, not kernel/xtask source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)