### PR TITLE
block: introduce BlockDevice trait; migrate virtio_blk behind it

### DIFF
--- a/kernel/src/block/mod.rs
+++ b/kernel/src/block/mod.rs
@@ -8,25 +8,158 @@
 //! against the first detected virtio-blk device. No caching, no
 //! interrupts — polled I/O only (issue #81 added the write path on top
 //! of the original step-1 read-only driver from #43).
+//!
+//! # `BlockDevice` trait
+//!
+//! Per RFC 0004 (Workstream C), the block-device interface consumed by
+//! the buffer cache and filesystem drivers is the byte-offset
+//! [`BlockDevice`] trait — not the LBA-indexed module-level `read`/
+//! `write` helpers. The trait object is what `BlockCache` and the ext2
+//! driver hold (`Arc<dyn BlockDevice>`); the module-level API is retained
+//! verbatim for the boot-time probe in `main.rs` and any remaining
+//! pre-cache callers.
 
 #[cfg(any(test, target_os = "none"))]
 pub mod virtio_blk;
+
+#[cfg(any(test, target_os = "none"))]
+use alloc::sync::Arc;
+#[cfg(any(test, target_os = "none"))]
+use spin::Mutex;
 
 /// Size of one disk sector in bytes. The virtio-blk spec fixes this at
 /// 512 regardless of the underlying medium's physical block size.
 pub const SECTOR_SIZE: usize = 512;
 
