### PR TITLE
kernel: bump KSYMTAB_BYTES from 256 KiB to 320 KiB for ext2 symbol growth

### DIFF
--- a/kernel/src/ksymtab.rs
+++ b/kernel/src/ksymtab.rs
@@ -32,8 +32,10 @@ const VERSION: u8 = 1;
 
 /// Fixed reservation for the symbol table. Patched in place by xtask.
 /// Sized so a debug kernel's full symbol set fits with headroom; debug
-/// builds today come in around 2–3k symbols × ~50 bytes/entry.
-pub const KSYMTAB_BYTES: usize = 256 * 1024;
+/// builds today come in around 2–3k symbols × ~50 bytes/entry. The
+/// reservation was bumped from 256 KiB to 320 KiB after ext2 landed
+/// (#610) pushed the blob past the previous cap.
+pub const KSYMTAB_BYTES: usize = 320 * 1024;
 
 /// Fixed-size reservation patched in place by xtask after linking. We
 /// deliberately DO NOT use a custom `#[link_section]` — a separate


### PR DESCRIPTION
Closes #615

## Summary

Main CI has been red since PR #610 (ext2 on-mount orphan-chain validation) merged, with:

```
ksymtab blob 262892 bytes exceeds reservation 262144; bump KSYMTAB_BYTES
```

The kernel's exported-symbol blob grew past the prior 256 KiB cap. Bump the reservation in \`kernel/src/ksymtab.rs\` to 320 KiB so the build succeeds and there's headroom for further symbol-count growth before the next bump.

## Test plan

- [x] \`cargo xtask build\` succeeds locally (blob reports 157139/327680 bytes after bump)
- [x] \`cargo fmt --all\` clean
- [ ] CI green (fmt, clippy, build, test, smoke)