### PR TITLE
fs/ext2: on-mount orphan-chain validation (#564)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -370,3 +370,8 @@ required-features = ["ext2"]
 name = "ext2_file_read"
 harness = false
 required-features = ["ext2"]
+
+[[test]]
+name = "ext2_orphan_chain"
+harness = false
+required-features = ["ext2"]

--- a/kernel/src/fs/ext2/fs.rs
+++ b/kernel/src/fs/ext2/fs.rs
@@ -363,6 +363,26 @@ impl FileSystem for Ext2Fs {
         }
         debug_assert_eq!(bgdt.len() as u32, groups);
 
+        // 7b. Mount-time orphan-chain validation (issue #564, RFC 0004
+        //     §Orphan list + §Mount-time recovery). Runs as a raw walk
+        //     *before* the `s_state := ERROR_FS` stamp so that a
+        //     corrupt chain demotes us to RO before any write hits
+        //     disk. The walk phase is pure-read; the pin phase (which
+        //     needs the `Arc<SuperBlock>`) runs after construction
+        //     below. We stash the surviving inos here for phase 2.
+        let (orphan_verdict, orphan_inos) = super::orphan::walk_orphan_chain_raw(
+            &cache,
+            device_id,
+            &on_disk_sb,
+            &bgdt,
+            inode_size,
+            block_size,
+        );
+        if orphan_verdict == super::orphan::ForceRo::Yes {
+            effective_rdonly = true;
+            ext2_flags |= Ext2MountFlags::FORCED_RDONLY;
+        }
+
         // 8. RW bring-up: stamp `s_state := ERROR_FS` so an unclean
         //    crash is detectable on the next mount. The canonical
         //    `VALID_FS` is rewritten only by a clean unmount. RO
@@ -461,6 +481,16 @@ impl FileSystem for Ext2Fs {
                 return Err(e);
             }
         }
+
+        // Phase 2 of mount-time orphan-chain validation (#564): now
+        // that the SuperBlock is built and the root inode is live,
+        // pin each surviving orphan ino into
+        // `super_ops.orphan_list` so its blocks remain reserved for
+        // the life of the mount. A failure here is logged and
+        // skipped — a successful raw walk proved the slot looked
+        // orphan-ish, and a late pin failure shouldn't retroactively
+        // tear down a mount the caller has committed to.
+        super::orphan::pin_orphans(&super_ops, &sb, &orphan_inos);
 
         Ok(sb)
     }

--- a/kernel/src/fs/ext2/mod.rs
+++ b/kernel/src/fs/ext2/mod.rs
@@ -58,6 +58,13 @@ pub mod inode;
 #[cfg(all(feature = "ext2", target_os = "none"))]
 pub mod file;
 
+// Mount-time orphan-chain validation (#564). Same feature gate as
+// `fs` / `inode`: it consumes `Ext2Super` and uses the BlockCache to
+// read inode-table blocks. Host unit tests for pure helpers inside
+// live behind `#[cfg(test)]`.
+#[cfg(all(feature = "ext2", target_os = "none"))]
+pub mod orphan;
+
 #[cfg(all(feature = "ext2", target_os = "none"))]
 pub use fs::{Ext2Fs, Ext2MountFlags, Ext2Super, SUPERBLOCK_BYTE_OFFSET};
 
@@ -66,3 +73,6 @@ pub use inode::{iget, iget_root, Ext2FileOps, Ext2Inode, Ext2InodeMeta};
 
 #[cfg(all(feature = "ext2", target_os = "none"))]
 pub use file::read_file_at;
+
+#[cfg(all(feature = "ext2", target_os = "none"))]
+pub use orphan::{validate_orphan_chain, ForceRo};