-/// Errors surfaced by the block API.
+/// Block-layer error enum, consumable by the buffer cache, filesystem
+/// drivers, and the legacy module-level `read`/`write` API.
+///
+/// Mappable onto kernel errnos at the VFS syscall boundary:
+///
+/// | Variant         | errno    |
+/// |-----------------|----------|
+/// | `DeviceError`   | `EIO`    |
+/// | `Enospc`        | `ENOSPC` |
+/// | `BadAlign`      | `EINVAL` |
+/// | `NotInitialized`| `ENODEV` |
+/// | `Timeout`       | `EIO`    |
+/// | `OutOfRange`    | `EINVAL` |
+///
+/// Kept deliberately small — the cache and ext2 driver only need to
+/// distinguish "retry is useless" from "range was invalid" from
+/// "no space on device".
+///
+/// Pre-RFC-0004 code (the virtio-blk driver and the legacy `read`/
+/// `write` helpers) used a narrower `BlkError { NotInitialized, BadAlign,
+/// DeviceError, Timeout }`; the two names now refer to the same enum via
+/// the [`BlkError`] alias.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum BlkError {
+pub enum BlockError {
     /// No block backend was successfully brought up during init.
     NotInitialized,
-    /// Buffer length isn't a non-zero multiple of [`SECTOR_SIZE`].
+    /// Offset or buffer length violates the backend's alignment /
+    /// granularity requirements (must be a non-zero multiple of
+    /// `block_size()`, and — for virtio-blk step-1 — ≤ 4 KiB).
     BadAlign,
-    /// Device reported an error completing the request.
+    /// Device reported or the driver inferred an I/O error (bad status
+    /// byte, DMA fault, unrecoverable read).
     DeviceError,
     /// Bounded spin-wait for request completion elapsed.
     Timeout,
+    /// Write would have extended the device past its capacity.
+    Enospc,
+    /// The requested byte range lies outside `[0, capacity())`.
+    OutOfRange,
+}
+
+/// Legacy error alias. See [`BlockError`] for the full taxonomy.
+///
+/// New code (the buffer cache, filesystem drivers) should prefer
+/// [`BlockError`] directly; this alias exists so existing virtio-blk and
+/// `block::read`/`write` call sites continue to compile unchanged.
+pub type BlkError = BlockError;
+
+/// Byte-offset block-device interface consumed by the buffer cache and
+/// filesystem drivers.
+///
+/// Implementations are expected to be **synchronous and polled** for this
+/// epic — no IRQ-driven or async I/O (see RFC 0004 Workstream C). Reads
+/// and writes block the caller until the device acks or the
+/// implementation-defined timeout elapses.
+///
+/// # Invariants
+///
+/// - `offset` and `buf.len()` are each a non-zero multiple of
+///   [`block_size`](BlockDevice::block_size); violating implementations
+///   return [`BlockError::BadAlign`].
+/// - `offset + buf.len() as u64 <= capacity()`; violating implementations
+///   return [`BlockError::OutOfRange`].
+/// - `read_at` does not observe writes from a concurrent `write_at` on
+///   the same device unless the write has already returned `Ok`.
+///
+/// # Why byte-offset and not LBA
+///
+/// The buffer cache keys on `(DeviceId, block_no)` but `block_no` is
+/// cache-block-sized (typically 1024 or 4096 bytes), not 512-byte
+/// sectors — which is what the virtio-blk wire protocol and other
+/// future backends (loopback file, ramdisk) work in. Byte-offset is
+/// the narrowest common denominator that lets the same trait object
+/// serve a 1 KiB ext2 and a 4 KiB ext4 mount without a conversion
+/// layer at each call site.
+///
+/// `BlockDevice` is `Send + Sync` so it can live inside
+/// `Arc<dyn BlockDevice>`: the cache, the writeback daemon, and the
+/// mount point all need to share one logical device.
+pub trait BlockDevice: Send + Sync {
+    /// Read `buf.len()` bytes starting at byte `offset`.
+    ///
+    /// `offset` and `buf.len()` must both be non-zero multiples of
+    /// [`block_size`](Self::block_size); otherwise
+    /// [`BlockError::BadAlign`] is returned. `offset + buf.len()` must
+    /// not exceed [`capacity`](Self::capacity); otherwise
+    /// [`BlockError::OutOfRange`] is returned.
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError>;
+
+    /// Write `buf.len()` bytes starting at byte `offset`.
+    ///
+    /// Same alignment / bounds rules as [`read_at`](Self::read_at).
+    /// Writes that would extend past `capacity()` return
+    /// [`BlockError::Enospc`] rather than `OutOfRange` — it's a
+    /// distinct user-facing failure.
+    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError>;
+
+    /// Logical block size in bytes. The minimum granularity for
+    /// `read_at`/`write_at`. Typically 512 for virtio-blk; the buffer
+    /// cache and filesystem layer can stack larger logical block sizes
+    /// on top.
+    fn block_size(&self) -> u32;
+
+    /// Total addressable capacity in bytes.
+    fn capacity(&self) -> u64;
+}
+
+/// Default block device brought up at boot. Populated by [`init`] and
+/// read by the buffer cache / filesystem mount path. `None` if no
+/// backend probed successfully.
+#[cfg(any(test, target_os = "none"))]
+static DEFAULT_DEVICE: Mutex<Option<Arc<dyn BlockDevice>>> = Mutex::new(None);
+
+/// Return the default block device registered at boot, if any.
+///
+/// The returned `Arc<dyn BlockDevice>` is cheap to clone — the buffer
+/// cache holds one, each mount holds one, etc.
+#[cfg(any(test, target_os = "none"))]
+pub fn default_device() -> Option<Arc<dyn BlockDevice>> {
+    DEFAULT_DEVICE.lock().clone()
+}
+
+/// Register `dev` as the default block device. Idempotent in the sense
+/// that a second call simply replaces the slot; there is currently no
+/// buffer cache attached that would need to be torn down first. Intended
+/// for the boot probe path and for tests that inject a ramdisk.
+#[cfg(any(test, target_os = "none"))]
+pub fn set_default_device(dev: Arc<dyn BlockDevice>) {
+    *DEFAULT_DEVICE.lock() = Some(dev);
 }
 
 /// Probe PCI and bring up the first supported block device. Called once
