### PR TITLE
kernel/syscall: wire unlink(2) and unlinkat(2) to VFS InodeOps

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -291,6 +291,10 @@ name = "syscall_rmdir"
 harness = false
 
 [[test]]
+name = "syscall_unlink"
+harness = false
+
+[[test]]
 name = "ntty_sigint_flush"
 harness = false
 

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -818,6 +818,19 @@ pub unsafe extern "C" fn syscall_dispatch(
         // InodeOps::rmdir on the parent after path-walking to the leaf.
         RMDIR => super::syscalls::vfs::sys_rmdir_impl(a0),
 
+        // unlink(path) — remove a non-directory from its parent. Same
+        // RFC 0004 A ↔ B gate as MKDIR/MKDIRAT: with `vfs_creds` off
+        // the arm is absent and the dispatcher's default returns
+        // `-ENOSYS`. Integration tests exercise the impl directly via
+        // `sys_unlink_impl` once the feature is on.
+        #[cfg(feature = "vfs_creds")]
+        UNLINK => super::syscalls::vfs::sys_unlink_impl(a0),
+
+        // unlinkat(dfd, path, flags) — unlink or rmdir (AT_REMOVEDIR)
+        // relative to `dfd`. Same gate as UNLINK.
+        #[cfg(feature = "vfs_creds")]
+        UNLINKAT => super::syscalls::vfs::sys_unlinkat_impl(a0 as i32, a1, a2 as u32),
+
         // poll(fds, nfds, timeout_ms) — wait for readiness on a set of fds.
         POLL => crate::poll::syscalls::sys_poll(a0, a1, a2 as i64),
 
@@ -1413,6 +1426,8 @@ pub mod syscall_nr {
     pub const MKDIR: u64 = 83;
     pub const MKDIRAT: u64 = 258;
     pub const RMDIR: u64 = 84;
+    pub const UNLINK: u64 = 87;
+    pub const UNLINKAT: u64 = 263;
     pub const POLL: u64 = 7;
     pub const SELECT: u64 = 23;
     pub const PSELECT6: u64 = 270;
@@ -1495,5 +1510,7 @@ mod tests {
 
         // Directory removal
         assert_eq!(syscall_nr::RMDIR, 84, "SYS_rmdir must be 84");
+        assert_eq!(syscall_nr::UNLINK, 87, "SYS_unlink must be 87");
+        assert_eq!(syscall_nr::UNLINKAT, 263, "SYS_unlinkat must be 263");
     }
 }

--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -33,8 +33,8 @@ use crate::fs::vfs::{
 };
 use crate::fs::vfs::{Access, Credential};
 use crate::fs::{
-    flags as oflags, FileBackend, FileDescription, EBADF, EEXIST, EINVAL, EISDIR, ENAMETOOLONG,
-    ENOENT, ENOMEM, ENOTDIR,
+    flags as oflags, FileBackend, FileDescription, EBADF, EBUSY, EEXIST, EINVAL, EISDIR,
+    ENAMETOOLONG, ENOENT, ENOMEM, ENOTDIR, EPERM,
 };
 
 /// Linux x86_64 value of the "use the current working directory"
@@ -49,6 +49,15 @@ pub const AT_SYMLINK_NOFOLLOW: u32 = 0x100;
 /// `AT_EMPTY_PATH` — treat an empty `path` as a reference to the file
 /// behind `dfd` (used by `fstatat(fd, "", &st, AT_EMPTY_PATH)`).
 pub const AT_EMPTY_PATH: u32 = 0x1000;
+
+/// `AT_REMOVEDIR` — flag to `unlinkat(2)` that dispatches to `rmdir`
+/// semantics instead of `unlink`. Mirrors Linux's value.
+pub const AT_REMOVEDIR: u32 = 0x200;
+
+/// `S_ISVTX` — the POSIX "sticky bit" in `InodeMeta.mode`. When set on
+/// a directory, `unlink`/`rename` require the caller to own either the
+/// target file or the directory (or be root). Linux value 0o1000.
+const S_ISVTX: u16 = 0o1000;
 
 /// Copy a user path into a heap buffer sized at `PATH_MAX + 1`. The
 /// `+1` lets `copy_path_from_user_pub` observe the terminating NUL
@@ -931,4 +940,169 @@ pub unsafe fn sys_rmdir_impl(path_uva: u64) -> i64 {
         Ok(()) => 0,
         Err(e) => e,
     }
+}
+
+/// Shared body for `unlink(2)` / `unlinkat(2)`.
+///
+/// Resolves the parent directory, splits off the leaf name, then
+/// dispatches to `InodeOps::unlink` (default) or `InodeOps::rmdir`
+/// (when `AT_REMOVEDIR` is set in `flags`). Enforces the common POSIX
+/// pre-checks the trait impls must not each reinvent:
+///
+/// - Trailing-slash leaf forces directory semantics: non-`AT_REMOVEDIR`
+///   `unlink("foo/")` returns `EISDIR` since the caller named a
+///   directory explicitly.
+/// - A `.` / `..` / empty leaf is rejected upfront via `split_parent`.
+/// - The leaf may not itself be a mountpoint — `EBUSY` per POSIX
+///   (rmdir/unlink on a mount root is always refused).
+/// - Sticky-bit (`S_ISVTX`) on the parent directory forces the caller
+///   to own the parent or the target file; root bypasses.
+///
+/// The body is always compiled — only the syscall *dispatch arms*
+/// upstream are gated behind `#[cfg(feature = "vfs_creds")]`. Tests
+/// reach this impl directly through `sys_unlink_impl` /
+/// `sys_unlinkat_impl`, mirroring the convention `sys_mkdir_impl`
+/// established in #585. Until Workstream B flips `vfs_creds` on,
+/// ring-3 callers see `-ENOSYS` because the dispatcher's default
+/// arm catches the syscall numbers.
+fn unlinkat_impl(dfd: i32, path_uva: u64, flags: u32) -> i64 {
+    // Only AT_REMOVEDIR is recognised today. Everything else must be
+    // whitelisted explicitly so a silent-accept never masks a future
+    // flag bit.
+    if flags & !AT_REMOVEDIR != 0 {
+        return EINVAL;
+    }
+    let remove_dir = flags & AT_REMOVEDIR != 0;
+
+    let buf = match copy_user_path(path_uva) {
+        Ok(b) => b,
+        Err(e) => return e,
+    };
+    let path = buf.as_slice();
+
+    // `*at` preconditions mirror `openat`: non-AT_FDCWD dfd with a
+    // relative path is out of scope until per-fd cwd lands (#239).
+    let is_absolute = path.first() == Some(&b'/');
+    if dfd != AT_FDCWD && !is_absolute {
+        return EINVAL;
+    }
+
+    // Trailing-slash means the caller explicitly named a directory.
+    // POSIX unlink(2) on a trailing-slash path returns EISDIR (or
+    // ENOTDIR if the final component does not resolve to a directory);
+    // Linux picks EISDIR when the named leaf itself is a directory and
+    // we mirror that here. `rmdir`/`AT_REMOVEDIR` accepts a trailing
+    // slash since that's the POSIX-preferred spelling for directories.
+    let trailing_slash = path.len() > 1 && path.last() == Some(&b'/');
+
+    let (parent_path, leaf) = match split_parent(path) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
+    // Resolve the parent (follow symlinks on every intermediate
+    // component — standard POSIX behaviour).
+    let (parent_inode, pnd) = match resolve_inode(parent_path, /* follow */ true) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    if parent_inode.kind != InodeKind::Dir {
+        return ENOTDIR;
+    }
+
+    // Resolve the leaf via lookup on the parent so we can run the
+    // mountpoint + sticky checks before calling into the FS driver.
+    // We intentionally do NOT go back through `path_walk` for the
+    // leaf — that would cross a symlink on a symlinked leaf and delete
+    // the wrong thing. `unlink`/`rmdir` always act on the name itself.
+    let leaf_inode = match parent_inode.ops.lookup(&parent_inode, leaf) {
+        Ok(i) => i,
+        Err(e) => return e,
+    };
+
+    // Mountpoint check: we need the leaf's dentry to inspect `.mount`.
+    // `pnd.path.dentry` is the parent-directory dentry after the walk.
+    // Look the leaf up in the parent's child cache — if a mount edge
+    // is attached to the leaf dentry, refuse with `EBUSY` per POSIX.
+    // A miss in the child cache (or a negative entry) means nothing
+    // is mounted on the leaf, so there is no mountpoint to refuse.
+    if let Ok(leaf_dstr) = crate::fs::vfs::DString::try_from_bytes(leaf) {
+        let parent_dentry = pnd.path.dentry.clone();
+        let children = parent_dentry.children.read();
+        if let Some(crate::fs::vfs::ChildState::Resolved(child)) = children.get(&leaf_dstr) {
+            if child.mount.read().is_some() {
+                return EBUSY;
+            }
+        }
+    }
+
+    // Kind-based dispatch. `unlink` on a directory is EISDIR; `rmdir`
+    // on a non-directory is ENOTDIR. Drivers can still reject on their
+    // own, but catching it up front gives a consistent errno across
+    // backends.
+    if remove_dir {
+        if leaf_inode.kind != InodeKind::Dir {
+            return ENOTDIR;
+        }
+    } else {
+        if leaf_inode.kind == InodeKind::Dir {
+            return EISDIR;
+        }
+        if trailing_slash {
+            // unlink("foo/") where foo is a symlink to a directory is
+            // still refused (ENOTDIR on Linux). Here the leaf isn't a
+            // directory but the caller named a directory explicitly,
+            // so ENOTDIR best describes the mismatch. Unreachable for
+            // regular files via split_parent today, but kept as a
+            // defensive guard for future resolver behaviour.
+            return ENOTDIR;
+        }
+    }
+
+    // Sticky-bit check. When S_ISVTX is set on the parent, POSIX
+    // requires the caller to own either the parent or the target
+    // file, or be the super-user. Uses `Credential::kernel()` as a
+    // placeholder — replaced by the per-task credential when
+    // Workstream B flips `vfs_creds` on (#546).
+    let cred = Credential::kernel();
+    let parent_meta = parent_inode.meta.read();
+    if parent_meta.mode & S_ISVTX != 0 && cred.uid != 0 {
+        let leaf_uid = leaf_inode.meta.read().uid;
+        if cred.uid != parent_meta.uid && cred.uid != leaf_uid {
+            return EPERM;
+        }
+    }
+    drop(parent_meta);
+
+    let r = if remove_dir {
+        parent_inode.ops.rmdir(&parent_inode, leaf)
+    } else {
+        parent_inode.ops.unlink(&parent_inode, leaf)
+    };
+    match r {
+        Ok(()) => 0,
+        Err(e) => e,
+    }
+}
+
+/// `unlink(path)` — remove a non-directory from its parent. Thin
+/// wrapper over [`unlinkat_impl`] with `dfd = AT_FDCWD` and no flags.
+///
+/// Reachable from ring-3 only when the `vfs_creds` feature is on
+/// (the dispatch arm is gated). Tests call this entry point directly
+/// to exercise the impl regardless of feature state, mirroring the
+/// `sys_mkdir_impl` convention from #585.
+pub unsafe fn sys_unlink_impl(path_uva: u64) -> i64 {
+    unlinkat_impl(AT_FDCWD, path_uva, 0)
+}
+
+/// `unlinkat(dfd, path, flags)` — `unlink` or `rmdir` (when `flags`
+/// sets `AT_REMOVEDIR`) relative to `dfd`. `AT_FDCWD` and absolute
+/// paths only; a real fd with a relative path returns `EINVAL` until
+/// per-fd cwd semantics land (#239).
+///
+/// Reachable from ring-3 only when `vfs_creds` is on (gated dispatch
+/// arm). See [`sys_unlink_impl`] for the test-path convention.
+pub unsafe fn sys_unlinkat_impl(dfd: i32, path_uva: u64, flags: u32) -> i64 {
+    unlinkat_impl(dfd, path_uva, flags)
 }

