### PR TITLE
sys: wire rmdir(2) to VFS InodeOps::rmdir

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -287,6 +287,10 @@ name = "syscall_mkdir"
 harness = false
 
 [[test]]
+name = "syscall_rmdir"
+harness = false
+
+[[test]]
 name = "ntty_sigint_flush"
 harness = false
 

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -814,6 +814,10 @@ pub unsafe extern "C" fn syscall_dispatch(
         #[cfg(feature = "vfs_creds")]
         MKDIRAT => super::syscalls::vfs::sys_mkdirat_impl(a0 as i32, a1, a2),
 
+        // rmdir(path) — remove an empty directory. Dispatches to
+        // InodeOps::rmdir on the parent after path-walking to the leaf.
+        RMDIR => super::syscalls::vfs::sys_rmdir_impl(a0),
+
         // poll(fds, nfds, timeout_ms) — wait for readiness on a set of fds.
         POLL => crate::poll::syscalls::sys_poll(a0, a1, a2 as i64),
 
@@ -1408,6 +1412,7 @@ pub mod syscall_nr {
     pub const MKNODAT: u64 = 259;
     pub const MKDIR: u64 = 83;
     pub const MKDIRAT: u64 = 258;
+    pub const RMDIR: u64 = 84;
     pub const POLL: u64 = 7;
     pub const SELECT: u64 = 23;
     pub const PSELECT6: u64 = 270;
@@ -1487,5 +1492,8 @@ mod tests {
         assert_eq!(syscall_nr::MKNODAT, 259, "SYS_mknodat must be 259");
         assert_eq!(syscall_nr::MKDIR, 83, "SYS_mkdir must be 83");
         assert_eq!(syscall_nr::MKDIRAT, 258, "SYS_mkdirat must be 258");
+
+        // Directory removal
+        assert_eq!(syscall_nr::RMDIR, 84, "SYS_rmdir must be 84");
     }
 }

--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -878,19 +878,20 @@ pub unsafe fn sys_rmdir_impl(path_uva: u64) -> i64 {
     if path.is_empty() {
         return ENOENT;
     }
-    // `rmdir("/")` never succeeds — the FS root is a mountpoint that
-    // cannot be removed. Return EBUSY per Linux's root-removal errno.
-    if path == b"/" {
-        return crate::fs::EBUSY;
+
+    // Collapse *all* trailing slashes so "/foo", "/foo/", and "/foo//"
+    // share the leaf check and the parent split. Bare "/" survives as
+    // "/" because the loop only strips while `len > 1`.
+    let mut trimmed: &[u8] = path;
+    while trimmed.len() > 1 && *trimmed.last().unwrap() == b'/' {
+        trimmed = &trimmed[..trimmed.len() - 1];
     }
 
-    // Strip trailing slash so ".../foo/" and ".../foo" share the leaf
-    // check. Keep bare "/" handled above since `split_parent` rejects it.
-    let trimmed: &[u8] = if path.len() > 1 && *path.last().unwrap() == b'/' {
-        &path[..path.len() - 1]
-    } else {
-        path
-    };
+    // `rmdir("/")` never succeeds — the FS root is a mountpoint that
+    // cannot be removed. Return EBUSY per Linux's root-removal errno.
+    if trimmed == b"/" {
+        return crate::fs::EBUSY;
+    }
 
     // Locate the leaf to enforce POSIX's `.` / `..` rejection before
     // committing to a full path walk. The resolver below would
@@ -910,7 +911,11 @@ pub unsafe fn sys_rmdir_impl(path_uva: u64) -> i64 {
         return crate::fs::ENOTEMPTY;
     }
 
-    let (parent_path, leaf) = match split_parent(path) {
+    // Pass the trailing-slash-collapsed path to `split_parent` so the
+    // inner strip logic sees a clean leaf (it only peels one slash
+    // itself, so multi-slash inputs would otherwise come back with an
+    // empty leaf → ENOENT).
+    let (parent_path, leaf) = match split_parent(trimmed) {
         Ok(v) => v,
         Err(e) => return e,
     };

--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -847,3 +847,83 @@ pub unsafe fn sys_mkdir_impl(path_uva: u64, mode: u64) -> i64 {
 pub unsafe fn sys_mkdirat_impl(dfd: i32, path_uva: u64, mode: u64) -> i64 {
     mkdir_impl(dfd, path_uva, mode as u32)
 }
+
+/// `rmdir(path)` — remove an empty directory.
+///
+/// RFC 0004 — Workstream A: wires the syscall to
+/// [`crate::fs::vfs::ops::InodeOps::rmdir`] on the parent directory's
+/// inode. The trait implementation is responsible for verifying the
+/// target is a directory, that it is empty (non-empty → `-ENOTEMPTY`),
+/// taking `dir_rwsem` for the parent, and decrementing the parent's
+/// `nlink` for the removed `..` backlink.
+///
+/// Shaping done here (POSIX deltas that the per-FS op can't see):
+/// - Empty path → `-ENOENT`.
+/// - Bare `/` → `-EBUSY` (removing the mount root is always refused).
+/// - Leaf of `.` (e.g. `rmdir(".")` or `rmdir("foo/.")`) → `-EINVAL`.
+/// - Leaf of `..` (e.g. `rmdir("..")` or `rmdir("foo/..")`) →
+///   `-ENOTEMPTY`, matching Linux. Kept separate from `.` so callers
+///   can tell "current directory" from "parent of".
+/// - Parent not a directory → `-ENOTDIR`.
+///
+/// Credential is `Credential::kernel()` until Workstream B (#546)
+/// lands per-task credentials.
+pub unsafe fn sys_rmdir_impl(path_uva: u64) -> i64 {
+    let buf = match copy_user_path(path_uva) {
+        Ok(b) => b,
+        Err(e) => return e,
+    };
+    let path = buf.as_slice();
+
+    if path.is_empty() {
+        return ENOENT;
+    }
+    // `rmdir("/")` never succeeds — the FS root is a mountpoint that
+    // cannot be removed. Return EBUSY per Linux's root-removal errno.
+    if path == b"/" {
+        return crate::fs::EBUSY;
+    }
+
+    // Strip trailing slash so ".../foo/" and ".../foo" share the leaf
+    // check. Keep bare "/" handled above since `split_parent` rejects it.
+    let trimmed: &[u8] = if path.len() > 1 && *path.last().unwrap() == b'/' {
+        &path[..path.len() - 1]
+    } else {
+        path
+    };
+
+    // Locate the leaf to enforce POSIX's `.` / `..` rejection before
+    // committing to a full path walk. The resolver below would
+    // otherwise resolve `.` / `..` silently and mis-target an ancestor.
+    let leaf_after_slash = trimmed
+        .iter()
+        .rposition(|&b| b == b'/')
+        .map(|i| &trimmed[i + 1..])
+        .unwrap_or(trimmed);
+    if leaf_after_slash == b"." {
+        // POSIX: rmdir(".") is always EINVAL.
+        return EINVAL;
+    }
+    if leaf_after_slash == b".." {
+        // Linux: rmdir("..") returns ENOTEMPTY because the parent
+        // directory has `.` and children referring back.
+        return crate::fs::ENOTEMPTY;
+    }
+
+    let (parent_path, leaf) = match split_parent(path) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let (parent_inode, _pnd) = match resolve_inode(parent_path, /* follow */ true) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    if parent_inode.kind != InodeKind::Dir {
+        return ENOTDIR;
+    }
+
+    match parent_inode.ops.rmdir(&parent_inode, leaf) {
+        Ok(()) => 0,
+        Err(e) => e,
+    }
+}

--- a/kernel/tests/syscall_rmdir.rs
+++ b/kernel/tests/syscall_rmdir.rs
@@ -1,0 +1,238 @@
+//! Integration test for issue #539 / RFC 0004 Workstream A:
+//! `rmdir(2)` wired to `InodeOps::rmdir`.
+//!
+//! Drives the SYS_RMDIR dispatch arm end-to-end through the `/tmp`
+//! ramfs mount. The test pre-populates directory state via the ramfs
+//! `InodeOps::mkdir` (since the `mkdir` syscall is a separate wiring
+//! issue, #538) and then verifies that the syscall path:
+//!
+//! - Removes an empty directory successfully (`rc == 0`).
+//! - Returns `ENOTEMPTY` when the target contains entries.
+//! - Returns `ENOENT` on a missing name.
+//! - Returns `ENOTDIR` when the target is a regular file.
+//! - Rejects `rmdir(".")` with `EINVAL`.
+//! - Rejects `rmdir("..")` with `ENOTEMPTY` (Linux convention).
+//! - Refuses to remove the mount root (`rmdir("/")` → `EBUSY`).
+//! - Accepts and normalises a trailing-slash path.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use core::panic::PanicInfo;
+use core::ptr;
+
+use vibix::arch::x86_64::syscall::syscall_dispatch;
+use vibix::fs::vfs::path_walk::{path_walk, LookupFlags, NameIdata};
+use vibix::fs::vfs::{Credential, GlobalMountResolver, Inode};
+use vibix::fs::{EBUSY, EINVAL, ENOENT, ENOTDIR, ENOTEMPTY};
+use vibix::mem::vmatree::{Share, Vma};
+use vibix::mem::vmobject::AnonObject;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+use x86_64::structures::paging::PageTableFlags;
+
+const SYS_RMDIR: u64 = 84;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    vibix::task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "rmdir_removes_empty_dir",
+            &(rmdir_removes_empty_dir as fn()),
+        ),
+        ("rmdir_enotempty", &(rmdir_enotempty as fn())),
+        ("rmdir_enoent", &(rmdir_enoent as fn())),
+        (
+            "rmdir_enotdir_on_regular_file",
+            &(rmdir_enotdir_on_regular_file as fn()),
+        ),
+        ("rmdir_dot_einval", &(rmdir_dot_einval as fn())),
+        ("rmdir_dotdot_enotempty", &(rmdir_dotdot_enotempty as fn())),
+        ("rmdir_root_ebusy", &(rmdir_root_ebusy as fn())),
+        (
+            "rmdir_trailing_slash_ok",
+            &(rmdir_trailing_slash_ok as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+// --- User-staging helpers ------------------------------------------------
+
+const USER_PAGE_VA: usize = 0x0000_2004_0000_0000;
+const USER_PAGE_LEN: usize = 4 * 4096;
+
+fn install_user_staging_vma() {
+    static INSTALLED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+    if INSTALLED.swap(true, core::sync::atomic::Ordering::SeqCst) {
+        return;
+    }
+    let prot_pte =
+        (PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE).bits();
+    vibix::task::install_vma_on_current(Vma::new(
+        USER_PAGE_VA,
+        USER_PAGE_VA + USER_PAGE_LEN,
+        0x3,
+        prot_pte,
+        Share::Private,
+        AnonObject::new(Some(USER_PAGE_LEN / 4096)),
+        0,
+    ));
+    unsafe {
+        let dst = USER_PAGE_VA as *mut u8;
+        let mut i = 0;
+        while i < USER_PAGE_LEN {
+            ptr::write_volatile(dst.add(i), 0);
+            i += 4096;
+        }
+    }
+}
+
+fn stage_path(bytes: &[u8]) -> u64 {
+    install_user_staging_vma();
+    assert!(bytes.len() < 4096);
+    unsafe {
+        let dst = USER_PAGE_VA as *mut u8;
+        for (i, b) in bytes.iter().enumerate() {
+            ptr::write_volatile(dst.add(i), *b);
+        }
+        ptr::write_volatile(dst.add(bytes.len()), 0);
+    }
+    USER_PAGE_VA as u64
+}
+
+fn rmdir(path: &[u8]) -> i64 {
+    let uva = stage_path(path);
+    unsafe { syscall_dispatch(core::ptr::null_mut(), SYS_RMDIR, uva, 0, 0, 0, 0, 0) }
+}
+
+// --- Direct VFS helpers (sidestep missing mkdir/create/unlink syscalls) --
+
+/// Resolve `path` to an `Arc<Inode>` through `path_walk`, rooted at the
+/// VFS namespace root. Panics on miss — the test authors seed only
+/// known-good paths through this helper.
+fn resolve(path: &[u8]) -> Arc<Inode> {
+    let root = vibix::fs::vfs::root().expect("vfs root not live");
+    let mut nd = NameIdata::new(
+        root.clone(),
+        root,
+        Credential::kernel(),
+        LookupFlags::default(),
+    )
+    .expect("seed namei");
+    path_walk(&mut nd, path, &GlobalMountResolver).expect("path_walk");
+    nd.path.inode.clone()
+}
+
+/// Create a subdirectory `name` under the `/tmp` ramfs root.
+fn mkdir_in_tmp(name: &[u8]) -> Arc<Inode> {
+    let tmp = resolve(b"/tmp");
+    tmp.ops.mkdir(&tmp, name, 0o755).expect("mkdir in /tmp")
+}
+
+/// Create a regular file `name` under `/tmp` (used to drive the
+/// `ENOTDIR` path — rmdir against a non-directory).
+fn touch_in_tmp(name: &[u8]) {
+    let tmp = resolve(b"/tmp");
+    tmp.ops.create(&tmp, name, 0o644).expect("create in /tmp");
+}
+
+// --- Tests ---------------------------------------------------------------
+
+fn rmdir_removes_empty_dir() {
+    mkdir_in_tmp(b"rmdir-basic");
+    let r = rmdir(b"/tmp/rmdir-basic");
+    assert_eq!(r, 0, "rmdir(empty) must succeed, got {}", r);
+
+    // Second attempt must fail because the dir is gone.
+    let r = rmdir(b"/tmp/rmdir-basic");
+    assert_eq!(
+        r, ENOENT,
+        "rmdir of already-removed dir must ENOENT, got {}",
+        r
+    );
+}
+
+fn rmdir_enotempty() {
+    let child = mkdir_in_tmp(b"rmdir-enotempty");
+    child
+        .ops
+        .create(&child, b"inner", 0o644)
+        .expect("create inner");
+    let r = rmdir(b"/tmp/rmdir-enotempty");
+    assert_eq!(r, ENOTEMPTY, "rmdir(non-empty) must ENOTEMPTY, got {}", r);
+}
+
+fn rmdir_enoent() {
+    let r = rmdir(b"/tmp/never-existed");
+    assert_eq!(r, ENOENT, "rmdir(missing) must ENOENT, got {}", r);
+}
+
+fn rmdir_enotdir_on_regular_file() {
+    touch_in_tmp(b"rmdir-regfile");
+    let r = rmdir(b"/tmp/rmdir-regfile");
+    assert_eq!(r, ENOTDIR, "rmdir(regfile) must ENOTDIR, got {}", r);
+}
+
+fn rmdir_dot_einval() {
+    let r = rmdir(b".");
+    assert_eq!(r, EINVAL, "rmdir(\".\") must EINVAL, got {}", r);
+
+    // Also with a parent component ("foo/.").
+    mkdir_in_tmp(b"rmdir-dot-parent");
+    let r = rmdir(b"/tmp/rmdir-dot-parent/.");
+    assert_eq!(r, EINVAL, "rmdir(\"/tmp/.../.\") must EINVAL, got {}", r);
+    // Clean up.
+    let r = rmdir(b"/tmp/rmdir-dot-parent");
+    assert_eq!(r, 0, "cleanup rmdir failed: {}", r);
+}
+
+fn rmdir_dotdot_enotempty() {
+    let r = rmdir(b"..");
+    assert_eq!(r, ENOTEMPTY, "rmdir(\"..\") must ENOTEMPTY, got {}", r);
+
+    mkdir_in_tmp(b"rmdir-dotdot-parent");
+    let r = rmdir(b"/tmp/rmdir-dotdot-parent/..");
+    assert_eq!(r, ENOTEMPTY, "rmdir(\".../..\") must ENOTEMPTY, got {}", r);
+    // Clean up.
+    let r = rmdir(b"/tmp/rmdir-dotdot-parent");
+    assert_eq!(r, 0, "cleanup rmdir failed: {}", r);
+}
+
+fn rmdir_root_ebusy() {
+    let r = rmdir(b"/");
+    assert_eq!(r, EBUSY, "rmdir(\"/\") must EBUSY, got {}", r);
+}
+
+fn rmdir_trailing_slash_ok() {
+    mkdir_in_tmp(b"rmdir-trailing");
+    let r = rmdir(b"/tmp/rmdir-trailing/");
+    assert_eq!(
+        r, 0,
+        "rmdir with trailing slash on empty dir must succeed, got {}",
+        r
+    );
+}


### PR DESCRIPTION
## Summary

Implements the `rmdir(2)` syscall per RFC 0004 Workstream A (wave 1). Adds syscall #84 (`SYS_rmdir`) to the x86_64 dispatcher, and a small shaping layer in `kernel/src/arch/x86_64/syscalls/vfs.rs` that POSIX-validates the path before dispatching to `InodeOps::rmdir` on the parent.

- Empty path → `ENOENT`
- `"/"`       → `EBUSY` (mount root never removable)
- Leaf `"."`  → `EINVAL` (POSIX)
- Leaf `".."` → `ENOTEMPTY` (Linux convention)
- Parent not a dir → `ENOTDIR`
- Otherwise path-walks the parent and dispatches to `InodeOps::rmdir(parent, leaf)`. The per-FS op already owns `dir_rwsem`, emptiness checking (→ `ENOTEMPTY`), and the parent `nlink--` for the removed `..` backlink.

Uses `Credential::kernel()`, matching every other VFS syscall entry today. Real per-task credentials are the A-before-B gate (#546 / Workstream B).

## Scope clarification

The user task dispatched this agent against issue #539 with the scope `kernel/syscall: wire rmdir(2) to VFS InodeOps::rmdir`, but GitHub issue #539's body is actually about `unlink`/`unlinkat`. The `rmdir` checkbox is part of issue #538 (mkdir/mkdirat + rmdir). I've done only the rmdir work here — mkdir and the rest of #538 remain available for a sibling agent. This PR doesn't auto-close any issue so the human can assign it to whichever ticket they prefer.

Refs #537 (parent epic), #538 (rmdir listed alongside mkdir in body), #539 (dispatcher routing the agent).

## Test plan

- [x] `cargo xtask build` — green
- [x] `cargo xtask smoke` — all 33 markers present
- [x] `cargo test --target x86_64-unknown-none --test syscall_rmdir` — 8/8 tests pass:
  - `rmdir_removes_empty_dir` (success + double-remove → ENOENT)
  - `rmdir_enotempty` (populated dir → ENOTEMPTY)
  - `rmdir_enoent` (missing name)
  - `rmdir_enotdir_on_regular_file` (rmdir of a regular file → ENOTDIR)
  - `rmdir_dot_einval` (`"."` and `"foo/."` → EINVAL)
  - `rmdir_dotdot_enotempty` (`".."` and `"foo/.."` → ENOTEMPTY)
  - `rmdir_root_ebusy` (`"/"` → EBUSY)
  - `rmdir_trailing_slash_ok` (trailing `/` normalised)
- [x] `cargo test --target x86_64-unknown-none --test syscall_vfs --test syscall_mkfifo` — unchanged, all pass
- [x] `cargo fmt --check` — clean

## Notes on pre-existing main issues surfaced

- `cargo xtask lint` fails on `kernel/build.rs:109` with three `clippy::manual_is_multiple_of` errors — **not my change**, pre-existing on `main`. Would deserve a small follow-up.
- `kernel/tests/wait4_condvar_race.rs :: wait4_concurrent_exits_reaps_all` was slow enough on one run to trip the 30s xtask timeout, but passed on a later direct run — timing-sensitive flake, also pre-existing.