### PR TITLE
block: BlockCache::sync_fs(device_id) flushes one mount's dirty buffers

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -313,3 +313,7 @@ harness = false
 [[test]]
 name = "signal_sa_restart_preserves_args"
 harness = false
+
+[[test]]
+name = "block_cache_sync_fs"
+harness = false

--- a/kernel/src/block/cache.rs
+++ b/kernel/src/block/cache.rs
@@ -694,6 +694,95 @@ impl BlockCache {
         // decrements it.
     }
 
+    /// Flush every dirty buffer owned by `device_id` to the backing
+    /// device, in ascending `(DeviceId, u64)` key order.
+    ///
+    /// Implements RFC 0004 §Buffer cache `sync_fs` — the per-mount
+    /// writeback primitive. Wired by the VFS layer into
+    /// `SuperOps::sync_fs` and called from the `umount` path before the
+    /// superblock is detached so on-disk state is consistent across a
+    /// remount.
+    ///
+    /// # Filtering
+    ///
+    /// Only keys whose `DeviceId` equals `device_id` are flushed. The
+    /// cache may host multiple mounts backed by the same
+    /// `Arc<dyn BlockDevice>` (each with its own `DeviceId` allocated
+    /// via [`register_device`](Self::register_device)); `sync_fs` on
+    /// one mount must not flush another mount's dirty buffers.
+    ///
+    /// # Best-effort error propagation
+    ///
+    /// No batching: each matching dirty key is handed to
+    /// [`sync_dirty_buffer`](Self::sync_dirty_buffer) in turn. The
+    /// first `Err(BlockError)` is captured and returned; subsequent
+    /// flushes continue so a transient failure on one buffer doesn't
+    /// leave the rest of the mount's dirty state on the floor. Buffers
+    /// that fail keep `STATE_DIRTY` set (per `sync_dirty_buffer`'s
+    /// contract) and remain enlisted in the dirty set, so a retry
+    /// (e.g. from the writeback daemon) will pick them up.
+    ///
+    /// # Concurrent mutation
+    ///
+    /// The dirty-set snapshot is taken under the dirty-set mutex then
+    /// released before issuing any I/O, so concurrent `mark_dirty` /
+    /// `sync_dirty_buffer` callers don't contend on the set for the
+    /// duration of the sweep. A buffer enlisted after the snapshot
+    /// won't be observed by this call — that's acceptable: a
+    /// just-dirtied buffer is covered by the next `sync_fs` (or by the
+    /// writeback daemon). A buffer whose key is in the snapshot but
+    /// has since been evicted is silently skipped via the residency
+    /// lookup inside `sync_dirty_buffer`.
+    pub fn sync_fs(&self, device_id: DeviceId) -> Result<(), BlockError> {
+        // Snapshot the dirty keys for this device under the dirty-set
+        // mutex, then release it: issuing device I/O with a spinlock
+        // held violates the OS-engineer B5 hazard (RFC 0004 §Buffer
+        // cache) and would starve concurrent `mark_dirty` callers.
+        let keys: alloc::vec::Vec<(DeviceId, u64)> = {
+            let dirty = self.dirty.lock();
+            dirty
+                .iter()
+                .filter(|(dev, _)| *dev == device_id)
+                .copied()
+                .collect()
+        };
+
+        let mut first_err: Option<BlockError> = None;
+        for key in keys {
+            // Re-look-up the buffer out of `entries` under the inner
+            // lock. If it was evicted between snapshot and now, there's
+            // nothing for us to flush — `sync_dirty_buffer` itself has
+            // the same "not resident → success" fallback, but doing the
+            // lookup here lets us skip the state CAS entirely.
+            let bh = {
+                let inner = self.inner.lock();
+                inner.entries.get(&key).cloned()
+            };
+            let bh = match bh {
+                Some(bh) => bh,
+                None => {
+                    // Evicted since snapshot. Drop the stale dirty-set
+                    // entry so we don't keep re-observing it.
+                    self.dirty.lock().remove(&key);
+                    continue;
+                }
+            };
+            if let Err(e) = self.sync_dirty_buffer(&bh) {
+                // Best-effort: keep flushing the rest of the mount.
+                // Surface only the first error so the caller has a
+                // single actionable failure to log.
+                if first_err.is_none() {
+                    first_err = Some(e);
+                }
+            }
+        }
+
+        match first_err {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
+    }
+
     /// CLOCK-Pro eviction sweep.
     ///
     /// Rotates `clock_hand` through resident entries in BTreeMap key
@@ -1638,5 +1727,249 @@ mod tests {
         );
         // LOCKED_IO was never taken — fast-path bailed before CAS.
         assert!(!bh.state_has(STATE_LOCKED_IO));
+    }
+
+    // ---------- sync_fs (issue #554) ----------
+
+    /// `sync_fs` on a mount with no dirty buffers is a successful no-op
+    /// that issues no device writes.
+    #[test]
+    fn sync_fs_on_clean_cache_is_noop() {
+        let (cache, disk, dev) = ramdisk_cache(512, 8, 4);
+        disk.seed_block(0, 0x11);
+        let _bh = cache.bread(dev, 0).expect("bread");
+        let writes_before = disk.writes();
+        cache.sync_fs(dev).expect("clean sync_fs ok");
+        assert_eq!(
+            disk.writes(),
+            writes_before,
+            "no dirty buffers → no device writes",
+        );
+    }
+
+    /// `sync_fs` flushes every dirty buffer owned by the target
+    /// `DeviceId`, clears the dirty bit, and drops the dirty-set keys.
+    #[test]
+    fn sync_fs_flushes_all_dirty_for_device() {
+        let (cache, disk, dev) = ramdisk_cache(512, 16, 8);
+        for b in 0..4 {
+            disk.seed_block(b, 0);
+        }
+
+        // Dirty four buffers under `dev`.
+        let mut handles = alloc::vec::Vec::new();
+        for b in 0..4u64 {
+            let bh = cache.bread(dev, b).expect("bread");
+            {
+                let mut data = bh.data.write();
+                for slot in data.iter_mut() {
+                    *slot = b as u8;
+                }
+            }
+            cache.mark_dirty(&bh);
+            assert!(bh.state_has(STATE_DIRTY));
+            handles.push(bh);
+        }
+        assert_eq!(cache.dirty.lock().len(), 4);
+
+        let writes_before = disk.writes();
+        cache.sync_fs(dev).expect("sync_fs");
+        assert_eq!(
+            disk.writes(),
+            writes_before + 4,
+            "one device write per dirty buffer",
+        );
+
+        // DIRTY bits cleared, dirty set drained.
+        for bh in &handles {
+            assert!(!bh.state_has(STATE_DIRTY));
+            assert!(!bh.state_has(STATE_LOCKED_IO));
+        }
+        assert!(cache.dirty.lock().is_empty());
+
+        // On-disk bytes match what we wrote.
+        {
+            let storage = disk.storage.lock();
+            for b in 0..4usize {
+                let off = b * 512;
+                assert!(
+                    storage[off..off + 512].iter().all(|byte| *byte == b as u8),
+                    "block {} not flushed correctly",
+                    b,
+                );
+            }
+        }
+    }
+
+    /// `sync_fs(dev_a)` must not flush buffers owned by `dev_b`, even
+    /// when both devices share the same underlying `Arc<dyn BlockDevice>`.
+    /// This is the whole point of filtering by `DeviceId` — one mount's
+    /// sync is not allowed to affect another mount.
+    #[test]
+    fn sync_fs_is_scoped_to_device_id() {
+        let (cache, disk, dev_a) = ramdisk_cache(512, 16, 8);
+        // Second DeviceId on the same cache (models two concurrent mounts
+        // sharing the same ramdisk — RFC 0004 §Buffer cache).
+        let dev_b = cache.register_device();
+
+        let bh_a = cache.bread(dev_a, 0).expect("bread a");
+        {
+            let mut data = bh_a.data.write();
+            for slot in data.iter_mut() {
+                *slot = 0xaa;
+            }
+        }
+        cache.mark_dirty(&bh_a);
+
+        let bh_b = cache.bread(dev_b, 0).expect("bread b");
+        {
+            let mut data = bh_b.data.write();
+            for slot in data.iter_mut() {
+                *slot = 0x55;
+            }
+        }
+        cache.mark_dirty(&bh_b);
+
+        assert!(bh_a.state_has(STATE_DIRTY));
+        assert!(bh_b.state_has(STATE_DIRTY));
+        assert_eq!(cache.dirty.lock().len(), 2);
+
+        let writes_before = disk.writes();
+        cache.sync_fs(dev_a).expect("sync_fs dev_a");
+        assert_eq!(
+            disk.writes(),
+            writes_before + 1,
+            "sync_fs(dev_a) flushes exactly one buffer",
+        );
+
+        // dev_a buffer: clean. dev_b buffer: still dirty (untouched).
+        assert!(!bh_a.state_has(STATE_DIRTY), "dev_a buffer flushed");
+        assert!(bh_b.state_has(STATE_DIRTY), "dev_b buffer must be left dirty");
+        assert!(!cache.dirty.lock().contains(&(dev_a, 0)));
+        assert!(cache.dirty.lock().contains(&(dev_b, 0)));
+    }
+
+    /// `sync_fs` propagates the first `BlockError` from the underlying
+    /// device but continues flushing the rest of the mount's dirty
+    /// buffers (best-effort).
+    #[test]
+    fn sync_fs_best_effort_on_device_error() {
+        /// Device that fails the Nth write (1-indexed); all other
+        /// writes succeed and land in an in-memory backing store.
+        struct FailingDisk {
+            block_size: u32,
+            storage: Mutex<alloc::vec::Vec<u8>>,
+            writes: AtomicU32,
+            fail_on_nth: u32,
+        }
+        impl BlockDevice for FailingDisk {
+            fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
+                let storage = self.storage.lock();
+                let off = offset as usize;
+                if off + buf.len() > storage.len() {
+                    return Err(BlockError::OutOfRange);
+                }
+                buf.copy_from_slice(&storage[off..off + buf.len()]);
+                Ok(())
+            }
+            fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
+                let n = self.writes.fetch_add(1, Ordering::Relaxed) + 1;
+                if n == self.fail_on_nth {
+                    return Err(BlockError::DeviceError);
+                }
+                let mut storage = self.storage.lock();
+                let off = offset as usize;
+                storage[off..off + buf.len()].copy_from_slice(buf);
+                Ok(())
+            }
+            fn block_size(&self) -> u32 {
+                self.block_size
+            }
+            fn capacity(&self) -> u64 {
+                self.storage.lock().len() as u64
+            }
+        }
+
+        let disk = Arc::new(FailingDisk {
+            block_size: 512,
+            storage: Mutex::new(vec![0u8; 512 * 16]),
+            writes: AtomicU32::new(0),
+            // Fail the *second* device write of the sweep.
+            fail_on_nth: 2,
+        });
+        let cache = BlockCache::new(disk.clone() as Arc<dyn BlockDevice>, 512, 8);
+        let dev = cache.register_device();
+
+        // Dirty three buffers. Flush order follows BTreeSet iteration —
+        // ascending `(dev, blk)` — so block 1 will be the 2nd (failing)
+        // write.
+        let mut handles = alloc::vec::Vec::new();
+        for b in 0..3u64 {
+            let bh = cache.bread(dev, b).expect("bread");
+            {
+                let mut data = bh.data.write();
+                for slot in data.iter_mut() {
+                    *slot = (b + 1) as u8;
+                }
+            }
+            cache.mark_dirty(&bh);
+            handles.push(bh);
+        }
+
+        let err = cache.sync_fs(dev).expect_err("first device error surfaces");
+        assert_eq!(err, BlockError::DeviceError);
+
+        // Device saw three writes — the sweep did not bail on the first
+        // error, it best-effort continued.
+        assert_eq!(disk.writes.load(Ordering::Relaxed), 3);
+
+        // Block 0 and block 2 are clean; block 1 is still dirty (kept
+        // enlisted for a retry).
+        assert!(!handles[0].state_has(STATE_DIRTY));
+        assert!(handles[1].state_has(STATE_DIRTY));
+        assert!(!handles[2].state_has(STATE_DIRTY));
+        assert!(cache.dirty.lock().contains(&(dev, 1)));
+        assert!(!cache.dirty.lock().contains(&(dev, 0)));
+        assert!(!cache.dirty.lock().contains(&(dev, 2)));
+    }
+
+    /// A dirty key whose buffer was evicted between snapshot and flush
+    /// is silently skipped (and dropped from the dirty set) — `sync_fs`
+    /// must not error on a stale dirty-set entry.
+    #[test]
+    fn sync_fs_skips_evicted_dirty_keys() {
+        let (cache, disk, dev) = ramdisk_cache(512, 16, 4);
+        disk.seed_block(7, 0x00);
+        let bh = cache.bread(dev, 7).expect("bread");
+        cache.mark_dirty(&bh);
+        assert!(cache.dirty.lock().contains(&(dev, 7)));
+
+        // Simulate eviction of the buffer while the dirty-set entry
+        // lingers. Clear the DIRTY bit so the pulled-out `Arc` doesn't
+        // fence the inner-lock eviction path; the dirty *set* key is
+        // what `sync_fs` iterates.
+        bh.state.fetch_and(!STATE_DIRTY, Ordering::AcqRel);
+        drop(bh);
+        // Forcibly remove the entry from the cache.
+        {
+            let mut inner = cache.inner.lock();
+            inner.entries.remove(&(dev, 7));
+            inner.classes.remove(&(dev, 7));
+        }
+        // Re-inject a stale dirty-set entry that no longer has a
+        // resident buffer.
+        cache.dirty.lock().insert((dev, 7));
+
+        let writes_before = disk.writes();
+        cache.sync_fs(dev).expect("stale dirty entry tolerated");
+        assert_eq!(
+            disk.writes(),
+            writes_before,
+            "evicted buffer must not drive a write",
+        );
+        assert!(
+            !cache.dirty.lock().contains(&(dev, 7)),
+            "stale dirty-set entry must be dropped",
+        );
     }
 }

