### PR TITLE
kernel/syscall: wire mkdir(2) and mkdirat(2) to VFS InodeOps::mkdir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,22 +36,31 @@ jobs:
       - name: Check vfs_creds is not default-on without Task::credentials
         run: |
           set -euo pipefail
-          # Workstream B sentinel: presence of `Task::credentials` as a
-          # field or method declaration in kernel sources.
-          if grep -rE '(pub[[:space:]]+)?credentials[[:space:]]*:[[:space:]]*.*Credential' kernel/src >/dev/null 2>&1 \
-             || grep -rE 'fn[[:space:]]+credentials[[:space:]]*\(' kernel/src >/dev/null 2>&1; then
-            echo "Task::credentials present — gate satisfied."
-            exit 0
+          # Workstream B sentinel: presence of `Task::credentials` on the
+          # Task type specifically. We scope to files that define or
+          # impl `Task` so an unrelated `credentials` field on some other
+          # type (e.g. a session or config struct) can't satisfy the gate.
+          task_files=$(grep -rlE '(^|[[:space:]])(struct|impl([[:space:]]|<))[[:space:]]*Task([[:space:]]|<|\{|$)' kernel/src 2>/dev/null || true)
+          if [ -n "$task_files" ]; then
+            if echo "$task_files" | xargs grep -E '(pub[[:space:]]+)?credentials[[:space:]]*:[[:space:]]*.*Credential' >/dev/null 2>&1 \
+               || echo "$task_files" | xargs grep -E 'fn[[:space:]]+credentials[[:space:]]*\(' >/dev/null 2>&1; then
+              echo "Task::credentials present — gate satisfied."
+              exit 0
+            fi
           fi
           # Sentinel absent: verify `vfs_creds` is not on by default.
-          default_line=$(awk '/^\[features\]/,/^\[/' kernel/Cargo.toml \
-                        | grep -E '^default[[:space:]]*=' || true)
-          if echo "$default_line" | grep -q 'vfs_creds'; then
+          # We parse Cargo.toml with Python/tomllib instead of awk ranges —
+          # `awk '/^\[features\]/,/^\[/'` fails open because the end
+          # pattern also matches the opening `[features]` header, making
+          # the awk block a single-line no-op and turning the DAC-bypass
+          # gate into a rubber stamp.
+          if python3 -c "import sys; tomllib=__import__('tomllib') if sys.version_info>=(3,11) else __import__('tomli'); cargo=tomllib.load(open('kernel/Cargo.toml','rb')); sys.exit(1 if 'vfs_creds' in cargo.get('features',{}).get('default',[]) else 0)"; then
+            echo "vfs_creds is gated off and Task::credentials is absent — consistent."
+          else
             echo "ERROR: vfs_creds is default-on but Task::credentials is absent." >&2
             echo "This would expose an unauthenticated DAC-bypass window (RFC 0004 §Security)." >&2
             exit 1
           fi
-          echo "vfs_creds is gated off and Task::credentials is absent — consistent."
 
   # Fast lane: formatting, clippy (host-only), and release build sanity.
   # Does not need QEMU, so it finishes well ahead of the kernel test jobs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,46 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # RFC 0004 Workstream A ↔ B gate: the `vfs_creds` feature must not be