--- a/kernel/tests/syscall_unlink.rs
+++ b/kernel/tests/syscall_unlink.rs
@@ -1,0 +1,292 @@
+//! Integration test for issue #539: `unlink(2)` / `unlinkat(2)` wired
+//! to `InodeOps::unlink` / `InodeOps::rmdir` (via `AT_REMOVEDIR`).
+//!
+//! The dispatcher arms for SYS_unlink (87) and SYS_unlinkat (263) are
+//! gated behind `#[cfg(feature = "vfs_creds")]` per RFC 0004 Workstream
+//! A; until Workstream B turns that feature on, both numbers fall
+//! through to the dispatcher's default `-ENOSYS` arm. The shared impl
+//! (`sys_unlink_impl` / `sys_unlinkat_impl`) is always compiled — tests
+//! call the impl entry points directly so they exercise the VFS wiring
+//! regardless of feature state, mirroring the convention established
+//! by `sys_mkdir_impl` in #585.
+//!
+//! Coverage:
+//! - `syscall_dispatch(SYS_unlink, ...)` returns `-ENOSYS` (the
+//!   anti-regression anchor for the A-before-B ordering until #546
+//!   flips the gate on).
+//! - `sys_unlink_impl` removes a regular file; subsequent `stat`
+//!   misses with `-ENOENT`.
+//! - Errno table from RFC 0004 §Kernel-Userspace Interface:
+//!   `EISDIR` (unlink on dir), `ENOTDIR` (rmdir on file), `ENOENT`
+//!   (missing), `EINVAL` (unknown flag bit).
+//! - `sys_unlinkat_impl(AT_REMOVEDIR)` dispatches to `rmdir` on an
+//!   empty directory.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use core::ptr;
+
+use vibix::arch::x86_64::syscall::syscall_dispatch;
+use vibix::arch::x86_64::syscalls::vfs::{
+    sys_mkdir_impl, sys_unlink_impl, sys_unlinkat_impl, AT_FDCWD, AT_REMOVEDIR,
+};
+use vibix::fs::vfs::ops::Stat;
+use vibix::fs::{EINVAL, EISDIR, ENOENT, ENOTDIR};
+use vibix::mem::vmatree::{Share, Vma};
+use vibix::mem::vmobject::AnonObject;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+use x86_64::structures::paging::PageTableFlags;
+
+const SYS_UNLINK: u64 = 87;
+const SYS_STAT: u64 = 4;
+const SYS_OPEN: u64 = 2;
+const SYS_CLOSE: u64 = 3;
+
+const O_WRONLY: u64 = 0o1;
+const O_CREAT: u64 = 0o100;
+
+const ENOSYS: i64 = -38;
+
+const USER_PAGE_VA: usize = 0x0000_2004_0000_0000;
+const USER_PAGE_LEN: usize = 4 * 4096;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    vibix::task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "unlink_dispatcher_is_enosys_until_b_lands",
+            &(unlink_dispatcher_is_enosys as fn()),
+        ),
+        (
+            "unlink_removes_regular_file",
+            &(unlink_removes_regular_file as fn()),
+        ),
+        (
+            "unlink_on_missing_enoent",
+            &(unlink_on_missing_enoent as fn()),
+        ),
+        ("unlink_on_dir_eisdir", &(unlink_on_dir_eisdir as fn())),
+        (
+            "unlinkat_atfdcwd_absolute",
+            &(unlinkat_atfdcwd_absolute as fn()),
+        ),
+        (
+            "unlinkat_at_removedir_on_dir",
+            &(unlinkat_at_removedir_on_dir as fn()),
+        ),
+        (
+            "unlinkat_at_removedir_on_file_enotdir",
+            &(unlinkat_at_removedir_on_file_enotdir as fn()),
+        ),
+        (
+            "unlinkat_rejects_unknown_flag",
+            &(unlinkat_rejects_unknown_flag as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+fn install_user_staging_vma() {
+    static INSTALLED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+    if INSTALLED.swap(true, core::sync::atomic::Ordering::SeqCst) {
+        return;
+    }
+    let prot_pte =
+        (PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE).bits();
+    vibix::task::install_vma_on_current(Vma::new(
+        USER_PAGE_VA,
+        USER_PAGE_VA + USER_PAGE_LEN,
+        0x3,
+        prot_pte,
+        Share::Private,
+        AnonObject::new(Some(USER_PAGE_LEN / 4096)),
+        0,
+    ));
+    unsafe {
+        let dst = USER_PAGE_VA as *mut u8;
+        let mut i = 0;
+        while i < USER_PAGE_LEN {
+            ptr::write_volatile(dst.add(i), 0);
+            i += 4096;
+        }
+    }
+}
+
+fn stage(bytes: &[u8]) -> u64 {
+    install_user_staging_vma();
+    assert!(bytes.len() < 4096);
+    unsafe {
+        let dst = USER_PAGE_VA as *mut u8;
+        for (i, b) in bytes.iter().enumerate() {
+            ptr::write_volatile(dst.add(i), *b);
+        }
+        ptr::write_volatile(dst.add(bytes.len()), 0);
+    }
+    USER_PAGE_VA as u64
+}
+
+fn unlink(path: &[u8]) -> i64 {
+    let uva = stage(path);
+    unsafe { sys_unlink_impl(uva) }
+}
+
+fn unlinkat(dfd: i32, path: &[u8], flags: u32) -> i64 {
+    let uva = stage(path);
+    unsafe { sys_unlinkat_impl(dfd, uva, flags) }
+}
+
+fn open(path: &[u8], flags: u64, mode: u64) -> i64 {
+    let uva = stage(path);
+    unsafe { syscall_dispatch(core::ptr::null_mut(), SYS_OPEN, uva, flags, mode, 0, 0, 0) }
+}
+
+fn close(fd: i64) -> i64 {
+    unsafe { syscall_dispatch(core::ptr::null_mut(), SYS_CLOSE, fd as u64, 0, 0, 0, 0, 0) }
+}
+
+fn stat(path: &[u8], statbuf: u64) -> i64 {
+    let uva = stage(path);
+    unsafe { syscall_dispatch(core::ptr::null_mut(), SYS_STAT, uva, statbuf, 0, 0, 0, 0) }
+}
+
+fn create_regular(path: &[u8]) {
+    let fd = open(path, O_WRONLY | O_CREAT, 0o644);
+    assert!(fd >= 3, "create({:?}) expected fd, got {}", path, fd);
+    close(fd);
+}
+
+/// Seed a directory under `/tmp` (which is RamFs and writable). The
+/// root `/` is TarFs at boot and refuses mkdir, so all directory
+/// fixtures must live under `/tmp`.
+fn create_dir(path: &[u8]) {
+    let uva = stage(path);
+    let r = unsafe { sys_mkdir_impl(uva, 0o755) };
+    assert_eq!(r, 0, "mkdir({:?}) must succeed, got {}", path, r);
+}
+
+// --- A-before-B dispatcher gate -----------------------------------------
+
+/// The RFC 0004 A-before-B ordering: until Workstream B's terminal PR
+/// flips `vfs_creds` on, the SYS_unlink dispatcher arm is absent and
+/// the syscall number falls through to the `-ENOSYS` default. A
+/// non-ENOSYS return from the dispatcher under the default feature set
+/// would mean the gate is leaking — block that regression here.
+#[cfg(not(feature = "vfs_creds"))]
+fn unlink_dispatcher_is_enosys() {
+    let uva = stage(b"/tmp/anything");
+    let r = unsafe { syscall_dispatch(core::ptr::null_mut(), SYS_UNLINK, uva, 0, 0, 0, 0, 0) };
+    assert_eq!(
+        r, ENOSYS,
+        "SYS_unlink must dispatch to ENOSYS until vfs_creds flips on, got {}",
+        r
+    );
+}
+
+/// With the feature on, the same dispatcher arm wires through to the
+/// impl — confirm it is no longer ENOSYS (any other return is fine
+/// because the path may or may not exist).
+#[cfg(feature = "vfs_creds")]
+fn unlink_dispatcher_is_enosys() {
+    let uva = stage(b"/tmp/anything");
+    let r = unsafe { syscall_dispatch(core::ptr::null_mut(), SYS_UNLINK, uva, 0, 0, 0, 0, 0) };
+    assert!(
+        r != ENOSYS,
+        "SYS_unlink dispatcher must reach the impl with vfs_creds on, got ENOSYS"
+    );
+}
+
+// --- Impl-level coverage (always runs, regardless of feature) -----------
+
+fn unlink_removes_regular_file() {
+    create_regular(b"/tmp/unlink-target");
+    let r = unlink(b"/tmp/unlink-target");
+    assert_eq!(r, 0, "unlink on live regular file must return 0, got {}", r);
+    // Follow-up stat must now miss.
+    let mut sb = Stat::default();
+    let r = stat(b"/tmp/unlink-target", &mut sb as *mut Stat as usize as u64);
+    assert_eq!(r, ENOENT, "stat after unlink must ENOENT, got {}", r);
+}
+
+fn unlink_on_missing_enoent() {
+    let r = unlink(b"/tmp/no-such-file-for-unlink");
+    assert_eq!(r, ENOENT, "unlink of missing path must ENOENT, got {}", r);
+}
+
+fn unlink_on_dir_eisdir() {
+    // `/tmp` itself is a mountpoint (the boot init mounts ramfs there,
+    // see fs/vfs/init.rs) so unlink against `/tmp` returns EBUSY before
+    // the kind dispatch. Seed a plain non-mountpoint directory under
+    // `/tmp/` (which is the writable RamFs leg) to exercise the EISDIR
+    // arm specifically.
+    create_dir(b"/tmp/eisdir-target");
+    let r = unlink(b"/tmp/eisdir-target");
+    assert_eq!(r, EISDIR, "unlink on a directory must EISDIR, got {}", r);
+    // Clean up via rmdir (AT_REMOVEDIR) so the test is idempotent.
+    let _ = unlinkat(AT_FDCWD, b"/tmp/eisdir-target", AT_REMOVEDIR);
+}
+
+fn unlinkat_atfdcwd_absolute() {
+    create_regular(b"/tmp/unlinkat-target");
+    let r = unlinkat(AT_FDCWD, b"/tmp/unlinkat-target", 0);
+    assert_eq!(r, 0, "unlinkat on live file must return 0, got {}", r);
+}
+
+fn unlinkat_at_removedir_on_dir() {
+    // Seed a fresh subdirectory under `/tmp/` (the RamFs leg). The root
+    // `/` is TarFs at boot and refuses mkdir, so directory fixtures must
+    // live on RamFs.
+    create_dir(b"/tmp/rmdir-target");
+    let r = unlinkat(AT_FDCWD, b"/tmp/rmdir-target", AT_REMOVEDIR);
+    assert_eq!(
+        r, 0,
+        "unlinkat(AT_REMOVEDIR) on empty dir must return 0, got {}",
+        r
+    );
+}
+
+fn unlinkat_at_removedir_on_file_enotdir() {
+    create_regular(b"/tmp/rmdir-on-file");
+    let r = unlinkat(AT_FDCWD, b"/tmp/rmdir-on-file", AT_REMOVEDIR);
+    assert_eq!(
+        r, ENOTDIR,
+        "unlinkat(AT_REMOVEDIR) on a regular file must ENOTDIR, got {}",
+        r
+    );
+    // Clean up.
+    let _ = unlink(b"/tmp/rmdir-on-file");
+}
+
+fn unlinkat_rejects_unknown_flag() {
+    // 0x8000 is not a defined `at_*` flag. Must be rejected with EINVAL.
+    let r = unlinkat(AT_FDCWD, b"/tmp/anything", 0x8000);
+    assert_eq!(
+        r, EINVAL,
+        "unlinkat must reject unknown flags with EINVAL, got {}",
+        r
+    );
+}


### PR DESCRIPTION
Closes #539

## Summary

- Wires SYS_unlink (87) and SYS_unlinkat (263, including AT_REMOVEDIR) through a shared unlinkat_impl that dispatches to InodeOps::unlink or InodeOps::rmdir. Enforces the POSIX pre-checks the FS-driver impls must not each reinvent: AT_REMOVEDIR-only flags whitelist, non-AT_FDCWD + relative rejected (until per-fd cwd lands in #239), trailing-slash directory semantics, leaf mountpoint EBUSY, kind dispatch (EISDIR/ENOTDIR), and parent sticky-bit S_ISVTX ownership enforcement. Leaf lookup uses parent.ops.lookup -- never path_walk -- so unlink("sym") never follows a symlink and deletes the wrong file.
- Follows the convention #585 set for mkdir: the dispatch arms are gated behind #[cfg(feature = "vfs_creds")] so ring-3 callers see -ENOSYS until Workstream B lands Task::credentials and flips the gate on (#546). The impl entry points (sys_unlink_impl / sys_unlinkat_impl) are always compiled and tests reach them directly. The vfs_creds feature, the default-off Cargo gate, and the CI A-before-B ordering job already exist on main from #585.
- Adds integration test syscall_unlink covering: syscall_dispatch(SYS_unlink, ...) == -ENOSYS (anti-regression anchor for the A-before-B ordering until #546 flips the gate on); sys_unlink_impl removes a regular file with subsequent stat ENOENT; the RFC 0004 errno table (EISDIR, ENOTDIR, ENOENT, EINVAL on unknown flags); unlinkat(AT_FDCWD, "/abs", 0) round-trip; unlinkat(AT_FDCWD, "/tmp/dir", AT_REMOVEDIR) removes an empty dir.

## Test plan

- [x] cargo fmt --all -- --check clean.
- [x] cargo xtask build clean (only pre-existing is_guard_hit dead-code warning).
- [x] cargo xtask test --test syscall_unlink -- all 8 tests pass.
- [x] cargo xtask smoke -- all 33 markers present.
- [x] cargo build --features vfs_creds --test syscall_unlink --target x86_64-unknown-none -Zbuild-std=... compiles cleanly.

Note: PR was rebased onto current main (mkdir #585 landed in parallel). Force-pushed with --force-with-lease. CodeRabbit re-review will trigger automatically.

Generated with Claude Code (https://claude.com/claude-code)