--- a/kernel/src/block/cache.rs
+++ b/kernel/src/block/cache.rs
@@ -1844,7 +1844,10 @@ mod tests {
 
         // dev_a buffer: clean. dev_b buffer: still dirty (untouched).
         assert!(!bh_a.state_has(STATE_DIRTY), "dev_a buffer flushed");
-        assert!(bh_b.state_has(STATE_DIRTY), "dev_b buffer must be left dirty");
+        assert!(
+            bh_b.state_has(STATE_DIRTY),
+            "dev_b buffer must be left dirty"
+        );
         assert!(!cache.dirty.lock().contains(&(dev_a, 0)));
         assert!(cache.dirty.lock().contains(&(dev_b, 0)));
     }

--- a/kernel/src/fs/vfs/mount_table.rs
+++ b/kernel/src/fs/vfs/mount_table.rs
@@ -180,8 +180,24 @@ pub fn unmount(target: &Arc<Dentry>, flags: UmountFlags) -> Result<(), i64> {
     };
 
     gc_drain_for(&sb);
-    // Phase B: sb.ops.unmount() is infallible per the SuperOps contract —
-    // the mount is already detached; we always return Ok(()).
+    // Phase B: flush any dirty buffers this mount owns *before*
+    // `sb.ops.unmount()` tears the driver's device plumbing down. Errors
+    // are logged and absorbed — the detach is unconditional, matching
+    // `SuperOps::unmount`'s infallibility contract. A later retry can
+    // pick up buffers that `sync_fs` failed to flush via the writeback
+    // daemon or an explicit `sync(2)`.
+    //
+    // See RFC 0004 §Buffer cache and issue #554 for the normative
+    // contract on flush-before-detach ordering.
+    if let Err(errno) = sb.ops.sync_fs(&sb) {
+        crate::serial_println!(
+            "vfs: sync_fs failed during unmount ({}): errno={}",
+            sb.fs_type,
+            errno,
+        );
+    }
+    // Phase B cont.: sb.ops.unmount() is infallible per the SuperOps
+    // contract — the mount is already detached; we always return Ok(()).
     sb.ops.unmount();
     Ok(())
 }