+  # the default until Workstream B lands `Task::credentials`. Without
+  # per-task credentials, every VFS write syscall runs as root
+  # (`Credential::kernel()`) — enabling the feature before B merges
+  # would expose an unauthenticated full-DAC bypass. This is a
+  # belt-and-suspenders second line of defense behind the compile-time
+  # feature gate in `kernel/src/arch/x86_64/syscall.rs`.
+  #
+  # Rule:
+  #   - If `Task::credentials` is absent from the tree, `default` in
+  #     `kernel/Cargo.toml` must not contain `vfs_creds`.
+  #   - If `Task::credentials` is present, the gate is satisfied;
+  #     enabling `vfs_creds` by default is allowed.
+  vfs-creds-gate:
+    name: RFC 0004 vfs_creds gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Check vfs_creds is not default-on without Task::credentials
+        run: |
+          set -euo pipefail
+          # Workstream B sentinel: presence of `Task::credentials` as a
+          # field or method declaration in kernel sources.
+          if grep -rE '(pub[[:space:]]+)?credentials[[:space:]]*:[[:space:]]*.*Credential' kernel/src >/dev/null 2>&1 \
+             || grep -rE 'fn[[:space:]]+credentials[[:space:]]*\(' kernel/src >/dev/null 2>&1; then
+            echo "Task::credentials present — gate satisfied."
+            exit 0
+          fi
+          # Sentinel absent: verify `vfs_creds` is not on by default.
+          default_line=$(awk '/^\[features\]/,/^\[/' kernel/Cargo.toml \
+                        | grep -E '^default[[:space:]]*=' || true)
+          if echo "$default_line" | grep -q 'vfs_creds'; then
+            echo "ERROR: vfs_creds is default-on but Task::credentials is absent." >&2
+            echo "This would expose an unauthenticated DAC-bypass window (RFC 0004 §Security)." >&2
+            exit 1
+          fi
+          echo "vfs_creds is gated off and Task::credentials is absent — consistent."
+
   # Fast lane: formatting, clippy (host-only), and release build sanity.
   # Does not need QEMU, so it finishes well ahead of the kernel test jobs.
   fmt-build:

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -49,6 +49,14 @@ bench = []
 # never ship it. Enable with `cargo xtask run --features fork-trace` (or
 # `--features fork-trace` on any xtask subcommand).
 fork-trace = []
+# Workstream A ↔ B gate (RFC 0004). When off, POSIX write-side VFS
+# syscalls added by Workstream A (mkdir/mkdirat today; rmdir/unlink/…
+# in sibling PRs) compile to `-ENOSYS`. Workstream B flips this on in
+# the same PR that lands `Task::credentials`, so per-task credentials
+# are always available at every DAC-sensitive call site. Keeps a
+# partially-landed Workstream A from exposing an unauthenticated
+# DAC-bypass window.
+vfs_creds = []
 
 [[test]]
 name = "basic_boot"
@@ -272,6 +280,10 @@ harness = false
 
 [[test]]
 name = "syscall_mkfifo"