@@ -34,6 +167,9 @@ pub enum BlkError {
 #[cfg(target_os = "none")]
 pub fn init() {
     virtio_blk::init();
+    if virtio_blk::ready() {
+        set_default_device(Arc::new(virtio_blk::VirtioBlk::new()) as Arc<dyn BlockDevice>);
+    }
 }
 
 /// Read `buf.len() / 512` sectors starting at `lba` into `buf`.
@@ -42,7 +178,7 @@ pub fn init() {
 /// calling task on a polled spin-wait; intended for boot-time probes and
 /// the not-yet-existent filesystem layer, not for general user traffic.
 #[cfg(target_os = "none")]
-pub fn read(lba: u64, buf: &mut [u8]) -> Result<(), BlkError> {
+pub fn read(lba: u64, buf: &mut [u8]) -> Result<(), BlockError> {
     virtio_blk::read(lba, buf)
 }
 
@@ -53,7 +189,7 @@ pub fn read(lba: u64, buf: &mut [u8]) -> Result<(), BlkError> {
 /// buffer cap). Blocks on a polled spin-wait until the device reports
 /// completion or the poll budget elapses.
 #[cfg(target_os = "none")]
-pub fn write(lba: u64, buf: &[u8]) -> Result<(), BlkError> {
+pub fn write(lba: u64, buf: &[u8]) -> Result<(), BlockError> {
     virtio_blk::write(lba, buf)
 }
 
@@ -61,4 +197,177 @@ pub fn write(lba: u64, buf: &[u8]) -> Result<(), BlkError> {
 #[cfg(target_os = "none")]
 pub fn ready() -> bool {
     virtio_blk::ready()
+}
+
+#[cfg(all(test, not(target_os = "none")))]
+mod tests {
+    use super::*;
+    use alloc::sync::Arc;
+    use alloc::vec;
+    use alloc::vec::Vec;
+    use spin::Mutex;
+
+    /// In-memory block device used to exercise the [`BlockDevice`] trait
+    /// round-trip without standing up virtio-blk.
+    struct RamBlockDevice {
+        block_size: u32,
+        storage: Mutex<Vec<u8>>,
+    }
+
+    impl RamBlockDevice {
+        fn new(block_size: u32, blocks: usize) -> Self {
+            let bytes = (block_size as usize) * blocks;
+            Self {
+                block_size,
+                storage: Mutex::new(vec![0u8; bytes]),
+            }
+        }
+    }
+
+    impl BlockDevice for RamBlockDevice {
+        fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
+            let bs = self.block_size as u64;
+            if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
+                return Err(BlockError::BadAlign);
+            }
+            let end = offset
+                .checked_add(buf.len() as u64)
+                .ok_or(BlockError::OutOfRange)?;
+            let storage = self.storage.lock();
+            if end > storage.len() as u64 {
+                return Err(BlockError::OutOfRange);
+            }
+            let off = offset as usize;
+            buf.copy_from_slice(&storage[off..off + buf.len()]);
+            Ok(())
+        }
+
+        fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
+            let bs = self.block_size as u64;
+            if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
+                return Err(BlockError::BadAlign);
+            }
+            let end = offset
+                .checked_add(buf.len() as u64)
+                .ok_or(BlockError::Enospc)?;
+            let mut storage = self.storage.lock();
+            if end > storage.len() as u64 {
+                return Err(BlockError::Enospc);
+            }
+            let off = offset as usize;
+            storage[off..off + buf.len()].copy_from_slice(buf);
+            Ok(())
+        }
+
+        fn block_size(&self) -> u32 {
+            self.block_size
+        }
+
+        fn capacity(&self) -> u64 {
+            self.storage.lock().len() as u64
+        }
+    }
+
+    /// Trait-object round-trip: write via `&dyn BlockDevice`, read back
+    /// via the same trait object, assert the bytes match. Exercises the
+    /// full virtual dispatch path the buffer cache will use.
+    #[test]
+    fn trait_object_roundtrip() {
+        let dev: Arc<dyn BlockDevice> = Arc::new(RamBlockDevice::new(512, 16));
+        assert_eq!(dev.block_size(), 512);
+        assert_eq!(dev.capacity(), 512 * 16);
+
+        let mut payload = [0u8; 512];
+        for (i, b) in payload.iter_mut().enumerate() {
+            *b = (i as u8).wrapping_mul(3).wrapping_add(0x5a);
+        }
+        dev.write_at(512 * 4, &payload).expect("write_at");
+
+        let mut readback = [0u8; 512];
+        dev.read_at(512 * 4, &mut readback).expect("read_at");
+        assert_eq!(readback, payload);
+
+        // Untouched block is still zeros — proves the write hit the
+        // right offset and didn't spill.
+        let mut other = [0xffu8; 512];
+        dev.read_at(0, &mut other).expect("read_at lba 0");
+        assert!(other.iter().all(|b| *b == 0));
+    }
+
+    #[test]
+    fn misaligned_offset_and_length_are_rejected() {
+        let dev: Arc<dyn BlockDevice> = Arc::new(RamBlockDevice::new(512, 4));
+        let mut buf = [0u8; 512];
+
+        // Misaligned offset.
+        assert_eq!(
+            dev.read_at(1, &mut buf),
+            Err(BlockError::BadAlign),
+            "offset 1 should be rejected"
+        );
+
+        // Misaligned length.
+        let mut short = [0u8; 511];
+        assert_eq!(
+            dev.read_at(0, &mut short),
+            Err(BlockError::BadAlign),
+            "511-byte read should be rejected"
+        );
+
+        // Empty buffer.
+        let mut empty: [u8; 0] = [];
+        assert_eq!(dev.read_at(0, &mut empty), Err(BlockError::BadAlign));
+    }
+
+    #[test]
+    fn out_of_range_read_returns_oor() {
+        let dev: Arc<dyn BlockDevice> = Arc::new(RamBlockDevice::new(512, 4));
+        // Capacity is 4 * 512 = 2048. Offset 2048 is one past the last
+        // byte, so any non-zero read should fail.
+        let mut buf = [0u8; 512];
+        assert_eq!(dev.read_at(2048, &mut buf), Err(BlockError::OutOfRange));
+        assert_eq!(
+            dev.read_at(1536, &mut [0u8; 1024]),
+            Err(BlockError::OutOfRange)
+        );
+    }
+
+    #[test]
+    fn out_of_range_write_returns_enospc() {
+        let dev: Arc<dyn BlockDevice> = Arc::new(RamBlockDevice::new(512, 4));
+        let buf = [0u8; 512];
+        assert_eq!(dev.write_at(2048, &buf), Err(BlockError::Enospc));
+    }
+
+    /// Exercises the `set_default_device` / `default_device` registry
+    /// path the boot probe uses. Host-only — the target-side init path
+    /// is covered by the QEMU boot log.
+    #[test]
+    fn default_device_registry_roundtrip() {
+        // Leave the slot in whatever state we found it in — other tests
+        // running in the same binary might have set it. We assert only
+        // that a set call followed by a get returns our exact device.
+        let dev: Arc<dyn BlockDevice> = Arc::new(RamBlockDevice::new(1024, 8));
+        let ptr = Arc::as_ptr(&dev) as *const ();
+        set_default_device(dev);
+        let fetched = default_device().expect("default_device after set_default_device");
+        assert_eq!(Arc::as_ptr(&fetched) as *const (), ptr);
+        assert_eq!(fetched.block_size(), 1024);
+        assert_eq!(fetched.capacity(), 1024 * 8);
+    }
+
+    /// Pin `BlkError` as a compatibility alias for `BlockError` so old
+    /// match arms keep working — protects the virtio-blk driver and the
+    /// legacy `block::read`/`write` helpers from silent breakage.
+    #[test]
+    fn blkerror_is_block_error() {
+        let e: BlkError = BlockError::BadAlign;
+        assert_eq!(e, BlockError::BadAlign);
+
+        // Every legacy variant still resolves through the alias.
+        let _: BlkError = BlkError::NotInitialized;
+        let _: BlkError = BlkError::BadAlign;
+        let _: BlkError = BlkError::DeviceError;
+        let _: BlkError = BlkError::Timeout;
+    }
 }

--- a/kernel/src/block/virtio_blk.rs
+++ b/kernel/src/block/virtio_blk.rs
@@ -29,6 +29,10 @@
 #[cfg(target_os = "none")]
 use super::BlkError;
 #[cfg(target_os = "none")]
+use super::BlockDevice;
+#[cfg(target_os = "none")]
+use super::BlockError;
+#[cfg(target_os = "none")]
 use super::SECTOR_SIZE;
 
 #[cfg(target_os = "none")]
@@ -671,6 +675,87 @@ unsafe fn write16(base: u16, reg: u16, v: u16) {
 unsafe fn write32(base: u16, reg: u16, v: u32) {
     let mut p: Port<u32> = Port::new(base + reg);
     p.write(v);
+}
+
+/// [`BlockDevice`] wrapper around the singleton virtio-blk driver.
+///
+/// The driver itself is a module-level `DEVICE: Mutex<Option<BlkDevice>>`
+/// singleton — there is at most one virtio-blk in the system today — but
+/// the buffer cache and filesystem drivers want an `Arc<dyn BlockDevice>`
+/// per mount so they can hold a stable handle without reaching into this
+/// module. `VirtioBlk` is a zero-sized adapter that forwards each trait
+/// method to the underlying module-level `read`/`write`.
+///
+/// It is only meaningful to construct a `VirtioBlk` after
+/// [`init`] has brought the device up and [`ready`] returns `true`;
+/// calls against a not-yet-initialized device surface
+/// [`BlockError::NotInitialized`].
+///
+/// `SECTOR_SIZE` is reported as the block size. Future backends with
+/// different geometries (4 KiB on NVMe, for example) will report their
+/// own value.
+///
+/// # Capacity
+///
+/// The legacy virtio-blk driver does not read the device configuration
+/// registers that carry `capacity`; we therefore report `u64::MAX` as a
+/// conservative upper bound. Callers that need a real capacity (mount
+/// path, file-backed boot check) must obtain it out of band — the
+/// buffer cache keys on `(DeviceId, block_no)` and doesn't bounds-check
+/// against `capacity()`, so this is not yet a correctness gap.
+#[cfg(target_os = "none")]
+pub struct VirtioBlk;
+
+#[cfg(target_os = "none")]
+impl VirtioBlk {
+    /// Construct a new adapter. Cheap — the real driver state lives in
+    /// the module-level singleton and is shared across all adapters.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[cfg(target_os = "none")]
+impl Default for VirtioBlk {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(target_os = "none")]
+impl BlockDevice for VirtioBlk {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
+        let bs = SECTOR_SIZE as u64;
+        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
+            return Err(BlockError::BadAlign);
+        }
+        let lba = offset / bs;
+        read(lba, buf)
+    }
+
+    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
+        let bs = SECTOR_SIZE as u64;
+        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
+            return Err(BlockError::BadAlign);
+        }
+        let lba = offset / bs;
+        // Legacy driver doesn't know device capacity — writes past the
+        // end will surface as device error from the virtio backend
+        // (which is already mapped to `Eio` via `BlkError::DeviceError`).
+        write(lba, buf)
+    }
+
+    fn block_size(&self) -> u32 {
+        SECTOR_SIZE as u32
+    }
+
+    fn capacity(&self) -> u64 {
+        // Capacity is not yet plumbed up from the config BAR; report the
+        // conservative upper bound documented on the struct. Unblocks
+        // the trait contract without constraining callers that don't
+        // consult `capacity()`.
+        u64::MAX
+    }
 }
 
 #[cfg(all(test, not(target_os = "none")))]