--- a/kernel/src/fs/vfs/ops.rs
+++ b/kernel/src/fs/vfs/ops.rs
@@ -167,6 +167,31 @@ pub trait SuperOps: Send + Sync {
         Ok(())
     }
     fn statfs(&self) -> Result<StatFs, i64>;
+    /// Flush every dirty buffer belonging to this mount to stable
+    /// storage. Called from the `umount` path (before
+    /// [`unmount`](Self::unmount) detaches the superblock) and,
+    /// eventually, by the `sync(2)` syscall (Workstream F).
+    ///
+    /// Contract (RFC 0004 §Buffer cache, issue #554):
+    ///
+    /// - In-memory filesystems (ramfs, tarfs, devfs) have no backing
+    ///   device; the default impl returns `Ok(())`.
+    /// - Filesystems backed by a [`BlockCache`](crate::block::cache::BlockCache)
+    ///   must delegate to
+    ///   [`BlockCache::sync_fs`](crate::block::cache::BlockCache::sync_fs)
+    ///   with the mount's [`DeviceId`](crate::block::cache::DeviceId)
+    ///   so only that mount's dirty buffers are flushed.
+    /// - Best-effort error propagation: if multiple buffers fail, the
+    ///   first error is returned and the rest are flushed anyway. A
+    ///   dirty buffer that fails to flush remains enlisted for a later
+    ///   retry (writeback daemon or a subsequent explicit sync).
+    ///
+    /// The `sb` argument is passed so a driver that owns more than one
+    /// `BlockCache` (future sharded layout) can route to the right
+    /// one; single-cache drivers can ignore it.
+    fn sync_fs(&self, _sb: &SuperBlock) -> Result<(), i64> {
+        Ok(())
+    }
     /// Called during Phase B of `unmount()`, after the mount edge has been
     /// removed from the table (Phase A).  At this point the mount is
     /// irrevocably gone regardless of what this method does.

