### PR TITLE
cred: extend Credential with euid/suid/egid/sgid and plumb per-task snapshot (#546)

### DIFF
--- a/kernel/src/fs/vfs/mod.rs
+++ b/kernel/src/fs/vfs/mod.rs
@@ -98,26 +98,111 @@ pub struct Timespec {
 
 /// Caller credentials consulted by [`InodeOps::permission`].
 ///
+/// Carries the full POSIX.1-2017 §2.4 saved-set-user-ID model: a real,
+/// effective, and saved ID for both user and group, plus the
+/// supplementary-group list. [`default_permission`] (and conforming
+/// overrides of `InodeOps::permission`) consult the **effective** IDs
+/// — `euid`, `egid`, `groups` — for access decisions; the real and
+/// saved IDs exist so `setuid`/`setresuid` and friends can implement
+/// the "drop privilege, reclaim later" pattern POSIX requires.
+///
+/// `Credential` values are immutable once constructed. A mid-syscall
+/// credential change (another thread running `setuid`) builds a fresh
+/// `Credential` and swaps the `Arc` inside
+/// [`Task::credentials`](crate::task::Task) — syscall entries clone the
+/// `Arc` once and carry that snapshot through the rest of the operation
+/// so a concurrent change cannot tear the read.
+///
 /// `Default` is deliberately not implemented: a default-constructed
 /// `Credential` would be uid 0, which `default_permission` treats as
 /// the root bypass — that would let any caller who reaches for
-/// `Credential::default()` accidentally elevate. Construct via
-/// [`Credential::kernel`] (root) or by setting fields explicitly.
+/// `Credential::default()` accidentally elevate. Prefer
+/// [`Credential::from_task_ids`] for a full six-ID construction from a
+/// task snapshot; direct field-literal construction elsewhere in the
+/// kernel is discouraged and should be limited to tests and the
+/// privileged [`Credential::kernel`] helper.
 #[derive(Clone, Debug)]
 pub struct Credential {
+    /// Real user ID (`getuid(2)`). The login identity; does not change
+    /// on `setuid(2)` by an unprivileged process.
     pub uid: u32,
+    /// Effective user ID (`geteuid(2)`). The identity consulted for
+    /// DAC checks. Equal to `uid` for most processes; differs after
+    /// `setuid(2)` or exec of a setuid binary.
+    pub euid: u32,
+    /// Saved set-user-ID (POSIX §2.4). Remembers a prior effective ID
+    /// so an unprivileged process that temporarily dropped `euid` can
+    /// reclaim it via `seteuid(suid)`.
+    pub suid: u32,
+    /// Real group ID (`getgid(2)`).
     pub gid: u32,
+    /// Effective group ID (`getegid(2)`). Consulted for DAC group-bit
+    /// checks alongside [`Self::groups`].
+    pub egid: u32,
+    /// Saved set-group-ID (POSIX §2.4). Group-side counterpart of
+    /// [`Self::suid`].
+    pub sgid: u32,
+    /// Supplementary group list (`getgroups(2)`). A caller matches the
+    /// group access bits of a file if `egid` OR any entry here equals
+    /// the file's group.
     pub groups: Vec<u32>,
 }
 
 impl Credential {
-    /// Kernel-internal credential: root. Use only from kernel code
-    /// paths that are not acting on behalf of a userspace task.
+    /// Kernel-internal credential: root on every ID. Use only from
+    /// kernel code paths that are not acting on behalf of a userspace
+    /// task (initial mount, kernel-thread I/O, test fixtures).
+    ///
+    /// Production userspace-driven VFS syscalls must **not** reach for
+    /// this helper: they read the caller's per-task snapshot via
+    /// `task.credentials.read().clone()` instead. Using
+    /// `Credential::kernel()` on a userspace-initiated path is an
+    /// unauthenticated full-DAC bypass (RFC 0004 §Security
+    /// Considerations); the RFC 0004 Workstream A ↔ B CI gate and the
+    /// `#[cfg(feature = "vfs_creds")]` guard on syscall dispatch arms
+    /// exist specifically to prevent that regression while the
+    /// Workstream B syscall wiring is still in progress.
     pub fn kernel() -> Self {
         Self {
             uid: 0,
+            euid: 0,
+            suid: 0,
             gid: 0,
+            egid: 0,
+            sgid: 0,
             groups: Vec::new(),
+        }
+    }
+
+    /// Build a `Credential` from the full six-ID saved-set-user-ID
+    /// tuple plus a supplementary group list. This is the preferred
+    /// constructor for non-root credentials: it takes every field at
+    /// once so forgetting one is a compile error rather than a silent
+    /// `0` that reads as root.
+    ///
+    /// Field-literal construction (`Credential { uid, euid, ... }`) is
+    /// discouraged outside of this module and tests; future additions
+    /// to the struct (filesystem-UID, login-UID, audit-UID) would
+    /// silently acquire arbitrary defaults at every call site that
+    /// skipped them. Use `from_task_ids` so the compiler surfaces the
+    /// new field.
+    pub fn from_task_ids(
+        uid: u32,
+        euid: u32,
+        suid: u32,
+        gid: u32,
+        egid: u32,
+        sgid: u32,
+        groups: Vec<u32>,
+    ) -> Self {
+        Self {
+            uid,
+            euid,
+            suid,
+            gid,
+            egid,
+            sgid,
+            groups,
         }
     }
 }

--- a/kernel/src/fs/vfs/ops.rs
+++ b/kernel/src/fs/vfs/ops.rs
@@ -278,13 +278,16 @@ pub trait FileOps: Send + Sync {
 }
 
 /// Default POSIX permission check: owner / group / other bits in
-/// `InodeMeta.mode`. uid 0 (root) bypasses all checks. The `execute`
-/// bit on a directory is interpreted as "search" per POSIX §4.5.
+/// `InodeMeta.mode`. DAC decisions consult the **effective** IDs
+/// (`euid`, `egid`, supplementary `groups`) per POSIX.1-2017 §2.4 —
+/// `uid` and `gid` (real IDs) are not read here. `euid == 0` (root)
+/// bypasses all checks. The `execute` bit on a directory is
+/// interpreted as "search" per POSIX §4.5.
 ///
 /// Drivers that need richer semantics (ACLs, capabilities) override
 /// `InodeOps::permission` directly.
 pub fn default_permission(inode: &Inode, cred: &Credential, access: Access) -> Result<(), i64> {
-    if cred.uid == 0 {
+    if cred.euid == 0 {
         // Root bypass, with one twist: POSIX requires EXECUTE to still
         // fail on a non-dir file with no execute bits set anywhere, so
         // root can't "run" a data file. Matches Linux `generic_permission`.
@@ -299,9 +302,13 @@ pub fn default_permission(inode: &Inode, cred: &Credential, access: Access) -> R
 
     let meta = inode.meta.read();
     let mode = meta.mode as u32;
-    let bits = if cred.uid == meta.uid {
+    // POSIX §4.4.2 "File Access Permissions": once a class matches, its
+    // bits decide the result — even if a later class (other) would be
+    // more permissive. The first-match terminates semantics falls out
+    // of the if/else-if chain below.
+    let bits = if cred.euid == meta.uid {
         (mode >> 6) & 0o7
-    } else if cred.gid == meta.gid || cred.groups.iter().any(|&g| g == meta.gid) {
+    } else if cred.egid == meta.gid || cred.groups.iter().any(|&g| g == meta.gid) {
         (mode >> 3) & 0o7
     } else {
         mode & 0o7
@@ -362,6 +369,60 @@ pub(crate) fn meta_into_stat(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::fs::vfs::FsId;
+    use crate::fs::vfs::super_block::{SbFlags, SuperBlock};
+    use alloc::sync::Arc;
+    use alloc::vec;
+
+    struct StubInodeOps;
+    impl InodeOps for StubInodeOps {
+        fn getattr(&self, _inode: &Inode, _out: &mut Stat) -> Result<(), i64> {
+            Ok(())
+        }
+    }
+
+    struct StubFileOps;
+    impl FileOps for StubFileOps {}
+
+    struct StubSuper;
+    impl SuperOps for StubSuper {
+        fn root_inode(&self) -> Arc<Inode> {
+            unreachable!()
+        }
+        fn statfs(&self) -> Result<StatFs, i64> {
+            Ok(StatFs::default())
+        }
+        fn unmount(&self) {}
+    }
+
+    /// Build a regular-file inode with the given mode/uid/gid for
+    /// driving `default_permission` in the tests below. Anchors a real
+    /// `SuperBlock` so the inode's `Weak<SuperBlock>` stays live for
+    /// the duration of the closure.
+    fn with_inode<R>(mode: u16, uid: u32, gid: u32, f: impl FnOnce(&Inode) -> R) -> R {
+        let sb = Arc::new(SuperBlock::new(
+            FsId(1),
+            Arc::new(StubSuper),
+            "stub",
+            512,
+            SbFlags::default(),
+        ));
+        let ino = Inode::new(
+            1,
+            Arc::downgrade(&sb),
+            Arc::new(StubInodeOps),
+            Arc::new(StubFileOps),
+            InodeKind::Reg,
+            InodeMeta {
+                mode,
+                uid,
+                gid,
+                nlink: 1,
+                ..Default::default()
+            },
+        );
+        f(&ino)
+    }
 
     #[test]
     fn meta_into_stat_saturates_u64_max_size_and_blocks() {
@@ -390,5 +451,154 @@ mod tests {
         assert_eq!(st.st_size, 1_234_567);
         assert_eq!(st.st_blocks, 2_400);
         assert_eq!(st.st_blksize, 4096);
+    }
+
+    // ---- Credential constructor + default_permission DAC tests ----
+
+    #[test]
+    fn credential_from_task_ids_populates_every_field() {
+        let cred = Credential::from_task_ids(10, 11, 12, 20, 21, 22, vec![100, 101]);
+        assert_eq!(cred.uid, 10);
+        assert_eq!(cred.euid, 11);
+        assert_eq!(cred.suid, 12);
+        assert_eq!(cred.gid, 20);
+        assert_eq!(cred.egid, 21);
+        assert_eq!(cred.sgid, 22);
+        assert_eq!(cred.groups, vec![100, 101]);
+    }
+
+    #[test]
+    fn credential_kernel_is_root_on_every_id() {
+        let cred = Credential::kernel();
+        assert_eq!(cred.uid, 0);
+        assert_eq!(cred.euid, 0);
+        assert_eq!(cred.suid, 0);
+        assert_eq!(cred.gid, 0);
+        assert_eq!(cred.egid, 0);
+        assert_eq!(cred.sgid, 0);
+        assert!(cred.groups.is_empty());
+    }
+
+    #[test]
+    fn permission_owner_class_uses_euid_not_uid() {
+        // File 0o600 owned by uid 1000. Caller has real uid != 1000 but
+        // effective uid == 1000 (i.e. ran a setuid binary owned by 1000).
+        // POSIX requires the effective ID to win — owner class matches.
+        with_inode(0o600, 1000, 2000, |inode| {
+            let cred = Credential::from_task_ids(42, 1000, 42, 99, 99, 99, vec![]);
+            assert!(default_permission(inode, &cred, Access::READ).is_ok());
+            assert!(default_permission(inode, &cred, Access::WRITE).is_ok());
+            // No execute bit → EXECUTE denied even for owner.
+            assert_eq!(
+                default_permission(inode, &cred, Access::EXECUTE),
+                Err(EACCES)
+            );
+        });
+    }
+
+    #[test]
+    fn permission_group_class_uses_egid_not_gid() {
+        // File 0o040 (group-read only) owned by uid 1000, gid 2000.
+        // Caller's real gid is unrelated, but effective gid matches.
+        with_inode(0o040, 1000, 2000, |inode| {
+            let cred = Credential::from_task_ids(50, 50, 50, 7777, 2000, 2000, vec![]);
+            assert!(default_permission(inode, &cred, Access::READ).is_ok());
+            // Group has no write bit → write denied via group class
+            // (owner class doesn't match euid != 1000), and "other" is
+            // 0 so the fall-through also denies.
+            assert_eq!(
+                default_permission(inode, &cred, Access::WRITE),
+                Err(EACCES)
+            );
+        });
+    }
+
+    #[test]
+    fn permission_supplementary_groups_match_group_class() {
+        // File 0o050 (group r-x) gid 2000. Caller's egid is something
+        // else but 2000 is in the supplementary list → group class.
+        with_inode(0o050, 1000, 2000, |inode| {
+            let cred = Credential::from_task_ids(50, 50, 50, 60, 60, 60, vec![1500, 2000, 3000]);
+            assert!(default_permission(inode, &cred, Access::READ).is_ok());
+            assert!(default_permission(inode, &cred, Access::EXECUTE).is_ok());
+            assert_eq!(
+                default_permission(inode, &cred, Access::WRITE),
+                Err(EACCES)
+            );
+        });
+    }
+
+    #[test]
+    fn permission_other_class_when_neither_owner_nor_group_match() {
+        // File 0o604: owner rw, group ---, world r--. Caller is none of
+        // owner/group/supplementary → falls through to "other" bits.
+        with_inode(0o604, 1000, 2000, |inode| {
+            let cred = Credential::from_task_ids(50, 50, 50, 60, 60, 60, vec![70, 80]);
+            assert!(default_permission(inode, &cred, Access::READ).is_ok());
+            assert_eq!(
+                default_permission(inode, &cred, Access::WRITE),
+                Err(EACCES)
+            );
+        });
+    }
+
+    #[test]
+    fn permission_owner_class_terminates_even_when_other_is_more_permissive() {
+        // POSIX §4.4.2 first-match-terminates: if owner matches and
+        // owner has --x, the caller is denied READ even though
+        // "other" grants r--. (Linux-conformant behaviour.)
+        with_inode(0o104, 1000, 2000, |inode| {
+            let cred = Credential::from_task_ids(50, 1000, 50, 60, 60, 60, vec![]);
+            assert_eq!(
+                default_permission(inode, &cred, Access::READ),
+                Err(EACCES),
+                "owner class is consulted first; world r-- must not rescue the caller"
+            );
+            assert!(default_permission(inode, &cred, Access::EXECUTE).is_ok());
+        });
+    }
+
+    #[test]
+    fn permission_root_bypasses_via_euid_not_uid() {
+        // euid==0 root bypass. The caller's *real* uid is non-zero
+        // (post-`setuid(0)` from a setuid-root binary, before saved-uid
+        // recovery) but effective uid is 0 → root powers apply.
+        with_inode(0o000, 4242, 4242, |inode| {
+            let cred = Credential::from_task_ids(1234, 0, 1234, 5678, 5678, 5678, vec![]);
+            assert!(default_permission(inode, &cred, Access::READ).is_ok());
+            assert!(default_permission(inode, &cred, Access::WRITE).is_ok());
+        });
+    }
+
+    #[test]
+    fn permission_root_execute_still_requires_one_x_bit_on_files() {
+        // Linux generic_permission: even root cannot "execute" a regular
+        // file with 0 execute bits anywhere. Mirrors that.
+        with_inode(0o644, 1, 1, |inode| {
+            let cred = Credential::kernel();
+            assert_eq!(
+                default_permission(inode, &cred, Access::EXECUTE),
+                Err(EACCES)
+            );
+        });
+        // One execute bit anywhere → root execute allowed.
+        with_inode(0o744, 1, 1, |inode| {
+            let cred = Credential::kernel();
+            assert!(default_permission(inode, &cred, Access::EXECUTE).is_ok());
+        });
+    }
+
+    #[test]
+    fn permission_real_uid_alone_does_not_grant_owner_class() {
+        // Caller's real uid matches the file owner but euid does not.
+        // Owner class must NOT match — POSIX consults effective IDs.
+        with_inode(0o600, 1000, 2000, |inode| {
+            let cred = Credential::from_task_ids(1000, 50, 1000, 60, 60, 60, vec![]);
+            assert_eq!(
+                default_permission(inode, &cred, Access::READ),
+                Err(EACCES),
+                "owner DAC must be gated on euid, not uid"
+            );
+        });
     }
 }

--- a/kernel/src/fs/vfs/ops.rs
+++ b/kernel/src/fs/vfs/ops.rs
@@ -369,8 +369,8 @@ pub(crate) fn meta_into_stat(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::fs::vfs::FsId;
     use crate::fs::vfs::super_block::{SbFlags, SuperBlock};
+    use crate::fs::vfs::FsId;
     use alloc::sync::Arc;
     use alloc::vec;
 
@@ -506,10 +506,7 @@ mod tests {
             // Group has no write bit → write denied via group class
             // (owner class doesn't match euid != 1000), and "other" is
             // 0 so the fall-through also denies.
-            assert_eq!(
-                default_permission(inode, &cred, Access::WRITE),
-                Err(EACCES)
-            );
+            assert_eq!(default_permission(inode, &cred, Access::WRITE), Err(EACCES));
         });
     }
 
@@ -521,10 +518,7 @@ mod tests {
             let cred = Credential::from_task_ids(50, 50, 50, 60, 60, 60, vec![1500, 2000, 3000]);
             assert!(default_permission(inode, &cred, Access::READ).is_ok());
             assert!(default_permission(inode, &cred, Access::EXECUTE).is_ok());
-            assert_eq!(
-                default_permission(inode, &cred, Access::WRITE),
-                Err(EACCES)
-            );
+            assert_eq!(default_permission(inode, &cred, Access::WRITE), Err(EACCES));
         });
     }
 
@@ -535,10 +529,7 @@ mod tests {
         with_inode(0o604, 1000, 2000, |inode| {
             let cred = Credential::from_task_ids(50, 50, 50, 60, 60, 60, vec![70, 80]);
             assert!(default_permission(inode, &cred, Access::READ).is_ok());
-            assert_eq!(
-                default_permission(inode, &cred, Access::WRITE),
-                Err(EACCES)
-            );
+            assert_eq!(default_permission(inode, &cred, Access::WRITE), Err(EACCES));
         });
     }
 

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -153,6 +153,7 @@ pub fn fork_current_task(
         parent_address_space,
         parent_fd_table,
         parent_cwd,
+        parent_credentials,
         parent_priority,
         parent_affinity,
         parent_fpu_ptr,
@@ -178,10 +179,19 @@ pub fn fork_current_task(
             crate::arch::x86_64::fpu::save(&mut cur.fpu);
         }
         crate::fork_trace!("fork-trace: [fork_current_task] ← fpu::save(parent)");
+        // Snapshot the parent's credentials Arc under the rwlock. POSIX
+        // fork(2) gives the child the parent's credentials at fork time;
+        // a concurrent setuid on the parent thread (impossible today —
+        // we are single-threaded per process — but the contract holds)
+        // would race the snapshot, and the Arc-snapshot pattern is what
+        // makes that race benign: the child gets whichever Credential
+        // was current at the instant of `read()`.
+        let parent_credentials = Arc::clone(&*cur.credentials.read());
         (
             Arc::clone(&cur.address_space),
             Arc::clone(&cur.fd_table),
             cur.cwd.clone(),
+            parent_credentials,
             cur.priority,
             cur.affinity,
             // SAFETY: the parent Task is the currently-running task and stays
@@ -228,6 +238,7 @@ pub fn fork_current_task(
             child_cr3,
             child_fd,
             parent_cwd,
+            parent_credentials,
         )
     }?;
     let child_id = child.id;

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -29,9 +29,11 @@ use x86_64::VirtAddr;
 
 use crate::arch::x86_64::fpu::FpuArea;
 use crate::fork_abi::prime_fork_child_stack;
+use crate::fs::vfs::Credential;
 use crate::fs::FileDescTable;
 use crate::mem::addrspace::AddressSpace;
 use crate::mem::paging;
+use crate::sync::BlockingRwLock;
 
 use super::priority::{AFFINITY_ALL, DEFAULT_PRIORITY};
 use super::switch::{fork_child_sysret, task_entry_trampoline};
@@ -143,6 +145,28 @@ pub(super) struct Task {
     /// it unchanged.
     pub cwd: Option<alloc::sync::Arc<crate::fs::vfs::Dentry>>,
 
+    /// Per-task POSIX credentials (uid/euid/suid + gid/egid/sgid +
+    /// supplementary groups). Stored as `Arc<Credential>` behind a
+    /// blocking rwlock so:
+    ///
+    /// - Syscall entries take a single `read()` snapshot of the `Arc`
+    ///   and drop the lock before walking the path. A concurrent
+    ///   `setuid(2)` on a sibling thread swaps the inner `Arc` but
+    ///   cannot tear the in-flight read — the snapshot keeps the old
+    ///   `Credential` alive for the duration of the syscall (RFC 0004
+    ///   §Credential model).
+    /// - `setuid`-family syscalls take `write()`, build a fresh
+    ///   `Credential`, and replace the `Arc`. They never mutate the
+    ///   `Credential` in place; immutability is what makes the snapshot
+    ///   read race-free.
+    ///
+    /// Defaults to `Credential::kernel()` (root) — every task spawned
+    /// today is a kernel task or a fork descendant of `init`, both of
+    /// which run as root. The `setuid`-family syscalls and exec of a
+    /// setuid binary will be the first call sites that produce a
+    /// non-root snapshot here (Workstream B follow-ups).
+    pub credentials: BlockingRwLock<Arc<Credential>>,
+
     /// Top of this task's dedicated SYSCALL kernel stack (set when this
     /// task runs in ring-3 and needs its own syscall entry point).
     ///
@@ -185,6 +209,7 @@ impl Task {
             fpu: FpuArea::new_initialized(),
             fd_table: Arc::new(Mutex::new(FileDescTable::new_with_stdio())),
             cwd: None,
+            credentials: BlockingRwLock::new(Arc::new(Credential::kernel())),
             syscall_stack_top: 0,
         }
     }
@@ -275,6 +300,7 @@ impl Task {
             fpu: FpuArea::new_initialized(),
             fd_table: Arc::new(Mutex::new(FileDescTable::new_with_stdio())),
             cwd: None,
+            credentials: BlockingRwLock::new(Arc::new(Credential::kernel())),
             syscall_stack_top: 0, // kernel-only task — no ring-3 syscall stack needed yet
         }
     }
@@ -331,6 +357,7 @@ impl Task {
         child_cr3: PhysFrame<Size4KiB>,
         child_fd_table: alloc::sync::Arc<Mutex<crate::fs::FileDescTable>>,
         child_cwd: Option<alloc::sync::Arc<crate::fs::vfs::Dentry>>,
+        child_credentials: Arc<Credential>,
     ) -> Result<Self, crate::mem::addrspace::ForkError> {
         crate::fork_trace!(
             "fork-trace: [Task::new_forked enter] user_rip={:#x} user_rsp={:#x}",
@@ -432,6 +459,7 @@ impl Task {
             fpu,
             fd_table: child_fd_table,
             cwd: child_cwd,
+            credentials: BlockingRwLock::new(child_credentials),
             // The child task runs in ring-3; it needs its own SYSCALL stack
             // so it doesn't clobber the parent's saved SYSCALL context on the
             // shared INIT_KERNEL_STACK. Use the top of this task's kernel stack.


### PR DESCRIPTION
## Summary

Implements RFC 0004 Workstream B wave 1 (issue #546). Foundational plumbing for POSIX DAC enforcement; the syscall entries are **not yet** switched off `Credential::kernel()` — that is a later Workstream B PR (likely #550) that flips the `vfs_creds` feature gate on. This PR satisfies the `vfs-creds-gate` CI job that #585 introduced — `Task::credentials` is now present on the kernel `Task` struct, so a follow-up may safely enable `vfs_creds` by default.

- `Credential` extended to the full POSIX §2.4 saved-set-uid model: `uid`/`euid`/`suid` + `gid`/`egid`/`sgid` + supplementary `groups`.
- `Credential::from_task_ids(...)` is the preferred non-root constructor (six IDs + groups, all at once). Doc-comments discourage field-literal construction so a future field addition surfaces every call site rather than silently defaulting to 0 (which `default_permission` reads as root).
- `default_permission` now consults **effective** IDs (`euid`/`egid`/`groups`). The real `uid`/`gid` are not read in DAC decisions. POSIX §4.4.2 first-match-terminates is preserved.
- `Credential::kernel()` is preserved with a doc-comment that flags it as privileged and points userspace-driven syscalls at the per-task snapshot (`task.credentials.read().clone()`). Kept available because integration tests and genuinely kernel-initiated paths (initial mount, kernel-thread I/O) still need it.
- New `Task::credentials: BlockingRwLock<Arc<Credential>>`. Syscall entries take a single `read()` snapshot of the `Arc` and drop the lock before walking; a concurrent `setuid` (future Workstream B work) swaps the inner `Arc` and cannot tear the in-flight read. `fork()` inherits the parent's snapshot. Defaults to `Credential::kernel()` for every task spawned today.
- Unit tests cover: the new constructor, all three POSIX mode classes (owner/group/other), euid-vs-uid regression, supplementary-groups match, first-match-terminates (owner --x with world r-- still denies READ), root execute-bit requirement on regular files, and the explicit \"real uid alone does not grant owner class\" guard.

## Out of scope (per issue #546)

- Individual `setuid(2)` / `setgid(2)` / `setresuid(2)` / `setgroups(2)` / `getuid(2)` / ... syscalls — next Workstream B issue.
- Replacing `Credential::kernel()` at every VFS syscall entry with the per-task snapshot, and flipping the `vfs_creds` default-feature gate — terminal Workstream B PR.
- Touching `kernel/src/arch/x86_64/syscalls/vfs.rs` (contested with #586 rmdir / #539 unlink); per the auto-manager scope sequencing for this issue, that wiring waits.

## Test plan

- [x] `cargo xtask build` — clean (only the pre-existing `is_guard_hit` dead-code warning).
- [x] `cargo xtask test-unit` — 394 host unit tests pass.
- [ ] `cargo xtask test` — full host + QEMU integration suite (running in CI).
- [x] New tests added in `kernel/src/fs/vfs/ops.rs` cover the three POSIX classes and the euid-vs-uid distinction (verified to compile under the kernel target).

## Pre-existing main issues surfaced

None new. Known pre-existing items not touched by this PR: `kernel/build.rs:109` clippy `manual_is_multiple_of`, `kernel/src/task/task.rs` `is_guard_hit` dead-code warning, `kernel/tests/wait4_condvar_race.rs` timing flake, smoke-test cold-cache marker loss.

Closes #546.

🤖 Generated with [Claude Code](https://claude.com/claude-code)