### PR TITLE
fs/ext2: FileOps::write extend path with lazy indirect-block allocation (#567)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -394,3 +394,8 @@ required-features = ["ext2"]
 name = "ext2_ialloc"
 harness = false
 required-features = ["ext2"]
+
+[[test]]
+name = "ext2_file_write"
+harness = false
+required-features = ["ext2"]

--- a/kernel/src/fs/ext2/file.rs
+++ b/kernel/src/fs/ext2/file.rs
@@ -66,10 +66,18 @@
 
 use alloc::sync::Arc;
 
-use super::fs::Ext2Super;
-use super::indirect::{resolve_block, Geometry, MetadataMap, WalkError};
+use super::balloc::alloc_block;
+use super::disk::{
+    Ext2Inode as DiskInode, EXT2_INODE_SIZE_V0, EXT2_N_BLOCKS, RO_COMPAT_LARGE_FILE,
+};
+use super::fs::{Ext2MountFlags, Ext2Super};
+use super::indirect::{
+    resolve_block, Geometry, MetadataMap, WalkError, EXT2_DIND_BLOCK, EXT2_DIRECT_BLOCKS,
+    EXT2_IND_BLOCK, EXT2_TIND_BLOCK,
+};
 use crate::fs::vfs::inode::Inode;
-use crate::fs::{EIO, EISDIR};
+use crate::fs::vfs::Timespec;
+use crate::fs::{EFBIG, EINVAL, EIO, EISDIR, EROFS};
 
 /// Read at most `buf.len()` bytes from `inode` starting at byte
 /// offset `off`. Short reads (fewer bytes than requested) indicate
@@ -293,6 +301,619 @@ pub(super) fn build_metadata_map(super_: &Arc<Ext2Super>) -> MetadataMap {
     // by dropping later-starting duplicates via `dedup_contiguous`.
     dedup_contiguous(&mut raw);
     MetadataMap::from_sorted_ranges(raw)
+}
+
+/// Write up to `buf.len()` bytes into `inode` starting at byte offset
+/// `off`, extending the file as needed.
+///
+/// RFC 0004 §Write extend + §Write Ordering (`docs/RFC/0004-ext2-
+/// filesystem-driver.md`) is the normative spec. The pipeline mirrors
+/// [`read_file_at`] with three mutation points layered on top:
+///
+/// 1. **Allocate** any missing indirect-block pointers for the logical
+///    blocks in `[off, off+len)` via [`super::balloc::alloc_block`],
+///    zero each freshly-allocated pointer block through the buffer
+///    cache, and only then **link** the pointer into its parent slot.
+///    Ordering matters: a crash between allocate-and-zero and link
+///    leaks a block (bitmap says "used", no parent points at it — a
+///    fixable `e2fsck` warning). The reverse order could leave a
+///    parent pointing at uninitialised bytes that the next reader
+///    would interpret as indirect pointers — a structural corruption.
+/// 2. **Allocate** the data block itself, `bread` its cache entry,
+///    overlay the user bytes, `mark_dirty`, `sync_dirty_buffer`. The
+///    data block is linked into its parent (direct slot or indirect
+///    leaf) *before* the user bytes are copied — because the block is
+///    freshly allocated, nothing else can observe it yet, so zero-on-
+///    allocate is the only pre-link invariant we need.
+/// 3. **Update** `i_size`, `i_blocks`, `i_mtime`, `i_ctime` on both
+///    the driver-owned [`super::inode::Ext2InodeMeta`] and the
+///    VFS-level [`crate::fs::vfs::inode::InodeMeta`]; flush the inode
+///    slot back to disk. `i_size` update is last in the sequence so a
+///    crash between data-block write and size update leaves readers
+///    seeing the *old* size (correct, just short), never a size that
+///    claims blocks that weren't written.
+///
+/// # Return value
+///
+/// - `Ok(n)` where `0 <= n <= buf.len()`. A short write indicates
+///   `ENOSPC` or `EFBIG` hit mid-buffer — the bytes already committed
+///   remain visible to subsequent reads. The caller (syscall layer)
+///   surfaces the partial-write count to userspace; a final `Err(_)`
+///   is only returned when *no* bytes were committed.
+/// - `Err(EROFS)` — mount is RO (user-requested or feature-forced).
+/// - `Err(EISDIR)` — write(2) on a directory.
+/// - `Err(EINVAL)` — write(2) on a symlink / device node / FIFO (same
+///   dispatch rule as [`read_file_at`]; the open path is expected to
+///   bind a driver-specific FileOps at the fd).
+/// - `Err(EFBIG)` — `off + len` exceeds the maximum file size the
+///   driver can address (past triple-indirect or past `u32::MAX`
+///   logical blocks or past `i64::MAX` bytes on a 32-bit-size image).
+/// - `Err(ENOSPC)` — no free blocks anywhere *and* no bytes committed
+///   yet.
+/// - `Err(EIO)` — buffer-cache I/O failure or an image-forged
+///   pointer tripped the walker's corruption detector.
+pub fn write_file_at(
+    inode: &Inode,
+    ext2_inode: &super::inode::Ext2Inode,
+    buf: &[u8],
+    off: u64,
+) -> Result<usize, i64> {
+    use crate::fs::vfs::inode::InodeKind;
+
+    match inode.kind {
+        InodeKind::Reg => {}
+        InodeKind::Dir => return Err(EISDIR),
+        InodeKind::Link => return Err(EINVAL),
+        InodeKind::Chr | InodeKind::Blk | InodeKind::Fifo | InodeKind::Sock => return Err(EINVAL),
+    }
+
+    let super_ref = ext2_inode.super_ref.upgrade().ok_or(EIO)?;
+
+    if super_ref.ext2_flags.contains(Ext2MountFlags::RDONLY)
+        || super_ref.ext2_flags.contains(Ext2MountFlags::FORCED_RDONLY)
+    {
+        return Err(EROFS);
+    }
+    if buf.is_empty() {
+        return Ok(0);
+    }
+
+    let block_size = super_ref.block_size as u64;
+    debug_assert!(block_size > 0, "mount validated block_size != 0");
+
+    // Structural upper bound on file size. Ext2 can address
+    // `12 + p + p^2 + p^3` logical blocks where `p = block_size / 4`.
+    // That's well under `u64::MAX * block_size` for any legal block
+    // size, but we still compute it in `u64` to stay overflow-safe on
+    // 64 KiB blocks (`p = 16384`, `p^3 = 2^42`).
+    let p64 = block_size / 4;
+    let max_logical_blocks: u64 = (EXT2_DIRECT_BLOCKS as u64) + p64 + p64 * p64 + p64 * p64 * p64;
+    let max_file_size: u64 = max_logical_blocks.saturating_mul(block_size);
+
+    let off_end = off.checked_add(buf.len() as u64).ok_or(EFBIG)?;
+    if off_end > max_file_size {
+        return Err(EFBIG);
+    }
+    // i_size on disk maxes out at 2^63 - 1 even with large_file
+    // (s_size + s_size_high is u64 on disk but POSIX `off_t` is `i64`).
+    // Reject anything past that.
+    if off_end > i64::MAX as u64 {
+        return Err(EFBIG);
+    }
+
+    let (s_first_data_block, s_blocks_count, s_inodes_per_group) = {
+        let sb = super_ref.sb_disk.lock();
+        (
+            sb.s_first_data_block,
+            sb.s_blocks_count,
+            sb.s_inodes_per_group,
+        )
+    };
+    let geom =
+        Geometry::new(super_ref.block_size, s_first_data_block, s_blocks_count).ok_or(EIO)?;
+    let md = build_metadata_map(&super_ref);
+
+    // Hold the inode's metadata lock write-locked across the whole
+    // extend. RFC 0004 §Write extend mandates this against concurrent
+    // truncate (truncate will acquire the same lock in Workstream E);
+    // it also serialises two racing `write(2)`s on the same inode so
+    // their block allocations don't trample each other.
+    let mut meta = ext2_inode.meta.write();
+
+    // Hint-group for `alloc_block`: the ext2 "data locality" heuristic
+    // is to allocate each new block in the same group as the inode
+    // itself. Compute the inode's group once up front.
+    let inode_group = if s_inodes_per_group == 0 {
+        0
+    } else {
+        (ext2_inode.ino - 1) / s_inodes_per_group
+    };
+
+    let mut copied = 0usize;
+    let mut new_i_blocks_bump: u64 = 0;
+    let mut last_error: Option<i64> = None;
+
+    while copied < buf.len() {
+        let cur = off + copied as u64;
+        let logical: u32 = (cur / block_size).try_into().map_err(|_| EFBIG)?;
+        let in_block = (cur % block_size) as usize;
+        let remaining_in_block = block_size as usize - in_block;
+        let chunk = core::cmp::min(remaining_in_block, buf.len() - copied);
+
+        // Ensure the full path to `logical` is allocated. Each new
+        // pointer / data block counts toward `new_i_blocks_bump` in
+        // 512-byte units.
+        let data_block = match ensure_block_allocated(
+            &super_ref,
+            &geom,
+            &md,
+            &mut meta.i_block,
+            logical,
+            inode_group,
+            &mut new_i_blocks_bump,
+        ) {
+            Ok(b) => b,
+            Err(e) => {
+                // Out-of-space or I/O error part-way through a
+                // multi-block write. Preserve the copied count and
+                // surface the error to the caller only if nothing has
+                // landed yet — otherwise fall through to the metadata
+                // flush and report a short write.
+                last_error = Some(e);
+                break;
+            }
+        };
+
+        // RMW the data block through the buffer cache: read, overlay,
+        // sync. `bread` on a freshly-allocated block still routes
+        // through the cache; our own `zero_block` populated the entry
+        // above with a zeroed page, so the RMW sees the expected
+        // zero prefix + suffix outside our chunk.
+        let bh = match super_ref
+            .cache
+            .bread(super_ref.device_id, data_block as u64)
+        {
+            Ok(b) => b,
+            Err(_) => {
+                last_error = Some(EIO);
+                break;
+            }
+        };
+        {
+            let mut data = bh.data.write();
+            debug_assert!(in_block + chunk <= data.len());
+            data[in_block..in_block + chunk].copy_from_slice(&buf[copied..copied + chunk]);
+        }
+        super_ref.cache.mark_dirty(&bh);
+        if super_ref.cache.sync_dirty_buffer(&bh).is_err() {
+            last_error = Some(EIO);
+            break;
+        }
+
+        copied += chunk;
+    }
+
+    // If we got zero bytes out, surface the error instead of an
+    // empty-success return.
+    if copied == 0 {
+        return Err(last_error.unwrap_or(EIO));
+    }
+
+    // Update in-memory metadata. `i_blocks` is in on-disk 512-byte
+    // units; `new_i_blocks_bump` was accumulated in those same units.
+    let new_size = meta.size.max(off + copied as u64);
+    meta.size = new_size;
+    meta.i_blocks = meta.i_blocks.saturating_add(new_i_blocks_bump as u32);
+    let now = Timespec::now();
+    meta.mtime = now.sec as u32;
+    meta.ctime = now.sec as u32;
+
+    // Mirror the size / block count / mtime / ctime onto the VFS-layer
+    // `Inode::meta` so subsequent `stat(2)` sees the fresh values.
+    {
+        let mut vfs_meta = inode.meta.write();
+        vfs_meta.size = new_size;
+        vfs_meta.blocks = meta.i_blocks as u64;
+        vfs_meta.mtime = now;
+        vfs_meta.ctime = now;
+    }
+
+    // Flush the inode slot to disk. This carries the updated `i_size`,
+    // `i_blocks`, `i_mtime`, `i_ctime`, and the fresh `i_block[]`
+    // pointers. RFC 0004 §Write Ordering: the inode flush is last so a
+    // crash leaves readers with at-worst the *old* size — never an
+    // `i_size` that claims blocks whose data hasn't hit the device.
+    flush_inode_slot(&super_ref, ext2_inode.ino, &meta)?;
+
+    Ok(copied)
+}
+
+/// Ensure the logical block `logical` has an allocated data block
+/// backing it, creating any missing indirect-block pointers along the
+/// way. Returns the absolute data block number.
+///
+/// Mutates `i_block_mut` in place to install new top-level (direct /
+/// indirect / double-indirect / triple-indirect) pointers. Each
+/// newly-allocated indirect block is zeroed through the buffer cache
+/// before the parent pointer is updated — the RFC 0004 §Write Ordering
+/// rule.
+///
+/// `new_blocks_bump` accumulates the *on-disk 512-byte-unit* cost of
+/// every block this call allocated (one fs-block = `block_size / 512`
+/// 512-byte units), so the caller can bump `i_blocks` once at the end
+/// of the write.
+fn ensure_block_allocated(
+    super_: &Arc<Ext2Super>,
+    geom: &Geometry,
+    md: &MetadataMap,
+    i_block_mut: &mut [u32; EXT2_N_BLOCKS],
+    logical: u32,
+    hint_group: u32,
+    new_blocks_bump: &mut u64,
+) -> Result<u32, i64> {
+    let p = geom.ptrs_per_block as u64;
+    let direct_limit = EXT2_DIRECT_BLOCKS as u64;
+    let single_limit = direct_limit + p;
+    let double_limit = single_limit + p * p;
+    let triple_limit = double_limit + p * p * p;
+    let logical64 = logical as u64;
+
+    let blocks_per_512 = (geom.block_size / 512) as u64;
+
+    if logical64 < direct_limit {
+        // Direct: slot `i_block[logical]` *is* the data block pointer.
+        let slot = &mut i_block_mut[logical as usize];
+        if *slot != 0 {
+            validate_existing_pointer(*slot, geom, md)?;
+            return Ok(*slot);
+        }
+        let data_blk = alloc_and_zero_data_block(super_, hint_group, new_blocks_bump)?;
+        *slot = data_blk;
+        *new_blocks_bump += blocks_per_512;
+        Ok(data_blk)
+    } else if logical64 < single_limit {
+        let idx0 = (logical64 - direct_limit) as u32;
+        let ind = ensure_indirect_ptr(
+            super_,
+            &mut i_block_mut[EXT2_IND_BLOCK],
+            geom,
+            md,
+            hint_group,
+            new_blocks_bump,
+        )?;
+        finish_leaf_slot(super_, ind, idx0, geom, md, hint_group, new_blocks_bump)
+    } else if logical64 < double_limit {
+        let rel = logical64 - single_limit;
+        let idx_outer = (rel / p) as u32;
+        let idx_inner = (rel % p) as u32;
+        let dind = ensure_indirect_ptr(
+            super_,
+            &mut i_block_mut[EXT2_DIND_BLOCK],
+            geom,
+            md,
+            hint_group,
+            new_blocks_bump,
+        )?;
+        let ind = ensure_slot_block(
+            super_,
+            dind,
+            idx_outer,
+            geom,
+            md,
+            hint_group,
+            new_blocks_bump,
+        )?;
+        finish_leaf_slot(
+            super_,
+            ind,
+            idx_inner,
+            geom,
+            md,
+            hint_group,
+            new_blocks_bump,
+        )
+    } else if logical64 < triple_limit {
+        let rel = logical64 - double_limit;
+        let p_sq = p * p;
+        let idx_l0 = (rel / p_sq) as u32;
+        let rem = rel % p_sq;
+        let idx_l1 = (rem / p) as u32;
+        let idx_l2 = (rem % p) as u32;
+        let tind = ensure_indirect_ptr(
+            super_,
+            &mut i_block_mut[EXT2_TIND_BLOCK],
+            geom,
+            md,
+            hint_group,
+            new_blocks_bump,
+        )?;
+        let dind = ensure_slot_block(super_, tind, idx_l0, geom, md, hint_group, new_blocks_bump)?;
+        let ind = ensure_slot_block(super_, dind, idx_l1, geom, md, hint_group, new_blocks_bump)?;
+        finish_leaf_slot(super_, ind, idx_l2, geom, md, hint_group, new_blocks_bump)
+    } else {
+        Err(EFBIG)
+    }
+}
+
+/// Validate that `p` — an in-memory pointer we already committed to
+/// `i_block[]` or read back out of an indirect block — is a legal
+/// data-block pointer (non-zero, in `[s_first_data_block,
+/// s_blocks_count)`, not in a metadata range). A malformed pointer
+/// here is the same attacker-forged-image confused-deputy vector the
+/// read walker guards against.
+fn validate_existing_pointer(p: u32, geom: &Geometry, md: &MetadataMap) -> Result<(), i64> {
+    if !geom.in_data_range(p) || md.contains(p) {
+        return Err(EIO);
+    }
+    Ok(())
+}
+
+/// Ensure a top-level indirect slot (single, double, or triple) is
+/// populated. If the slot is zero, allocate a fresh indirect block,
+/// zero it through the cache, then install the pointer. Returns the
+/// absolute indirect-block number.
+fn ensure_indirect_ptr(
+    super_: &Arc<Ext2Super>,
+    slot: &mut u32,
+    geom: &Geometry,
+    md: &MetadataMap,
+    hint_group: u32,
+    new_blocks_bump: &mut u64,
+) -> Result<u32, i64> {
+    if *slot != 0 {
+        validate_existing_pointer(*slot, geom, md)?;
+        return Ok(*slot);
+    }
+    let new_blk = alloc_and_zero_pointer_block(super_, hint_group, new_blocks_bump)?;
+    *slot = new_blk;
+    *new_blocks_bump += (geom.block_size / 512) as u64;
+    Ok(new_blk)
+}
+
+/// Ensure slot `index` of the pointer block at absolute `parent_blk`
+/// holds a non-zero pointer. If it's zero, allocate a new pointer
+/// block, zero it, link it into the parent (RMW the parent through
+/// the buffer cache), and flush the parent. Returns the absolute
+/// pointer-block number now installed at `parent[index]`.
+fn ensure_slot_block(
+    super_: &Arc<Ext2Super>,
+    parent_blk: u32,
+    index: u32,
+    geom: &Geometry,
+    md: &MetadataMap,
+    hint_group: u32,
+    new_blocks_bump: &mut u64,
+) -> Result<u32, i64> {
+    let (existing, bh) = read_pointer_slot_raw(super_, parent_blk, index, geom)?;
+    if existing != 0 {
+        validate_existing_pointer(existing, geom, md)?;
+        return Ok(existing);
+    }
+    // Allocate + zero the child before linking.
+    let child = alloc_and_zero_pointer_block(super_, hint_group, new_blocks_bump)?;
+    *new_blocks_bump += (geom.block_size / 512) as u64;
+    // Link into the parent at slot `index`.
+    {
+        let mut data = bh.data.write();
+        let off = (index as usize) * 4;
+        debug_assert!(off + 4 <= data.len());
+        data[off..off + 4].copy_from_slice(&child.to_le_bytes());
+    }
+    super_.cache.mark_dirty(&bh);
+    super_.cache.sync_dirty_buffer(&bh).map_err(|_| EIO)?;
+    Ok(child)
+}
+
+/// Leaf path: `parent_blk[index]` holds (or will hold) a data-block
+/// pointer. If the slot is zero, allocate + zero a fresh data block,
+/// link it into the parent, flush. Returns the absolute data-block
+/// number.
+fn finish_leaf_slot(
+    super_: &Arc<Ext2Super>,
+    parent_blk: u32,
+    index: u32,
+    geom: &Geometry,
+    md: &MetadataMap,
+    hint_group: u32,
+    new_blocks_bump: &mut u64,
+) -> Result<u32, i64> {
+    let (existing, bh) = read_pointer_slot_raw(super_, parent_blk, index, geom)?;
+    if existing != 0 {
+        validate_existing_pointer(existing, geom, md)?;
+        return Ok(existing);
+    }
+    let data_blk = alloc_and_zero_data_block(super_, hint_group, new_blocks_bump)?;
+    *new_blocks_bump += (geom.block_size / 512) as u64;
+    {
+        let mut data = bh.data.write();
+        let off = (index as usize) * 4;
+        debug_assert!(off + 4 <= data.len());
+        data[off..off + 4].copy_from_slice(&data_blk.to_le_bytes());
+    }
+    super_.cache.mark_dirty(&bh);
+    super_.cache.sync_dirty_buffer(&bh).map_err(|_| EIO)?;
+    Ok(data_blk)
+}
+
+/// Read the pointer at slot `index` out of the indirect block `abs`
+/// and return both the decoded pointer *and* the buffer-cache handle
+/// so the caller can RMW the same slot on a miss without a second
+/// `bread`.
+fn read_pointer_slot_raw(
+    super_: &Arc<Ext2Super>,
+    abs: u32,
+    index: u32,
+    geom: &Geometry,
+) -> Result<(u32, Arc<crate::block::cache::BufferHead>), i64> {
+    debug_assert!(index < geom.ptrs_per_block);
+    let bh = super_
+        .cache
+        .bread(super_.device_id, abs as u64)
+        .map_err(|_| EIO)?;
+    let val = {
+        let data = bh.data.read();
+        let off = (index as usize) * 4;
+        let slot: [u8; 4] = data[off..off + 4]
+            .try_into()
+            .expect("pointer slot is exactly 4 bytes");
+        u32::from_le_bytes(slot)
+    };
+    Ok((val, bh))
+}
+
+/// Allocate a new block and synchronously zero it through the buffer
+/// cache. Used for both newly-allocated indirect pointer blocks and
+/// for freshly-allocated data blocks (so a crash between allocate-
+/// and-link leaves a zeroed block, never random recycled data from an
+/// earlier file's reuse). Returns the absolute block number.
+fn alloc_and_zero_pointer_block(
+    super_: &Arc<Ext2Super>,
+    hint_group: u32,
+    _new_blocks_bump: &mut u64,
+) -> Result<u32, i64> {
+    let blk = alloc_block(super_, Some(hint_group))?;
+    zero_block(super_, blk)?;
+    Ok(blk)
+}
+
+/// Same as [`alloc_and_zero_pointer_block`] but semantically marked
+/// "data" — distinguished so a reader of the write path sees that the
+/// zero-fill on data blocks is *intentional* (POSIX requires a sparse
+/// read of a hole-free-allocated-but-not-yet-written region to return
+/// zeros, and a crash after alloc + before the caller's `copy_from`
+/// is effectively that case).
+fn alloc_and_zero_data_block(
+    super_: &Arc<Ext2Super>,
+    hint_group: u32,
+    _new_blocks_bump: &mut u64,
+) -> Result<u32, i64> {
+    let blk = alloc_block(super_, Some(hint_group))?;
+    zero_block(super_, blk)?;
+    Ok(blk)
+}
+
+/// Zero the block at absolute `abs` through the per-mount buffer
+/// cache and flush it synchronously. A freshly-allocated block's
+/// cache entry can contain whatever bytes were previously resident at
+/// that physical position on disk — typically zeros on a fresh mkfs,
+/// but *not* guaranteed for a block reclaimed from a deleted file.
+fn zero_block(super_: &Arc<Ext2Super>, abs: u32) -> Result<(), i64> {
+    let bh = super_
+        .cache
+        .bread(super_.device_id, abs as u64)
+        .map_err(|_| EIO)?;
+    {
+        let mut data = bh.data.write();
+        for b in data.iter_mut() {
+            *b = 0;
+        }
+    }
+    super_.cache.mark_dirty(&bh);
+    super_.cache.sync_dirty_buffer(&bh).map_err(|_| EIO)?;
+    Ok(())
+}
+
+/// Flush the in-memory `Ext2InodeMeta` for `ino` back to its on-disk
+/// slot. RMW through the buffer cache: read the inode-table block,
+/// decode the 128-byte slot, overlay our driver-owned fields, encode
+/// back, `mark_dirty`, `sync_dirty_buffer`.
+///
+/// Intentionally spelled out here rather than factored with `iget` —
+/// the writeback surface for the full inode (setattr, truncate, link-
+/// count) will land with Workstream E's `write_inode` helper; until
+/// then `write_file_at` is the only site that needs to persist the
+/// fields it mutates (`i_size`, `i_blocks`, `i_mtime`, `i_ctime`,
+/// `i_block[]`). Using a local helper keeps the scope tight.
+fn flush_inode_slot(
+    super_: &Arc<Ext2Super>,
+    ino: u32,
+    meta: &super::inode::Ext2InodeMeta,
+) -> Result<(), i64> {
+    let inodes_per_group = {
+        let sb = super_.sb_disk.lock();
+        sb.s_inodes_per_group
+    };
+    if inodes_per_group == 0 {
+        return Err(EIO);
+    }
+    let group = (ino - 1) / inodes_per_group;
+    let index_in_group = (ino - 1) % inodes_per_group;
+    let bg_inode_table = {
+        let bgdt = super_.bgdt.lock();
+        if (group as usize) >= bgdt.len() {
+            return Err(EIO);
+        }
+        bgdt[group as usize].bg_inode_table
+    };
+
+    let inode_size = super_.inode_size;
+    let block_size = super_.block_size;
+    let byte_offset = (index_in_group as u64) * (inode_size as u64);
+    let block_in_table = byte_offset / (block_size as u64);
+    let offset_in_block = (byte_offset % (block_size as u64)) as usize;
+    let absolute_block = (bg_inode_table as u64)
+        .checked_add(block_in_table)
+        .ok_or(EIO)?;
+
+    let bh = super_
+        .cache
+        .bread(super_.device_id, absolute_block)
+        .map_err(|_| EIO)?;
+    {
+        let mut data = bh.data.write();
+        if offset_in_block + EXT2_INODE_SIZE_V0 > data.len() {
+            return Err(EIO);
+        }
+        let slot = &mut data[offset_in_block..offset_in_block + EXT2_INODE_SIZE_V0];
+        // Decode the current on-disk slot so we preserve the fields
+        // `Ext2InodeMeta` doesn't carry (`i_generation`, `i_file_acl`,
+        // `i_osd1`, fragment bits, …) via `DiskInode::encode_to_slot`'s
+        // byte-wise preservation guarantee.
+        let mut disk = DiskInode::decode(slot);
+        apply_meta_to_disk(meta, &mut disk, super_);
+        disk.encode_to_slot(slot);
+    }
+    super_.cache.mark_dirty(&bh);
+    super_.cache.sync_dirty_buffer(&bh).map_err(|_| EIO)?;
+    Ok(())
+}
+
+/// Overlay the fields `Ext2InodeMeta` owns onto a decoded on-disk
+/// `DiskInode`, preparing it for re-encode. Large-file size-high
+/// handling matches the read path's `Ext2InodeMeta::from_disk`:
+/// regular files with `RO_COMPAT_LARGE_FILE` set split `size` across
+/// `i_size` + `i_dir_acl_or_size_high`; everything else keeps the
+/// low 32 bits only.
+fn apply_meta_to_disk(
+    meta: &super::inode::Ext2InodeMeta,
+    disk: &mut DiskInode,
+    super_: &Arc<Ext2Super>,
+) {
+    let ro_compat = super_.sb_disk.lock().s_feature_ro_compat;
+    let large_file = (ro_compat & RO_COMPAT_LARGE_FILE) != 0;
+    let is_reg = (meta.mode & 0o170_000) == 0o100_000;
+
+    disk.i_mode = meta.mode;
+    if is_reg && large_file {
+        disk.i_size = (meta.size & 0xffff_ffff) as u32;
+        disk.i_dir_acl_or_size_high = (meta.size >> 32) as u32;
+    } else {
+        // Clamp to 32 bits — directories and non-large-file regular
+        // files can't go past `u32::MAX` bytes. The caller already
+        // rejected `off + len > max_file_size`, but guard here too.
+        disk.i_size = (meta.size & 0xffff_ffff) as u32;
+        // Don't clobber `i_dir_acl` on directories.
+    }
+    disk.set_uid(meta.uid);
+    disk.set_gid(meta.gid);
+    disk.i_atime = meta.atime;
+    disk.i_ctime = meta.ctime;
+    disk.i_mtime = meta.mtime;
+    disk.i_dtime = meta.dtime;
+    disk.i_links_count = meta.links_count;
+    disk.i_blocks = meta.i_blocks;
+    disk.i_flags = meta.flags;
+    disk.i_block = meta.i_block;
 }
 
 /// Merge overlapping / touching ranges in a sorted list into

--- a/kernel/src/fs/ext2/inode.rs
+++ b/kernel/src/fs/ext2/inode.rs
@@ -257,6 +257,13 @@ impl FileOps for Ext2Inode {
     fn read(&self, f: &OpenFile, buf: &mut [u8], off: u64) -> Result<usize, i64> {
         super::file::read_file_at(&f.inode, self, buf, off)
     }
+
+    /// Regular-file write with lazy indirect-block allocation. See
+    /// [`super::file::write_file_at`] for the normative pipeline and
+    /// ordering rules (RFC 0004 §Write extend + §Write Ordering).
+    fn write(&self, f: &OpenFile, buf: &[u8], off: u64) -> Result<usize, i64> {
+        super::file::write_file_at(&f.inode, self, buf, off)
+    }
 }
 
 /// Infer an [`InodeKind`] from the on-disk `i_mode` S_IFMT bits.

--- a/kernel/src/fs/ext2/mod.rs
+++ b/kernel/src/fs/ext2/mod.rs
@@ -91,7 +91,7 @@ pub use fs::{Ext2Fs, Ext2MountFlags, Ext2Super, SUPERBLOCK_BYTE_OFFSET};
 pub use inode::{iget, iget_root, Ext2FileOps, Ext2Inode, Ext2InodeMeta};
 
 #[cfg(all(feature = "ext2", target_os = "none"))]
-pub use file::read_file_at;
+pub use file::{read_file_at, write_file_at};
 
 #[cfg(all(feature = "ext2", target_os = "none"))]
 pub use orphan::{validate_orphan_chain, ForceRo};

--- a/kernel/tests/ext2_file_write.rs
+++ b/kernel/tests/ext2_file_write.rs
@@ -1,0 +1,461 @@
+//! Integration test for issue #567: ext2 `FileOps::write` extend path
+//! with lazy indirect-block allocation.
+//!
+//! RFC 0004 §Write extend + §Write Ordering. Mounts the 512 KiB
+//! `balloc_test.img` (two block groups of 256 blocks, 128 inodes, 1 KiB
+//! blocks) read-write, `alloc_inode`s a fresh inode, initialises its
+//! on-disk slot as a zero-length regular file, `iget`s it, then drives
+//! `FileOps::write` through a synthesised `OpenFile` against several
+//! extend patterns:
+//!
+//! - **Direct-only write (1 KiB)** — single direct slot, no indirect
+//!   allocation. Verifies `i_size` bumps, `i_blocks` bumps, data round-
+//!   trips through `FileOps::read`.
+//! - **Crosses direct→single-indirect (13 KiB)** — writes past the
+//!   12-direct boundary. Single-indirect pointer block is lazily
+//!   allocated and zeroed before link; the 13th logical block shows up
+//!   at a freshly-allocated data block.
+//! - **Sparse write past EOF** — writes one byte at offset 12 KiB on a
+//!   fresh inode; the bytes in `[0, 12 KiB)` read back as zeros (POSIX
+//!   sparse-file semantics), the byte at 12 KiB reads back as the
+//!   written value, and `i_size` reflects the offset + length.
+//! - **Append-style multi-call** — two successive writes grow the file
+//!   monotonically; the second write doesn't clobber the first.
+//! - **EROFS on RO mount** — `FileOps::write` on a read-only mount
+//!   returns `EROFS` without allocating anything.
+//! - **EISDIR on the root directory** — `FileOps::write` on the
+//!   directory inode rejects with `EISDIR`.
+//! - **ENOSPC propagates** — drain every free block, the next write
+//!   returns a short count (or `ENOSPC` when zero bytes committed).
+//!
+//! Each test starts from a fresh RamDisk copy of the fixture so
+//! mutations don't bleed between tests.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicU32, Ordering};
+
+use spin::Mutex;
+
+use vibix::block::{BlockDevice, BlockError};
+use vibix::fs::ext2::{alloc_block, alloc_inode, iget, Ext2Fs, Ext2Super};
+use vibix::fs::vfs::dentry::Dentry;
+use vibix::fs::vfs::inode::Inode;
+use vibix::fs::vfs::open_file::OpenFile;
+use vibix::fs::vfs::ops::{FileSystem as _, MountSource};
+use vibix::fs::vfs::super_block::{SbActiveGuard, SuperBlock};
+use vibix::fs::vfs::MountFlags;
+use vibix::fs::{EISDIR, ENOSPC, EROFS};
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+const BALLOC_IMG: &[u8; 524_288] = include_bytes!("../src/fs/ext2/fixtures/balloc_test.img");
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("write_small_direct", &(write_small_direct as fn())),
+        (
+            "write_crosses_single_indirect",
+            &(write_crosses_single_indirect as fn()),
+        ),
+        (
+            "write_sparse_past_eof_reads_zero_prefix",
+            &(write_sparse_past_eof_reads_zero_prefix as fn()),
+        ),
+        (
+            "write_append_grows_monotonically",
+            &(write_append_grows_monotonically as fn()),
+        ),
+        ("write_ro_mount_eros", &(write_ro_mount_eros as fn())),
+        (
+            "write_on_directory_returns_eisdir",
+            &(write_on_directory_returns_eisdir as fn()),
+        ),
+        (
+            "write_enospc_on_bitmap_exhaustion",
+            &(write_enospc_on_bitmap_exhaustion as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RamDisk — mirrors the copy in the other ext2 integration tests.
+// ---------------------------------------------------------------------------
+
+struct RamDisk {
+    block_size: u32,
+    storage: Mutex<Vec<u8>>,
+    writes: AtomicU32,
+}
+
+impl RamDisk {
+    fn from_image(bytes: &[u8], block_size: u32) -> Arc<Self> {
+        assert!(bytes.len() % block_size as usize == 0);
+        Arc::new(Self {
+            block_size,
+            storage: Mutex::new(bytes.to_vec()),
+            writes: AtomicU32::new(0),
+        })
+    }
+}
+
+impl BlockDevice for RamDisk {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
+        let bs = self.block_size as u64;
+        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
+            return Err(BlockError::BadAlign);
+        }
+        let storage = self.storage.lock();
+        let end = offset
+            .checked_add(buf.len() as u64)
+            .ok_or(BlockError::OutOfRange)?;
+        if end > storage.len() as u64 {
+            return Err(BlockError::OutOfRange);
+        }
+        let off = offset as usize;
+        buf.copy_from_slice(&storage[off..off + buf.len()]);
+        Ok(())
+    }
+    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
+        let bs = self.block_size as u64;
+        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
+            return Err(BlockError::BadAlign);
+        }
+        let mut storage = self.storage.lock();
+        let end = offset
+            .checked_add(buf.len() as u64)
+            .ok_or(BlockError::Enospc)?;
+        if end > storage.len() as u64 {
+            return Err(BlockError::Enospc);
+        }
+        let off = offset as usize;
+        storage[off..off + buf.len()].copy_from_slice(buf);
+        self.writes.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+    fn block_size(&self) -> u32 {
+        self.block_size
+    }
+    fn capacity(&self) -> u64 {
+        self.storage.lock().len() as u64
+    }
+}
+
+fn mount_rw() -> (Arc<SuperBlock>, Arc<Ext2Fs>, Arc<Ext2Super>) {
+    let disk = RamDisk::from_image(BALLOC_IMG.as_slice(), 512);
+    let fs = Ext2Fs::new_with_device(disk as Arc<dyn BlockDevice>);
+    let sb = fs
+        .mount(MountSource::None, MountFlags(0))
+        .expect("RW mount must succeed");
+    let super_arc = fs
+        .current_super()
+        .expect("current_super must upgrade after mount");
+    (sb, fs, super_arc)
+}
+
+fn mount_ro() -> (Arc<SuperBlock>, Arc<Ext2Fs>, Arc<Ext2Super>) {
+    let disk = RamDisk::from_image(BALLOC_IMG.as_slice(), 512);
+    let fs = Ext2Fs::new_with_device(disk as Arc<dyn BlockDevice>);
+    let sb = fs
+        .mount(MountSource::None, MountFlags::RDONLY)
+        .expect("RO mount must succeed");
+    let super_arc = fs
+        .current_super()
+        .expect("current_super must upgrade after mount");
+    (sb, fs, super_arc)
+}
+
+/// Stamp a freshly-allocated `ino`'s on-disk inode slot with a minimal
+/// regular-file layout: `i_mode = 0o100644`, `i_size = 0`, everything
+/// else zero. Flushes synchronously so a subsequent `iget` reads the
+/// new mode bits instead of whatever garbage the freed-file-or-zeroed
+/// slot previously held.
+fn init_reg_inode(super_arc: &Arc<Ext2Super>, ino: u32) {
+    use vibix::fs::ext2::disk::Ext2Inode as DiskInode;
+    let inodes_per_group = super_arc.sb_disk.lock().s_inodes_per_group;
+    let bg_inode_table =
+        super_arc.bgdt.lock()[((ino - 1) / inodes_per_group) as usize].bg_inode_table;
+    let block_size = super_arc.block_size;
+    let inode_size = super_arc.inode_size;
+    let index_in_group = (ino - 1) % inodes_per_group;
+    let byte_offset = (index_in_group as u64) * (inode_size as u64);
+    let block_in_table = byte_offset / (block_size as u64);
+    let offset_in_block = (byte_offset % (block_size as u64)) as usize;
+    let bh = super_arc
+        .cache
+        .bread(super_arc.device_id, bg_inode_table as u64 + block_in_table)
+        .expect("bread inode table");
+    {
+        let mut data = bh.data.write();
+        let slot_end = offset_in_block + 128;
+        // Zero the 128-byte prefix first so no garbage carries over.
+        for b in &mut data[offset_in_block..slot_end] {
+            *b = 0;
+        }
+        // Build a minimal disk inode: regular file, mode 0o644, zero
+        // size / blocks / links. `encode_to_slot` preserves the
+        // un-owned bytes after offset 100 verbatim from the zero fill.
+        let mut di = DiskInode::decode(&data[offset_in_block..slot_end]);
+        di.i_mode = 0o100644;
+        di.i_links_count = 1;
+        di.i_size = 0;
+        di.i_blocks = 0;
+        di.i_block = [0u32; 15];
+        di.encode_to_slot(&mut data[offset_in_block..slot_end]);
+    }
+    super_arc.cache.mark_dirty(&bh);
+    super_arc
+        .cache
+        .sync_dirty_buffer(&bh)
+        .expect("sync inode slot");
+}
+
+/// Build a minimal `OpenFile` for the given inode so we can route
+/// `FileOps::write` / `FileOps::read` calls through the real ops
+/// dispatch (matches the production `sys_write` / `sys_read` path).
+fn open_file(sb: &Arc<SuperBlock>, inode: Arc<Inode>) -> Arc<OpenFile> {
+    let dentry = Dentry::new_root(inode.clone());
+    let file_ops = inode.file_ops.clone();
+    let guard = SbActiveGuard::try_acquire(sb).expect("SbActiveGuard::try_acquire");
+    OpenFile::new(dentry, inode, file_ops, sb.clone(), 0, guard)
+}
+
+fn do_write(sb: &Arc<SuperBlock>, inode: &Arc<Inode>, buf: &[u8], off: u64) -> Result<usize, i64> {
+    let of = open_file(sb, inode.clone());
+    let r = of.ops.write(&of, buf, off);
+    drop(of);
+    r
+}
+
+fn do_read(
+    sb: &Arc<SuperBlock>,
+    inode: &Arc<Inode>,
+    buf: &mut [u8],
+    off: u64,
+) -> Result<usize, i64> {
+    let of = open_file(sb, inode.clone());
+    let r = of.ops.read(&of, buf, off);
+    drop(of);
+    r
+}
+
+/// Allocate a fresh inode on the mount and return an `Arc<Inode>`
+/// ready for `FileOps::write`. Stamps the on-disk slot so the mode
+/// bits parse as a regular file.
+fn fresh_regular(sb: &Arc<SuperBlock>, super_arc: &Arc<Ext2Super>) -> (u32, Arc<Inode>) {
+    let ino = alloc_inode(super_arc, Some(0), false).expect("alloc_inode");
+    init_reg_inode(super_arc, ino);
+    let inode = iget(super_arc, sb, ino).expect("iget fresh inode");
+    (ino, inode)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+fn write_small_direct() {
+    let (sb, _fs, super_arc) = mount_rw();
+    let (_ino, inode) = fresh_regular(&sb, &super_arc);
+
+    let data = b"hello ext2 write path #567\n";
+    let n = do_write(&sb, &inode, data, 0).expect("write");
+    assert_eq!(n, data.len());
+
+    // i_size bumped.
+    {
+        let m = inode.meta.read();
+        assert_eq!(m.size, data.len() as u64);
+        // One 1 KiB block allocated = 2 × 512-byte units.
+        assert_eq!(m.blocks, 2);
+    }
+
+    // Round-trip through read.
+    let mut buf = [0u8; 64];
+    let r = do_read(&sb, &inode, &mut buf, 0).expect("read back");
+    assert_eq!(r, data.len());
+    assert_eq!(&buf[..r], data);
+
+    drop(inode);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn write_crosses_single_indirect() {
+    let (sb, _fs, super_arc) = mount_rw();
+    let (_ino, inode) = fresh_regular(&sb, &super_arc);
+
+    // Block size is 1 KiB → direct slots cover logical blocks 0..=11
+    // (12 KiB). Write exactly 13 KiB so the 13th block (logical index
+    // 12) lands on the single-indirect chain.
+    let total = 13 * 1024usize;
+    let mut payload = vec![0u8; total];
+    for (i, b) in payload.iter_mut().enumerate() {
+        *b = (i & 0xff) as u8;
+    }
+    let n = do_write(&sb, &inode, &payload, 0).expect("write 13 KiB");
+    assert_eq!(n, total);
+
+    {
+        let m = inode.meta.read();
+        assert_eq!(m.size, total as u64);
+        // 13 data blocks + 1 single-indirect pointer block = 14 × 2 =
+        // 28 512-byte units.
+        assert_eq!(m.blocks, 28);
+    }
+
+    let mut buf = vec![0u8; total];
+    let r = do_read(&sb, &inode, &mut buf, 0).expect("read back 13 KiB");
+    assert_eq!(r, total);
+    assert_eq!(buf, payload);
+
+    drop(inode);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn write_sparse_past_eof_reads_zero_prefix() {
+    let (sb, _fs, super_arc) = mount_rw();
+    let (_ino, inode) = fresh_regular(&sb, &super_arc);
+
+    // Write 3 bytes at offset 8 KiB (logical block 8). Blocks 0..=7
+    // remain unallocated holes; a read of them returns zeros.
+    let payload = b"END";
+    let off = 8 * 1024u64;
+    let n = do_write(&sb, &inode, payload, off).expect("sparse write");
+    assert_eq!(n, payload.len());
+
+    {
+        let m = inode.meta.read();
+        assert_eq!(m.size, off + payload.len() as u64);
+        // Only one data block allocated (logical block 8), even
+        // though logical 0..=7 are addressable. 1 × 2 = 2 units.
+        assert_eq!(m.blocks, 2);
+    }
+
+    // Read [0, 8 KiB) — all zeros (holes).
+    let mut buf = vec![0xaau8; 8 * 1024];
+    let r = do_read(&sb, &inode, &mut buf, 0).expect("read hole");
+    assert_eq!(r, 8 * 1024);
+    assert!(buf.iter().all(|&b| b == 0), "sparse read must zero-fill");
+
+    // Read the live tail.
+    let mut tail = [0u8; 3];
+    let r = do_read(&sb, &inode, &mut tail, off).expect("read tail");
+    assert_eq!(r, 3);
+    assert_eq!(&tail, payload);
+
+    drop(inode);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn write_append_grows_monotonically() {
+    let (sb, _fs, super_arc) = mount_rw();
+    let (_ino, inode) = fresh_regular(&sb, &super_arc);
+
+    let first = b"first chunk of bytes ";
+    let second = b"second follows";
+    let n1 = do_write(&sb, &inode, first, 0).expect("write #1");
+    assert_eq!(n1, first.len());
+    let n2 = do_write(&sb, &inode, second, first.len() as u64).expect("write #2");
+    assert_eq!(n2, second.len());
+
+    let total = first.len() + second.len();
+    {
+        let m = inode.meta.read();
+        assert_eq!(m.size, total as u64);
+    }
+
+    let mut buf = vec![0u8; total];
+    let r = do_read(&sb, &inode, &mut buf, 0).expect("read back");
+    assert_eq!(r, total);
+    assert_eq!(&buf[..first.len()], first);
+    assert_eq!(&buf[first.len()..], second);
+
+    drop(inode);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn write_ro_mount_eros() {
+    // Mount RO, stamp a regular-file inode via the buffer cache (which
+    // doesn't itself honor RDONLY — it writes straight to the backing
+    // device), `iget` it, and verify `FileOps::write` short-circuits on
+    // `EROFS` before touching any allocator.
+    let (sb, _fs, super_arc) = mount_ro();
+    init_reg_inode(&super_arc, 12);
+    let inode = iget(&super_arc, &sb, 12).expect("iget fabricated reg");
+    let r = do_write(&sb, &inode, b"nope", 0);
+    assert_eq!(
+        r,
+        Err(EROFS),
+        "FileOps::write on RO mount must return EROFS"
+    );
+
+    drop(inode);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn write_on_directory_returns_eisdir() {
+    let (sb, _fs, super_arc) = mount_rw();
+    let root = iget(&super_arc, &sb, 2).expect("iget root");
+    let r = do_write(&sb, &root, b"nope", 0);
+    assert_eq!(r, Err(EISDIR));
+
+    drop(root);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn write_enospc_on_bitmap_exhaustion() {
+    let (sb, _fs, super_arc) = mount_rw();
+    let (_ino, inode) = fresh_regular(&sb, &super_arc);
+
+    // Drain every free block by calling alloc_block directly. Leaves
+    // the bitmap fully used so the next write from FileOps will fail
+    // its first allocation attempt.
+    loop {
+        match alloc_block(&super_arc, None) {
+            Ok(_) => {}
+            Err(ENOSPC) => break,
+            Err(e) => panic!("unexpected balloc error: {e}"),
+        }
+    }
+
+    // First write must fail outright — zero bytes committed means the
+    // caller gets the error directly rather than a partial count.
+    let r = do_write(&sb, &inode, b"no room at the inn", 0);
+    assert_eq!(r, Err(ENOSPC));
+
+    drop(inode);
+    sb.ops.unmount();
+    drop(super_arc);
+}


### PR DESCRIPTION
Closes #567

## Summary

- Implements `write_file_at` + wires `FileOps::write` for regular files on the ext2 driver. The walker mirrors the read path's direct / single / double / triple indirect topology but lazily allocates missing pointer blocks and data blocks along the way.
- Follows RFC 0004 §Write Ordering: each newly-allocated block is zeroed through the buffer cache before it is linked into its parent, and the inode slot flush (`i_size` / `i_blocks` / `mtime` / `ctime`) is the final step of a successful extend. A crash between alloc and link can never expose recycled bytes or a pointer that claims unwritten space.
- Partial-write safety: on allocator failure after bytes were already committed, the write returns the short count and still flushes the updated metadata; on first-block failure it returns the raw allocator error (`ENOSPC` / `EIO`). `RDONLY` / `FORCED_RDONLY` mounts short-circuit with `EROFS`; non-regular inodes return `EISDIR` / `EINVAL`.
- Exposes `write_file_at` from `fs::ext2` so integration tests can drive the path without routing through `sys_write`.

## Test plan

- [x] `cargo xtask build` (host + `x86_64-unknown-none`)
- [x] `cargo test --lib --features ext2` — 493 passed
- [x] `cargo test --package vibix --features ext2 --test ext2_file_write --target x86_64-unknown-none` — 7 passed (direct-only, cross-direct-to-single-indirect at 13 KiB, sparse past EOF with zero-fill, monotonic two-call append, EROFS on RO mount, EISDIR on directory, ENOSPC after draining block bitmap)
- [x] `cargo fmt --all` clean
- [ ] CI: full QEMU integration suite under `cargo xtask test`