--- a/kernel/tests/block_cache_sync_fs.rs
+++ b/kernel/tests/block_cache_sync_fs.rs
@@ -1,0 +1,261 @@
+//! Integration test for issue #554: `BlockCache::sync_fs` flushes one
+//! mount's dirty buffers to the backing device while leaving a
+//! different mount's dirty buffers alone.
+//!
+//! Runs the real kernel under QEMU. Exercises:
+//!
+//! - **write + sync_fs + drop cache + "remount"**: dirty a buffer,
+//!   flush via `sync_fs`, then drop the cache and reconstruct a fresh
+//!   one backed by the same ramdisk. `bread` on the second cache sees
+//!   the bytes on disk — proving `sync_fs` persisted them through the
+//!   cache teardown.
+//! - **cross-mount isolation**: a single `BlockCache` hosts two
+//!   `DeviceId`s (two concurrent mounts sharing the same physical
+//!   device — the shape RFC 0004 §Buffer cache allows). `sync_fs` on
+//!   one must leave the other's dirty buffer untouched.
+//!
+//! Complements the host-side unit tests in
+//! `kernel/src/block/cache.rs::tests`; this integration test
+//! re-exercises the same invariants against the live heap /
+//! interrupt-enabled kernel environment.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicU32, Ordering};
+
+use spin::Mutex;
+
+use vibix::block::cache::{BlockCache, STATE_DIRTY};
+use vibix::block::{BlockDevice, BlockError};
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "sync_fs_persists_across_cache_teardown",
+            &(sync_fs_persists_across_cache_teardown as fn()),
+        ),
+        (
+            "sync_fs_does_not_flush_other_mount",
+            &(sync_fs_does_not_flush_other_mount as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared in-memory ramdisk — lets two sequential `BlockCache` instances
+// share the same backing storage so test 1 can observe "remount"
+// semantics.
+// ---------------------------------------------------------------------------
+
+struct RamDisk {
+    block_size: u32,
+    storage: Mutex<Vec<u8>>,
+    writes: AtomicU32,
+}
+
+impl RamDisk {
+    fn new(block_size: u32, blocks: usize) -> Arc<Self> {
+        let bytes = (block_size as usize) * blocks;
+        Arc::new(Self {
+            block_size,
+            storage: Mutex::new(vec![0u8; bytes]),
+            writes: AtomicU32::new(0),
+        })
+    }
+
+    fn writes(&self) -> u32 {
+        self.writes.load(Ordering::Relaxed)
+    }
+}
+
+impl BlockDevice for RamDisk {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
+        let bs = self.block_size as u64;
+        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
+            return Err(BlockError::BadAlign);
+        }
+        let storage = self.storage.lock();
+        let end = offset
+            .checked_add(buf.len() as u64)
+            .ok_or(BlockError::OutOfRange)?;
+        if end > storage.len() as u64 {
+            return Err(BlockError::OutOfRange);
+        }
+        let off = offset as usize;
+        buf.copy_from_slice(&storage[off..off + buf.len()]);
+        Ok(())
+    }
+    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
+        self.writes.fetch_add(1, Ordering::Relaxed);
+        let bs = self.block_size as u64;
+        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
+            return Err(BlockError::BadAlign);
+        }
+        let mut storage = self.storage.lock();
+        let end = offset
+            .checked_add(buf.len() as u64)
+            .ok_or(BlockError::Enospc)?;
+        if end > storage.len() as u64 {
+            return Err(BlockError::Enospc);
+        }
+        let off = offset as usize;
+        storage[off..off + buf.len()].copy_from_slice(buf);
+        Ok(())
+    }
+    fn block_size(&self) -> u32 {
+        self.block_size
+    }
+    fn capacity(&self) -> u64 {
+        self.storage.lock().len() as u64
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Write a pattern through `BlockCache A`, `sync_fs`, drop the cache
+/// (models umount), then build a fresh `BlockCache B` on the same
+/// ramdisk (models a second mount) and verify `bread` returns the
+/// persisted bytes.
+///
+/// This is the "write + sync_fs + drop cache + remount; data is
+/// present" test from issue #554.
+fn sync_fs_persists_across_cache_teardown() {
+    let disk = RamDisk::new(512, 16);
+
+    // --- Phase 1: mount 1, dirty block 5, sync_fs, drop cache. ---
+    {
+        let cache_a = BlockCache::new(disk.clone() as Arc<dyn BlockDevice>, 512, 8);
+        let dev_a = cache_a.register_device();
+        let bh = cache_a.bread(dev_a, 5).expect("bread 5");
+        {
+            let mut data = bh.data.write();
+            for (i, slot) in data.iter_mut().enumerate() {
+                *slot = 0xc0u8.wrapping_add(i as u8);
+            }
+        }
+        cache_a.mark_dirty(&bh);
+        assert!(bh.state_has(STATE_DIRTY));
+
+        let writes_before = disk.writes();
+        cache_a.sync_fs(dev_a).expect("sync_fs ok");
+        assert_eq!(
+            disk.writes(),
+            writes_before + 1,
+            "sync_fs drove exactly one device write",
+        );
+        assert!(!bh.state_has(STATE_DIRTY), "DIRTY cleared after sync_fs");
+
+        // Drop explicit handle + the cache Arc. Cache goes away with any
+        // resident buffers; only the ramdisk bytes survive.
+        drop(bh);
+        drop(cache_a);
+    }
+
+    // --- Phase 2: fresh cache on the same ramdisk. bread must see the
+    //     bytes `sync_fs` committed, because the cache was empty on
+    //     construction — the only place the bytes can come from is the
+    //     backing device. ---
+    let cache_b = BlockCache::new(disk.clone() as Arc<dyn BlockDevice>, 512, 8);
+    let dev_b = cache_b.register_device();
+    let bh = cache_b.bread(dev_b, 5).expect("bread 5 on fresh cache");
+    let data = bh.data.read();
+    for (i, byte) in data.iter().enumerate() {
+        assert_eq!(
+            *byte,
+            0xc0u8.wrapping_add(i as u8),
+            "byte {} mismatch after remount — sync_fs did not persist",
+            i,
+        );
+    }
+}
+
+/// One `BlockCache` hosting two `DeviceId`s (the RFC 0004 §Buffer
+/// cache "two concurrent mounts backed by the same ramdisk" shape):
+/// `sync_fs(dev_a)` must not touch a dirty buffer owned by `dev_b`.
+///
+/// This is the "sync_fs does NOT flush buffers belonging to a
+/// different mount" test from issue #554.
+fn sync_fs_does_not_flush_other_mount() {
+    let disk = RamDisk::new(512, 16);
+    let cache = BlockCache::new(disk.clone() as Arc<dyn BlockDevice>, 512, 8);
+    let dev_a = cache.register_device();
+    let dev_b = cache.register_device();
+
+    // Dirty one buffer under each mount. Use the same block number on
+    // purpose — the `(DeviceId, u64)` key shape must keep them distinct.
+    let bh_a = cache.bread(dev_a, 3).expect("bread dev_a");
+    {
+        let mut data = bh_a.data.write();
+        for slot in data.iter_mut() {
+            *slot = 0xaa;
+        }
+    }
+    cache.mark_dirty(&bh_a);
+
+    let bh_b = cache.bread(dev_b, 3).expect("bread dev_b");
+    {
+        let mut data = bh_b.data.write();
+        for slot in data.iter_mut() {
+            *slot = 0x55;
+        }
+    }
+    cache.mark_dirty(&bh_b);
+
+    assert!(bh_a.state_has(STATE_DIRTY));
+    assert!(bh_b.state_has(STATE_DIRTY));
+
+    let writes_before = disk.writes();
+    cache.sync_fs(dev_a).expect("sync_fs dev_a");
+
+    // Exactly one device write: the dev_a buffer. dev_b is untouched.
+    assert_eq!(
+        disk.writes(),
+        writes_before + 1,
+        "sync_fs(dev_a) must drive exactly one write",
+    );
+    assert!(!bh_a.state_has(STATE_DIRTY), "dev_a flushed");
+    assert!(
+        bh_b.state_has(STATE_DIRTY),
+        "dev_b must remain dirty — sync_fs is scoped",
+    );
+
+    // Now flush dev_b to confirm it was still enlisted.
+    cache.sync_fs(dev_b).expect("sync_fs dev_b");
+    assert_eq!(
+        disk.writes(),
+        writes_before + 2,
+        "sync_fs(dev_b) now flushes the held-back buffer",
+    );
+    assert!(!bh_b.state_has(STATE_DIRTY));
+}


### PR DESCRIPTION
## Summary

Implements RFC 0004 §Buffer cache `sync_fs` for Workstream C wave 1 on top of the #553 `bread` / `mark_dirty` / `sync_dirty_buffer` / `release` surface. Gives the VFS a per-mount writeback primitive it can call from the `umount` path (and eventually from `sync(2)`) without touching other mounts' dirty buffers.

## Changes

- `kernel/src/block/cache.rs`: add `BlockCache::sync_fs(&self, device_id: DeviceId) -> Result<(), BlockError>`. Snapshots the dirty set under its own mutex, filters by the target `DeviceId`, then issues `sync_dirty_buffer` for each matching resident buffer. Best-effort propagation: the first `BlockError` is captured and returned; subsequent flushes continue so a transient single-buffer failure does not leave the rest of the mount's dirty state on the floor. Buffers whose keys were evicted between snapshot and flush are silently skipped (and their stale dirty-set entries dropped). I/O is issued with no cache / data lock held — the OS-engineer B5 hazard from RFC 0004 §Buffer cache still holds.
- `kernel/src/fs/vfs/ops.rs`: extend `SuperOps` with `fn sync_fs(&self, _sb: &SuperBlock) -> Result<(), i64>` defaulting to `Ok(())`. In-memory filesystems (ramfs, tarfs, devfs, bootstrap) inherit the default no-op since they have no backing device. Ext2-shaped drivers will override to delegate to `BlockCache::sync_fs(self.dev_id)`.
- `kernel/src/fs/vfs/mount_table.rs`: in `unmount()`, call `sb.ops.sync_fs(&sb)` in Phase B *before* `sb.ops.unmount()` tears the driver down. Errors are logged via `serial_println!` and absorbed — the detach is unconditional per the `SuperOps::unmount` contract, and any buffer that failed to flush remains DIRTY-enlisted for a later retry (writeback daemon or explicit sync).
- `kernel/tests/block_cache_sync_fs.rs`: new in-QEMU integration test covering the two behaviours the issue calls out.

## Issue checklist (from #554)

- [x] `BlockCache::sync_fs(&self, sb: &SuperBlock)` iterates the dirty set, filters by device ownership — takes `DeviceId` directly per the note in the issue body ("whichever matches the VFS surface"); `SuperOps::sync_fs` receives the `&SuperBlock` and drivers thread their own `DeviceId` through.
- [x] For each matching entry: `sync_dirty_buffer` in turn (no batching for simplicity).
- [x] Propagate the first `BlockError` to the caller; continue flushing the rest (best-effort).
- [x] Plumb `SuperOps::sync_fs` call from the VFS layer (new trait method, default `Ok(())`).
- [x] Wire into `umount` path: `sync_fs` BEFORE detaching the superblock (Phase B, before `sb.ops.unmount()`).
- [x] Integration test: write + sync_fs + drop cache + remount; data is present.
- [x] Integration test: sync_fs does NOT flush buffers belonging to a different mount.

## Test plan

- [x] `cargo test -p vibix --lib block::cache` — 31/31 pass (26 pre-existing + 5 new `sync_fs` tests).
- [x] `cargo xtask test-unit` — 414/414 pass (no regressions).
- [x] `cargo xtask test-integration` — `block_cache_sync_fs` test binary: `sync_fs_persists_across_cache_teardown` and `sync_fs_does_not_flush_other_mount` both `[ok]`; full suite still running in CI.
- [x] `cargo xtask build` — kernel builds clean.

## References

- RFC 0004 §Buffer cache — writeback / `sync_fs` contract, best-effort error propagation, one cache per mount with `(DeviceId, u64)` keys.
- Unblocker: #553 (merged as `b16ec78`) — shipped the `BufferHead` / `BlockCache` / CLOCK-Pro foundation this PR extends.

## Out of scope (per issue body)

- `sync(2)` syscall — Workstream F.
- Periodic writeback daemon — that is #555, the next C issue.

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)