### PR TITLE
userspace/init: pre/post-write diagnostic markers around first write(1) (#478)

### DIFF
--- a/userspace/init/src/main.rs
+++ b/userspace/init/src/main.rs
@@ -74,9 +74,33 @@ const HELLO_MSG: &[u8] = b"init: hello from pid 1\n";
 /// Emitted after the parent collects the child's exit status.
 const DONE_MSG: &[u8] = b"init: fork+exec+wait ok\n";
 
+/// Diagnostic marker for #478. Emitted on fd=2 as the very first userspace
+/// action — i.e. after `iretq` into ring 3 but before the first
+/// `write(1, HELLO_MSG)`. If the kernel-side `ring3-iretq:` marker fires
+/// but this one doesn't, the first SYSCALL instruction or the entry
+/// trampoline silently faulted before the handler ran. If this fires but
+/// `init: hello from pid 1` doesn't, the failure is specific to the fd=1
+/// write path, not ring-3 entry.
+const PRE_WRITE_MSG: &[u8] = b"init: pre-write marker\n";
+
+/// Diagnostic marker for #478. Emitted on fd=1 immediately after the
+/// first `write(1, HELLO_MSG)` returns. If `init: hello from pid 1` fires
+/// but this marker doesn't, the write syscall return path (SYSRET /
+/// restore of user context) is the culprit, not the write itself.
+const POST_WRITE_MSG: &[u8] = b"init: post-write marker\n";
+
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
+    // Pre-write diagnostic marker — see #478. Emitted on fd=2 so it
+    // exercises the syscall path but writes to a distinct stream from
+    // HELLO_MSG, making it easy to grep from the serial log.
+    write(2, PRE_WRITE_MSG);
+
     write(1, HELLO_MSG);
+
+    // Post-write diagnostic marker — see #478. Emitted immediately after
+    // the first `write(1, HELLO_MSG)` returns, before any further work.
+    write(1, POST_WRITE_MSG);
 
     // fork() — child PID returned to parent; 0 returned to child.
     let fork_ret: i64;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -106,7 +106,24 @@ const SMOKE_MARKERS: &[&str] = &[
     // `ring3-first-fault:` diagnostic line emitted by the IDT fault
     // handlers in that case).
     "ring3-iretq: rip=",
+    // #478 diagnostic: emitted by userspace init on fd=2 as the very first
+    // userspace action, immediately after ring-3 entry and before the first
+    // `write(1, HELLO_MSG)`. Three-marker localization:
+    //   - `ring3-iretq:` present, `pre-write marker` absent:
+    //     first SYSCALL instruction or the kernel syscall-entry trampoline
+    //     silently faulted before the Rust handler ran.
+    //   - `pre-write marker` present, `init: hello from pid 1` absent:
+    //     fd=1 write path (or state between the two writes) is the culprit,
+    //     not ring-3 entry.
+    //   - `init: hello from pid 1` present, `post-write marker` absent:
+    //     SYSRET / user-context restore is the culprit, not the write itself.
+    "init: pre-write marker",
     "init: hello from pid 1",
+    // #478 diagnostic: emitted on fd=1 immediately after the first
+    // `write(1, HELLO_MSG)` returns, before any further work (fork etc.).
+    // Missing this while `init: hello from pid 1` fires is a signal that the
+    // SYSRET / user-context restore after the first write is broken.
+    "init: post-write marker",
 ];
 
 /// Markers for the fork+exec+wait flow. These are flakey under un-accelerated


### PR DESCRIPTION
Subsumes #530 (same diagnostic content). Closes #484.

## Summary

Brackets `init::_start`'s first `write(1, HELLO_MSG)` with two additional diagnostic markers, both routed through the existing direct-syscall `write()` helper (so they exercise the identical syscall path):

- `init: pre-write marker` — emitted on fd=2 as the very first userspace action, immediately after `iretq` into ring 3 and before any other write.
- `init: post-write marker` — emitted on fd=1 right after the first `write(1, HELLO_MSG)` returns.

Registered in `xtask::SMOKE_MARKERS` with a three-way marker-localisation table so a flaked-out #478 boot can be classified from the serial log alone:

| Present | Absent | What's broken |
|---|---|---|
| `ring3-iretq:` | `init: pre-write marker` | First SYSCALL / entry trampoline silently faulted |
| `init: pre-write marker` | `init: hello from pid 1` | fd=1 write path or state between writes |
| `init: hello from pid 1` | `init: post-write marker` | SYSRET / user-context restore |

No behavioral change beyond the two extra `write()` calls.

## Repro status (on this branch, post-rebase onto main @ `b16ec78`)

A local bounded 30x TCG soak (`timeout 900 cargo xtask smoke`) reproduced #478 at ~10% flake rate. The failing iterations terminate with:

```
init: entering ring-3 entry=0x400000 rsp=0x7fffff58
init: iretq to ring-3
ring3-iretq: rip=0x400000 rsp=0x7fffff58 cs=0x23 ss=0x1b rflags=0x202
-----------------------
Error: "smoke: missing markers [\"init: hello from pid 1\", \"init: post-write marker\", \"init: pre-write marker\"]"
```

Three signals pin this to the **entry-trampoline class**:

1. `ring3-iretq:` fires — kernel reached the 5-word IRETQ frame push cleanly.
2. No `init: pre-write marker` — userspace never successfully completed its first SYSCALL.
3. No `ring3-first-fault:` — the IDT's one-shot CPL=3 fault latch never tripped, so whatever is happening is not a ring-3 #PF / #GP / #UD (each of which runs `log_first_ring3_fault`).

The follow-up fix (root-causing what stalls between `iretq` and the first user SYSCALL without taking any CPU exception) continues on #478. This PR lands the classification vehicle so the next flake leaves more evidence.

## Test plan

- [x] `cargo xtask build` on this branch — succeeds.
- [x] `cargo xtask smoke` — passes on green iterations with all 35 markers; the two new markers fire immediately after `ring3-iretq:` on the happy path.
- [x] Local 30-iter TCG soak reproduces #478 with the marker set (~10% flake rate) and pins the classification.
- [ ] CI: fmt + build, host unit tests, integration tests (QEMU), smoke test.
- [ ] Post-merge: 3 consecutive all-green main CI runs (tracked on #478 — gating criterion for the root-cause fix, not this diagnostic PR).

## Test plan (boilerplate checklist)

- [ ] CI `fmt + build` green
- [ ] CI `host unit tests` green
- [ ] CI `integration tests (QEMU)` green
- [ ] CI `smoke test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)