### PR TITLE
userspace/xtask: outb 0xe9 debug markers + -debugcon capture (diagnostic for #478)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,3 +215,14 @@ jobs:
 
       - name: cargo xtask smoke
         run: cargo xtask smoke
+
+      # #478 diagnostic step 1: port-0xE9 debugcon capture around the
+      # ring-0→ring-3 iretq. Upload on failure so investigators can see
+      # whether iretq retired at all, independent of the serial path.
+      - name: Upload debugcon log (#478 diagnostic)
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: smoke-debugcon-log
+          path: target/debugcon.log
+          if-no-files-found: ignore

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -226,12 +226,34 @@ pub unsafe fn jump_to_ring3(entry: u64, stack_top: u64) -> ! {
         USER_DATA_SELECTOR,
         0x202u64,
     );
+    // #478 diagnostic step 1: emit a single-byte marker on the QEMU debug
+    // console (port 0xe9) *immediately* before the iretq, and a second
+    // byte in the same asm block *after* the iretq frame is pushed but
+    // before the iretq retires. Because debugcon is captured to a separate
+    // file by xtask (`-debugcon file:...`), this signal is independent of
+    // the serial path and tells us whether iretq retired at all when the
+    // serial "init: hello from pid 1" marker goes missing.
+    //
+    // Byte assignments (step 1 of the 3-step plan):
+    //   0xE0 — kernel: about to push iretq frame
+    //   0xE1 — kernel: iretq frame pushed, iretq next instruction
+    // (Userspace markers 0xE2/0xE3 require IOPL=3 or an ioperm bitmap;
+    //  the kernel-side fallback — per the investigation plan — still
+    //  produces a useful signal on a silent #GP/#PF in the iretq path.)
+    core::arch::asm!(
+        "mov al, 0xE0",
+        "out 0xE9, al",
+        out("al") _,
+        options(nostack, preserves_flags),
+    );
     core::arch::asm!(
         "push {ss}",      // SS  = user data selector (stack segment)
         "push {sp}",      // RSP = user stack top
         "push 0x202",     // RFLAGS: IF=1, bit-1 reserved=1
         "push {cs}",      // CS  = user code selector
         "push {rip}",     // RIP = user entry point
+        "mov al, 0xE1",   // debugcon marker: iretq frame pushed
+        "out 0xE9, al",   // observable even if iretq faults silently
         "iretq",
         ss  = in(reg) USER_DATA_SELECTOR as u64,
         sp  = in(reg) stack_top,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1037,6 +1037,24 @@ fn smoke(opts: &BuildOpts) -> R<()> {
     let iso = iso(opts)?;
     let disk = ensure_test_disk()?;
 
+    // #478 diagnostic step 1: capture QEMU's port-0xE9 debug console to a
+    // file alongside serial. The kernel emits single-byte markers on 0xE9
+    // immediately around the ring-0→ring-3 iretq (see
+    // `kernel::arch::x86_64::syscall::jump_to_ring3`). Because the
+    // debugcon path is independent of the serial mux, seeing e.g. `0xE1`
+    // here when the "init: hello from pid 1" serial marker is missing
+    // proves iretq was attempted; missing `0xE1` points at a pre-iretq
+    // fault. Unconditional — the capture is cheap and always-on.
+    let debugcon_log: PathBuf = {
+        let mut p =
+            PathBuf::from(env::var_os("CARGO_TARGET_DIR").unwrap_or_else(|| "target".into()));
+        p.push("debugcon.log");
+        // Truncate any stale log from a previous run.
+        let _ = fs::remove_file(&p);
+        p
+    };
+    let debugcon_arg = format!("file:{}", debugcon_log.display());
+
     // Boot QEMU with serial to stdio; stdout is piped so we can read it
     // incrementally.  -no-shutdown keeps the kernel in hlt_loop forever
     // (the kernel never calls isa-debug-exit), so we are responsible for
@@ -1058,6 +1076,7 @@ fn smoke(opts: &BuildOpts) -> R<()> {
             "-device",
             "isa-debug-exit,iobase=0xf4,iosize=0x04",
         ])
+        .args(["-debugcon", &debugcon_arg])
         .args(virtio_blk_args(&disk))
         .arg("-cdrom")
         .arg(&iso)
@@ -1160,8 +1179,24 @@ fn smoke(opts: &BuildOpts) -> R<()> {
     let _ = reader_handle.join();
     let _ = child.wait();
 
+    // Helper to dump the debugcon log (#478 diagnostic step 1) on any
+    // failure path so CI log lines and uploaded artifacts both show it.
+    let dump_debugcon = |log_path: &Path| match fs::read(log_path) {
+        Ok(bytes) if !bytes.is_empty() => {
+            let hex: String = bytes.iter().map(|b| format!("{b:02x} ")).collect();
+            eprintln!(
+                    "--- captured debugcon (port 0xE9, {} bytes) ---\n{}\n-----------------------------------",
+                    bytes.len(),
+                    hex.trim_end()
+                );
+        }
+        Ok(_) => eprintln!("--- captured debugcon: <empty> ---"),
+        Err(e) => eprintln!("--- captured debugcon: <unreadable: {e}> ---"),
+    };
+
     if panicked {
         eprintln!("--- captured serial ---\n{accumulated}\n-----------------------");
+        dump_debugcon(&debugcon_log);
         return Err("smoke: kernel panic detected".into());
     }
 
@@ -1185,6 +1220,7 @@ fn smoke(opts: &BuildOpts) -> R<()> {
         let mut missing: Vec<&str> = remaining.into_iter().collect();
         missing.sort_unstable();
         eprintln!("--- captured serial ---\n{accumulated}\n-----------------------");
+        dump_debugcon(&debugcon_log);
         Err(format!("smoke: missing markers {:?}", missing).into())
     }
 }


### PR DESCRIPTION
## Summary

Step 1 of 3 of the diagnostic plan in
dburkart/vibix#478 (comment: https://github.com/dburkart/vibix/issues/478#issuecomment-4275270156).
Infra-only; does not change any production semantics and is safe to
merge green.

The prior IF=0 soak ruled out all architecturally-legal preemption/IRQ
races around the ring-0 -> ring-3 transition. The remaining candidates
require a signal independent of the serial/VGA path, so we can tell a
silent fault in the `iretq` window from a pre-iretq failure when the
"init: hello from pid 1" serial marker goes missing.

- Kernel-side `out 0xE9` markers (`0xE0` pre-frame, `0xE1` post-frame,
  pre-`iretq`) in `arch::x86_64::syscall::jump_to_ring3`. Kernel-side
  instead of userspace because userspace outb would #GP without
  IOPL=3 / an ioperm bitmap — the kernel-side hook at the iretq edge
  still produces a useful "iretq-about-to-fire" signal per the
  fallback documented in the investigation plan.
- `cargo xtask smoke` unconditionally attaches
  `-debugcon file:target/debugcon.log` to QEMU and hex-dumps the log
  to stderr on panic / missing-marker failure.
- CI smoke job uploads `target/debugcon.log` as the
  `smoke-debugcon-log` artifact on failure (`actions/upload-artifact`
  pinned to the same v4.6.2 SHA already used in `smoke-soak.yml`).

refs #478

## Test plan

- [ ] `cargo fmt --all -- --check` green
- [ ] `cargo xtask build` green
- [ ] CI smoke passes (or, if it trips #478, the new marker hex
      dump / uploaded artifact shows whether `0xE1` was emitted — which
      is itself the signal this PR exists to produce)

## Notes

- This PR may itself reproduce #478's smoke flake. The new markers
  help regardless: a boot that prints `0xE0` but not `0xE1` on
  debugcon points at the `iretq` instruction; a boot that prints
  both but no userspace serial "init: hello" points past `iretq`
  into the userspace-side path.

Generated with [Claude Code](https://claude.com/claude-code)