### PR TITLE
ci: fix file-bug allowed-tools (mcp__github__create_issue)

### DIFF
--- a/.github/workflows/file-bug.yml
+++ b/.github/workflows/file-bug.yml
@@ -37,7 +37,8 @@ jobs:
             "Skill(file-issue)"
             "mcp__github__search_issues"
             "mcp__github__add_issue_comment"
-            "mcp__github__issue_write"
+            "mcp__github__create_issue"
+            "mcp__github__update_issue"
           prompt: |
             The CI build on the main branch of the vibix kernel repo just failed.
 

--- a/.github/workflows/issue-backfill.yml
+++ b/.github/workflows/issue-backfill.yml
@@ -46,7 +46,8 @@ jobs:
             "Skill(file-issue)"
             "mcp__github__search_issues"
             "mcp__github__add_issue_comment"
-            "mcp__github__issue_write"
+            "mcp__github__create_issue"
+            "mcp__github__update_issue"
           prompt: |
             You are a technical project manager for the vibix kernel — a hobby OS kernel written in Rust.
 
@@ -112,7 +113,7 @@ jobs:
             For each gap, invoke the `file-issue` skill (`/file-issue`). The skill handles
             dedupe, enforces the label taxonomy from `docs/agent-playbooks/prioritization.md`,
             and writes the canonical body template. Do **not** call `gh issue create` or
-            `mcp__github__issue_write` directly — go through the skill so every filed issue
+            `mcp__github__create_issue` directly — go through the skill so every filed issue
             is triaged on creation.
 
             Feed the skill, per issue:


### PR DESCRIPTION
Closes #216.

## Summary

The `file-bug` workflow reports success but never actually files a CI-failure issue. Every Claude invocation finishes with `permission_denials_count >= 1` and `is_error: false`, yet no issue lands.

**Root cause.** The workflow's `--allowed-tools` list includes `mcp__github__issue_write`, but that tool does not exist in `github-mcp-server v0.17.1` (the version pinned by `claude-code-action@1c8b699`). Per `pkg/github/issues.go` the real tool names are `create_issue` and `update_issue`.

Flow that was actually happening on every CI failure:
1. `file-issue` skill tells Claude to call `mcp__github__issue_write` — no such tool.
2. Claude falls back to the real tool name `mcp__github__create_issue` — not in `allowed-tools`, permission denied.
3. Claude gives up, emits `is_error: false`, workflow reports success, backlog gets no bug.

`issue-backfill.yml` had the same broken entry and was silently failing to file any backfill issues too — explains why the recent issue list only contains human-authored items.

## Fix

Replace `"mcp__github__issue_write"` with `"mcp__github__create_issue"` + `"mcp__github__update_issue"` in both workflows. Also update the one prose reference in `issue-backfill.yml`.

## Out of scope

`.claude/skills/file-issue/SKILL.md` still references `mcp__github__issue_write` in two places. That's a markdown-only doc fix; leaving it for a follow-up PR so this one stays narrowly focused on the workflow files (per the #216 triage scope). With `create_issue` in the allowed-tools list, Claude can call the real tool at runtime even when the skill's example line is stale.

## Test plan

- [ ] Next CI failure on `main` triggers `file-bug.yml` and a new issue titled "CI: main branch build failed — …" actually appears in the tracker.
- [ ] Next scheduled `issue-backfill` run (every 8h) files at least one issue authored by `claude[bot]`.
- [ ] `permission_denials_count` in both workflow logs drops to 0.