### PR TITLE
sys: wire setuid/setgid family with POSIX saved-set-uid semantics (#548)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -303,6 +303,10 @@ name = "syscall_chmod_chown"
 harness = false
 
 [[test]]
+name = "syscall_setuid_family"
+harness = false
+
+[[test]]
 name = "ntty_sigint_flush"
 harness = false
 

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -930,15 +930,11 @@ pub unsafe extern "C" fn syscall_dispatch(
 
         // setresuid(ruid, euid, suid) — all three fields exposed to
         // the caller; no implicit suid update. (uid_t)-1 preserves.
-        SETRESUID => {
-            super::syscalls::creds::sys_setresuid(a0 as u32, a1 as u32, a2 as u32)
-        }
+        SETRESUID => super::syscalls::creds::sys_setresuid(a0 as u32, a1 as u32, a2 as u32),
 
         // setresgid(rgid, egid, sgid) — group-side mirror of
         // setresuid.
-        SETRESGID => {
-            super::syscalls::creds::sys_setresgid(a0 as u32, a1 as u32, a2 as u32)
-        }
+        SETRESGID => super::syscalls::creds::sys_setresgid(a0 as u32, a1 as u32, a2 as u32),
 
         _ => -38i64, // ENOSYS
     }

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -905,6 +905,41 @@ pub unsafe extern "C" fn syscall_dispatch(
         // getegid() — return the caller's effective group ID.
         GETEGID => super::syscalls::creds::sys_getegid(),
 
+        // setuid(uid) — POSIX.1-2017 §setuid. Privileged (euid==0)
+        // transition sets ruid=euid=suid=uid; unprivileged sets euid
+        // only, and only to ruid or suid. `uid == (uid_t)-1` is
+        // EINVAL (no unchanged sentinel in the single-arg form).
+        // Issue #548.
+        SETUID => super::syscalls::creds::sys_setuid(a0 as u32),
+
+        // setgid(gid) — POSIX.1-2017 §setgid. Group-side mirror of
+        // setuid. Still gated on effective *user* ID (euid == 0) for
+        // the privileged bypass per POSIX.1.
+        SETGID => super::syscalls::creds::sys_setgid(a0 as u32),
+
+        // setreuid(ruid, euid) — POSIX.1-2017 §setreuid. Each argument
+        // may be (uid_t)-1 to leave the field unchanged. Non-root
+        // requires each non-(-1) target ∈ {ruid, euid, suid}.
+        // Bumps suid := new euid when ruid was set or euid changed to
+        // a value != old ruid.
+        SETREUID => super::syscalls::creds::sys_setreuid(a0 as u32, a1 as u32),
+
+        // setregid(rgid, egid) — group-side mirror of setreuid with
+        // the same sgid-bump rule.
+        SETREGID => super::syscalls::creds::sys_setregid(a0 as u32, a1 as u32),
+
+        // setresuid(ruid, euid, suid) — all three fields exposed to
+        // the caller; no implicit suid update. (uid_t)-1 preserves.
+        SETRESUID => {
+            super::syscalls::creds::sys_setresuid(a0 as u32, a1 as u32, a2 as u32)
+        }
+
+        // setresgid(rgid, egid, sgid) — group-side mirror of
+        // setresuid.
+        SETRESGID => {
+            super::syscalls::creds::sys_setresgid(a0 as u32, a1 as u32, a2 as u32)
+        }
+
         _ => -38i64, // ENOSYS
     }
 }
@@ -1495,6 +1530,12 @@ pub mod syscall_nr {
     pub const GETGID: u64 = 104;
     pub const GETEUID: u64 = 107;
     pub const GETEGID: u64 = 108;
+    pub const SETUID: u64 = 105;
+    pub const SETGID: u64 = 106;
+    pub const SETREUID: u64 = 113;
+    pub const SETREGID: u64 = 114;
+    pub const SETRESUID: u64 = 117;
+    pub const SETRESGID: u64 = 119;
 }
 
 #[cfg(test)]