### PR DESCRIPTION
Closes #551

## Summary
- Adds `pub trait BlockDevice { read_at, write_at, block_size, capacity }` per RFC 0004 Workstream C wave 1 — the byte-offset interface the buffer cache (#552, #553) and ext2 driver (workstream D) will hold as `Arc<dyn BlockDevice>`.
- Extends the existing `BlkError` into a `BlockError` enum with two new variants (`Enospc`, `OutOfRange`); `BlkError` is preserved as a type alias so the virtio-blk driver and legacy `block::read`/`write` helpers compile unchanged.
- Adds a zero-sized `VirtioBlk` adapter implementing `BlockDevice` by forwarding to the module-level `DEVICE` singleton, and registers an `Arc<dyn BlockDevice>` in a `DEFAULT_DEVICE` slot at the end of `block::init` so mounts can fetch it via `default_device()`.
- `SECTOR_SIZE` reported as `block_size`; `capacity` conservatively reports `u64::MAX` (the legacy driver does not yet read the virtio-blk config BAR — documented on `VirtioBlk`'s doc comment; future work once a caller actually consults `capacity()`).

## Design notes
- **Byte-offset, not LBA.** The cache keys on `(DeviceId, block_no)` where `block_no` is cache-block-sized (1 KiB or 4 KiB for ext2), not 512-byte sectors. Byte-offset is the narrowest common denominator that lets one trait object serve a 1 KiB and a 4 KiB mount — and matches redoxfs's `Disk::read_at`/`write_at` shape the RFC calls out as the cleanest Rust precedent.
- **`Send + Sync`** so `Arc<dyn BlockDevice>` is viable across the cache, writeback daemon, and mount point.

## Test plan
- [x] `cargo xtask build` — clean (pre-existing `is_guard_hit` dead-code warning unchanged)
- [x] `cargo xtask test` — 383 host unit tests pass including 6 new block-trait tests (round-trip, misalignment, OOR/Enospc, registry, alias); in-QEMU integration suite `[ok]`
- [x] `cargo xtask smoke` — all 33 markers present
- [x] New `block::tests::*` exercise the trait object via virtual dispatch against an in-memory `RamBlockDevice`, so the dispatch path the cache will take is covered.

## Out of scope / follow-ups
- Plumbing real capacity from the virtio-blk config BAR (`BlockDevice::capacity` currently returns `u64::MAX`) — defer until a caller needs it.
- Loopback / ramdisk block devices — future epic per issue body.