+harness = false
+
+[[test]]
+name = "syscall_mkdir"
 harness = false
 
 [[test]]

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -798,6 +798,22 @@ pub unsafe extern "C" fn syscall_dispatch(
         // mknodat(dfd, path, mode, dev) — like mknod relative to dfd.
         MKNODAT => super::syscalls::vfs::sys_mknodat_impl(a0 as i32, a1, a2, a3),
 
+        // mkdir(path, mode) — create a directory at `path`.
+        //
+        // RFC 0004 Workstream A ↔ B gate: the dispatch arm is compiled
+        // behind `vfs_creds` so a partially-landed Workstream A (write
+        // syscalls without per-task credentials) cannot be reached from
+        // ring-3. With the feature off the arm is absent and `nr == 83`
+        // falls through to the `_ => -ENOSYS` default. Integration tests
+        // reach the impl directly through `sys_mkdir_impl`.
+        #[cfg(feature = "vfs_creds")]
+        MKDIR => super::syscalls::vfs::sys_mkdir_impl(a0, a1),
+
+        // mkdirat(dfd, path, mode) — like mkdir relative to dfd. Same
+        // gate as MKDIR.
+        #[cfg(feature = "vfs_creds")]
+        MKDIRAT => super::syscalls::vfs::sys_mkdirat_impl(a0 as i32, a1, a2),
+
         // poll(fds, nfds, timeout_ms) — wait for readiness on a set of fds.
         POLL => crate::poll::syscalls::sys_poll(a0, a1, a2 as i64),
 
@@ -1390,6 +1406,8 @@ pub mod syscall_nr {
     pub const PIPE2: u64 = 293;
     pub const MKNOD: u64 = 133;
     pub const MKNODAT: u64 = 259;
+    pub const MKDIR: u64 = 83;
+    pub const MKDIRAT: u64 = 258;
     pub const POLL: u64 = 7;
     pub const SELECT: u64 = 23;
     pub const PSELECT6: u64 = 270;
@@ -1467,5 +1485,7 @@ mod tests {
         assert_eq!(syscall_nr::PIPE2, 293, "SYS_pipe2 must be 293");
         assert_eq!(syscall_nr::MKNOD, 133, "SYS_mknod must be 133");
         assert_eq!(syscall_nr::MKNODAT, 259, "SYS_mknodat must be 259");
+        assert_eq!(syscall_nr::MKDIR, 83, "SYS_mkdir must be 83");
+        assert_eq!(syscall_nr::MKDIRAT, 258, "SYS_mkdirat must be 258");
     }
 }

--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -28,10 +28,10 @@ use crate::fs::vfs::ops::{meta_into_stat, Stat};
 use crate::fs::vfs::ops::{SetAttr, SetAttrMask};
 use crate::fs::vfs::path_walk::{path_walk, LookupFlags, MountResolver, NameIdata, PATH_MAX};
 use crate::fs::vfs::super_block::SbActiveGuard;
-use crate::fs::vfs::Credential;
 use crate::fs::vfs::{
     root as vfs_root, GlobalMountResolver, Inode, InodeKind, OpenFile, VfsBackend,
 };
+use crate::fs::vfs::{Access, Credential};
 use crate::fs::{
     flags as oflags, FileBackend, FileDescription, EBADF, EEXIST, EINVAL, EISDIR, ENAMETOOLONG,
     ENOENT, ENOMEM, ENOTDIR,
@@ -735,4 +735,110 @@ pub unsafe fn sys_mknod_impl(path_uva: u64, mode: u64, dev: u64) -> i64 {
 /// Only `AT_FDCWD` and absolute paths are honored today.
 pub unsafe fn sys_mknodat_impl(dfd: i32, path_uva: u64, mode: u64, dev: u64) -> i64 {
     mknod_impl(dfd, path_uva, mode as u32, dev)
+}
+
+/// Shared body for `mkdir(2)` / `mkdirat(2)`.
+///
+/// Resolves the parent directory, checks the caller holds `W|X` on it,
+/// then dispatches to [`crate::fs::vfs::ops::InodeOps::mkdir`]. Errors
+/// are surfaced per RFC 0004 §Kernel-Userspace Interface:
+///
+/// - `EEXIST` — final component already exists.
+/// - `ENOTDIR` — a non-terminal path component is not a directory, or
+///   the final component has a trailing slash and the parent isn't one.
+/// - `ENOENT` — a path component doesn't exist.
+/// - `EACCES` — caller lacks `W|X` on the parent directory.
+/// - `ENAMETOOLONG` — path or a component exceeds POSIX caps.
+///
+/// `ENOTEMPTY` and `EBUSY` are emitted by sibling write-syscalls
+/// (rmdir / unlink) that operate on populated / pinned directories;
+/// they are mentioned in the errno table for completeness of the
+/// POSIX mkdir(2) + rmdir(2) surface but do not arise from mkdir
+/// itself.
+///
+/// Per-process umask application is deferred: this kernel has no
+/// umask field on the task struct yet (tracked as a follow-up to
+/// RFC 0004 Workstream B). The mode is therefore passed through
+/// after masking off non-permission bits (`& 0o7777`), matching
+/// how `mknod_impl` handles `mode` today. When umask plumbing lands,
+/// the masked mode becomes `mode & ~umask & 0o7777` — a mechanical
+/// one-line change here.
+fn mkdir_impl(dfd: i32, path_uva: u64, mode: u32) -> i64 {
+    let buf = match copy_user_path(path_uva) {
+        Ok(b) => b,
+        Err(e) => return e,
+    };
+    let path = buf.as_slice();
+
+    // Per-process cwd / fd-rooted walks don't exist yet — accept only
+    // AT_FDCWD for relative paths (same precondition as openat/mknodat).
+    let is_absolute = path.first() == Some(&b'/');
+    if dfd != AT_FDCWD && !is_absolute {
+        return EINVAL;
+    }
+
+    // `split_parent` strips a trailing slash from the leaf. Directories
+    // are the one kind of thing where a trailing slash on the path is
+    // legitimate — `mkdir("/foo/")` is the same as `mkdir("/foo")` per
+    // POSIX — so no equivalent of `mknod_impl`'s trailing-slash rejection
+    // is needed here.
+
+    // Refuse if the target already exists. The pre-check races with a
+    // concurrent creator, but the authoritative check is the FS driver's
+    // own duplicate-insert path — RamFs returns EEXIST under the dir
+    // rwsem (see `ramfs::InodeOps::mkdir`). The pre-walk just avoids
+    // the more expensive permission-check + parent-resolution round-trip
+    // when we already know the answer.
+    if resolve_inode(path, /* follow */ false).is_ok() {
+        return EEXIST;
+    }
+
+    let (parent_path, leaf) = match split_parent(path) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let (parent_inode, _pnd) = match resolve_inode(parent_path, /* follow */ true) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    if parent_inode.kind != InodeKind::Dir {
+        return ENOTDIR;
+    }
+
+    // DAC check: POSIX `mkdir(2)` requires write + search (execute bit
+    // on a directory) on the parent. Goes through `InodeOps::permission`
+    // so ACL-style overrides can take effect once an FS driver implements
+    // them. Until Workstream B plumbs per-task credentials, the caller
+    // is always `Credential::kernel()` (root) — the dispatch arm is
+    // feature-gated so this placeholder is never reachable from ring-3.
+    let cred = Credential::kernel();
+    let access = Access::WRITE | Access::EXECUTE;
+    if let Err(e) = parent_inode.ops.permission(&parent_inode, &cred, access) {
+        return e;
+    }
+
+    // Strip non-permission bits from `mode` (caller may have spuriously
+    // OR'd in S_IF* constants per some libc idioms). The driver is
+    // responsible for setting the `S_IFDIR` type bit on the new inode.
+    let perm = (mode & 0o7777) as u16;
+    match parent_inode.ops.mkdir(&parent_inode, leaf, perm) {
+        Ok(_) => 0,
+        Err(e) => e,
+    }
+}
+
+/// `mkdir(path, mode)` — create a directory at `path`.
+///
+/// Dispatches through [`mkdir_impl`] with `dfd = AT_FDCWD`.
+pub unsafe fn sys_mkdir_impl(path_uva: u64, mode: u64) -> i64 {
+    mkdir_impl(AT_FDCWD, path_uva, mode as u32)
+}
+
+/// `mkdirat(dfd, path, mode)` — like `mkdir` but relative to `dfd`.
+///
+/// Honors `AT_FDCWD` (use the current working directory) and absolute
+/// paths; a real fd with a relative path returns `EINVAL` until
+/// per-process fd-rooted walks land (issue #239).
+pub unsafe fn sys_mkdirat_impl(dfd: i32, path_uva: u64, mode: u64) -> i64 {
+    mkdir_impl(dfd, path_uva, mode as u32)
 }

--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -783,6 +783,16 @@ fn mkdir_impl(dfd: i32, path_uva: u64, mode: u32) -> i64 {
     // POSIX — so no equivalent of `mknod_impl`'s trailing-slash rejection
     // is needed here.
 
+    // Normalize the leaf first so that invalid leaves (".", "..", "") are
+    // rejected with ENOENT (per the PR contract) before any EEXIST fast
+    // path gets a chance to classify them. Running `resolve_inode` first
+    // would let `/tmp/.` map to the existing `/tmp` inode and return
+    // EEXIST, which is the wrong errno.
+    let (parent_path, leaf) = match split_parent(path) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
     // Refuse if the target already exists. The pre-check races with a
     // concurrent creator, but the authoritative check is the FS driver's
     // own duplicate-insert path — RamFs returns EEXIST under the dir
@@ -792,11 +802,6 @@ fn mkdir_impl(dfd: i32, path_uva: u64, mode: u32) -> i64 {
     if resolve_inode(path, /* follow */ false).is_ok() {
         return EEXIST;
     }
-
-    let (parent_path, leaf) = match split_parent(path) {
-        Ok(v) => v,
-        Err(e) => return e,
-    };
     let (parent_inode, _pnd) = match resolve_inode(parent_path, /* follow */ true) {
         Ok(v) => v,
         Err(e) => return e,

--- a/kernel/tests/syscall_mkdir.rs
+++ b/kernel/tests/syscall_mkdir.rs
@@ -255,20 +255,14 @@ fn mkdir_missing_parent_is_enoent() {
 
 fn mkdir_dot_is_enoent() {
     // The leaf-normalizer in split_parent rejects ".", "..", and the
-    // empty string — they can't be nameable leaves. "/" is rejected
-    // too (maps to EEXIST since the root already exists).
+    // empty string — they can't be nameable leaves. The normalizer runs
+    // *before* the EEXIST fast path, so these must always return ENOENT
+    // (never EEXIST, even though `/tmp/.` resolves to the existing
+    // `/tmp` inode).
     let r = mkdir(b"/tmp/.", 0o755);
-    assert!(
-        r == ENOENT || r == EEXIST,
-        "mkdir('/tmp/.') must fail with ENOENT or EEXIST, got {}",
-        r
-    );
+    assert_eq!(r, ENOENT, "mkdir('/tmp/.') must ENOENT, got {}", r);
     let r = mkdir(b"/tmp/..", 0o755);
-    assert!(
-        r == ENOENT || r == EEXIST,
-        "mkdir('/tmp/..') must fail with ENOENT or EEXIST, got {}",
-        r
-    );
+    assert_eq!(r, ENOENT, "mkdir('/tmp/..') must ENOENT, got {}", r);
     let r = mkdir(b"", 0o755);
     assert_eq!(r, ENOENT, "mkdir('') must ENOENT, got {}", r);
 }

--- a/kernel/tests/syscall_mkdir.rs
+++ b/kernel/tests/syscall_mkdir.rs
@@ -1,0 +1,328 @@
+//! Integration test for issue #538: `mkdir(2)` / `mkdirat(2)` wired
+//! to `InodeOps::mkdir`.
+//!
+//! Drives the new `sys_mkdir_impl` / `sys_mkdirat_impl` entry points
+//! against the RamFs root:
+//!
+//! - `mkdir(path, mode)` creates a directory; a subsequent `stat`
+//!   returns `S_IFDIR`.
+//! - Re-creating the same path returns `-EEXIST`.
+//! - `mkdir` under a non-directory parent returns `-ENOTDIR`.
+//! - `mkdir` under a missing parent returns `-ENOENT`.
+//! - `mkdir(".")` / `mkdir("..")` / `mkdir("")` return `-ENOENT`
+//!   (the leaf-normalizer rejects them).
+//! - `mkdirat(AT_FDCWD, path, mode)` creates a directory.
+//! - `mkdirat(some_fd, "rel/path", mode)` returns `-EINVAL` — relative
+//!   paths against a real fd aren't supported until per-fd walks land
+//!   (issue #239).
+//!
+//! The test calls `sys_mkdir_impl` / `sys_mkdirat_impl` directly rather
+//! than through `syscall_dispatch`, because the dispatch arm is gated
+//! behind the RFC 0004 Workstream A ↔ B feature flag `vfs_creds` and
+//! would return `-ENOSYS` until Workstream B lands per-task credentials.
+//! Testing the impl function gives end-to-end coverage of the VFS
+//! wiring without depending on that feature being flipped.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use core::ptr;
+
+use vibix::arch::x86_64::syscalls::vfs::{sys_mkdir_impl, sys_mkdirat_impl, AT_FDCWD};
+use vibix::fs::vfs::ops::Stat;
+use vibix::fs::{EEXIST, EINVAL, ENOENT, ENOTDIR};
+use vibix::mem::vmatree::{Share, Vma};
+use vibix::mem::vmobject::AnonObject;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+use x86_64::structures::paging::PageTableFlags;
+
+use vibix::arch::x86_64::syscall::syscall_dispatch;
+
+const SYS_STAT: u64 = 4;
+
+const S_IFMT: u32 = 0o170_000;
+const S_IFDIR: u32 = 0o040_000;
+
+const USER_PAGE_VA: usize = 0x0000_2003_0000_0000;
+const USER_PAGE_LEN: usize = 4 * 4096;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    vibix::task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "mkdir_creates_directory",
+            &(mkdir_creates_directory as fn()),
+        ),
+        (
+            "mkdir_existing_is_eexist",
+            &(mkdir_existing_is_eexist as fn()),
+        ),
+        (
+            "mkdir_under_file_is_enotdir",
+            &(mkdir_under_file_is_enotdir as fn()),
+        ),
+        (
+            "mkdir_missing_parent_is_enoent",
+            &(mkdir_missing_parent_is_enoent as fn()),
+        ),
+        ("mkdir_dot_is_enoent", &(mkdir_dot_is_enoent as fn())),
+        (
+            "mkdir_trailing_slash_ok",
+            &(mkdir_trailing_slash_ok as fn()),
+        ),
+        (
+            "mkdirat_at_fdcwd_creates_directory",
+            &(mkdirat_at_fdcwd_creates_directory as fn()),
+        ),
+        (
+            "mkdirat_real_fd_relative_path_einval",
+            &(mkdirat_real_fd_relative_path_einval as fn()),
+        ),
+        (
+            "mkdir_strips_non_permission_bits",
+            &(mkdir_strips_non_permission_bits as fn()),
+        ),
+    ];
+    for (name, t) in tests {
+        serial_println!("syscall_mkdir: {}", name);
+        t.run();
+    }
+}
+
+fn install_user_staging_vma() {
+    static INSTALLED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+    if INSTALLED.swap(true, core::sync::atomic::Ordering::SeqCst) {
+        return;
+    }
+    let prot_pte =
+        (PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE).bits();
+    vibix::task::install_vma_on_current(Vma::new(
+        USER_PAGE_VA,
+        USER_PAGE_VA + USER_PAGE_LEN,
+        0x3,
+        prot_pte,
+        Share::Private,
+        AnonObject::new(Some(USER_PAGE_LEN / 4096)),
+        0,
+    ));
+    unsafe {
+        let dst = USER_PAGE_VA as *mut u8;
+        let mut i = 0;
+        while i < USER_PAGE_LEN {
+            ptr::write_volatile(dst.add(i), 0);
+            i += 4096;
+        }
+    }
+}
+
+fn stage(bytes: &[u8]) -> u64 {
+    install_user_staging_vma();
+    assert!(bytes.len() < 4096);
+    unsafe {
+        let dst = USER_PAGE_VA as *mut u8;
+        for (i, b) in bytes.iter().enumerate() {
+            ptr::write_volatile(dst.add(i), *b);
+        }
+        ptr::write_volatile(dst.add(bytes.len()), 0);
+    }
+    USER_PAGE_VA as u64
+}
+
+fn statbuf_uva() -> u64 {
+    install_user_staging_vma();
+    USER_PAGE_VA as u64 + 3 * 4096
+}
+
+fn read_stat() -> Stat {
+    unsafe { ptr::read_volatile(statbuf_uva() as *const Stat) }
+}
+
+fn mkdir(path: &[u8], mode: u64) -> i64 {
+    let uva = stage(path);
+    unsafe { sys_mkdir_impl(uva, mode) }
+}
+
+fn mkdirat(dfd: i32, path: &[u8], mode: u64) -> i64 {
+    let uva = stage(path);
+    unsafe { sys_mkdirat_impl(dfd, uva, mode) }
+}
+
+fn stat(path: &[u8]) -> i64 {
+    let uva = stage(path);
+    unsafe {
+        syscall_dispatch(
+            core::ptr::null_mut(),
+            SYS_STAT,
+            uva,
+            statbuf_uva(),
+            0,
+            0,
+            0,
+            0,
+        )
+    }
+}
+
+// --- mknod helper to synthesize a non-directory parent ----------------
+
+const SYS_MKNOD: u64 = 133;
+const S_IFREG: u64 = 0o100_000;
+
+fn mknod_reg(path: &[u8]) -> i64 {
+    let uva = stage(path);
+    unsafe {
+        syscall_dispatch(
+            core::ptr::null_mut(),
+            SYS_MKNOD,
+            uva,
+            S_IFREG | 0o644,
+            0,
+            0,
+            0,
+            0,
+        )
+    }
+}
+
+// --- Tests -----------------------------------------------------------------
+
+fn mkdir_creates_directory() {
+    let r = mkdir(b"/tmp/mkdir-basic", 0o755);
+    assert_eq!(r, 0, "mkdir must return 0, got {}", r);
+    // Verify the new inode is a directory.
+    let r = stat(b"/tmp/mkdir-basic");
+    assert_eq!(r, 0, "stat of new dir must succeed, got {}", r);
+    let st = read_stat();
+    assert_eq!(
+        st.st_mode & S_IFMT,
+        S_IFDIR,
+        "new inode must have S_IFDIR set, got mode {:#o}",
+        st.st_mode
+    );
+}
+
+fn mkdir_existing_is_eexist() {
+    let r = mkdir(b"/tmp/mkdir-eexist", 0o755);
+    assert_eq!(r, 0);
+    let r = mkdir(b"/tmp/mkdir-eexist", 0o755);
+    assert_eq!(
+        r, EEXIST,
+        "re-mkdir of existing path must EEXIST, got {}",
+        r
+    );
+}
+
+fn mkdir_under_file_is_enotdir() {
+    // Create a regular file, then attempt to mkdir under it.
+    let r = mknod_reg(b"/tmp/mkdir-notdir-parent");
+    assert_eq!(r, 0);
+    let r = mkdir(b"/tmp/mkdir-notdir-parent/child", 0o755);
+    assert_eq!(
+        r, ENOTDIR,
+        "mkdir under non-dir parent must ENOTDIR, got {}",
+        r
+    );
+}
+
+fn mkdir_missing_parent_is_enoent() {
+    let r = mkdir(b"/tmp/nonexistent-parent-xyz/child", 0o755);
+    assert_eq!(
+        r, ENOENT,
+        "mkdir under missing parent must ENOENT, got {}",
+        r
+    );
+}
+
+fn mkdir_dot_is_enoent() {
+    // The leaf-normalizer in split_parent rejects ".", "..", and the
+    // empty string — they can't be nameable leaves. "/" is rejected
+    // too (maps to EEXIST since the root already exists).
+    let r = mkdir(b"/tmp/.", 0o755);
+    assert!(
+        r == ENOENT || r == EEXIST,
+        "mkdir('/tmp/.') must fail with ENOENT or EEXIST, got {}",
+        r
+    );
+    let r = mkdir(b"/tmp/..", 0o755);
+    assert!(
+        r == ENOENT || r == EEXIST,
+        "mkdir('/tmp/..') must fail with ENOENT or EEXIST, got {}",
+        r
+    );
+    let r = mkdir(b"", 0o755);
+    assert_eq!(r, ENOENT, "mkdir('') must ENOENT, got {}", r);
+}
+
+fn mkdir_trailing_slash_ok() {
+    // POSIX: "mkdir(path)" with a trailing slash on `path` is equivalent
+    // to mkdir without it. `split_parent` strips it for us.
+    let r = mkdir(b"/tmp/mkdir-trailing/", 0o755);
+    assert_eq!(r, 0, "mkdir with trailing slash must succeed, got {}", r);
+    // Confirm the resulting inode is a directory.
+    let r = stat(b"/tmp/mkdir-trailing");
+    assert_eq!(r, 0);
+    let st = read_stat();
+    assert_eq!(st.st_mode & S_IFMT, S_IFDIR);
+}
+
+fn mkdirat_at_fdcwd_creates_directory() {
+    let r = mkdirat(AT_FDCWD, b"/tmp/mkdirat-fdcwd", 0o755);
+    assert_eq!(r, 0, "mkdirat(AT_FDCWD, abs) must return 0, got {}", r);
+    let r = stat(b"/tmp/mkdirat-fdcwd");
+    assert_eq!(r, 0);
+    let st = read_stat();
+    assert_eq!(st.st_mode & S_IFMT, S_IFDIR);
+}
+
+fn mkdirat_real_fd_relative_path_einval() {
+    // Per-fd walks don't exist yet (#239) — a real fd + relative path
+    // must bounce with -EINVAL, not silently walk from somewhere else.
+    let r = mkdirat(3, b"rel/child", 0o755);
+    assert_eq!(
+        r, EINVAL,
+        "mkdirat(real_fd, relative) must EINVAL, got {}",
+        r
+    );
+}
+
+fn mkdir_strips_non_permission_bits() {
+    // Caller may (incorrectly) OR a type bit into `mode`; we strip it.
+    // The new inode's mode must carry permission bits only — the VFS
+    // layer sets S_IFDIR itself.
+    let mode = 0o040_000 | 0o755; // S_IFDIR | 0o755
+    let r = mkdir(b"/tmp/mkdir-strip", mode);
+    assert_eq!(r, 0, "mkdir must ignore spurious type bits, got {}", r);
+    let r = stat(b"/tmp/mkdir-strip");
+    assert_eq!(r, 0);
+    let st = read_stat();
+    assert_eq!(
+        st.st_mode & S_IFMT,
+        S_IFDIR,
+        "type bits come from VFS, not caller"
+    );
+    assert_eq!(
+        st.st_mode & 0o7777,
+        0o755,
+        "permission bits must match caller's masked mode"
+    );
+}


### PR DESCRIPTION
Closes #538.

## Summary

Implements RFC 0004 Workstream A, wave 1 step 1: the two new
`mkdir(2)` / `mkdirat(2)` arms dispatch through the VFS to the
already-existing `InodeOps::mkdir` (reference implementation in
`kernel/src/fs/vfs/ramfs.rs`).

Per RFC 0004 §Security the dispatch arms land behind the
`vfs_creds` compile-time feature. With the feature off (today's
default) the syscall numbers fall through to `-ENOSYS`. Workstream
B flips the feature on in the same PR that lands per-task
`Task::credentials`, closing the A-before-B window where
`Credential::kernel()` would otherwise be reachable from ring-3
as an unauthenticated full-DAC bypass.

Belt-and-suspenders: a new `vfs-creds-gate` CI job fails the build
if `vfs_creds` is default-on while `Task::credentials` is absent
from `kernel/src`.

## Changes

- `kernel/src/arch/x86_64/syscalls/vfs.rs`: new `sys_mkdir_impl`,
  `sys_mkdirat_impl`, and shared `mkdir_impl` helper.
  Resolves parent via the existing `resolve_inode`, `split_parent`
  split off for the leaf, `InodeOps::permission(&parent, &cred,
  WRITE|EXECUTE)` for the DAC check, then `parent.ops.mkdir(...)`.
  Mode is masked to permission bits; per-process umask is deferred
  to a follow-up to Workstream B (no umask field on the task struct
  yet).
- `kernel/src/arch/x86_64/syscall.rs`: pins `MKDIR = 83`,
  `MKDIRAT = 258` in `syscall_nr` + matching assertions in the
  Linux-ABI sanity test (issue #278 regression anchor). Both
  dispatch arms are `#[cfg(feature = "vfs_creds")]`.
- `kernel/Cargo.toml`: declares the `vfs_creds` feature (default
  off).
- `.github/workflows/ci.yml`: adds the `vfs-creds-gate` job.
- `kernel/tests/syscall_mkdir.rs`: new integration test, nine
  subtests. Calls `sys_mkdir_impl` / `sys_mkdirat_impl` directly so
  coverage doesn't require flipping `vfs_creds` on.

## Errno table (RFC 0004 §Kernel-Userspace Interface)

| Condition                            | Errno       |
|--------------------------------------|-------------|
| Success                              | 0           |
| Leaf already exists                  | `EEXIST`    |
| Parent isn't a directory             | `ENOTDIR`   |
| Parent doesn't exist                 | `ENOENT`    |
| Caller lacks W or X on parent        | `EACCES`    |
| Leaf is `.`, `..`, or empty          | `ENOENT`    |
| Path too long                        | `ENAMETOOLONG` |
| Kernel OOM during path copy          | `ENOMEM`    |
| Real dfd + relative path (no cwd yet)| `EINVAL`    |

`ENOTEMPTY` and `EBUSY` are in the POSIX mkdir/rmdir errno table but
only arise from `rmdir(2)` / `unlink(2)` — those land in sibling
issues #539 / #540.

## Out of scope

- `rmdir` — sibling issue #539.
- `unlink` / `unlinkat` — sibling issue #540.
- Real credentials — blocked on Workstream B (#546).
- Per-process umask — deferred; see follow-up note in `mkdir_impl`.

## Test plan

- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy -p xtask --all-targets -- -D warnings` — clean.
- [x] `cargo xtask build` — succeeds default-features.
- [x] `cargo build --target x86_64-unknown-none --features vfs_creds`
      — succeeds with feature on (validates the `#[cfg]`-gated arms
      compile).
- [x] `cargo xtask test-unit` — 377 passed / 0 failed. The
      `syscall_numbers_match_linux_x86_64_abi` assertion covers the
      two new constants.
- [x] `cargo test --package vibix --test syscall_mkdir` — all 9
      subtests green (default features).
- [x] `cargo test --package vibix --test syscall_mkdir --features
      vfs_creds` — all 9 subtests green with the feature on too.
- [x] Regression: `syscall_mkfifo`, `syscall_vfs`, `vfs_backend`,
      `vfs_hello`, `syscall_open_mmap` — all green.
- [x] `cargo xtask smoke` — all 33 markers present.
- [x] `vfs-creds-gate` script run locally: reports "vfs_creds is
      gated off and Task::credentials is absent — consistent."

## Pre-existing issues surfaced (not caused by this PR)

- `cargo xtask test` under emulation is flaky on a couple of
  unrelated tests (`syscall_stack_switch`, `fork_refcount`) — they
  also time out on the pre-patch main tip, so it's an environmental
  flake, not new. Individual invocations of both tests pass when
  retried. Worth a follow-up issue if this recurs in CI.