### PR TITLE
kernel/syscall: implement mount(2) with fstype registry (#575)

### DIFF
--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -944,6 +944,16 @@ pub unsafe extern "C" fn syscall_dispatch(
         #[cfg(feature = "vfs_creds")]
         UTIMENSAT => super::syscalls::vfs::sys_utimensat_impl(a0 as i32, a1, a2, a3 as u32),
 
+        // mount(source, target, fstype, flags, data) — RFC 0004 §Mount API.
+        // Superuser-only; rejects unknown flag bits; resolves fstype by name
+        // against the fstype registry populated by `vfs::init`. See issue #575.
+        // Gated on `vfs_creds` so the euid==0 check has real task credentials
+        // to consult — before Workstream B wires them through every path,
+        // this arm would always let `kernel()`-rooted kernel tasks through,
+        // which is correct but only meaningful once userspace callers exist.
+        #[cfg(feature = "vfs_creds")]
+        MOUNT => unsafe { super::syscalls::vfs::sys_mount_impl(a0, a1, a2, a3, a4) },
+
         // poll(fds, nfds, timeout_ms) — wait for readiness on a set of fds.
         POLL => crate::poll::syscalls::sys_poll(a0, a1, a2 as i64),
 
@@ -1634,6 +1644,7 @@ pub mod syscall_nr {
     pub const FCHOWNAT: u64 = 260;
     pub const FCHMODAT: u64 = 268;
     pub const UTIMENSAT: u64 = 280;
+    pub const MOUNT: u64 = 165;
     pub const POLL: u64 = 7;
     pub const SELECT: u64 = 23;
     pub const PSELECT6: u64 = 270;
@@ -1766,5 +1777,8 @@ mod tests {
 
         // utimensat (issue #544)
         assert_eq!(syscall_nr::UTIMENSAT, 280, "SYS_utimensat must be 280");
+
+        // Mount plumbing (issue #575, RFC 0004 Workstream F)
+        assert_eq!(syscall_nr::MOUNT, 165, "SYS_mount must be 165");
     }
 }

--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -34,7 +34,7 @@ use crate::fs::vfs::{
 use crate::fs::vfs::{Access, Credential, Timespec};
 use crate::fs::{
     flags as oflags, FileBackend, FileDescription, EBADF, EBUSY, EEXIST, EFAULT, EFBIG, EINVAL,
-    EISDIR, ENAMETOOLONG, ENOENT, ENOMEM, ENOTDIR, EPERM, EROFS, EXDEV,
+    EISDIR, ENAMETOOLONG, ENODEV, ENOENT, ENOMEM, ENOTDIR, EPERM, EROFS, EXDEV,
 };
 
 /// Linux x86_64 value of the "use the current working directory"
@@ -2268,4 +2268,319 @@ pub unsafe fn sys_readlink_impl(path_uva: u64, buf_uva: u64, bufsize: u64) -> i6
 /// Only `AT_FDCWD` and absolute paths are honored until #239 lands.
 pub unsafe fn sys_readlinkat_impl(dfd: i32, path_uva: u64, buf_uva: u64, bufsize: u64) -> i64 {
     readlinkat_impl(dfd, path_uva, buf_uva, bufsize)
+}
+
+// ---------------------------------------------------------------------------
+// mount(2) — issue #575, RFC 0004 §Mount API.
+//
+// Signature: `mount(source, target, fstype, flags, data)`
+//   a0 = source   : *const u8 (may be NULL for pseudo-FSes)
+//   a1 = target   : *const u8
+//   a2 = fstype   : *const u8
+//   a3 = flags    : u64 (MS_RDONLY=0x01, MS_NOSUID=0x02, MS_NODEV=0x04,
+//                         MS_NOEXEC=0x08)
+//   a4 = data     : *const u8 (ignored — per-FS options not plumbed yet)
+// ---------------------------------------------------------------------------
+
+/// Linux `MS_*` bits that `mount(2)` honours in this vibix revision. Any
+/// other bit in the flags argument is rejected with `-EINVAL` so a future
+/// caller can tell "v1 doesn't support this yet" from "flags ignored".
+pub const MS_RDONLY: u64 = 0x0001;
+pub const MS_NOSUID: u64 = 0x0002;
+pub const MS_NODEV: u64 = 0x0004;
+pub const MS_NOEXEC: u64 = 0x0008;
+const MS_SUPPORTED: u64 = MS_RDONLY | MS_NOSUID | MS_NODEV | MS_NOEXEC;
+
+/// Copy a NUL-terminated user string at `uva` into a heap buffer. Sized
+/// at [`PATH_MAX`]+1 so paths at the boundary still see their NUL. An
+/// empty `uva` (0) returns an empty vector — callers map that to
+/// [`crate::fs::vfs::MountSource::None`] for source-less FSes.
+fn copy_optional_user_string(uva: u64) -> Result<Vec<u8>, i64> {
+    if uva == 0 {
+        return Ok(Vec::new());
+    }
+    copy_user_path(uva)
+}
+
+/// Max length of the `fstype` name. Linux caps at `PAGE_SIZE`; we use a
+/// much tighter bound because the registry is a linear scan over <10
+/// entries and a legitimate caller never passes more than a handful of
+/// bytes.
+const FSTYPE_MAX: usize = 64;
+
+/// Copy the fstype name. Rejects oversized (`-EINVAL`, matching Linux's
+/// `mount_fs_str` path for over-long names) and empty names.
+fn copy_fstype(uva: u64) -> Result<Vec<u8>, i64> {
+    if uva == 0 {
+        return Err(EINVAL);
+    }
+    let mut buf: Vec<u8> = Vec::new();
+    buf.try_reserve_exact(FSTYPE_MAX + 1).map_err(|_| ENOMEM)?;
+    buf.resize(FSTYPE_MAX + 1, 0u8);
+    let n = unsafe { copy_path_from_user_pub(uva as usize, &mut buf) }?;
+    buf.truncate(n);
+    if buf.is_empty() {
+        return Err(EINVAL);
+    }
+    Ok(buf)
+}
+
+/// `mount(source, target, fstype, flags, data)` — RFC 0004 §Mount API.
+///
+/// Contract:
+/// - `euid == 0` only. Non-root callers receive `-EPERM` **before** any
+///   path walk or string copy that could leak kernel state.
+/// - Unknown flag bits (outside [`MS_SUPPORTED`]) → `-EINVAL`.
+/// - Unknown fstype → `-EINVAL` (Linux-conformant).
+/// - Target path cannot be resolved → the walk's errno (typically
+///   `-ENOENT`).
+/// - Target is not a positive directory → `-ENOTDIR`.
+/// - Target already has something mounted on it → `-EBUSY` (race-safe:
+///   mount_table's own EBUSY path fires if another caller beats us
+///   between our pre-check and the publish).
+/// - Source resolution failed inside the factory (ext2 wants a block
+///   device, none is registered) → factory-returned errno, typically
+///   `-ENODEV`.
+///
+/// `data` is accepted for ABI compatibility but ignored — vibix does
+/// not parse per-FS mount options yet.
+pub unsafe fn sys_mount_impl(
+    source_uva: u64,
+    target_uva: u64,
+    fstype_uva: u64,
+    flags: u64,
+    _data_uva: u64,
+) -> i64 {
+    // 1. Superuser-only. Reject early so a bogus caller cannot even
+    //    probe which fstype names exist. Mirrors Linux's CAP_SYS_ADMIN
+    //    check at the entry of `ksys_mount`.
+    let cred = crate::task::current_credentials();
+    if cred.euid != 0 {
+        return EPERM;
+    }
+
+    // 2. Reject unknown flag bits. A caller that sets `MS_BIND` or
+    //    `MS_SHARED` today gets a clean EINVAL rather than a silently
+    //    ignored bit that causes divergence when the bit ships later.
+    if flags & !MS_SUPPORTED != 0 {
+        return EINVAL;
+    }
+    let mut mflags = crate::fs::vfs::MountFlags::default();
+    if flags & MS_RDONLY != 0 {
+        mflags = mflags | crate::fs::vfs::MountFlags::RDONLY;
+    }
+    if flags & MS_NOSUID != 0 {
+        mflags = mflags | crate::fs::vfs::MountFlags::NOSUID;
+    }
+    if flags & MS_NODEV != 0 {
+        mflags = mflags | crate::fs::vfs::MountFlags::NODEV;
+    }
+    if flags & MS_NOEXEC != 0 {
+        mflags = mflags | crate::fs::vfs::MountFlags::NOEXEC;
+    }
+
+    // 3. Copy the three user strings. `target` and `fstype` are
+    //    mandatory; `source` may be NULL for pseudo-filesystems.
+    let fstype_buf = match copy_fstype(fstype_uva) {
+        Ok(b) => b,
+        Err(e) => return e,
+    };
+    let fstype = match core::str::from_utf8(&fstype_buf) {
+        Ok(s) => s,
+        Err(_) => return EINVAL,
+    };
+
+    // Early-reject unknown fstype before walking the target path. Saves a
+    // heap allocation on the common misspelled-name failure path.
+    if !crate::fs::vfs::is_registered(fstype) {
+        return EINVAL;
+    }
+
+    let target_buf = match copy_user_path(target_uva) {
+        Ok(b) => b,
+        Err(e) => return e,
+    };
+    if target_buf.is_empty() {
+        return ENOENT;
+    }
+
+    let source_buf = match copy_optional_user_string(source_uva) {
+        Ok(b) => b,
+        Err(e) => return e,
+    };
+
+    // 4. Resolve the target path to a positive-directory dentry. The
+    //    walk uses the caller's credentials so an unsearchable ancestor
+    //    fails with `-EACCES`. Root reaches every directory via its
+    //    kernel.euid==0 bypass — we've already checked euid==0 above —
+    //    so the cred argument is primarily a defensive measure against
+    //    a future change that moves the euid gate elsewhere.
+    let root = match vfs_root() {
+        Some(r) => r,
+        None => return ENOENT,
+    };
+    let cwd = if target_buf.first() == Some(&b'/') {
+        root.clone()
+    } else {
+        crate::task::current_cwd().unwrap_or_else(|| root.clone())
+    };
+    let mut nd = match NameIdata::new(
+        root,
+        cwd,
+        (*cred).clone(),
+        LookupFlags::default() | LookupFlags::FOLLOW,
+    ) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    if let Err(e) = path_walk(&mut nd, &target_buf, &GlobalMountResolver) {
+        return e;
+    }
+    let target_dentry = nd.path.dentry.clone();
+
+    // Must be a positive directory. `mount_table::mount` checks the same
+    // thing under its write lock, but doing it here means the diagnostic
+    // `ENOTDIR` fires before the factory allocates driver state.
+    {
+        let inode_slot = target_dentry.inode.read();
+        let inode = match inode_slot.as_ref() {
+            Some(i) => i,
+            None => return ENOENT,
+        };
+        if inode.kind != InodeKind::Dir {
+            return ENOTDIR;
+        }
+    }
+    if target_dentry.mount.read().is_some() {
+        return EBUSY;
+    }
+
+    // 5. Build the `MountSource`. `source` may be empty (pseudo-FS) or a
+    //    path to a block-device node. Until devfs carries first-class
+    //    block-device inodes, a non-empty `source` is just forwarded to
+    //    the factory as a `MountSource::Path`; factories that need a
+    //    block device (ext2) reach for `block::default_device()` and
+    //    return `-ENODEV` if none is registered.
+    let msrc = if source_buf.is_empty() {
+        crate::fs::vfs::MountSource::None
+    } else {
+        crate::fs::vfs::MountSource::Path(&source_buf)
+    };
+
+    // 6. Build the FS via the registry and mount it.
+    let fs = match crate::fs::vfs::lookup_and_build(fstype, msrc) {
+        Ok(f) => f,
+        Err(e) => return e,
+    };
+    // Re-materialise the source so `FileSystem::mount` sees the same
+    // bytes. Using a second borrow of `source_buf` is fine — the factory
+    // call above has returned and the previous borrow is released.
+    let msrc2 = if source_buf.is_empty() {
+        crate::fs::vfs::MountSource::None
+    } else {
+        crate::fs::vfs::MountSource::Path(&source_buf)
+    };
+    match crate::fs::vfs::mount(msrc2, &target_dentry, fs, mflags) {
+        Ok(_edge) => 0,
+        // Surface `ENODEV` through unchanged (e.g. ext2 factory returned
+        // it; fs-side mount could also bubble the same errno for a
+        // missing device on the slow path).
+        Err(e) if e == ENODEV => ENODEV,
+        Err(e) => e,
+    }
+}
+
+#[cfg(test)]
+mod mount_tests {
+    use super::*;
+    use crate::fs::vfs::ops::{FileSystem, MountSource};
+    use crate::fs::vfs::registry::{register_filesystem, reset_for_tests};
+    use crate::fs::vfs::super_block::{SbFlags, SuperBlock};
+    use crate::fs::vfs::{
+        alloc_fs_id, FileOps, InodeOps, MountFlags, SetAttr, Stat, StatFs, SuperOps,
+    };
+    use alloc::boxed::Box;
+    use alloc::sync::Arc;
+
+    struct T;
+    impl InodeOps for T {
+        fn getattr(&self, _i: &crate::fs::vfs::Inode, _o: &mut Stat) -> Result<(), i64> {
+            Ok(())
+        }
+        fn setattr(&self, _i: &crate::fs::vfs::Inode, _a: &SetAttr) -> Result<(), i64> {
+            Ok(())
+        }
+    }
+    struct TF;
+    impl FileOps for TF {}
+    struct TSB;
+    impl SuperOps for TSB {
+        fn root_inode(&self) -> Arc<crate::fs::vfs::Inode> {
+            unreachable!()
+        }
+        fn statfs(&self) -> Result<StatFs, i64> {
+            Ok(Default::default())
+        }
+        fn unmount(&self) {}
+    }
+
+    struct MockFs;
+    impl FileSystem for MockFs {
+        fn name(&self) -> &'static str {
+            "mockfs"
+        }
+        fn mount(&self, _s: MountSource<'_>, _f: MountFlags) -> Result<Arc<SuperBlock>, i64> {
+            let sb = Arc::new(SuperBlock::new(
+                alloc_fs_id(),
+                Arc::new(TSB),
+                "mockfs",
+                512,
+                SbFlags::default(),
+            ));
+            let root = Arc::new(crate::fs::vfs::Inode::new(
+                1,
+                Arc::downgrade(&sb),
+                Arc::new(T),
+                Arc::new(TF),
+                crate::fs::vfs::InodeKind::Dir,
+                crate::fs::vfs::InodeMeta {
+                    mode: 0o755,
+                    nlink: 2,
+                    ..Default::default()
+                },
+            ));
+            sb.root.call_once(|| root);
+            Ok(sb)
+        }
+    }
+
+    #[test]
+    fn flag_mask_round_trip() {
+        // Every supported MS_* bit maps to its MountFlags equivalent.
+        assert_eq!(MS_RDONLY, 0x0001);
+        assert_eq!(MS_NOSUID, 0x0002);
+        assert_eq!(MS_NODEV, 0x0004);
+        assert_eq!(MS_NOEXEC, 0x0008);
+        assert_eq!(MS_SUPPORTED, 0x000F);
+    }
+
+    #[test]
+    fn registry_lookup_unknown_returns_einval() {
+        reset_for_tests();
+        // Pre-condition: nothing registered under this name.
+        assert!(!crate::fs::vfs::is_registered("nosuch"));
+        let r = crate::fs::vfs::lookup_and_build("nosuch", MountSource::None);
+        assert_eq!(r.err(), Some(EINVAL));
+    }
+
+    #[test]
+    fn registry_lookup_registered_builds_fs() {
+        reset_for_tests();
+        register_filesystem(
+            "mockfs",
+            Box::new(|_src| Ok(Arc::new(MockFs) as Arc<dyn FileSystem>)),
+        );
+        let fs = crate::fs::vfs::lookup_and_build("mockfs", MountSource::None).expect("registered");
+        assert_eq!(fs.name(), "mockfs");
+    }
 }

--- a/kernel/src/fs/vfs/init.rs
+++ b/kernel/src/fs/vfs/init.rs
@@ -32,10 +32,13 @@
 use alloc::sync::Arc;
 use spin::Once;
 
+use alloc::boxed::Box;
+
 use super::dentry::{ChildState, Dentry, MountFlags};
 use super::inode::{Inode, InodeKind, InodeMeta};
 use super::mount_table::{alloc_fs_id, mount};
-use super::ops::{FileOps, InodeOps, MountSource, SetAttr, Stat, StatFs, SuperOps};
+use super::ops::{FileOps, FileSystem, InodeOps, MountSource, SetAttr, Stat, StatFs, SuperOps};
+use super::registry::register_filesystem;
 use super::super_block::{SbFlags, SuperBlock};
 use super::{DevFs, RamFs, TarFs};
 
@@ -61,6 +64,12 @@ pub fn init() {
     if ROOT_DENTRY.get().is_some() {
         return;
     }
+
+    // Populate the fstype registry so `mount(2)` can resolve names. The
+    // factories here are stateless: ramfs/devfs/tarfs each mint a fresh
+    // `Arc<dyn FileSystem>` per mount. ext2 is feature-gated and
+    // registered separately below.
+    register_builtin_filesystems();
 
     let bootstrap = bootstrap_target();
 
@@ -249,6 +258,42 @@ fn bootstrap_target() -> Arc<Dentry> {
     core::mem::forget(bootstrap_sb);
 
     target
+}
+
+/// Register every built-in fstype (`ramfs`, `tmpfs`, `devfs`, `tarfs`,
+/// and — when the `ext2` feature is on — `ext2`) with the fstype
+/// registry. Called once from [`init`]; the registry itself is idempotent
+/// on re-registration so a second call is harmless.
+///
+/// `tmpfs` is intentionally aliased to the ramfs factory: vibix does
+/// not yet distinguish the two, but Linux userspace scripts reach for
+/// `tmpfs` by default and nothing about our ramfs semantics violates
+/// the tmpfs contract for the operations that currently exist.
+fn register_builtin_filesystems() {
+    register_filesystem(
+        "ramfs",
+        Box::new(|_src| Ok(Arc::new(RamFs) as Arc<dyn FileSystem>)),
+    );
+    register_filesystem(
+        "tmpfs",
+        Box::new(|_src| Ok(Arc::new(RamFs) as Arc<dyn FileSystem>)),
+    );
+    register_filesystem(
+        "devfs",
+        Box::new(|_src| Ok(Arc::new(DevFs) as Arc<dyn FileSystem>)),
+    );
+    register_filesystem(
+        "tarfs",
+        Box::new(|_src| Ok(TarFs::new_arc() as Arc<dyn FileSystem>)),
+    );
+    #[cfg(feature = "ext2")]
+    register_filesystem(
+        "ext2",
+        Box::new(|_src| match crate::block::default_device() {
+            Some(dev) => Ok(crate::fs::ext2::Ext2Fs::new_with_device(dev) as Arc<dyn FileSystem>),
+            None => Err(crate::fs::ENODEV),
+        }),
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/kernel/src/fs/vfs/mod.rs
+++ b/kernel/src/fs/vfs/mod.rs
@@ -56,6 +56,7 @@ pub mod open_file;
 pub mod ops;
 pub mod path_walk;
 pub mod ramfs;
+pub mod registry;
 pub mod super_block;
 pub mod tarfs;
 
@@ -75,6 +76,7 @@ pub use path_walk::{
     path_walk, Last, LookupFlags, MountResolver, NameIdata, NullMountResolver, Path, PATH_MAX,
 };
 pub use ramfs::RamFs;
+pub use registry::{is_registered, lookup_and_build, register_filesystem, FsFactory};
 pub use super_block::{SbActiveGuard, SbFlags, SuperBlock};
 pub use tarfs::TarFs;
 

--- a/kernel/src/fs/vfs/registry.rs
+++ b/kernel/src/fs/vfs/registry.rs
@@ -1,0 +1,194 @@
+//! Filesystem-type registry — bind fstype string → factory closure.
+//!
+//! `mount(2)` accepts an `fstype` argument by *name* (e.g. `"ext2"`,
+//! `"ramfs"`, `"tmpfs"`, `"devfs"`, `"tarfs"`). The VFS needs a way to
+//! turn that string into an `Arc<dyn FileSystem>` at runtime without
+//! hard-coding every fstype into the syscall entry point.
+//!
+//! ## Shape
+//!
+//! The registry is a small `Vec<Entry>` protected by a blocking
+//! `BlockingRwLock`. Linear scan is fine — RFC 0004 §Mount API caps the
+//! live fstype count in v1 at a handful (ramfs, tmpfs, devfs, tarfs,
+//! ext2). Registration is idempotent on name: a second `register_filesystem`
+//! with the same name replaces the previous factory.
+//!
+//! ## Factory signature
+//!
+//! A factory is an `Fn(MountSource<'_>) -> Result<Arc<dyn FileSystem>, i64>`.
+//! It receives the mount source so fstypes that need backing state at
+//! construction time (ext2 wants a block device) can reach for it;
+//! pseudo-filesystems that ignore the source simply discard it.
+//!
+//! Factories run **before** `FileSystem::mount` — a factory returning
+//! `ENODEV` is how "no block device found for this source" surfaces
+//! through the `mount(2)` syscall.
+
+use alloc::boxed::Box;
+use alloc::string::{String, ToString};
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+
+use super::ops::{FileSystem, MountSource};
+use crate::sync::BlockingRwLock;
+
+/// A factory closure producing an `Arc<dyn FileSystem>` from a
+/// [`MountSource`]. Boxed so the registry can own heterogeneous
+/// closures behind a single vector.
+pub type FsFactory =
+    Box<dyn Fn(MountSource<'_>) -> Result<Arc<dyn FileSystem>, i64> + Send + Sync + 'static>;
+
+struct Entry {
+    name: String,
+    factory: FsFactory,
+}
+
+static REGISTRY: BlockingRwLock<Vec<Entry>> = BlockingRwLock::new(Vec::new());
+
+/// Register `factory` under the fstype name `name`. Idempotent: a second
+/// registration for the same name replaces the earlier factory. Called
+/// from each driver's boot-time init (ramfs/devfs/tarfs/ext2).
+pub fn register_filesystem(name: &str, factory: FsFactory) {
+    let mut table = REGISTRY.write();
+    if let Some(slot) = table.iter_mut().find(|e| e.name == name) {
+        slot.factory = factory;
+        return;
+    }
+    table.push(Entry {
+        name: name.to_string(),
+        factory,
+    });
+}
+
+/// Resolve an fstype name to a fresh `Arc<dyn FileSystem>` for a new
+/// mount. Returns `EINVAL` if the name is not registered (matches
+/// Linux's `mount(2)` error for unknown fstypes); otherwise returns
+/// whatever the factory returns (including `ENODEV` if the source
+/// couldn't be resolved).
+pub fn lookup_and_build(name: &str, source: MountSource<'_>) -> Result<Arc<dyn FileSystem>, i64> {
+    let table = REGISTRY.read();
+    let entry = table
+        .iter()
+        .find(|e| e.name == name)
+        .ok_or(crate::fs::EINVAL)?;
+    (entry.factory)(source)
+}
+
+/// Test-only: clear the registry. Integration tests register their own
+/// fstypes against a fresh state.
+#[cfg(test)]
+pub(crate) fn reset_for_tests() {
+    REGISTRY.write().clear();
+}
+
+/// Return `true` if `name` is currently registered. Used by the
+/// `mount(2)` syscall path for an early `EINVAL` *before* any path
+/// walk, so a bad fstype fails without allocating walk state.
+pub fn is_registered(name: &str) -> bool {
+    REGISTRY.read().iter().any(|e| e.name == name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fs::vfs::super_block::{SbFlags, SuperBlock};
+    use crate::fs::vfs::{alloc_fs_id, MountFlags};
+    use spin::Mutex;
+
+    /// Integration-ordered registry tests mutate global state; serialise.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    struct StubFs {
+        name: &'static str,
+    }
+    impl FileSystem for StubFs {
+        fn name(&self) -> &'static str {
+            self.name
+        }
+        fn mount(&self, _src: MountSource<'_>, _flags: MountFlags) -> Result<Arc<SuperBlock>, i64> {
+            Err(crate::fs::EINVAL)
+        }
+    }
+
+    struct StubSuper;
+    impl crate::fs::vfs::ops::SuperOps for StubSuper {
+        fn root_inode(&self) -> Arc<crate::fs::vfs::Inode> {
+            unreachable!()
+        }
+        fn statfs(&self) -> Result<crate::fs::vfs::StatFs, i64> {
+            Ok(Default::default())
+        }
+        fn unmount(&self) {}
+    }
+
+    fn make_stub_sb() -> Arc<SuperBlock> {
+        Arc::new(SuperBlock::new(
+            alloc_fs_id(),
+            Arc::new(StubSuper),
+            "stub",
+            512,
+            SbFlags::default(),
+        ))
+    }
+
+    #[test]
+    fn register_and_lookup_round_trip() {
+        let _g = TEST_LOCK.lock();
+        reset_for_tests();
+        register_filesystem(
+            "stub",
+            Box::new(|_src| Ok(Arc::new(StubFs { name: "stub" }) as Arc<dyn FileSystem>)),
+        );
+        let fs = lookup_and_build("stub", MountSource::None).expect("registered");
+        assert_eq!(fs.name(), "stub");
+        assert!(is_registered("stub"));
+    }
+
+    #[test]
+    fn unknown_fstype_returns_einval() {
+        let _g = TEST_LOCK.lock();
+        reset_for_tests();
+        let r = lookup_and_build("nosuch", MountSource::None);
+        assert_eq!(r.err(), Some(crate::fs::EINVAL));
+        assert!(!is_registered("nosuch"));
+    }
+
+    #[test]
+    fn reregistration_replaces_previous_factory() {
+        let _g = TEST_LOCK.lock();
+        reset_for_tests();
+        register_filesystem(
+            "replaceme",
+            Box::new(|_src| Ok(Arc::new(StubFs { name: "first" }) as Arc<dyn FileSystem>)),
+        );
+        register_filesystem(
+            "replaceme",
+            Box::new(|_src| Ok(Arc::new(StubFs { name: "second" }) as Arc<dyn FileSystem>)),
+        );
+        let fs = lookup_and_build("replaceme", MountSource::None).expect("registered");
+        assert_eq!(fs.name(), "second");
+    }
+
+    #[test]
+    fn factory_error_propagates() {
+        let _g = TEST_LOCK.lock();
+        reset_for_tests();
+        register_filesystem("enodev", Box::new(|_src| Err(crate::fs::ENODEV)));
+        let r = lookup_and_build("enodev", MountSource::None);
+        assert_eq!(r.err(), Some(crate::fs::ENODEV));
+    }
+
+    // Silence unused import warning when `make_stub_sb` is not needed
+    // for every test; keep it around for future follow-ups.
+    #[allow(dead_code)]
+    fn _touch_sb(sb: Arc<SuperBlock>) {
+        drop(sb);
+    }
+
+    #[test]
+    fn make_stub_sb_produces_live_sb() {
+        let _g = TEST_LOCK.lock();
+        let sb = make_stub_sb();
+        assert_eq!(sb.fs_type, "stub");
+    }
+}


### PR DESCRIPTION
Closes #575

## Summary

Wires `SYS_mount` (nr 165) through the VFS mount-table API per RFC 0004 §Mount API. Superuser-only at entry; resolves fstype by name through a new `FileSystemRegistry` populated at VFS boot with ramfs/tmpfs/devfs/tarfs (and ext2 under the `ext2` feature). Enforces MS_RDONLY / MS_NOSUID / MS_NODEV / MS_NOEXEC; rejects unknown flag bits with EINVAL. Flag storage reuses the existing `MountFlags` on the `MountEdge` — no new layer.

Error surface matches Linux `mount(2)`:
- EPERM — euid != 0
- EINVAL — unknown flag bits, unknown/empty fstype
- ENOENT / ENOTDIR — target path walk
- EBUSY — target already hosts a mount
- ENODEV — factory couldn't resolve source (e.g. ext2 w/ no `default_device()`)

Dispatch arm is gated on `feature = "vfs_creds"` so the euid==0 gate sees real per-task credentials.

## Scope deferrals

- `MS_NOEXEC` enforcement at exec-time is deferred to a follow-up: the current `execve` arm hard-loads `userspace_hello.elf` rather than walking a path, so there is no `MountEdge` to consult yet. Ticketable once path-based execve lands.
- `/dev/<blkdev>` source resolution walks the default-device registry as a single slot; per-path devfs block-device resolution is a follow-up to issue #567+ (ext2 Workstream D surface).
- `MS_BIND`/`MS_MOVE`/`MS_SHARED` explicitly out of scope per RFC (v2).

## Test plan

- [x] `cargo xtask build` passes.
- [x] Host unit tests green (`cargo test -p vibix --lib`).
- [x] Registry unit tests in `fs::vfs::registry::tests` exercise register/lookup round-trip, unknown-fstype EINVAL, re-registration, and factory-error propagation.
- [x] New `syscall_nr::MOUNT == 165` ABI assertion added to the Linux-ABI regression test.
- [ ] QEMU integration test for end-to-end mount(2) from userspace — covered by follow-up once userspace has a real `mount` caller (parked behind #576 umount2 work).