### PR TITLE
docs(readme): document /auto-manager as orchestrator over /os-researcher + /auto-engineer

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,73 @@ to see how far autonomous agents can get before the wheels fall off.
 
 ## Instructions for Humans
 
+vibix has assembled a tiny agentic bureaucracy to build itself. There is a
+manager, a researcher, and an engineer. They all report to each other in a way
+that would probably fail a compliance audit. They are, collectively, writing
+a kernel.
+
+- **`/auto-manager`** — the middle manager. Takes an epic issue or a vague
+  hand-wave ("harden the boot path") and decides what to do. Design-heavy
+  work gets punted to `/os-researcher`; execution work gets filed as sub-issues
+  and handed off to a swarm of `/auto-engineer` subagents. It does not write
+  any kernel code itself. It is, however, very good at spawning things that
+  will.
+- **`/os-researcher`** — the one with strong opinions about POSIX. Reads real
+  kernel docs and academic papers, writes an RFC, convenes four imaginary
+  reviewers to argue with it, revises until they all relent, then merges. Then
+  it files implementation issues for someone else to do the actual work.
+- **`/auto-engineer`** — the one holding the keyboard. Picks an unblocked
+  issue, implements it, opens a PR, argues with the review bot, and loops.
+  Stops when main is broken or CI is unreachable. Does not stop for lunch.
+
+Any of the three can be summoned directly. `/auto-manager` is the usual entry
+point when the work is bigger than one issue — it will figure out which of its
+colleagues to bother.
+
+### `/auto-manager` — the epic orchestrator
+
+Defined in `.claude/skills/auto-manager/SKILL.md`. Accepts either a hard scope
+(`/auto-manager #18` against an epic issue or spec) or a vibes-based topic
+(`/auto-manager ship GA refusal handling`, `/auto-manager make wait4 less
+embarrassing`). The skill:
+
+1. **Discovers scope** — for fuzzy inputs, intersects the open backlog with a
+   codebase scan and proposes a scope. You get to say "yes", "no", or "not
+   like that" before anything is filed.
+2. **Runs an RFC gate** — if the topic is novel or foundational (new VFS,
+   scheduler rewrite, signals, IPC, ABI changes) or the design isn't locked,
+   it spawns `/os-researcher` as a worktree-isolated subagent and blocks until
+   the RFC merges. Execution-only grind and well-precedented changes get
+   waved through without ceremony.
+3. **Files sub-issues** via `/file-issue` — or, if `/os-researcher` ran, just
+   inherits the issues it already filed, like a manager taking credit.
+4. **Plans workstreams** — partitions issues into parallel tracks with an
+   explicit dependency graph, so the engineers don't rebase each other into
+   oblivion.
+5. **Orchestrates `/auto-engineer` subagents** in parallel (worktree-isolated,
+   background), respawning the next wave as predecessors land, until every
+   issue merges or something explodes loudly enough to need a human.
+
+Use `/auto-engineer` or `/os-researcher` directly when you want exactly one
+thing shipped or exactly one RFC written. Use `/auto-manager` when you want to
+close your laptop and come back later to find out whether a kernel now
+exists that didn't before.
+
 ### `/auto-engineer` — the implementation loop
 