@@ -1564,6 +1605,14 @@ mod tests {
         assert_eq!(syscall_nr::GETGID, 104, "SYS_getgid must be 104");
         assert_eq!(syscall_nr::GETEUID, 107, "SYS_geteuid must be 107");
         assert_eq!(syscall_nr::GETEGID, 108, "SYS_getegid must be 108");
+
+        // Credential writes (issue #548, RFC 0004 Workstream B)
+        assert_eq!(syscall_nr::SETUID, 105, "SYS_setuid must be 105");
+        assert_eq!(syscall_nr::SETGID, 106, "SYS_setgid must be 106");
+        assert_eq!(syscall_nr::SETREUID, 113, "SYS_setreuid must be 113");
+        assert_eq!(syscall_nr::SETREGID, 114, "SYS_setregid must be 114");
+        assert_eq!(syscall_nr::SETRESUID, 117, "SYS_setresuid must be 117");
+        assert_eq!(syscall_nr::SETRESGID, 119, "SYS_setresgid must be 119");
 
         // IPC / FIFO
         assert_eq!(syscall_nr::PIPE, 22, "SYS_pipe must be 22");

--- a/kernel/src/arch/x86_64/syscalls/creds.rs
+++ b/kernel/src/arch/x86_64/syscalls/creds.rs
@@ -1,13 +1,16 @@
-//! Credential-query syscalls: `getuid(2)`, `geteuid(2)`, `getgid(2)`,
-//! `getegid(2)`.
+//! Credential syscalls: read (`getuid(2)` / `geteuid(2)` / `getgid(2)` /
+//! `getegid(2)`) and write (`setuid(2)` / `setgid(2)` / `setreuid(2)` /
+//! `setregid(2)` / `setresuid(2)` / `setresgid(2)`).
 //!
-//! These are POSIX-mandated read-only accessors for the caller's
-//! real/effective user and group IDs. Per POSIX.1-2017 they are
-//! *infallible* — the manpage signature is `uid_t getuid(void)` with no
-//! errno contract — so every dispatch arm here returns the requested ID
-//! as a non-negative `i64`, never a negated errno.
+//! The read arms are POSIX-mandated infallible accessors for the
+//! caller's real/effective IDs; they return a non-negative `i64`, never
+//! a negated errno. The write arms implement POSIX.1-2017 §2.4
+//! saved-set-user-ID semantics: they validate the requested transition
+//! against the caller's current `{ruid, euid, suid}` set (and the
+//! privileged euid==0 bypass), build a fresh [`Credential`], and swap
+//! the inner `Arc` under the per-task `BlockingRwLock`.
 //!
-//! ## Wait-free Arc-snapshot read path
+//! ## Wait-free Arc-snapshot model
 //!
 //! [`Task::credentials`](crate::task::Task::credentials) is a
 //! `BlockingRwLock<Arc<Credential>>`. Readers take a short read-lock,
@@ -19,11 +22,40 @@
 //! `Arc::clone` + lock acquire — this is the "wait-free read" model
 //! called out in RFC 0004 §Credential model.
 //!
-//! Because these syscalls are read-only and never dereference a
-//! user-space pointer, they do not depend on the `vfs_creds` feature
-//! flag — the flag guards VFS paths that still straddle the
-//! Workstream A/B transition. `getuid`-family calls have no such
-//! mid-transition concern and wire up unconditionally.
+//! Because these syscalls operate on the caller's own task credentials
+//! rather than dereferencing a user-space pointer, they do not depend
+//! on the `vfs_creds` feature flag — the flag guards VFS paths that
+//! still straddle the Workstream A/B transition. `getuid`- and
+//! `setuid`-family calls have no such mid-transition concern and wire
+//! up unconditionally.
+//!
+//! ## POSIX.1-2017 decision matrix (issue #548)
+//!
+//! For the write arms, `u32::MAX` is the C `(uid_t)-1` sentinel. The
+//! single-argument forms (`setuid`, `setgid`) reject it with `EINVAL`
+//! because POSIX requires an explicit target; the pair and triple forms
+//! (`setreuid`, `setresuid`, `setregid`, `setresgid`) treat it as "leave
+//! this field unchanged" and so `set*reuid(-1, -1)` and
+//! `set*resuid(-1, -1, -1)` are valid no-op successes.
+//!
+//! | Syscall        | Privileged (euid==0)                              | Unprivileged rule                                                                                  |
+//! |----------------|---------------------------------------------------|----------------------------------------------------------------------------------------------------|
+//! | `setuid(u)`    | ruid=euid=suid=u                                  | Require u ∈ {ruid, suid}. Set euid=u only. (`u == euid` also accepted since euid ∈ {ruid, suid} after a prior setuid-bit exec or is already the current ID.) |
+//! | `setreuid(r,e)`| any r, any e; if r!=-1 or e!=-1 & e!=old ruid, suid=new euid | Each non-(-1) target must be ∈ {old ruid, old euid, old suid}. Same suid-bump rule.         |
+//! | `setresuid(r,e,s)` | any r/e/s (per -1)                            | Each non-(-1) target must be ∈ {old ruid, old euid, old suid}. suid takes `s` literally (or is unchanged if `s == -1`); no implicit bump. |
+//!
+//! The gid family mirrors the uid family field-for-field; the
+//! "privileged" predicate is still `euid == 0` (POSIX.1: only the
+//! effective *user* ID determines privilege for the `setgid` family too).
+
+use crate::fs::vfs::Credential;
+use crate::fs::{EINVAL, EPERM};
+
+// `u32::MAX` is the C `(uid_t)-1` sentinel. Named at module scope so
+// the intent is obvious at every use site and a future switch to a
+// signed transport (e.g. if we ever plumb `i32` through SYSCALL) is a
+// one-line change.
+const UID_UNCHANGED: u32 = u32::MAX;
 
 /// `getuid(2)` — return the caller's real user ID.
 ///
@@ -57,4 +89,222 @@ pub fn sys_getgid() -> i64 {
 /// `getegid(2)` — return the caller's effective group ID.
 pub fn sys_getegid() -> i64 {
     crate::task::current_credentials().egid as i64
+}
+
+/// Build a fresh `Credential` by cloning `cur` and overriding the four
+/// user-side fields. The group fields and supplementary groups are
+/// preserved verbatim — POSIX does not clear them on a uid transition
+/// (Linux rule per RFC 0004 §945-957).
+fn with_uids(cur: &Credential, uid: u32, euid: u32, suid: u32) -> Credential {
+    Credential::from_task_ids(
+        uid,
+        euid,
+        suid,
+        cur.gid,
+        cur.egid,
+        cur.sgid,
+        cur.groups.clone(),
+    )
+}
+
+/// Mirror of [`with_uids`] for the group-side transitions.
+fn with_gids(cur: &Credential, gid: u32, egid: u32, sgid: u32) -> Credential {
+    Credential::from_task_ids(
+        cur.uid,
+        cur.euid,
+        cur.suid,
+        gid,
+        egid,
+        sgid,
+        cur.groups.clone(),
+    )
+}
+
+/// Non-root membership check for the `{ruid, euid, suid}` triple.
+/// Returns `true` iff `target` equals any of the three current IDs.
+/// `u32::MAX` (the `-1` sentinel) is rejected at the call site before
+/// we get here; this helper deals only with real target values.
+fn is_member_uid(cur: &Credential, target: u32) -> bool {
+    target == cur.uid || target == cur.euid || target == cur.suid
+}
+
+fn is_member_gid(cur: &Credential, target: u32) -> bool {
+    target == cur.gid || target == cur.egid || target == cur.sgid
+}
+
+/// `setuid(uid)` — POSIX.1-2017 §setuid.
+///
+/// - `uid == (uid_t)-1`: `EINVAL`. The single-argument form has no
+///   "unchanged" sentinel; a `-1` target is always an invalid ID.
+/// - `euid == 0` (privileged): set `ruid = euid = suid = uid`. This is
+///   the irrevocable drop when a setuid-root process wants to shed root
+///   permanently (the classic idiom: `setuid(getuid())` from root).
+/// - Otherwise (unprivileged): `uid` must be `∈ {ruid, suid}`; sets
+///   `euid = uid` only. `ruid` and `suid` are preserved so the caller
+///   retains the authority to swap back via `seteuid(suid)` later.
+///   We check membership in `{ruid, suid}` (not `{ruid, euid, suid}`):
+///   the current euid is deliberately excluded to match Linux, which
+///   rejects a "keep euid as-is" self-set on this path with `EPERM`
+///   when neither ruid nor suid matches.
+///
+/// Returns `0` on success, negative errno on failure.
+pub fn sys_setuid(uid: u32) -> i64 {
+    if uid == UID_UNCHANGED {
+        return EINVAL;
+    }
+    let cur = crate::task::current_credentials();
+    let new_cred = if cur.euid == 0 {
+        with_uids(&cur, uid, uid, uid)
+    } else if uid == cur.uid || uid == cur.suid {
+        with_uids(&cur, cur.uid, uid, cur.suid)
+    } else {
+        return EPERM;
+    };
+    crate::task::replace_current_credentials(new_cred);
+    0
+}
+
+/// `setreuid(ruid, euid)` — POSIX.1-2017 §setreuid.
+///
+/// Either argument may be `(uid_t)-1` to leave that field unchanged.
+/// Non-root callers must pass targets drawn from the current
+/// `{ruid, euid, suid}` set. Root (euid == 0) skips the membership
+/// check.
+///
+/// Saved-set-user-ID update rule (POSIX §setreuid, fourth paragraph):
+/// if `ruid` was set (argument not `-1`), *or* `euid` was set to a
+/// value different from the current real uid, then `suid` is set to
+/// the new `euid`. Otherwise `suid` is unchanged. This is the
+/// "drop-and-restore" mechanism for a setuid binary: after
+/// `setreuid(ruid, 0)` the saved-set-uid is pinned to 0 so a later
+/// `setreuid(0, 0)` (or `seteuid(0)`) succeeds via membership.
+///
+/// `setreuid(-1, -1)` is a valid no-op success.
+pub fn sys_setreuid(ruid: u32, euid: u32) -> i64 {
+    let cur = crate::task::current_credentials();
+    let new_ruid = if ruid == UID_UNCHANGED { cur.uid } else { ruid };
+    let new_euid = if euid == UID_UNCHANGED { cur.euid } else { euid };
+    // Membership check (non-root only). Each *set* (i.e., non-(-1))
+    // target must be a current member. Root bypasses.
+    if cur.euid != 0 {
+        if ruid != UID_UNCHANGED && !is_member_uid(&cur, ruid) {
+            return EPERM;
+        }
+        if euid != UID_UNCHANGED && !is_member_uid(&cur, euid) {
+            return EPERM;
+        }
+    }
+    // suid-bump rule: fires when either ruid was set explicitly, or
+    // euid was set to a value != current ruid. We test against the
+    // *old* ruid per POSIX wording; `cur.uid` is that value.
+    let suid_bump = ruid != UID_UNCHANGED || (euid != UID_UNCHANGED && euid != cur.uid);
+    let new_suid = if suid_bump { new_euid } else { cur.suid };
+    let new_cred = with_uids(&cur, new_ruid, new_euid, new_suid);
+    crate::task::replace_current_credentials(new_cred);
+    0
+}
+
+/// `setresuid(ruid, euid, suid)` — POSIX.1-2017 (Linux extension in
+/// §2.4 spirit; not in POSIX.1-2017 §setresuid directly but the
+/// reference the RFC follows).
+///
+/// Any argument may be `(uid_t)-1` to leave that field unchanged. Root
+/// (euid == 0) may set any of the three to any value; non-root callers
+/// must draw each non-(-1) target from the current `{ruid, euid, suid}`
+/// set.
+///
+/// Unlike `setreuid`, there is **no** implicit `suid := euid` update:
+/// `setresuid` exposes all three fields to the caller directly, so the
+/// caller controls `suid` explicitly (either by passing the literal
+/// value or by passing `-1` to preserve).
+pub fn sys_setresuid(ruid: u32, euid: u32, suid: u32) -> i64 {
+    let cur = crate::task::current_credentials();
+    if cur.euid != 0 {
+        if ruid != UID_UNCHANGED && !is_member_uid(&cur, ruid) {
+            return EPERM;
+        }
+        if euid != UID_UNCHANGED && !is_member_uid(&cur, euid) {
+            return EPERM;
+        }
+        if suid != UID_UNCHANGED && !is_member_uid(&cur, suid) {
+            return EPERM;
+        }
+    }
+    let new_ruid = if ruid == UID_UNCHANGED { cur.uid } else { ruid };
+    let new_euid = if euid == UID_UNCHANGED { cur.euid } else { euid };
+    let new_suid = if suid == UID_UNCHANGED { cur.suid } else { suid };
+    let new_cred = with_uids(&cur, new_ruid, new_euid, new_suid);
+    crate::task::replace_current_credentials(new_cred);
+    0
+}
+
+/// `setgid(gid)` — POSIX.1-2017 §setgid.
+///
+/// Group-side mirror of [`sys_setuid`]. The privileged predicate is
+/// still `euid == 0` per POSIX.1 (only the effective *user* ID confers
+/// privilege; effective group ID alone does not). `gid == (gid_t)-1`
+/// is `EINVAL` for the same reason `setuid(-1)` is: no unchanged
+/// sentinel in the single-argument form.
+pub fn sys_setgid(gid: u32) -> i64 {
+    if gid == UID_UNCHANGED {
+        return EINVAL;
+    }
+    let cur = crate::task::current_credentials();
+    let new_cred = if cur.euid == 0 {
+        with_gids(&cur, gid, gid, gid)
+    } else if gid == cur.gid || gid == cur.sgid {
+        with_gids(&cur, cur.gid, gid, cur.sgid)
+    } else {
+        return EPERM;
+    };
+    crate::task::replace_current_credentials(new_cred);
+    0
+}
+
+/// `setregid(rgid, egid)` — POSIX.1-2017 §setregid.
+///
+/// Group-side mirror of [`sys_setreuid`], including the `sgid := new
+/// egid` bump rule when the real gid is set or the effective gid
+/// changes to a value `!=` old real gid.
+pub fn sys_setregid(rgid: u32, egid: u32) -> i64 {
+    let cur = crate::task::current_credentials();
+    let new_rgid = if rgid == UID_UNCHANGED { cur.gid } else { rgid };
+    let new_egid = if egid == UID_UNCHANGED { cur.egid } else { egid };
+    if cur.euid != 0 {
+        if rgid != UID_UNCHANGED && !is_member_gid(&cur, rgid) {
+            return EPERM;
+        }
+        if egid != UID_UNCHANGED && !is_member_gid(&cur, egid) {
+            return EPERM;
+        }
+    }
+    let sgid_bump = rgid != UID_UNCHANGED || (egid != UID_UNCHANGED && egid != cur.gid);
+    let new_sgid = if sgid_bump { new_egid } else { cur.sgid };
+    let new_cred = with_gids(&cur, new_rgid, new_egid, new_sgid);
+    crate::task::replace_current_credentials(new_cred);
+    0
+}
+
+/// `setresgid(rgid, egid, sgid)` — group-side mirror of
+/// [`sys_setresuid`]. No implicit `sgid` update; caller controls all
+/// three fields.
+pub fn sys_setresgid(rgid: u32, egid: u32, sgid: u32) -> i64 {
+    let cur = crate::task::current_credentials();
+    if cur.euid != 0 {
+        if rgid != UID_UNCHANGED && !is_member_gid(&cur, rgid) {
+            return EPERM;
+        }
+        if egid != UID_UNCHANGED && !is_member_gid(&cur, egid) {
+            return EPERM;
+        }
+        if sgid != UID_UNCHANGED && !is_member_gid(&cur, sgid) {
+            return EPERM;
+        }
+    }
+    let new_rgid = if rgid == UID_UNCHANGED { cur.gid } else { rgid };
+    let new_egid = if egid == UID_UNCHANGED { cur.egid } else { egid };
+    let new_sgid = if sgid == UID_UNCHANGED { cur.sgid } else { sgid };
+    let new_cred = with_gids(&cur, new_rgid, new_egid, new_sgid);
+    crate::task::replace_current_credentials(new_cred);
+    0
 }

--- a/kernel/src/arch/x86_64/syscalls/creds.rs
+++ b/kernel/src/arch/x86_64/syscalls/creds.rs
@@ -183,7 +183,11 @@ pub fn sys_setuid(uid: u32) -> i64 {
 pub fn sys_setreuid(ruid: u32, euid: u32) -> i64 {
     let cur = crate::task::current_credentials();
     let new_ruid = if ruid == UID_UNCHANGED { cur.uid } else { ruid };
-    let new_euid = if euid == UID_UNCHANGED { cur.euid } else { euid };
+    let new_euid = if euid == UID_UNCHANGED {
+        cur.euid
+    } else {
+        euid
+    };
     // Membership check (non-root only). Each *set* (i.e., non-(-1))
     // target must be a current member. Root bypasses.
     if cur.euid != 0 {
@@ -231,8 +235,16 @@ pub fn sys_setresuid(ruid: u32, euid: u32, suid: u32) -> i64 {
         }
     }
     let new_ruid = if ruid == UID_UNCHANGED { cur.uid } else { ruid };
-    let new_euid = if euid == UID_UNCHANGED { cur.euid } else { euid };
-    let new_suid = if suid == UID_UNCHANGED { cur.suid } else { suid };
+    let new_euid = if euid == UID_UNCHANGED {
+        cur.euid
+    } else {
+        euid
+    };
+    let new_suid = if suid == UID_UNCHANGED {
+        cur.suid
+    } else {
+        suid
+    };
     let new_cred = with_uids(&cur, new_ruid, new_euid, new_suid);
     crate::task::replace_current_credentials(new_cred);
     0
@@ -269,7 +281,11 @@ pub fn sys_setgid(gid: u32) -> i64 {
 pub fn sys_setregid(rgid: u32, egid: u32) -> i64 {
     let cur = crate::task::current_credentials();
     let new_rgid = if rgid == UID_UNCHANGED { cur.gid } else { rgid };
-    let new_egid = if egid == UID_UNCHANGED { cur.egid } else { egid };
+    let new_egid = if egid == UID_UNCHANGED {
+        cur.egid
+    } else {
+        egid
+    };
     if cur.euid != 0 {
         if rgid != UID_UNCHANGED && !is_member_gid(&cur, rgid) {
             return EPERM;
@@ -302,8 +318,16 @@ pub fn sys_setresgid(rgid: u32, egid: u32, sgid: u32) -> i64 {
         }
     }
     let new_rgid = if rgid == UID_UNCHANGED { cur.gid } else { rgid };
-    let new_egid = if egid == UID_UNCHANGED { cur.egid } else { egid };
-    let new_sgid = if sgid == UID_UNCHANGED { cur.sgid } else { sgid };
+    let new_egid = if egid == UID_UNCHANGED {
+        cur.egid
+    } else {
+        egid
+    };
+    let new_sgid = if sgid == UID_UNCHANGED {
+        cur.sgid
+    } else {
+        sgid
+    };
     let new_cred = with_gids(&cur, new_rgid, new_egid, new_sgid);
     crate::task::replace_current_credentials(new_cred);
     0

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -440,6 +440,42 @@ pub fn current_credentials() -> alloc::sync::Arc<crate::fs::vfs::Credential> {
     snapshot
 }
 
+/// Atomically replace the currently-running task's credentials with
+/// `new_cred`. The write-side partner of [`current_credentials`]: the
+/// caller constructs a fresh [`Credential`](crate::fs::vfs::Credential)
+/// (typically by cloning the existing snapshot and overriding the
+/// relevant `uid`/`gid` fields) and this helper swaps the inner `Arc`
+/// under the per-task `BlockingRwLock`.
+///
+/// Readers that took an earlier `Arc` snapshot via
+/// `current_credentials()` continue to see the pre-swap `Credential` —
+/// the swap only becomes visible on the next read. Combined with
+/// `Credential`'s immutability, this is the atomic `Arc`-swap model
+/// documented in RFC 0004 §Credential model: a `setuid(2)` family write
+/// cannot tear an in-flight VFS DAC check on a sibling thread.
+///
+/// Mirrors the SCHED-lock pattern used by [`current_credentials`] — we
+/// take `SCHED` once, acquire the per-task credentials lock through it,
+/// and drop both under a single inner scope so the lock guards release
+/// in the correct order.
+///
+/// # Panics
+/// Panics if called before [`init`] (no running task yet).
+pub fn replace_current_credentials(new_cred: crate::fs::vfs::Credential) {
+    let sched = SCHED.lock();
+    let cur = sched
+        .current
+        .as_ref()
+        .expect("replace_current_credentials: no running task");
+    // Inner scope forces the `RwLockWriteGuard` to drop before the
+    // outer `sched` (`IrqLockGuard`), same as `current_credentials`.
+    {
+        let mut guard = cur.credentials.write();
+        *guard = alloc::sync::Arc::new(new_cred);
+    }
+    drop(sched);
+}
+
 /// Return the per-process current working directory dentry, or `None`
 /// if no cwd has been set (bootstrap / kernel-only tasks). Callers
 /// should fall back to [`crate::fs::vfs::root`] on `None`.

--- a/kernel/tests/syscall_setuid_family.rs
+++ b/kernel/tests/syscall_setuid_family.rs
@@ -1,0 +1,464 @@
+//! Integration test for issue #548 / RFC 0004 Workstream B:
+//! `setuid(2)` / `setgid(2)` / `setreuid(2)` / `setregid(2)` /
+//! `setresuid(2)` / `setresgid(2)` dispatch arms.
+//!
+//! Each test builds a fresh `Credential` snapshot, installs it on the
+//! currently-running task via
+//! [`vibix::task::replace_current_credentials`], dispatches the
+//! relevant syscall through the real dispatcher, then asserts both the
+//! numeric return code (0 on success, negative errno on failure) and
+//! the post-swap `{ruid, euid, suid}` / `{rgid, egid, sgid}` triple as
+//! observed through `current_credentials()`.
+//!
+//! Cross-checking after each write validates the Arc-swap is visible
+//! to the read path — the "atomic update via Arc swap" contract from
+//! RFC 0004 §Credential model that pairs these write arms with the
+//! `getuid`-family read arms merged in #547.
+//!
+//! The test matrix covers (per the issue body):
+//! - root setuid drops all three to non-zero and cannot regain
+//! - setuid-binary drop-and-restore via setreuid(ruid, suid)
+//! - setresuid with -1 preserves fields
+//! - setregid(-1, new_egid) transitions egid only
+//! Plus the POSIX edge cases: `setuid(-1)` rejected with EINVAL,
+//! `setreuid(-1, -1)` no-op, same-value self-set always succeeds,
+//! non-root transitions outside `{ruid, euid, suid}` rejected with
+//! EPERM.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use core::panic::PanicInfo;
+
+use vibix::arch::x86_64::syscall::syscall_dispatch;
+use vibix::fs::vfs::Credential;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+// Syscall numbers (Linux x86_64 ABI; parity-checked in the unit test
+// at `kernel/src/arch/x86_64/syscall.rs::tests`).
+const SYS_SETUID: u64 = 105;
+const SYS_SETGID: u64 = 106;
+const SYS_SETREUID: u64 = 113;
+const SYS_SETREGID: u64 = 114;
+const SYS_SETRESUID: u64 = 117;
+const SYS_SETRESGID: u64 = 119;
+
+// C errno contract (negated to match syscall return convention).
+const EPERM: i64 = -1;
+const EINVAL: i64 = -22;
+
+// The C `(uid_t)-1` / `(gid_t)-1` sentinel — u32 wire transport, so
+// `-1` is `u32::MAX` when zero-extended into the syscall register.
+const MINUS_ONE: u64 = u32::MAX as u64;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    vibix::task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("setuid_minus_one_einval", &(setuid_minus_one_einval as fn())),
+        ("setgid_minus_one_einval", &(setgid_minus_one_einval as fn())),
+        (
+            "root_setuid_drops_all_three",
+            &(root_setuid_drops_all_three as fn()),
+        ),
+        (
+            "dropped_uid_cannot_regain",
+            &(dropped_uid_cannot_regain as fn()),
+        ),
+        (
+            "setreuid_minus_one_minus_one_is_noop",
+            &(setreuid_minus_one_minus_one_is_noop as fn()),
+        ),
+        (
+            "setuid_binary_drop_and_restore",
+            &(setuid_binary_drop_and_restore as fn()),
+        ),
+        (
+            "setresuid_minus_one_preserves",
+            &(setresuid_minus_one_preserves as fn()),
+        ),
+        (
+            "setregid_minus_one_new_egid_transitions_egid_only",
+            &(setregid_minus_one_new_egid_transitions_egid_only as fn()),
+        ),
+        (
+            "nonroot_setuid_to_outside_set_eperm",
+            &(nonroot_setuid_to_outside_set_eperm as fn()),
+        ),
+        (
+            "nonroot_same_value_is_success",
+            &(nonroot_same_value_is_success as fn()),
+        ),
+        (
+            "setresuid_nonroot_outside_set_eperm",
+            &(setresuid_nonroot_outside_set_eperm as fn()),
+        ),
+        (
+            "setresuid_root_sets_all_three",
+            &(setresuid_root_sets_all_three as fn()),
+        ),
+        (
+            "setreuid_ruid_change_bumps_suid",
+            &(setreuid_ruid_change_bumps_suid as fn()),
+        ),
+        (
+            "setgid_family_mirrors_uid_family",
+            &(setgid_family_mirrors_uid_family as fn()),
+        ),
+        (
+            "uid_transition_preserves_supplementary_groups",
+            &(uid_transition_preserves_supplementary_groups as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+// ---- Test helpers ---------------------------------------------------
+
+/// Install a fresh six-ID + groups snapshot on the currently-running
+/// task. All tests call this on entry so the matrix is
+/// state-independent (each case sets exactly the initial credential it
+/// wants, then drives the syscall).
+fn install_cred(uid: u32, euid: u32, suid: u32, gid: u32, egid: u32, sgid: u32) {
+    let cred = Credential::from_task_ids(uid, euid, suid, gid, egid, sgid, Vec::new());
+    vibix::task::replace_current_credentials(cred);
+}
+
+fn install_cred_with_groups(
+    uid: u32,
+    euid: u32,
+    suid: u32,
+    gid: u32,
+    egid: u32,
+    sgid: u32,
+    groups: Vec<u32>,
+) {
+    let cred = Credential::from_task_ids(uid, euid, suid, gid, egid, sgid, groups);
+    vibix::task::replace_current_credentials(cred);
+}
+
+/// Dispatch a syscall through the real entry point.
+fn dispatch(nr: u64, a0: u64, a1: u64, a2: u64) -> i64 {
+    // `ctx` is never dereferenced by any credential syscall arm (they
+    // do not sleep, signal-restart, or copy_to_user), so a null pointer
+    // is fine — matches the pattern used by `syscall_getuid_family`.
+    unsafe { syscall_dispatch(core::ptr::null_mut(), nr, a0, a1, a2, 0, 0, 0) }
+}
+
+fn cur() -> alloc::sync::Arc<Credential> {
+    vibix::task::current_credentials()
+}
+
+// ---- Tests: single-arg EINVAL on -1 ---------------------------------
+
+fn setuid_minus_one_einval() {
+    install_cred(0, 0, 0, 0, 0, 0);
+    let rc = dispatch(SYS_SETUID, MINUS_ONE, 0, 0);
+    assert_eq!(
+        rc, EINVAL,
+        "setuid((uid_t)-1) must return EINVAL (single-arg form has no unchanged sentinel); got {rc}"
+    );
+    // Snapshot unchanged.
+    let c = cur();
+    assert_eq!((c.uid, c.euid, c.suid), (0, 0, 0));
+}
+
+fn setgid_minus_one_einval() {
+    install_cred(0, 0, 0, 0, 0, 0);
+    let rc = dispatch(SYS_SETGID, MINUS_ONE, 0, 0);
+    assert_eq!(rc, EINVAL, "setgid((gid_t)-1) must return EINVAL; got {rc}");
+    let c = cur();
+    assert_eq!((c.gid, c.egid, c.sgid), (0, 0, 0));
+}
+
+// ---- Tests: root drops ----------------------------------------------
+
+fn root_setuid_drops_all_three() {
+    install_cred(0, 0, 0, 0, 0, 0);
+    let rc = dispatch(SYS_SETUID, 1000, 0, 0);
+    assert_eq!(rc, 0, "root setuid(1000) must succeed; got {rc}");
+    let c = cur();
+    assert_eq!(
+        (c.uid, c.euid, c.suid),
+        (1000, 1000, 1000),
+        "root setuid(u) sets ruid=euid=suid=u per POSIX.1 §setuid"
+    );
+}
+
+fn dropped_uid_cannot_regain() {
+    // After an irrevocable drop, reclaiming root is EPERM — there is
+    // no 0 anywhere in {ruid, euid, suid} to authorise the setuid.
+    install_cred(1000, 1000, 1000, 1000, 1000, 1000);
+    let rc = dispatch(SYS_SETUID, 0, 0, 0);
+    assert_eq!(
+        rc, EPERM,
+        "non-root setuid(0) with 0 ∉ {{ruid, euid, suid}} must be EPERM; got {rc}"
+    );
+    let c = cur();
+    assert_eq!(
+        (c.uid, c.euid, c.suid),
+        (1000, 1000, 1000),
+        "failed setuid must not mutate any field"
+    );
+}
+
+// ---- Tests: setreuid -------------------------------------------------
+
+fn setreuid_minus_one_minus_one_is_noop() {
+    install_cred(500, 600, 700, 0, 0, 0);
+    let rc = dispatch(SYS_SETREUID, MINUS_ONE, MINUS_ONE, 0);
+    assert_eq!(rc, 0, "setreuid(-1, -1) must be a no-op success; got {rc}");
+    let c = cur();
+    assert_eq!(
+        (c.uid, c.euid, c.suid),
+        (500, 600, 700),
+        "setreuid(-1, -1) must not touch any field"
+    );
+}
+
+fn setuid_binary_drop_and_restore() {
+    // Classic "setuid-root binary" pattern: we exec'd as uid=1000 with
+    // the setuid bit flipping euid to 0, giving us {ruid=1000, euid=0,
+    // suid=0}. Drop euid to the real uid to run the non-privileged
+    // section, then reclaim root via euid=suid later.
+    install_cred(1000, 0, 0, 0, 0, 0);
+
+    // Drop: setreuid(-1, 1000) → euid=1000. The suid-bump rule fires
+    // only when euid changes to a value != old ruid; here new euid
+    // (1000) == old ruid (1000), so suid stays at 0. That preserved
+    // suid=0 is what authorises reclaiming root below.
+    let rc = dispatch(SYS_SETREUID, MINUS_ONE, 1000, 0);
+    assert_eq!(rc, 0, "setreuid(-1, 1000) from root must succeed; got {rc}");
+    let c = cur();
+    assert_eq!(
+        (c.uid, c.euid, c.suid),
+        (1000, 1000, 0),
+        "drop phase: ruid preserved, euid=1000, suid still 0 (new euid == old ruid, no bump)"
+    );
+
+    // Restore: setreuid(-1, 0). suid=0 is in {ruid, euid, suid} so
+    // euid=0 is authorised. The bump rule fires because new euid (0)
+    // != old ruid (1000), so suid is updated to the new euid. suid
+    // stays at 0, which is what we want.
+    let rc = dispatch(SYS_SETREUID, MINUS_ONE, 0, 0);
+    assert_eq!(rc, 0, "restore phase: setreuid(-1, 0) must succeed when suid=0; got {rc}");
+    let c = cur();
+    assert_eq!(
+        (c.uid, c.euid, c.suid),
+        (1000, 0, 0),
+        "restore phase: ruid preserved, euid reclaimed to 0, suid still 0"
+    );
+}
+
+fn setreuid_ruid_change_bumps_suid() {
+    // When ruid is set (argument is not -1), suid := new euid per the
+    // POSIX.1 §setreuid fourth paragraph bump rule. Here we run as
+    // root so the membership check is bypassed.
+    install_cred(0, 0, 0, 0, 0, 0);
+    let rc = dispatch(SYS_SETREUID, 1000, 2000, 0);
+    assert_eq!(rc, 0, "root setreuid(1000, 2000) must succeed; got {rc}");
+    let c = cur();
+    assert_eq!(
+        (c.uid, c.euid, c.suid),
+        (1000, 2000, 2000),
+        "ruid was set, so suid := new euid (POSIX bump rule)"
+    );
+}
+
+// ---- Tests: setresuid -----------------------------------------------
+
+fn setresuid_minus_one_preserves() {
+    install_cred(100, 200, 300, 0, 0, 0);
+    // Non-root caller (euid=200 != 0). Change only euid; target 100
+    // is a member of {ruid=100, euid=200, suid=300} so the
+    // membership check passes. -1 preserves ruid and suid verbatim.
+    let rc = dispatch(SYS_SETRESUID, MINUS_ONE, 100, MINUS_ONE);
+    assert_eq!(
+        rc, 0,
+        "setresuid(-1, 100, -1) with 100=ruid must succeed; got {rc}"
+    );
+    let c = cur();
+    assert_eq!(
+        (c.uid, c.euid, c.suid),
+        (100, 100, 300),
+        "setresuid(-1, X, -1) changes only euid — ruid and suid preserved"
+    );
+}
+
+fn setresuid_nonroot_outside_set_eperm() {
+    install_cred(100, 200, 300, 0, 0, 0);
+    // 999 is not in {100, 200, 300} — reject with EPERM.
+    let rc = dispatch(SYS_SETRESUID, 999, MINUS_ONE, MINUS_ONE);
+    assert_eq!(
+        rc, EPERM,
+        "non-root setresuid with target ∉ {{ruid, euid, suid}} must be EPERM; got {rc}"
+    );
+    let c = cur();
+    assert_eq!(
+        (c.uid, c.euid, c.suid),
+        (100, 200, 300),
+        "failed setresuid must not mutate any field"
+    );
+}
+
+fn setresuid_root_sets_all_three() {
+    install_cred(0, 0, 0, 0, 0, 0);
+    let rc = dispatch(SYS_SETRESUID, 111, 222, 333);
+    assert_eq!(rc, 0, "root setresuid(111, 222, 333) must succeed; got {rc}");
+    let c = cur();
+    assert_eq!(
+        (c.uid, c.euid, c.suid),
+        (111, 222, 333),
+        "root setresuid writes all three fields literally — no implicit suid bump"
+    );
+}
+
+// ---- Tests: setregid -------------------------------------------------
+
+fn setregid_minus_one_new_egid_transitions_egid_only() {
+    // euid=0 so we're root — pass the membership check trivially, and
+    // confirm the field-selection logic: setregid(-1, new_egid)
+    // touches only egid. The sgid-bump rule fires because egid
+    // changes to a value != old rgid, so sgid := new egid.
+    install_cred(0, 0, 0, 10, 20, 30);
+    let rc = dispatch(SYS_SETREGID, MINUS_ONE, 999, 0);
+    assert_eq!(
+        rc, 0,
+        "root setregid(-1, 999) must succeed; got {rc}"
+    );
+    let c = cur();
+    assert_eq!(
+        (c.gid, c.egid, c.sgid),
+        (10, 999, 999),
+        "setregid(-1, e) with e != old rgid: rgid preserved, egid=e, sgid bumped to e"
+    );
+    assert_eq!(
+        (c.uid, c.euid, c.suid),
+        (0, 0, 0),
+        "setregid must not touch any uid field"
+    );
+}
+
+// ---- Tests: non-root edge cases -------------------------------------
+
+fn nonroot_setuid_to_outside_set_eperm() {
+    install_cred(100, 100, 100, 0, 0, 0);
+    let rc = dispatch(SYS_SETUID, 42, 0, 0);
+    assert_eq!(
+        rc, EPERM,
+        "non-root setuid(u) with u ∉ {{ruid, suid}} must be EPERM; got {rc}"
+    );
+    let c = cur();
+    assert_eq!(
+        (c.uid, c.euid, c.suid),
+        (100, 100, 100),
+        "failed setuid must not mutate any field"
+    );
+}
+
+fn nonroot_same_value_is_success() {
+    // POSIX: "Setting the same field to its current value is a success,
+    // not EPERM." For non-root `setuid(u)` this works because u == ruid
+    // (and ruid is a valid target).
+    install_cred(100, 100, 100, 0, 0, 0);
+    let rc = dispatch(SYS_SETUID, 100, 0, 0);
+    assert_eq!(
+        rc, 0,
+        "non-root setuid(current ruid) must succeed (same-value case); got {rc}"
+    );
+    let c = cur();
+    assert_eq!((c.uid, c.euid, c.suid), (100, 100, 100));
+}
+
+// ---- Tests: gid mirrors uid -----------------------------------------
+
+fn setgid_family_mirrors_uid_family() {
+    // Root (euid == 0) can set all three gid fields via setgid(g).
+    install_cred(0, 0, 0, 0, 0, 0);
+    let rc = dispatch(SYS_SETGID, 1000, 0, 0);
+    assert_eq!(rc, 0, "root setgid(1000) must succeed; got {rc}");
+    let c = cur();
+    assert_eq!(
+        (c.gid, c.egid, c.sgid),
+        (1000, 1000, 1000),
+        "root setgid(g) sets rgid=egid=sgid=g"
+    );
+    assert_eq!(
+        (c.uid, c.euid, c.suid),
+        (0, 0, 0),
+        "setgid must not touch any uid field"
+    );
+
+    // After the transition to non-root effective *user* id, setgid is
+    // no longer privileged (POSIX: only euid confers privilege). So
+    // install {euid=500} and check non-root rejection of an
+    // out-of-set target.
+    install_cred(500, 500, 500, 1000, 1000, 1000);
+    let rc = dispatch(SYS_SETGID, 42, 0, 0);
+    assert_eq!(
+        rc, EPERM,
+        "non-root setgid(g) with g ∉ {{rgid, sgid}} must be EPERM; got {rc}"
+    );
+
+    // setresgid root path.
+    install_cred(0, 0, 0, 0, 0, 0);
+    let rc = dispatch(SYS_SETRESGID, 111, 222, 333);
+    assert_eq!(rc, 0, "root setresgid(111,222,333) must succeed; got {rc}");
+    let c = cur();
+    assert_eq!((c.gid, c.egid, c.sgid), (111, 222, 333));
+}
+
+// ---- Tests: supplementary groups preserved --------------------------
+
+fn uid_transition_preserves_supplementary_groups() {
+    // RFC 0004 §945-957: supplementary groups are NOT cleared on any
+    // setuid/setgid transition (Linux rule, not BSD). setgroups
+    // remains the explicit-mutation path.
+    let groups: Vec<u32> = [10u32, 20, 30].iter().copied().collect();
+    install_cred_with_groups(0, 0, 0, 0, 0, 0, groups.clone());
+
+    let rc = dispatch(SYS_SETUID, 1000, 0, 0);
+    assert_eq!(rc, 0, "root setuid(1000) must succeed");
+    let c = cur();
+    assert_eq!(
+        c.groups.as_slice(),
+        [10, 20, 30],
+        "supplementary groups must survive a uid transition (Linux rule per RFC 0004)"
+    );
+
+    // A successful gid transition must also preserve the list. The
+    // task is now non-root (uid=euid=suid=1000 after the setuid above)
+    // so pass a same-value target (0 == current rgid) to land on the
+    // unprivileged success path.
+    let rc = dispatch(SYS_SETGID, 0, 0, 0);
+    assert_eq!(rc, 0, "non-root setgid(current rgid) must succeed; got {rc}");
+    let c = cur();
+    assert_eq!(
+        c.groups.as_slice(),
+        [10, 20, 30],
+        "supplementary groups must survive a gid transition too"
+    );
+}

--- a/kernel/tests/syscall_setuid_family.rs
+++ b/kernel/tests/syscall_setuid_family.rs
@@ -74,8 +74,14 @@ fn panic(info: &PanicInfo) -> ! {
 
 fn run_tests() {
     let tests: &[(&str, &dyn Testable)] = &[
-        ("setuid_minus_one_einval", &(setuid_minus_one_einval as fn())),
-        ("setgid_minus_one_einval", &(setgid_minus_one_einval as fn())),
+        (
+            "setuid_minus_one_einval",
+            &(setuid_minus_one_einval as fn()),
+        ),
+        (
+            "setgid_minus_one_einval",
+            &(setgid_minus_one_einval as fn()),
+        ),
         (
             "root_setuid_drops_all_three",
             &(root_setuid_drops_all_three as fn()),
@@ -264,7 +270,10 @@ fn setuid_binary_drop_and_restore() {
     // != old ruid (1000), so suid is updated to the new euid. suid
     // stays at 0, which is what we want.
     let rc = dispatch(SYS_SETREUID, MINUS_ONE, 0, 0);
-    assert_eq!(rc, 0, "restore phase: setreuid(-1, 0) must succeed when suid=0; got {rc}");
+    assert_eq!(
+        rc, 0,
+        "restore phase: setreuid(-1, 0) must succeed when suid=0; got {rc}"
+    );
     let c = cur();
     assert_eq!(
         (c.uid, c.euid, c.suid),
@@ -327,7 +336,10 @@ fn setresuid_nonroot_outside_set_eperm() {
 fn setresuid_root_sets_all_three() {
     install_cred(0, 0, 0, 0, 0, 0);
     let rc = dispatch(SYS_SETRESUID, 111, 222, 333);
-    assert_eq!(rc, 0, "root setresuid(111, 222, 333) must succeed; got {rc}");
+    assert_eq!(
+        rc, 0,
+        "root setresuid(111, 222, 333) must succeed; got {rc}"
+    );
     let c = cur();
     assert_eq!(
         (c.uid, c.euid, c.suid),
@@ -345,10 +357,7 @@ fn setregid_minus_one_new_egid_transitions_egid_only() {
     // changes to a value != old rgid, so sgid := new egid.
     install_cred(0, 0, 0, 10, 20, 30);
     let rc = dispatch(SYS_SETREGID, MINUS_ONE, 999, 0);
-    assert_eq!(
-        rc, 0,
-        "root setregid(-1, 999) must succeed; got {rc}"
-    );
+    assert_eq!(rc, 0, "root setregid(-1, 999) must succeed; got {rc}");
     let c = cur();
     assert_eq!(
         (c.gid, c.egid, c.sgid),
@@ -454,7 +463,10 @@ fn uid_transition_preserves_supplementary_groups() {
     // so pass a same-value target (0 == current rgid) to land on the
     // unprivileged success path.
     let rc = dispatch(SYS_SETGID, 0, 0, 0);
-    assert_eq!(rc, 0, "non-root setgid(current rgid) must succeed; got {rc}");
+    assert_eq!(
+        rc, 0,
+        "non-root setgid(current rgid) must succeed; got {rc}"
+    );
     let c = cur();
     assert_eq!(
         c.groups.as_slice(),


### PR DESCRIPTION
## Summary

Closes #548. Wires six write-side credential syscalls into the dispatcher, partnering the wait-free read arms merged in #547.

| # | Syscall | Linux SYS_nr | Semantics |
|---|---------|:-:|---|
| 105 | `setuid(uid)` | `SETUID` | `-1` → `EINVAL`; `euid==0` sets all three to `uid`; else `uid ∈ {ruid, suid}` required, sets `euid` only |
| 106 | `setgid(gid)` | `SETGID` | group-side mirror of `setuid`; privileged on `euid == 0` |
| 113 | `setreuid(r, e)` | `SETREUID` | `-1` preserves; non-root: each set target `∈ {ruid, euid, suid}`; `suid := new euid` when ruid set or euid changed `!=` old ruid (POSIX §setreuid ¶4) |
| 114 | `setregid(r, e)` | `SETREGID` | group mirror of `setreuid`, same sgid-bump rule |
| 117 | `setresuid(r, e, s)` | `SETRESUID` | `-1` preserves any field; non-root: each set target `∈ {ruid, euid, suid}`; no implicit suid update |
| 119 | `setresgid(r, e, s)` | `SETRESGID` | group mirror of `setresuid` |

### Atomicity

Each handler builds a fresh `Credential` by cloning the current snapshot and overriding selected fields, then swaps the inner `Arc` under the task's `BlockingRwLock` via a new `task::replace_current_credentials` helper (same SCHED-lock pattern as `current_credentials`). Readers with an earlier `Arc` snapshot continue to see the pre-swap `Credential` until they re-read — the atomic-swap model from RFC 0004 §Credential model.

### Errno coverage (RFC 0004 errno table)

- `0` on success (C convention).
- `-EINVAL` on `(uid_t)-1` passed to the single-argument forms (`setuid` / `setgid`).
- `-EPERM` on unprivileged transitions outside `{ruid, euid, suid}`.

### Supplementary groups

**Preserved verbatim on every uid/gid transition** (Linux rule per RFC 0004 §945-957). `setgroups` remains the explicit-mutation path (separate, out-of-scope issue).

### POSIX edge cases verified in the test matrix

- `setuid(-1)` → `EINVAL`, state unchanged.
- `setreuid(-1, -1)` → no-op success.
- Non-root same-value self-set is a success, not `EPERM`.
- Root irrevocable drop cannot reclaim root.
- Setuid-binary drop-and-restore via `setreuid(-1, ruid)` then `setreuid(-1, 0)`.
- `setresuid(-1, X, -1)` preserves `ruid` and `suid`.
- `setregid(-1, new_egid)` transitions egid only (and bumps sgid per the pair-form rule).

### Out of scope (explicit per issue #548)

- `setfsuid` / `setfsgid` — deferred.
- POSIX capabilities (`CAP_SETUID` / `CAP_SETGID`) — explicit non-goal per RFC 0004.
- `setgroups` / `getgroups` — separate issue.

### Depends-on

- #546 (`Credential` struct + per-task snapshot)
- #547 (`getuid`-family read arms + `current_credentials` helper)

## Test plan

- [x] `cargo xtask build` clean
- [x] `cargo xtask test` — all 409 host unit + every integration test pass, including the new 15-case `syscall_setuid_family` matrix
- [x] Syscall-number parity asserts added alongside the #547 pattern: `SETUID=105`, `SETGID=106`, `SETREUID=113`, `SETREGID=114`, `SETRESUID=117`, `SETRESGID=119`
- [x] No conflicts with concurrent #541 (chmod/chown — touches `vfs.rs`) or #557 (ext2 disk types)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)