--- a/kernel/src/fs/ext2/orphan.rs
+++ b/kernel/src/fs/ext2/orphan.rs
@@ -179,11 +179,16 @@ fn read_disk_inode(
 
 /// Classify an on-disk inode read during the orphan walk.
 ///
-/// A valid orphan has `i_links_count == 0` and some nonzero `i_mode`
-/// (the mode stays set while the inode is still open — Linux only
-/// zeroes it after the last close). The next-pointer lives in
-/// `i_dtime` until the chain is drained. Anything else is treated as
-/// corruption and the walk is aborted with [`Corruption::NotOrphan`].
+/// A valid orphan has `i_links_count == 0`; the next-pointer lives in
+/// `i_dtime` until the chain is drained. A nonzero `i_links_count` is
+/// the only condition this helper treats as corruption —
+/// [`Corruption::NotOrphan`] is returned in that case and the walk
+/// aborts. `i_mode` is **not** checked: Linux leaves `i_mode` set
+/// while the inode is open and only zeroes it on the last close, but
+/// a crash mid-unlink can leave either state on disk, so a lenient
+/// parse that accepts both is what `e2fsck` does. The bookkeeping is
+/// safe either way — we only consume `i_dtime` (the next-pointer)
+/// and the `i_links_count` gate.
 ///
 /// Return value is the chain's next pointer (the on-disk `i_dtime`),
 /// to be consumed by the walk loop. A terminator (next == 0) ends

--- a/kernel/src/fs/ext2/orphan.rs
+++ b/kernel/src/fs/ext2/orphan.rs
@@ -1,0 +1,489 @@
+//! Mount-time orphan-chain validation (issue #564).
+//!
+//! RFC 0004 (`docs/RFC/0004-ext2-filesystem-driver.md`) §Orphan list is
+//! the normative spec. On disk ext2 threads a singly-linked list of
+//! unlinked-but-still-open inodes through the superblock's
+//! [`s_last_orphan`](super::disk::Ext2SuperBlock::s_last_orphan) head;
+//! each on-chain inode stores the next ino in its
+//! [`i_dtime`](super::disk::Ext2Inode::i_dtime) slot (the field is
+//! reused because an orphan isn't fully deleted yet — its real dtime is
+//! zero while it's on the list). A previous mount can crash or lose
+//! power mid-unlink and leave the chain populated; a malicious image
+//! can forge a cycle, a self-loop, or an entry pointing at a reserved
+//! inode number.
+//!
+//! This module is the defensive walk that runs inside
+//! [`super::fs::Ext2Fs::mount`] **after** the block-group descriptor
+//! table has been read and **before** the VFS sees the mount. The walk
+//! is bounded at `s_inodes_count` iterations (anything longer is a
+//! cycle or corruption), rejects any ino outside
+//! `EXT2_ROOT_INO ∪ [s_first_ino, s_inodes_count]`, and detects cycles
+//! via a seen-set indexed by ino. On any corruption the driver forces
+//! the mount read-only (via [`ForceRo::Yes`]) and leaves the chain
+//! alone — a user-space `fsck` is what repairs the on-disk state; the
+//! kernel's job is only to refuse to scribble on a filesystem it can't
+//! trust.
+//!
+//! # Out of scope
+//!
+//! - Draining (RW replay): freeing truncated-to-zero inodes back to the
+//!   allocator. The allocator itself is Workstream E (#565+); until
+//!   that lands the orphan-chain validator pins surviving entries into
+//!   the in-memory [`super::inode::OrphanList`] so their blocks remain
+//!   reserved for the life of the mount. On unmount the list drops
+//!   (`Arc<Inode>` refcount hits zero) and the entries are implicitly
+//!   re-orphaned on the next mount — the on-disk chain is never
+//!   modified by this pass.
+//! - Orphan-add / orphan-remove during runtime unlink: that's
+//!   Workstream E's unlink/rmdir path (#565+). The map this pass
+//!   populates is the same [`super::inode::OrphanList`] the unlink
+//!   path will push into at runtime.
+
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
+
+use super::disk::{
+    Ext2Inode as DiskInode, Ext2SuperBlock, EXT2_GOOD_OLD_FIRST_INO, EXT2_INODE_SIZE_V0,
+    EXT2_ROOT_INO,
+};
+use super::fs::Ext2Super;
+use super::inode::iget;
+
+use crate::block::cache::{BlockCache, DeviceId};
+use crate::fs::vfs::super_block::SuperBlock;
+use crate::{kinfo, kwarn};
+
+/// Outcome of a mount-time orphan-chain walk.
+///
+/// [`ForceRo::No`] means the chain was consistent and (if nonempty) its
+/// surviving entries are now pinned in
+/// [`Ext2Super::orphan_list`](super::inode::Ext2Super::orphan_list).
+/// [`ForceRo::Yes`] means the chain was corrupt (cycle, out-of-range
+/// ino, reserved ino, non-orphan state) and the mount must be forced
+/// to read-only — the caller ORs [`SbFlags::RDONLY`] into the mount's
+/// effective flags.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ForceRo {
+    /// Chain was consistent; proceed with the caller-requested flags.
+    No,
+    /// Chain was corrupt; demote the mount to read-only and log.
+    Yes,
+}
+
+/// Error classes that force the mount read-only. Returned from
+/// [`classify_corruption`] and surfaced by [`validate_orphan_chain`]
+/// via `kwarn!`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Corruption {
+    /// Next-pointer pointed at an inode number outside
+    /// `[1, s_inodes_count]` or into the reserved range (ino in
+    /// `1..EXT2_GOOD_OLD_FIRST_INO` other than `EXT2_ROOT_INO`).
+    OutOfRange,
+    /// A node already visited in this walk — the chain has a cycle.
+    Cycle,
+    /// Walked more than `s_inodes_count` entries without terminating.
+    /// Distinguished from [`Corruption::Cycle`] because the seen-set
+    /// check is by-ino and a degenerate "N distinct inos all on the
+    /// chain plus one extra hop" image would still hit the bound
+    /// rather than the seen-set.
+    LengthExceeded,
+    /// The on-disk inode for a chain entry wasn't in a valid orphan
+    /// state (`i_links_count > 0` with `i_dtime == 0`, or the read
+    /// itself failed with EIO).
+    NotOrphan,
+}
+
+/// Decide whether `ino` is a legal next-pointer in the orphan chain.
+///
+/// Legal inos are `EXT2_ROOT_INO` (2, because the root is in the
+/// reserved range but is the one caller-visible reserved inode) and
+/// any ino in `[EXT2_GOOD_OLD_FIRST_INO, s_inodes_count]`. Everything
+/// else — ino 0 (the chain terminator, checked by the walk loop
+/// before this helper), ino 1 (`EXT2_BAD_INO`), and the journal /
+/// resize reservations in `3..=10` — is rejected.
+///
+/// Note that ino 0 is specifically **not** handled here — the walk
+/// loop treats it as the chain terminator and breaks out before
+/// calling this. Passing ino 0 is a programmer error; we still return
+/// `false` to be safe.
+#[inline]
+fn is_valid_orphan_ino(ino: u32, s_inodes_count: u32) -> bool {
+    if ino == 0 {
+        return false;
+    }
+    if ino > s_inodes_count {
+        return false;
+    }
+    if ino == EXT2_ROOT_INO {
+        // Root on the orphan list is technically legal under the
+        // on-disk format, even if nothing sane ever puts it there.
+        // Accept so we match Linux's lenient parse.
+        return true;
+    }
+    if ino < EXT2_GOOD_OLD_FIRST_INO {
+        // Reserved range (1, 3..=10). Reject.
+        return false;
+    }
+    true
+}
+
+/// Read the 128-byte rev-0 prefix of the on-disk inode slot for
+/// `ino`, without constructing any VFS-layer state. Replays the
+/// per-group + block-in-table arithmetic from
+/// [`super::inode::iget`] because the walk needs to see `i_dtime` /
+/// `i_links_count` for inodes whose `i_mode` may be zero — a
+/// just-unlinked orphan typically has `i_mode == 0` once its dtime is
+/// stamped, which `iget` would reject.
+///
+/// Returns `None` on any geometry / I/O error; the caller treats this
+/// as [`Corruption::NotOrphan`] and force-ROs the mount.
+fn read_disk_inode(
+    cache: &BlockCache,
+    device_id: DeviceId,
+    sb_disk: &Ext2SuperBlock,
+    bgdt: &[super::disk::Ext2GroupDesc],
+    inode_size: u32,
+    block_size: u32,
+    ino: u32,
+) -> Option<DiskInode> {
+    if ino == 0 || ino > sb_disk.s_inodes_count {
+        return None;
+    }
+    let inodes_per_group = sb_disk.s_inodes_per_group;
+    if inodes_per_group == 0 {
+        return None;
+    }
+    let group = (ino - 1) / inodes_per_group;
+    let index_in_group = (ino - 1) % inodes_per_group;
+    let group_idx = group as usize;
+    if group_idx >= bgdt.len() {
+        return None;
+    }
+    let bg = &bgdt[group_idx];
+
+    let byte_offset = (index_in_group as u64) * (inode_size as u64);
+    let block_in_table = byte_offset / (block_size as u64);
+    let offset_in_block = (byte_offset % (block_size as u64)) as usize;
+    let absolute_block = (bg.bg_inode_table as u64).checked_add(block_in_table)?;
+
+    let bh = cache.bread(device_id, absolute_block).ok()?;
+    let data = bh.data.read();
+    if offset_in_block + EXT2_INODE_SIZE_V0 > data.len() {
+        return None;
+    }
+    let mut slot = [0u8; EXT2_INODE_SIZE_V0];
+    slot.copy_from_slice(&data[offset_in_block..offset_in_block + EXT2_INODE_SIZE_V0]);
+    Some(DiskInode::decode(&slot))
+}
+
+/// Classify an on-disk inode read during the orphan walk.
+///
+/// A valid orphan has `i_links_count == 0` and some nonzero `i_mode`
+/// (the mode stays set while the inode is still open — Linux only
+/// zeroes it after the last close). The next-pointer lives in
+/// `i_dtime` until the chain is drained. Anything else is treated as
+/// corruption and the walk is aborted with [`Corruption::NotOrphan`].
+///
+/// Return value is the chain's next pointer (the on-disk `i_dtime`),
+/// to be consumed by the walk loop. A terminator (next == 0) ends
+/// the walk normally.
+fn classify_orphan_state(disk: &DiskInode) -> Result<u32, Corruption> {
+    if disk.i_links_count != 0 {
+        return Err(Corruption::NotOrphan);
+    }
+    Ok(disk.i_dtime)
+}
+
+/// Walk the on-disk orphan list and pin any surviving entries into the
+/// in-memory [`super::inode::OrphanList`].
+///
+/// Contract:
+///
+/// - Returns [`ForceRo::No`] on a clean walk (empty chain or all
+///   entries pinned successfully).
+/// - Returns [`ForceRo::Yes`] on any detected corruption; the walk
+///   is aborted at the first bad node, a warning is `kwarn!`'d, and
+///   the caller is expected to OR `SbFlags::RDONLY` into the mount's
+///   effective flags. The on-disk chain is not modified either way.
+/// - Never panics on a corrupt image. Bounded by `s_inodes_count`
+///   iterations; cycle-detected via a seen-set.
+///
+/// The caller provides the freshly-built `Arc<Ext2Super>` and the
+/// `Arc<SuperBlock>` *before* `SuperBlock::root` is populated —
+/// [`iget`] doesn't consult `sb.root`, so this is safe. The pins are
+/// inserted into `super_ref.orphan_list` keyed by ino; duplicates
+/// (would only happen on a cycle, which we already reject) are
+/// ignored defensively.
+pub fn validate_orphan_chain(super_ref: &Arc<Ext2Super>, sb: &Arc<SuperBlock>) -> ForceRo {
+    let (decision, drained) = walk_orphan_chain(super_ref);
+    if decision == ForceRo::Yes {
+        return ForceRo::Yes;
+    }
+    if drained.is_empty() {
+        return ForceRo::No;
+    }
+    pin_orphans(super_ref, sb, &drained);
+    ForceRo::No
+}
+
+/// Phase 1 of the mount-time orphan walk: pure read-only traversal of
+/// the on-disk chain, producing the list of surviving orphan inos and
+/// a [`ForceRo`] verdict.
+///
+/// Split out from [`validate_orphan_chain`] so the caller can run the
+/// walk **before** building the `Arc<SuperBlock>` — a corrupt chain
+/// needs to flip the sb's `RDONLY` flag, which is immutable after
+/// `SuperBlock::new`. The caller phase-2s the pinning after building
+/// the sb, via [`pin_orphans`].
+pub fn walk_orphan_chain(super_ref: &Arc<Ext2Super>) -> (ForceRo, Vec<u32>) {
+    walk_orphan_chain_raw(
+        &super_ref.cache,
+        super_ref.device_id,
+        &super_ref.sb_disk,
+        &super_ref.bgdt,
+        super_ref.inode_size,
+        super_ref.block_size,
+    )
+}
+
+/// Dependency-lean variant of [`walk_orphan_chain`] that consumes only
+/// the raw block-layer + on-disk-state pieces rather than an assembled
+/// `Arc<Ext2Super>`. Called from the mount path before the
+/// `Ext2Super` / `SuperBlock` pair has been constructed; a corrupt
+/// chain has to flip the effective `RDONLY` flag *before* the
+/// `SuperBlock` is built (its `SbFlags` is immutable post-construction).
+pub fn walk_orphan_chain_raw(
+    cache: &BlockCache,
+    device_id: DeviceId,
+    sb_disk: &Ext2SuperBlock,
+    bgdt: &[super::disk::Ext2GroupDesc],
+    inode_size: u32,
+    block_size: u32,
+) -> (ForceRo, Vec<u32>) {
+    let head = sb_disk.s_last_orphan;
+    if head == 0 {
+        // Fast path: no chain to walk. The vast majority of cleanly-
+        // unmounted images hit this branch.
+        return (ForceRo::No, Vec::new());
+    }
+
+    let s_inodes_count = sb_disk.s_inodes_count;
+    // Bound: any chain longer than the total number of inodes must
+    // contain a repeat. Use `as usize` for the Vec-based seen-set;
+    // ext2 tops out at u32::MAX inodes which fits fine.
+    let max_walk = s_inodes_count as usize;
+    // Seen-set: BitVec indexed by ino. Sized to s_inodes_count + 1 so
+    // ino `s_inodes_count` itself is addressable (inos are 1-based).
+    // Allocating a Vec<bool> rather than a packed bitset keeps this
+    // module standalone; a 64 KiB fixture is 16 bytes here, and even
+    // a 4M-inode filesystem is only 4 MiB — allocated once at mount
+    // and dropped immediately after.
+    let mut seen: Vec<bool> = vec![false; (s_inodes_count as usize) + 1];
+
+    let mut cur = head;
+    let mut drained: Vec<u32> = Vec::new();
+
+    for _step in 0..=max_walk {
+        if cur == 0 {
+            // Normal terminator. The list walked cleanly.
+            break;
+        }
+        if !is_valid_orphan_ino(cur, s_inodes_count) {
+            kwarn!(
+                "ext2: orphan chain: ino {} out of range (reserved or >= s_inodes_count), forcing RO",
+                cur,
+            );
+            return (ForceRo::Yes, Vec::new());
+        }
+        let cur_idx = cur as usize;
+        if seen[cur_idx] {
+            kwarn!(
+                "ext2: orphan chain: cycle detected at ino {}, forcing RO",
+                cur,
+            );
+            return (ForceRo::Yes, Vec::new());
+        }
+        seen[cur_idx] = true;
+
+        let disk =
+            match read_disk_inode(cache, device_id, sb_disk, bgdt, inode_size, block_size, cur) {
+                Some(d) => d,
+                None => {
+                    kwarn!(
+                        "ext2: orphan chain: unreadable inode {} during walk, forcing RO",
+                        cur,
+                    );
+                    return (ForceRo::Yes, Vec::new());
+                }
+            };
+        let next = match classify_orphan_state(&disk) {
+            Ok(n) => n,
+            Err(e) => {
+                // `classify_orphan_state` only ever returns
+                // `Corruption::NotOrphan` today; the other
+                // `Corruption` variants are produced by the walk loop
+                // (range check, cycle, length-exceeded) above and
+                // don't reach this arm. Match all for forward-
+                // compat so any new variant added to the enum forces
+                // an explicit handling decision here.
+                match e {
+                    Corruption::NotOrphan => kwarn!(
+                        "ext2: orphan chain: inode {} has i_links_count={} != 0 (not an orphan), forcing RO",
+                        cur,
+                        disk.i_links_count,
+                    ),
+                    Corruption::OutOfRange
+                    | Corruption::Cycle
+                    | Corruption::LengthExceeded => kwarn!(
+                        "ext2: orphan chain: inode {} classified as corrupt ({:?}), forcing RO",
+                        cur,
+                        e,
+                    ),
+                }
+                return (ForceRo::Yes, Vec::new());
+            }
+        };
+
+        drained.push(cur);
+        cur = next;
+    }
+
+    // If the loop exited on the bound instead of hitting a 0 terminator
+    // or a seen-set hit, the chain is still too long. The `_step` loop
+    // runs `0..=max_walk` iterations (max_walk + 1), so reaching the
+    // end with cur != 0 means we walked at least s_inodes_count + 1
+    // distinct inos — impossible without a cycle the seen-set somehow
+    // missed, or without the image claiming more inodes than it can
+    // address. Either way: corruption.
+    if cur != 0 {
+        let _ = Corruption::LengthExceeded; // keep the variant reachable for future refactors
+        kwarn!(
+            "ext2: orphan chain: exceeded s_inodes_count={} without terminator, forcing RO",
+            s_inodes_count,
+        );
+        return (ForceRo::Yes, Vec::new());
+    }
+
+    (ForceRo::No, drained)
+}
+
+/// Phase 2 of the mount-time orphan walk: pin each surviving orphan
+/// ino into `super_ref.orphan_list` as an `Arc<Inode>` so its data
+/// blocks remain reserved for the life of the mount.
+///
+/// Separate from [`walk_orphan_chain`] so the caller can run the walk
+/// before building `Arc<SuperBlock>` (the sb's `RDONLY` flag needs to
+/// be settled before construction — it's immutable afterwards), then
+/// run this phase against the built sb.
+///
+/// An `iget` failure here downgrades to a warning rather than
+/// force-ROing the mount: the raw read already confirmed the slot
+/// looked orphan-ish, and we don't want a late-phase failure to
+/// retroactively tear down a mount the caller has already committed
+/// to. The cost of a skipped pin is "blocks might get reallocated on
+/// a later write" — only matters on RW mounts, and full allocator
+/// drain is Workstream E territory.
+pub fn pin_orphans(super_ref: &Arc<Ext2Super>, sb: &Arc<SuperBlock>, inos: &[u32]) {
+    if inos.is_empty() {
+        return;
+    }
+    let mut list = super_ref.orphan_list.lock();
+    let mut pinned = 0usize;
+    for ino in inos {
+        match iget(super_ref, sb, *ino) {
+            Ok(inode) => {
+                list.entry(*ino).or_insert(inode);
+                pinned += 1;
+            }
+            Err(e) => {
+                kwarn!(
+                    "ext2: orphan chain: could not iget surviving orphan {} (errno={}), skipping pin",
+                    *ino,
+                    e,
+                );
+            }
+        }
+    }
+    kinfo!(
+        "ext2: orphan chain: pinned {} surviving orphan(s) from s_last_orphan",
+        pinned,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    //! Host-side unit tests for the pure-logic helpers. The full walk
+    //! is covered by `kernel/tests/ext2_orphan_chain.rs` which drives
+    //! the real mount path against crafted in-memory images.
+    use super::*;
+
+    #[test]
+    fn valid_orphan_ino_accepts_root_and_user_range() {
+        // Root is the one reserved ino we accept.
+        assert!(is_valid_orphan_ino(EXT2_ROOT_INO, 1024));
+        // User-allocatable range.
+        assert!(is_valid_orphan_ino(EXT2_GOOD_OLD_FIRST_INO, 1024));
+        assert!(is_valid_orphan_ino(12, 1024));
+        assert!(is_valid_orphan_ino(1024, 1024));
+    }
+
+    #[test]
+    fn valid_orphan_ino_rejects_zero_reserved_and_oob() {
+        // Zero is the terminator, not a legal next-pointer here.
+        assert!(!is_valid_orphan_ino(0, 1024));
+        // EXT2_BAD_INO and the 3..=10 journal / resize reservations.
+        assert!(!is_valid_orphan_ino(1, 1024));
+        assert!(!is_valid_orphan_ino(3, 1024));
+        assert!(!is_valid_orphan_ino(10, 1024));
+        // Past s_inodes_count.
+        assert!(!is_valid_orphan_ino(1025, 1024));
+        assert!(!is_valid_orphan_ino(u32::MAX, 1024));
+    }
+
+    #[test]
+    fn classify_orphan_state_reads_next_pointer_on_links_zero() {
+        let disk = DiskInode {
+            i_mode: 0o100_644,
+            i_uid: 0,
+            i_size: 0,
+            i_atime: 0,
+            i_ctime: 0,
+            i_mtime: 0,
+            // i_dtime carries the next-pointer while on the orphan list.
+            i_dtime: 42,
+            i_gid: 0,
+            i_links_count: 0,
+            i_blocks: 0,
+            i_flags: 0,
+            i_block: [0u32; super::super::disk::EXT2_N_BLOCKS],
+            i_dir_acl_or_size_high: 0,
+            l_i_uid_high: 0,
+            l_i_gid_high: 0,
+        };
+        assert_eq!(classify_orphan_state(&disk), Ok(42));
+    }
+
+    #[test]
+    fn classify_orphan_state_rejects_live_inode() {
+        let disk = DiskInode {
+            i_mode: 0o100_644,
+            i_uid: 0,
+            i_size: 0,
+            i_atime: 0,
+            i_ctime: 0,
+            i_mtime: 0,
+            i_dtime: 42,
+            i_gid: 0,
+            // i_links_count > 0 → not an orphan; walk must refuse.
+            i_links_count: 1,
+            i_blocks: 0,
+            i_flags: 0,
+            i_block: [0u32; super::super::disk::EXT2_N_BLOCKS],
+            i_dir_acl_or_size_high: 0,
+            l_i_uid_high: 0,
+            l_i_gid_high: 0,
+        };
+        assert_eq!(classify_orphan_state(&disk), Err(Corruption::NotOrphan));
+    }
+}

--- a/kernel/tests/ext2_orphan_chain.rs
+++ b/kernel/tests/ext2_orphan_chain.rs
@@ -116,7 +116,9 @@ fn run_tests() {
 }
 
 // ---------------------------------------------------------------------------
-// RamDisk (mirrors ext2_mount.rs / ext2_inode_iget.rs)
+// RamDisk (mirrors ext2_mount.rs / ext2_inode_iget.rs, simplified to a
+// single owning constructor since every test here patches the image
+// in-place before mount).
 // ---------------------------------------------------------------------------
 
 struct RamDisk {
@@ -126,11 +128,11 @@ struct RamDisk {
 }
 
 impl RamDisk {
-    fn from_image(bytes: &[u8], block_size: u32) -> Arc<Self> {
+    fn new(bytes: Vec<u8>, block_size: u32) -> Arc<Self> {
         assert!(bytes.len() % block_size as usize == 0);
         Arc::new(Self {
             block_size,
-            storage: Mutex::new(bytes.to_vec()),
+            storage: Mutex::new(bytes),
             writes: AtomicU32::new(0),
         })
     }
@@ -230,7 +232,7 @@ fn mount_with(
     Arc<vibix::fs::ext2::Ext2Fs>,
     Arc<vibix::fs::ext2::Ext2Super>,
 ) {
-    let disk = Arc::new(RamDiskOwned::new(img, 512));
+    let disk = RamDisk::new(img, 512);
     let fs = Ext2Fs::new_with_device(disk as Arc<dyn BlockDevice>);
     let sb = fs
         .mount(MountSource::None, flags)
@@ -239,37 +241,6 @@ fn mount_with(
         .current_super()
         .expect("current_super must upgrade after a successful mount");
     (sb, fs, super_arc)
-}
-
-// A RamDisk that owns its starting bytes (mirrors the `from_image`
-// constructor but takes an owned Vec so each test can patch
-// independently).
-struct RamDiskOwned(RamDisk);
-
-impl RamDiskOwned {
-    fn new(bytes: Vec<u8>, block_size: u32) -> Self {
-        assert!(bytes.len() % block_size as usize == 0);
-        Self(RamDisk {
-            block_size,
-            storage: Mutex::new(bytes),
-            writes: AtomicU32::new(0),
-        })
-    }
-}
-
-impl BlockDevice for RamDiskOwned {
-    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
-        self.0.read_at(offset, buf)
-    }
-    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
-        self.0.write_at(offset, buf)
-    }
-    fn block_size(&self) -> u32 {
-        self.0.block_size()
-    }
-    fn capacity(&self) -> u64 {
-        self.0.capacity()
-    }
 }
 
 // ---------------------------------------------------------------------------

--- a/kernel/tests/ext2_orphan_chain.rs
+++ b/kernel/tests/ext2_orphan_chain.rs
@@ -1,0 +1,387 @@
+//! Integration test for issue #564: mount-time orphan-chain validation.
+//!
+//! Runs under QEMU with the real kernel. Starts from the 64 KiB
+//! `golden.img` mkfs.ext2 fixture (16 inodes, 1 KiB blocks, one block
+//! group), patches `s_last_orphan` and selected inodes' `i_dtime` /
+//! `i_links_count` / `i_mode` in-memory, then mounts through
+//! [`Ext2Fs`] and asserts on the observable outcomes:
+//!
+//! - **Valid 3-entry chain** — mounts cleanly, `orphan_list` carries
+//!   the three pinned inodes, the sb is **not** forced RO.
+//! - **Chain with a cycle** — mount succeeds but is demoted to RO
+//!   (`SbFlags::RDONLY`), `orphan_list` is empty (we refuse to pin
+//!   anything when the chain is corrupt).
+//! - **Chain pointing at ino 0 via a malformed reserved ino** — mount
+//!   succeeds, forced RO, empty orphan_list. (Ino 0 terminates the
+//!   chain, so we test the reserved-ino rejection by pointing the
+//!   head at ino 1 `EXT2_BAD_INO`, which is the spiritually-equivalent
+//!   "points at a reserved slot" case the issue calls for.)
+//! - **Length > s_inodes_count** — by wiring up a chain that's valid
+//!   but exceeds the bound via a forged seen-set-evading nonsense
+//!   next-pointer (impossible in practice; exercised via repeated
+//!   same-ino rejected-by-cycle instead) — covered by the cycle test.
+//!
+//! The fixture image has only 16 inodes; once lost+found (ino 11) is
+//! accounted for, inos 12..=16 are free-but-allocatable slots. The
+//! test uses 12/13/14 for the valid-chain entries (they sit in the
+//! same inode-table block as lost+found so the arithmetic is simple).
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicU32, Ordering};
+
+use spin::Mutex;
+
+use vibix::block::{BlockDevice, BlockError};
+use vibix::fs::ext2::Ext2Fs;
+use vibix::fs::vfs::ops::{FileSystem as _, MountSource};
+use vibix::fs::vfs::super_block::SbFlags;
+use vibix::fs::vfs::MountFlags;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+/// 64 KiB `mkfs.ext2` image. See `kernel/src/fs/ext2/fixtures/README.md`.
+const GOLDEN_IMG: &[u8; 65_536] = include_bytes!("../src/fs/ext2/fixtures/golden.img");
+
+// ---------------------------------------------------------------------------
+// On-disk offsets the patcher needs (duplicated from
+// `vibix::fs::ext2::disk`; that module's constants are crate-private
+// offsets, so copies here are deliberate — the tests pin the values
+// against the real image layout rather than consuming the module's
+// internal offsets).
+// ---------------------------------------------------------------------------
+const SB_BYTE_OFFSET: usize = 1024;
+const SB_OFF_INODES_COUNT: usize = 0;
+const SB_OFF_LAST_ORPHAN: usize = 232;
+
+const BGDT_BYTE_OFFSET_1K: usize = 2048;
+const BGD_OFF_INODE_TABLE: usize = 8;
+
+const INODE_SIZE: usize = 128;
+const INODE_OFF_MODE: usize = 0;
+const INODE_OFF_DTIME: usize = 20;
+const INODE_OFF_LINKS_COUNT: usize = 26;
+
+const BLOCK_SIZE_BYTES: usize = 1024;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "valid_orphan_chain_pins_entries",
+            &(valid_orphan_chain_pins_entries as fn()),
+        ),
+        (
+            "cycle_forces_ro_and_empty_orphan_list",
+            &(cycle_forces_ro_and_empty_orphan_list as fn()),
+        ),
+        (
+            "reserved_ino_head_forces_ro",
+            &(reserved_ino_head_forces_ro as fn()),
+        ),
+        (
+            "oob_next_pointer_forces_ro",
+            &(oob_next_pointer_forces_ro as fn()),
+        ),
+        (
+            "empty_chain_on_clean_image",
+            &(empty_chain_on_clean_image as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RamDisk (mirrors ext2_mount.rs / ext2_inode_iget.rs)
+// ---------------------------------------------------------------------------
+
+struct RamDisk {
+    block_size: u32,
+    storage: Mutex<Vec<u8>>,
+    writes: AtomicU32,
+}
+
+impl RamDisk {
+    fn from_image(bytes: &[u8], block_size: u32) -> Arc<Self> {
+        assert!(bytes.len() % block_size as usize == 0);
+        Arc::new(Self {
+            block_size,
+            storage: Mutex::new(bytes.to_vec()),
+            writes: AtomicU32::new(0),
+        })
+    }
+}
+
+impl BlockDevice for RamDisk {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
+        let bs = self.block_size as u64;
+        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
+            return Err(BlockError::BadAlign);
+        }
+        let storage = self.storage.lock();
+        let end = offset
+            .checked_add(buf.len() as u64)
+            .ok_or(BlockError::OutOfRange)?;
+        if end > storage.len() as u64 {
+            return Err(BlockError::OutOfRange);
+        }
+        let off = offset as usize;
+        buf.copy_from_slice(&storage[off..off + buf.len()]);
+        Ok(())
+    }
+    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
+        let bs = self.block_size as u64;
+        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
+            return Err(BlockError::BadAlign);
+        }
+        let mut storage = self.storage.lock();
+        let end = offset
+            .checked_add(buf.len() as u64)
+            .ok_or(BlockError::Enospc)?;
+        if end > storage.len() as u64 {
+            return Err(BlockError::Enospc);
+        }
+        let off = offset as usize;
+        storage[off..off + buf.len()].copy_from_slice(buf);
+        self.writes.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+    fn block_size(&self) -> u32 {
+        self.block_size
+    }
+    fn capacity(&self) -> u64 {
+        self.storage.lock().len() as u64
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Image-patching helpers. The fixture is a 1 KiB-block, 16-inode,
+// single-group image — the inode-table block for ino N lives at the
+// block named by `bgdt[0].bg_inode_table`, slot offset `(N - 1) * 128`.
+// ---------------------------------------------------------------------------
+
+fn u32_le(bytes: &[u8], off: usize) -> u32 {
+    u32::from_le_bytes(bytes[off..off + 4].try_into().unwrap())
+}
+
+fn patch_u32_le(bytes: &mut [u8], off: usize, v: u32) {
+    bytes[off..off + 4].copy_from_slice(&v.to_le_bytes());
+}
+
+fn patch_u16_le(bytes: &mut [u8], off: usize, v: u16) {
+    bytes[off..off + 2].copy_from_slice(&v.to_le_bytes());
+}
+
+fn inode_slot_offset(image: &[u8], ino: u32) -> usize {
+    // Single group in the 64 KiB fixture; the inode table base block
+    // sits in the first group descriptor at BGDT offset +8.
+    let itab_block = u32_le(image, BGDT_BYTE_OFFSET_1K + BGD_OFF_INODE_TABLE) as usize;
+    let slot_in_table = (ino as usize) - 1;
+    itab_block * BLOCK_SIZE_BYTES + slot_in_table * INODE_SIZE
+}
+
+/// Set `i_links_count = 0`, `i_dtime = next_ino`, and keep `i_mode`
+/// nonzero (so classify_orphan_state reads it as "an orphan with an
+/// on-disk next-pointer", mirroring Linux's on-disk state for a
+/// just-unlinked-but-still-open inode).
+fn make_orphan(image: &mut [u8], ino: u32, next: u32) {
+    let slot = inode_slot_offset(image, ino);
+    // i_mode: force to S_IFREG|0600 if it was zero so the orphan looks
+    // like a user file.
+    let cur_mode = u16::from_le_bytes(image[slot..slot + 2].try_into().unwrap());
+    if cur_mode & 0o170_000 == 0 {
+        patch_u16_le(image, slot + INODE_OFF_MODE, 0o100_600);
+    }
+    patch_u16_le(image, slot + INODE_OFF_LINKS_COUNT, 0);
+    patch_u32_le(image, slot + INODE_OFF_DTIME, next);
+}
+
+/// Mount the (possibly-patched) image RO-or-RW per `flags` and hand
+/// back the live `Arc<SuperBlock>` plus the concrete `Arc<Ext2Super>`.
+fn mount_with(
+    img: Vec<u8>,
+    flags: MountFlags,
+) -> (
+    Arc<vibix::fs::vfs::super_block::SuperBlock>,
+    Arc<vibix::fs::ext2::Ext2Fs>,
+    Arc<vibix::fs::ext2::Ext2Super>,
+) {
+    let disk = Arc::new(RamDiskOwned::new(img, 512));
+    let fs = Ext2Fs::new_with_device(disk as Arc<dyn BlockDevice>);
+    let sb = fs
+        .mount(MountSource::None, flags)
+        .expect("mount must succeed");
+    let super_arc = fs
+        .current_super()
+        .expect("current_super must upgrade after a successful mount");
+    (sb, fs, super_arc)
+}
+
+// A RamDisk that owns its starting bytes (mirrors the `from_image`
+// constructor but takes an owned Vec so each test can patch
+// independently).
+struct RamDiskOwned(RamDisk);
+
+impl RamDiskOwned {
+    fn new(bytes: Vec<u8>, block_size: u32) -> Self {
+        assert!(bytes.len() % block_size as usize == 0);
+        Self(RamDisk {
+            block_size,
+            storage: Mutex::new(bytes),
+            writes: AtomicU32::new(0),
+        })
+    }
+}
+
+impl BlockDevice for RamDiskOwned {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
+        self.0.read_at(offset, buf)
+    }
+    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
+        self.0.write_at(offset, buf)
+    }
+    fn block_size(&self) -> u32 {
+        self.0.block_size()
+    }
+    fn capacity(&self) -> u64 {
+        self.0.capacity()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+fn empty_chain_on_clean_image() {
+    // Sanity: the golden image ships with `s_last_orphan == 0` and the
+    // validator fast-pathes. Mount RO (leave s_state alone) and confirm
+    // the orphan_list stays empty and the mount isn't RO-forced.
+    let img = GOLDEN_IMG.to_vec();
+    assert_eq!(
+        u32_le(&img, SB_BYTE_OFFSET + SB_OFF_LAST_ORPHAN),
+        0,
+        "baseline fixture must have empty s_last_orphan",
+    );
+    let (sb, _fs, super_arc) = mount_with(img, MountFlags::RDONLY);
+    assert!(super_arc.orphan_list.lock().is_empty());
+    assert!(sb.flags.contains(SbFlags::RDONLY));
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn valid_orphan_chain_pins_entries() {
+    // Craft: s_last_orphan -> 12 -> 13 -> 14 -> 0. All three entries
+    // are user inodes in range, with links_count=0 and valid
+    // next-pointers. The walk must pin all three into orphan_list
+    // and NOT force RO.
+    let mut img = GOLDEN_IMG.to_vec();
+    patch_u32_le(&mut img, SB_BYTE_OFFSET + SB_OFF_LAST_ORPHAN, 12);
+    make_orphan(&mut img, 12, 13);
+    make_orphan(&mut img, 13, 14);
+    make_orphan(&mut img, 14, 0);
+
+    let (sb, _fs, super_arc) = mount_with(img, MountFlags::RDONLY);
+    let list = super_arc.orphan_list.lock();
+    assert_eq!(
+        list.len(),
+        3,
+        "valid 3-entry chain must pin exactly 3 orphans"
+    );
+    assert!(list.contains_key(&12));
+    assert!(list.contains_key(&13));
+    assert!(list.contains_key(&14));
+    // RO-requested mount stays RO, but the `FORCED_RDONLY` hint must
+    // NOT be set — the chain was clean.
+    let ext2_flags = super_arc.ext2_flags;
+    assert!(
+        !ext2_flags.contains(vibix::fs::ext2::Ext2MountFlags::FORCED_RDONLY),
+        "clean orphan chain must NOT set FORCED_RDONLY",
+    );
+    drop(list);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn cycle_forces_ro_and_empty_orphan_list() {
+    // Craft a 2-cycle: head -> 12 -> 13 -> 12 -> …
+    let mut img = GOLDEN_IMG.to_vec();
+    patch_u32_le(&mut img, SB_BYTE_OFFSET + SB_OFF_LAST_ORPHAN, 12);
+    make_orphan(&mut img, 12, 13);
+    make_orphan(&mut img, 13, 12);
+
+    let (sb, _fs, super_arc) = mount_with(img, MountFlags::RDONLY);
+    assert!(
+        super_arc.orphan_list.lock().is_empty(),
+        "corrupt chain must leave orphan_list empty"
+    );
+    assert!(
+        sb.flags.contains(SbFlags::RDONLY),
+        "cycle must force the mount RO",
+    );
+    assert!(
+        super_arc
+            .ext2_flags
+            .contains(vibix::fs::ext2::Ext2MountFlags::FORCED_RDONLY),
+        "cycle must set FORCED_RDONLY hint",
+    );
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn reserved_ino_head_forces_ro() {
+    // s_last_orphan points at EXT2_BAD_INO (1) — reserved, must reject.
+    let mut img = GOLDEN_IMG.to_vec();
+    patch_u32_le(&mut img, SB_BYTE_OFFSET + SB_OFF_LAST_ORPHAN, 1);
+
+    let (sb, _fs, super_arc) = mount_with(img, MountFlags::RDONLY);
+    assert!(super_arc.orphan_list.lock().is_empty());
+    assert!(sb.flags.contains(SbFlags::RDONLY));
+    assert!(super_arc
+        .ext2_flags
+        .contains(vibix::fs::ext2::Ext2MountFlags::FORCED_RDONLY));
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn oob_next_pointer_forces_ro() {
+    // head -> 12 with i_dtime (next-pointer) = s_inodes_count + 1 =
+    // 17. Must refuse: next ino is > s_inodes_count.
+    let mut img = GOLDEN_IMG.to_vec();
+    patch_u32_le(&mut img, SB_BYTE_OFFSET + SB_OFF_LAST_ORPHAN, 12);
+    // Confirm s_inodes_count == 16 on the fixture (mkfs -N 16).
+    assert_eq!(u32_le(&img, SB_BYTE_OFFSET + SB_OFF_INODES_COUNT), 16);
+    make_orphan(&mut img, 12, 17);
+
+    let (sb, _fs, super_arc) = mount_with(img, MountFlags::RDONLY);
+    assert!(super_arc.orphan_list.lock().is_empty());
+    assert!(sb.flags.contains(SbFlags::RDONLY));
+    assert!(super_arc
+        .ext2_flags
+        .contains(vibix::fs::ext2::Ext2MountFlags::FORCED_RDONLY));
+    sb.ops.unmount();
+    drop(super_arc);
+}


### PR DESCRIPTION
Closes #564.

## Summary

- Walks the on-disk `s_last_orphan` chain at mount time (RFC 0004 §Orphan list + §Mount-time recovery): bounded at `s_inodes_count` iterations, cycle-detected via a seen-set, rejects ino 0 / reserved / out-of-range next-pointers.
- On any corruption: forces the mount read-only (sets `SbFlags::RDONLY` + `Ext2MountFlags::FORCED_RDONLY`) and logs via `kwarn!`. The on-disk chain is never modified — fsck repairs the state.
- On a clean chain: pins each surviving orphan into `Ext2Super.orphan_list` via `iget`, so its data blocks remain reserved for the life of the mount. Full allocator drain is Workstream E.
- New file `kernel/src/fs/ext2/orphan.rs` (keeps the mount-path patch in `fs.rs` minimal to avoid conflicts with #561/#562 in parallel).
- Two-phase split: `walk_orphan_chain_raw` runs *before* building the `SuperBlock` (so the verdict can flip `effective_rdonly` before `SbFlags` is sealed); `pin_orphans` runs *after* `iget_root` when an `Arc<SuperBlock>` is available for `iget`.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo build -p vibix --target x86_64-unknown-none -Z build-std=... --features ext2` clean
- [x] `cargo xtask build` (kernel builds without ext2 feature) clean
- [x] `kernel/tests/ext2_orphan_chain.rs` — 5 tests under QEMU:
  - `empty_chain_on_clean_image` — fast-path on the unmodified fixture
  - `valid_orphan_chain_pins_entries` — 3-entry chain, all pinned, no force-RO
  - `cycle_forces_ro_and_empty_orphan_list` — 2-cycle → force-RO, empty list
  - `reserved_ino_head_forces_ro` — `s_last_orphan = 1` (EXT2_BAD_INO)
  - `oob_next_pointer_forces_ro` — next-pointer = `s_inodes_count + 1`
- [x] `kernel/tests/ext2_mount.rs` + `kernel/tests/ext2_inode_iget.rs` regression — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)