-The primary build driver. Defined in `.claude/skills/auto-engineer/SKILL.md`,
-it picks an unblocked GitHub issue, plans the change, implements it, opens a
-PR, chases CI + review-bot feedback until green, and loops. A companion skill
-at `.cursor/skills/cursor-cloud-auto-engineer/SKILL.md` mirrors the same flow
-for Cursor Cloud.
+The workhorse. Defined in `.claude/skills/auto-engineer/SKILL.md`. Picks an
+unblocked GitHub issue off the backlog, plans the change, implements it,
+opens a PR, argues with CI and the review bot until both stop complaining,
+and then — in a move that would alarm any sane engineering manager — picks
+the next issue and does it again. A companion skill at
+`.cursor/skills/cursor-cloud-auto-engineer/SKILL.md` mirrors the same flow
+for Cursor Cloud, in case one autonomous agent writing your kernel felt
+insufficient.
 
 To run the loop yourself, you need Docker, a Claude Code login on the host
 (`claude` logged in at least once, so `~/.claude.json` + `~/.claude/`
-exist), and a GitHub token with repo write access.
+exist), and a GitHub token with repo write access. Also: the willingness to
+find out what your credit card thinks of all this later.
 
 ```sh
 # one-time: add yourself to the docker group so the wrapper doesn't need sudo
@@ -34,8 +90,9 @@ export GITHUB_TOKEN=ghp_...
 The wrapper builds a container image (first run ~5–10 min) that bundles every
 build/test dep — Rust nightly, `qemu-system-x86_64`, `xorriso`, `gh`, and
 Claude Code itself — then runs `claude --dangerously-skip-permissions` against
-a fresh clone inside the container. Your host `~/.claude` auth is bind-mounted
-in, so the container talks to Anthropic as you.
+a fresh clone inside the container. The flag name is not a joke. Your host
+`~/.claude` auth is bind-mounted in, so the container talks to Anthropic as
+you and, when things go well, also merges PRs as you.
 
 Under the hood:
 
@@ -45,27 +102,32 @@ Under the hood:
 - **`scripts/auto-engineer.sh`** — host wrapper: sources `.env`, builds the
   image, and runs the container with the right mounts + SELinux handling.
 
-Ctrl-C at any time to stop the loop.
+Ctrl-C at any time to stop the loop. You will probably need to.
 
 ### `/os-researcher` — design before implementation
 
-Before a non-trivial subsystem gets built, this skill designs it. Defined in
-`.claude/skills/os-researcher/SKILL.md`, it takes an OS topic (e.g. "virtual
+Before a non-trivial subsystem gets built, this skill designs it — with the
+solemnity of a real OS project and the staffing of a very small one. Defined
+in `.claude/skills/os-researcher/SKILL.md`. Takes an OS topic (e.g. "virtual
 filesystem layer", "POSIX signals", "demand paging") and runs a full
 research-to-RFC pipeline:
 
-1. **Research** — spawns parallel sub-agents to query OSDev Wiki, Linux kernel
-   docs, Intel/AMD manuals, the POSIX spec, and academic literature, then
-   synthesizes the findings into a research brief.
+1. **Research** — spawns parallel sub-agents to query OSDev Wiki, Linux
+   kernel docs, Intel/AMD manuals, the POSIX spec, and academic literature,
+   then synthesizes it all into a research brief. This is the part where the
+   agent reads more of the Linux source than most people ever will.
 2. **Draft** — writes a structured RFC under `docs/RFC/` covering motivation,
    design, security/performance considerations, alternatives, and an
-   implementation roadmap.
-3. **Peer review** — four archetype reviewers (security researcher, OS engineer,
-   user-space staff engineer, academic) post structured review comments on the
-   PR. The skill defends blocking findings across up to two revision cycles.
-4. **Merge and file issues** — once all reviewers approve, the RFC is marked
-   `Accepted`, merged, and each roadmap item is filed as a tracked GitHub issue
-   for `/auto-engineer` to pick up.
+   implementation roadmap. Looks suspiciously like a real RFC.
+3. **Peer review** — four archetype reviewers (security researcher, OS
+   engineer, user-space staff engineer, academic) — plus additional
+   specialists the skill conjures up when the topic needs them — post
+   structured review comments on the PR. The skill defends blocking findings
+   across up to four revision cycles. The reviewers are imaginary. The
+   feedback is disconcertingly real.
+4. **Merge and file issues** — once every reviewer relents, the RFC is marked
+   `Accepted`, merged, and each roadmap item is filed as a tracked GitHub
+   issue for `/auto-engineer` to eventually pick up and ship.
 
 Invoke it in a Claude Code session:
 
@@ -74,7 +136,8 @@ Invoke it in a Claude Code session:
 ```
 
 Pass `--skip-research` to jump straight to drafting if a research summary is
-already in context.
+already in context, or `--defense-cycles=<N>` to tell the imaginary reviewers
+how many rounds they get.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary

- Rewrite the README's "Instructions for Humans" section to reflect that vibix now has three cooperating skills — `/auto-manager` orchestrates, `/os-researcher` designs, `/auto-engineer` implements — and explain how they hand off to each other.
- Add a dedicated `/auto-manager` subsection covering the scope discovery, RFC gate, sub-issue filing, workstream planning, and parallel `/auto-engineer` orchestration phases.
- Punch up the tone across all three subsections to match the project's self-aware framing (it is, after all, a kernel being written by an agentic bureaucracy).
- Fix a stale detail: `/os-researcher` now supports up to four defense cycles (configurable via `--defense-cycles`), not two.

## Test plan

- [ ] Render the README on GitHub and eyeball the three-skill section for flow.
- [ ] Confirm `/auto-manager` slash-command references match the actual skill in `.claude/skills/auto-manager/SKILL.md`.