### PR TITLE
kernel/idt: skip ring3-first-fault log for resolved user #PFs

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -14,16 +14,29 @@ use crate::arch::x86_64::interrupts::{
 };
 use crate::serial_println;
 
-/// #478 diagnostic latch: the first CPL=3 fault of the session logs a
-/// `ring3-first-fault:` line with full frame state before the handler
-/// runs its normal path. Subsequent ring-3 faults are common (SIGSEGV
-/// delivery etc.) and must not flood the log. One-shot by design.
+/// #478 / #527 diagnostic latch: the first *unexpected* CPL=3 fault of the
+/// session logs a `ring3-first-fault:` line with full frame state before
+/// the handler runs its normal path. Subsequent ring-3 faults are common
+/// (SIGSEGV delivery etc.) and must not flood the log. One-shot by design.
+///
+/// "Unexpected" here means a fault that the kernel could not resolve via
+/// its normal dispatch (CoW first-touch, demand-page fill, growsdown stack
+/// extension, etc.).  The `#PF` path only calls this helper on the
+/// fall-through / access-violation branch; the successfully-handled
+/// CoW / demand-page returns skip the log entirely.  That keeps the marker
+/// as a high-signal first-unexpected-fault breadcrumb instead of firing on
+/// every boot's legitimate first-fork CoW fault (issue #527).
 static FIRST_RING3_FAULT_LOGGED: AtomicBool = AtomicBool::new(false);
 
-/// Emit one `ring3-first-fault:` line on the first CPL=3 fault ever
-/// observed. `extra` is vector-specific trailer (e.g. `code=0x0` for #GP,
-/// `cr2=0x400000 code=PROTECTION` for #PF) — no user memory is touched
-/// while formatting, only scalars copied out of the hardware frame.
+/// Emit one `ring3-first-fault:` line on the first *unresolved* CPL=3 fault
+/// ever observed. `extra` is vector-specific trailer (e.g. `code=0x0` for
+/// `#GP`, `cr2=0x400000 code=PROTECTION` for `#PF`) — no user memory is
+/// touched while formatting, only scalars copied out of the hardware frame.
+///
+/// Callers: `#UD` / `#GP` call unconditionally (no legitimate resolution
+/// path for those in ring 3). `#PF` calls only after the VMA-backed
+/// resolver and growsdown extension have both declined to handle the
+/// fault — so a routine CoW or demand-page fault is silent.
 fn log_first_ring3_fault(vector: &str, frame: &InterruptStackFrame, extra: core::fmt::Arguments) {
     if (frame.code_segment.0 & 0b11) == 0 {
         return;
@@ -136,11 +149,12 @@ extern "x86-interrupt" fn page_fault(mut frame: InterruptStackFrame, code: PageF
     }
     let addr_u64 = x86_64::registers::control::Cr2::read_raw();
 
-    log_first_ring3_fault(
-        "#PF",
-        &frame,
-        format_args!("cr2={:#x} code={:?}", addr_u64, code),
-    );
+    // Note: log_first_ring3_fault is intentionally NOT called here.  The
+    // diagnostic latch fires only on CPL=3 faults that reach the
+    // access-violation fall-through below, so a routine CoW first-touch
+    // or demand-page fault on the parent's post-fork stack page (issue
+    // #527) stays silent.  SMAP, RSVD, and USER_VA_END panics log their
+    // own dedicated exception lines, so they don't need the marker.
 
     if let Some(expected) = crate::test_hook::take_page_fault_expectation() {
         use crate::test_harness::{exit_qemu, QemuExitCode};
@@ -327,6 +341,14 @@ extern "x86-interrupt" fn page_fault(mut frame: InterruptStackFrame, code: PageF
     // with DefaultAction::Terminate. The helper calls `task::exit()`, so
     // IRETQ never runs; the scheduler context-switches to the next task.
     if cpl != 0 {
+        // Only fire the one-shot ring-3 first-fault latch for faults that
+        // could not be resolved above.  See #527 and the doc comment on
+        // `log_first_ring3_fault`.
+        log_first_ring3_fault(
+            "#PF",
+            &frame,
+            format_args!("cr2={:#x} code={:?}", addr_u64, code),
+        );
         serial_println!(
             "#PF ring-3 access violation addr={:#x} code={:?}",
             addr_u64,


### PR DESCRIPTION
Closes #527

## Summary

- The `ring3-first-fault:` one-shot diagnostic was firing on the first CPL=3 page fault of the session — which in steady state is always a legitimate CoW first-touch on the parent's post-fork stack page. The fault is handled correctly by `cow_copy_and_remap`, but the log line made the 100× soak output look like a live flake and blocked the epic #501 three-green-nightlies gate per issue #527.
- Move the `#PF` call to `log_first_ring3_fault` into the access-violation fall-through branch so the marker only fires for faults the kernel could not resolve (real SIGSEGV-class bugs — the original #478 intent). SMAP / RSVD / USER_VA_END panic paths each emit their own dedicated EXCEPTION line already; `#UD` / `#GP` still log unconditionally because neither has a legitimate ring-3 resolution path.
- No userspace changes — PR #532 already fixed the inline-asm clobber bug that had been conflating the runaway-cycles failure mode with this fault.

## Root cause (1 sentence)

The latch at the top of the `#PF` handler emitted on every first CPL=3 fault regardless of outcome, so the normal post-fork CoW fault on the parent's stack (`rip` just past `syscall`, `cr2` at `rsp+0`) tripped it on cycle 1 of every boot — issue #527's "smoking gun" was the diagnostic, not a bug in the fault path.

## Test plan

- [x] `cargo xtask build` — ok.
- [x] `cargo xtask smoke` — all 33 markers present, 0 `ring3-first-fault` lines in serial log.
- [x] `cargo xtask repro-fork` — 500 cycles complete, 0 `ring3-first-fault` lines, every `repro: cycle K alive` heartbeat at K=50..500 fires.
- [x] `cargo xtask test` — 377 host unit tests + integration tests pass. The `page_fault.rs` test still drives `test_hook::expect_page_fault` (which runs before the moved log call), so its exit-on-match contract is unchanged.
- [x] `cargo test -p xtask` — 34 tests pass.
- [x] `cargo fmt --all -- --check` clean.
- [x] Longer `REPRO_FORK_CYCLES=50000 cargo xtask repro-fork` run makes forward progress past cycle 13200 with zero `ring3-first-fault` markers before hitting an unrelated heartbeat stall from accumulated stack-VA-slot leaks (separate #501 sub-issue — the `stack VA slot ... leaked` line this PR does not chase).
- [ ] CI green on fmt+build / host unit tests / integration tests (QEMU) / smoke.
- [ ] Post-merge manual `workflow_dispatch` of `smoke-soak` on main (count=100, min_pass_rate=80), expected pass rate ≥ 80 %.
