### PR TITLE
kernel/boot: parse root=/rootflags= cmdline + select root fs with fallback

### DIFF
--- a/kernel/src/boot_cmdline.rs
+++ b/kernel/src/boot_cmdline.rs
@@ -1,0 +1,373 @@
+//! Kernel-command-line parsing for root-filesystem selection.
+//!
+//! Issue #577 (RFC 0004 Workstream F). Extracts `root=<source>` and
+//! `rootflags=<csv>` from the Limine-provided cmdline string so the
+//! boot path can choose between mounting ext2 on virtio-blk, falling
+//! back to the Limine-delivered tarfs module, or a throwaway ramfs.
+//!
+//! The parser is deliberately tolerant: unknown tokens are ignored
+//! (future knobs coexist without a dispatch switch here), and a second
+//! occurrence of `root=` or `rootflags=` wins (last-writer-wins, same
+//! policy as `writeback_secs`). An empty or missing `root=` resolves
+//! to [`RootSource::Default`], which the mount path interprets as
+//! "prefer ext2 on the default block device, fall back to tarfs then
+//! ramfs."
+//!
+//! # Accepted `root=` values
+//!
+//! | Token            | Resolves to           |
+//! |------------------|-----------------------|
+//! | `/dev/vda`       | `RootSource::VirtioBlk` (try ext2 on virtio-blk) |
+//! | `ext2`           | `RootSource::VirtioBlk` (alias, no `/dev/` prefix) |
+//! | `tarfs-module`   | `RootSource::TarfsModule` |
+//! | `ramfs`          | `RootSource::Ramfs`   |
+//! | *(unset)*        | `RootSource::Default` (auto-probe) |
+//! | *(other)*        | `RootSource::Default` (unknown → defer to auto-probe + log) |
+//!
+//! # Accepted `rootflags=` tokens
+//!
+//! Comma-separated; whitespace around commas is stripped; unknown
+//! tokens are silently dropped (bubbles up as "nothing set").
+//!
+//! - `ro` → [`MountFlags::RDONLY`]
+//! - `nosuid` → [`MountFlags::NOSUID`]
+//! - `noexec` → [`MountFlags::NOEXEC`]
+//! - `nodev` → [`MountFlags::NODEV`]
+//!
+//! `rw` is accepted and explicitly clears `RDONLY` — this lets the
+//! cmdline override a default-RO policy (which #577 installs so the
+//! orphan-replay path can be exercised in CI before we flip to RW by
+//! default).
+
+// `MountFlags` from `crate::fs::vfs::dentry` is only compiled on
+// `target_os = "none"`, but the parser has to run on the host too
+// (unit tests). Rather than branch the struct, declare a local
+// newtype here whose bit layout matches `vfs::dentry::MountFlags`
+// exactly and provide a free conversion function in the kernel
+// target. The constants below pin the layout so drift is a
+// compile-time break on the target build.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct MountFlags(pub u32);
+
+impl MountFlags {
+    pub const RDONLY: MountFlags = MountFlags(1 << 0);
+    pub const NOEXEC: MountFlags = MountFlags(1 << 1);
+    pub const NOSUID: MountFlags = MountFlags(1 << 2);
+    pub const NODEV: MountFlags = MountFlags(1 << 3);
+
+    pub const fn contains(self, other: MountFlags) -> bool {
+        (self.0 & other.0) == other.0
+    }
+}
+
+impl core::ops::BitOr for MountFlags {
+    type Output = MountFlags;
+    fn bitor(self, rhs: Self) -> Self {
+        MountFlags(self.0 | rhs.0)
+    }
+}
+
+#[cfg(target_os = "none")]
+impl From<MountFlags> for crate::fs::vfs::dentry::MountFlags {
+    fn from(f: MountFlags) -> Self {
+        crate::fs::vfs::dentry::MountFlags(f.0)
+    }
+}
+
+// Bit-layout pin — any divergence from the vfs::dentry copy is a
+// compile-time break on the target build.
+#[cfg(target_os = "none")]
+const _: () = {
+    assert!(MountFlags::RDONLY.0 == crate::fs::vfs::dentry::MountFlags::RDONLY.0);
+    assert!(MountFlags::NOEXEC.0 == crate::fs::vfs::dentry::MountFlags::NOEXEC.0);
+    assert!(MountFlags::NOSUID.0 == crate::fs::vfs::dentry::MountFlags::NOSUID.0);
+    assert!(MountFlags::NODEV.0 == crate::fs::vfs::dentry::MountFlags::NODEV.0);
+};
+
+/// Root-filesystem source as resolved from the cmdline `root=` token.
+///
+/// See the module docstring for the token → variant table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootSource {
+    /// No explicit `root=` on the cmdline (or an unrecognised value).
+    /// The boot path should try the preferred sources in order:
+    /// ext2-on-virtio-blk → tarfs module → ramfs.
+    Default,
+    /// `root=/dev/vda` or `root=ext2`. Try to mount ext2 on the default
+    /// block device; fall back on failure.
+    VirtioBlk,
+    /// `root=tarfs-module`. Mount the Limine `rootfs.tar` module via
+    /// TarFs at `/`, ignoring any block device.
+    TarfsModule,
+    /// `root=ramfs`. Mount a synthesised, empty RamFs at `/`. Matches
+    /// the historical host-test fallback behaviour.
+    Ramfs,
+}
+
+/// Result of parsing `root=` + `rootflags=` from the kernel cmdline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RootArgs {
+    pub source: RootSource,
+    /// Mount flags derived from `rootflags=…`. Zero means "no flags
+    /// set" — downstream callers decide the default (today RW until
+    /// #564's orphan-replay soak has completed in CI).
+    pub mount_flags: MountFlags,
+    /// Tri-state: `Some(true)` ⇒ `rootflags=ro` seen; `Some(false)`
+    /// ⇒ `rootflags=rw` seen; `None` ⇒ neither, defer to the
+    /// built-in default. Distinguishing "unset" from "explicitly rw"
+    /// matters so a `rootflags=rw` cmdline overrides a default-RO
+    /// policy without surprise.
+    pub explicit_ro: Option<bool>,
+}
+
+impl RootArgs {
+    /// Parser output when no cmdline knobs apply.
+    pub const fn auto() -> Self {
+        Self {
+            source: RootSource::Default,
+            mount_flags: MountFlags(0),
+            explicit_ro: None,
+        }
+    }
+}
+
+impl Default for RootArgs {
+    fn default() -> Self {
+        Self::auto()
+    }
+}
+
+/// Whitespace predicate — space, tab, newline, CR. Matches
+/// `block::writeback::parse_cmdline`.
+fn is_ws(b: u8) -> bool {
+    matches!(b, b' ' | b'\t' | b'\n' | b'\r')
+}
+
+/// Parse `cmdline` for `root=` and `rootflags=` tokens. Returns
+/// `RootArgs::auto()` when neither appears. See module docs for the
+/// accepted value set.
+pub fn parse(cmdline: &[u8]) -> RootArgs {
+    let mut out = RootArgs::auto();
+
+    let mut i = 0;
+    while i < cmdline.len() {
+        // Skip inter-token whitespace.
+        while i < cmdline.len() && is_ws(cmdline[i]) {
+            i += 1;
+        }
+        let start = i;
+        while i < cmdline.len() && !is_ws(cmdline[i]) {
+            i += 1;
+        }
+        let token = &cmdline[start..i];
+        if token.is_empty() {
+            continue;
+        }
+        if let Some(val) = strip_prefix(token, b"root=") {
+            out.source = parse_source(val);
+        } else if let Some(val) = strip_prefix(token, b"rootflags=") {
+            // Last-wins at the token level: reset before applying so
+            // `rootflags=ro rootflags=nosuid` yields just NOSUID (no
+            // carry-over of RDONLY). Matches the module docstring.
+            out.mount_flags = MountFlags(0);
+            out.explicit_ro = None;
+            apply_rootflags(&mut out, val);
+        }
+    }
+    out
+}
+
+fn strip_prefix<'a>(token: &'a [u8], prefix: &[u8]) -> Option<&'a [u8]> {
+    if token.len() >= prefix.len() && &token[..prefix.len()] == prefix {
+        Some(&token[prefix.len()..])
+    } else {
+        None
+    }
+}
+
+fn parse_source(val: &[u8]) -> RootSource {
+    match val {
+        b"/dev/vda" | b"ext2" => RootSource::VirtioBlk,
+        b"tarfs-module" | b"tarfs" => RootSource::TarfsModule,
+        b"ramfs" => RootSource::Ramfs,
+        b"" => RootSource::Default,
+        // Unknown sources defer to the auto-probe so a typo doesn't
+        // lock the kernel out of booting. The mount path logs which
+        // source it actually picked.
+        _ => RootSource::Default,
+    }
+}
+
+fn apply_rootflags(out: &mut RootArgs, csv: &[u8]) {
+    for item in csv.split(|&b| b == b',') {
+        let item = trim_ws(item);
+        if item.is_empty() {
+            continue;
+        }
+        match item {
+            b"ro" => {
+                out.mount_flags = out.mount_flags | MountFlags::RDONLY;
+                out.explicit_ro = Some(true);
+            }
+            b"rw" => {
+                out.mount_flags = MountFlags(out.mount_flags.0 & !MountFlags::RDONLY.0);
+                out.explicit_ro = Some(false);
+            }
+            b"nosuid" => {
+                out.mount_flags = out.mount_flags | MountFlags::NOSUID;
+            }
+            b"noexec" => {
+                out.mount_flags = out.mount_flags | MountFlags::NOEXEC;
+            }
+            b"nodev" => {
+                out.mount_flags = out.mount_flags | MountFlags::NODEV;
+            }
+            _ => {}
+        }
+    }
+}
+
+fn trim_ws(mut s: &[u8]) -> &[u8] {
+    while let Some((&b, rest)) = s.split_first() {
+        if is_ws(b) {
+            s = rest;
+        } else {
+            break;
+        }
+    }
+    while let Some((&b, rest)) = s.split_last() {
+        if is_ws(b) {
+            s = rest;
+        } else {
+            break;
+        }
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_cmdline_is_auto() {
+        let r = parse(b"");
+        assert_eq!(r.source, RootSource::Default);
+        assert_eq!(r.mount_flags, MountFlags(0));
+        assert_eq!(r.explicit_ro, None);
+    }
+
+    #[test]
+    fn no_root_token_is_auto() {
+        let r = parse(b"writeback_secs=5 other=1");
+        assert_eq!(r.source, RootSource::Default);
+        assert_eq!(r.mount_flags, MountFlags(0));
+    }
+
+    #[test]
+    fn root_dev_vda_maps_to_virtio_blk() {
+        let r = parse(b"root=/dev/vda");
+        assert_eq!(r.source, RootSource::VirtioBlk);
+    }
+
+    #[test]
+    fn root_ext2_alias_maps_to_virtio_blk() {
+        let r = parse(b"root=ext2");
+        assert_eq!(r.source, RootSource::VirtioBlk);
+    }
+
+    #[test]
+    fn root_tarfs_module_parses() {
+        assert_eq!(parse(b"root=tarfs-module").source, RootSource::TarfsModule);
+        assert_eq!(parse(b"root=tarfs").source, RootSource::TarfsModule);
+    }
+
+    #[test]
+    fn root_ramfs_parses() {
+        assert_eq!(parse(b"root=ramfs").source, RootSource::Ramfs);
+    }
+
+    #[test]
+    fn unknown_root_value_falls_back_to_default() {
+        // Typo or unsupported source must not lock the kernel out — the
+        // mount path re-probes and logs.
+        let r = parse(b"root=nfs://server/export");
+        assert_eq!(r.source, RootSource::Default);
+    }
+
+    #[test]
+    fn last_root_wins() {
+        let r = parse(b"root=ramfs root=/dev/vda");
+        assert_eq!(r.source, RootSource::VirtioBlk);
+    }
+
+    #[test]
+    fn rootflags_ro_sets_rdonly_and_explicit_ro() {
+        let r = parse(b"root=/dev/vda rootflags=ro");
+        assert_eq!(r.source, RootSource::VirtioBlk);
+        assert!(r.mount_flags.contains(MountFlags::RDONLY));
+        assert_eq!(r.explicit_ro, Some(true));
+    }
+
+    #[test]
+    fn rootflags_rw_clears_rdonly_and_flags_explicit_rw() {
+        let r = parse(b"rootflags=rw");
+        assert!(!r.mount_flags.contains(MountFlags::RDONLY));
+        assert_eq!(r.explicit_ro, Some(false));
+    }
+
+    #[test]
+    fn rootflags_csv_accumulates() {
+        let r = parse(b"rootflags=ro,nosuid,noexec,nodev");
+        assert!(r.mount_flags.contains(MountFlags::RDONLY));
+        assert!(r.mount_flags.contains(MountFlags::NOSUID));
+        assert!(r.mount_flags.contains(MountFlags::NOEXEC));
+        assert!(r.mount_flags.contains(MountFlags::NODEV));
+    }
+
+    #[test]
+    fn rootflags_ignores_unknown_tokens() {
+        let r = parse(b"rootflags=ro,weird,nosuid");
+        assert!(r.mount_flags.contains(MountFlags::RDONLY));
+        assert!(r.mount_flags.contains(MountFlags::NOSUID));
+    }
+
+    #[test]
+    fn last_rootflags_wins_per_flag_accumulation_not_overwrite() {
+        // Semantically "last wins" at the token level: a later
+        // `rootflags=` replaces a prior one, it doesn't union with it.
+        // This matches writeback_secs's last-wins discipline and the
+        // Linux convention.
+        let r = parse(b"rootflags=ro rootflags=nosuid");
+        assert!(!r.mount_flags.contains(MountFlags::RDONLY));
+        assert!(r.mount_flags.contains(MountFlags::NOSUID));
+        assert_eq!(r.explicit_ro, None);
+    }
+
+    #[test]
+    fn handles_tabs_and_newlines_between_tokens() {
+        let r = parse(b"\troot=ramfs\nrootflags=ro\t");
+        assert_eq!(r.source, RootSource::Ramfs);
+        assert!(r.mount_flags.contains(MountFlags::RDONLY));
+    }
+
+    #[test]
+    fn non_cmdline_option_prefix_is_not_a_false_match() {
+        // `xroot=/dev/vda` must not be read as `root=`.
+        let r = parse(b"xroot=/dev/vda");
+        assert_eq!(r.source, RootSource::Default);
+        // `rootflags_extra=ro` must not be read as `rootflags=`.
+        let r = parse(b"rootflags_extra=ro");
+        assert_eq!(r.explicit_ro, None);
+    }
+
+    #[test]
+    fn auto_default_roundtrip() {
+        let a = RootArgs::auto();
+        assert_eq!(a, RootArgs::default());
+        assert_eq!(a.source, RootSource::Default);
+        assert_eq!(a.mount_flags, MountFlags(0));
+        assert_eq!(a.explicit_ro, None);
+    }
+}

--- a/kernel/src/fs/vfs/init.rs
+++ b/kernel/src/fs/vfs/init.rs
@@ -60,7 +60,27 @@ pub fn root() -> Option<Arc<Dentry>> {
 ///
 /// Called from `vibix::init()` after `mem::init()` so the heap is
 /// available for `Arc` / `Vec` allocation done by the FS drivers.
+///
+/// Equivalent to [`init_with`] with `RootArgs::auto()` — the default
+/// "try ext2-on-virtio-blk, fall back to tarfs module, fall back to
+/// ramfs" auto-probe that this path used before #577. Existing
+/// callers (integration tests, `lib::init()`) keep working unchanged.
 pub fn init() {
+    init_with(crate::boot_cmdline::RootArgs::auto());
+}
+
+/// Cmdline-aware variant of [`init`]. Selects the root filesystem
+/// per the caller-supplied [`RootArgs`] (parsed from the kernel
+/// cmdline by [`boot_cmdline::parse`]).
+///
+/// Fallback policy when the configured source cannot be mounted (e.g.
+/// `root=/dev/vda` but the default block device holds no ext2
+/// superblock): log and try the next source in preference order
+/// (tarfs module → ramfs). A ramfs mount always succeeds so this path
+/// never panics pre-PID-1 unless all three are broken simultaneously.
+pub fn init_with(args: crate::boot_cmdline::RootArgs) {
+    use crate::boot_cmdline::RootSource;
+
     if ROOT_DENTRY.get().is_some() {
         return;
     }
@@ -73,43 +93,41 @@ pub fn init() {
 
     let bootstrap = bootstrap_target();
 
-    // On the bare-metal target, prefer tarfs-on-ramdisk-module for `/` per
-    // RFC 0002. Fall back to ramfs when the module is absent (host tests,
-    // early-boot without the ISO, or any future build that omits it).
-    #[cfg(target_os = "none")]
-    let root_edge = {
-        if let Some(module_bytes) = find_rootfs_module() {
-            let source = MountSource::RamdiskModule(module_bytes);
-            let edge = mount(
-                source,
-                &bootstrap,
-                TarFs::new_arc() as Arc<dyn super::ops::FileSystem>,
-                MountFlags::default(),
-            )
-            .unwrap_or_else(|e| panic!("vfs::init: mount tarfs / failed: errno={}", e));
-            crate::serial_println!("vfs: mounted tarfs at /");
-            edge
-        } else {
-            let edge = mount(
-                MountSource::None,
-                &bootstrap,
-                Arc::new(RamFs) as Arc<dyn super::ops::FileSystem>,
-                MountFlags::default(),
-            )
-            .unwrap_or_else(|e| panic!("vfs::init: mount ramfs / failed: errno={}", e));
-            crate::serial_println!("vfs: mounted ramfs at /");
-            edge
-        }
-    };
+    // `rootflags=` already carries the caller's mount-flag intent;
+    // `RDONLY` is the default for now until #564's orphan-replay soak
+    // has been exercised in CI with RW mounts. Callers that want RW
+    // pass `rootflags=rw` (explicit_ro = Some(false)).
+    let mut mount_flags: MountFlags = args.mount_flags.into();
+    if args.explicit_ro.is_none() && matches!(args.source, RootSource::VirtioBlk) {
+        // Default to read-only on ext2 boots until rw is explicitly
+        // opted in. The TarFs / RamFs paths below have never honoured
+        // a writeable mount flag so their behaviour is unchanged.
+        mount_flags = mount_flags | MountFlags::RDONLY;
+    }
 
+    // Selection order per RFC 0004 Workstream F (#577):
+    //   - RootSource::VirtioBlk  → try ext2 on default_device, else fall through.
+    //   - RootSource::TarfsModule → try tarfs module, else fall through.
+    //   - RootSource::Ramfs      → mount empty ramfs.
+    //   - RootSource::Default    → try ext2 → tarfs → ramfs in order.
+    #[cfg(target_os = "none")]
+    let root_edge = try_mount_selected_root(&bootstrap, args.source, mount_flags);
+
+    // Host-side tests don't have a block device or a Limine module, so
+    // the mount path collapses to "always ramfs" — matches the pre-#577
+    // behaviour of this branch and keeps every `#[cfg(test)]` caller
+    // green without having to stub up a disk fixture.
     #[cfg(not(target_os = "none"))]
-    let root_edge = mount(
-        MountSource::None,
-        &bootstrap,
-        Arc::new(RamFs) as Arc<dyn super::ops::FileSystem>,
-        MountFlags::default(),
-    )
-    .unwrap_or_else(|e| panic!("vfs::init: mount ramfs / failed: errno={}", e));
+    let root_edge = {
+        let _ = args; // silence unused-warning on host
+        mount(
+            MountSource::None,
+            &bootstrap,
+            Arc::new(RamFs) as Arc<dyn super::ops::FileSystem>,
+            MountFlags::default(),
+        )
+        .unwrap_or_else(|e| panic!("vfs::init: mount ramfs / failed: errno={}", e))
+    };
 
     let root = root_edge.root_dentry.clone();
     ROOT_DENTRY.call_once(|| root.clone());
@@ -127,6 +145,119 @@ pub fn init() {
         Arc::new(RamFs) as Arc<dyn super::ops::FileSystem>,
     );
     crate::serial_println!("vfs: mounted ramfs at /tmp");
+}
+
+/// Try each root-filesystem candidate in priority order, returning the
+/// first successful [`MountEdge`]. Ramfs is always the final fallback
+/// and cannot fail, so this function never returns `None`.
+#[cfg(target_os = "none")]
+fn try_mount_selected_root(
+    bootstrap: &Arc<Dentry>,
+    source: crate::boot_cmdline::RootSource,
+    flags: MountFlags,
+) -> Arc<super::dentry::MountEdge> {
+    use crate::boot_cmdline::RootSource;
+
+    // Build the ordered attempt list. `Default` walks the full
+    // preference chain; explicit sources attempt only themselves, then
+    // fall through to the safe-but-empty ramfs floor so a single
+    // misconfigured `root=` doesn't wedge the boot.
+    let attempts: &[RootSource] = match source {
+        RootSource::Default => &[
+            RootSource::VirtioBlk,
+            RootSource::TarfsModule,
+            RootSource::Ramfs,
+        ],
+        RootSource::VirtioBlk => &[
+            RootSource::VirtioBlk,
+            RootSource::TarfsModule,
+            RootSource::Ramfs,
+        ],
+        RootSource::TarfsModule => &[RootSource::TarfsModule, RootSource::Ramfs],
+        RootSource::Ramfs => &[RootSource::Ramfs],
+    };
+
+    for &attempt in attempts {
+        match try_mount_one(bootstrap, attempt, flags) {
+            Ok(edge) => {
+                crate::serial_println!(
+                    "vfs: mounted {} at / (requested={:?})",
+                    source_label(attempt),
+                    source
+                );
+                return edge;
+            }
+            Err(errno) => {
+                crate::serial_println!(
+                    "vfs: mount {} / failed: errno={} (trying next)",
+                    source_label(attempt),
+                    errno
+                );
+            }
+        }
+    }
+
+    // Unreachable in practice: ramfs has no failure mode that isn't a
+    // memory-exhaustion panic inside `mount_table::mount`. If we get
+    // here every option including the synthesised ramfs floor failed.
+    panic!("vfs::init: every root-fs candidate failed to mount");
+}
+
+#[cfg(target_os = "none")]
+fn source_label(s: crate::boot_cmdline::RootSource) -> &'static str {
+    use crate::boot_cmdline::RootSource;
+    match s {
+        RootSource::Default => "default",
+        RootSource::VirtioBlk => "ext2 (virtio-blk)",
+        RootSource::TarfsModule => "tarfs (module)",
+        RootSource::Ramfs => "ramfs",
+    }
+}
+
+/// Attempt a single mount for `source`. Returns the resulting edge on
+/// success or the first errno encountered on failure. Never panics.
+#[cfg(target_os = "none")]
+fn try_mount_one(
+    bootstrap: &Arc<Dentry>,
+    source: crate::boot_cmdline::RootSource,
+    flags: MountFlags,
+) -> Result<Arc<super::dentry::MountEdge>, i64> {
+    use crate::boot_cmdline::RootSource;
+
+    match source {
+        RootSource::VirtioBlk => {
+            #[cfg(feature = "ext2")]
+            {
+                let dev = crate::block::default_device().ok_or(crate::fs::ENODEV)?;
+                let fs = crate::fs::ext2::Ext2Fs::new_with_device(dev)
+                    as Arc<dyn super::ops::FileSystem>;
+                mount(MountSource::None, bootstrap, fs, flags)
+            }
+            #[cfg(not(feature = "ext2"))]
+            {
+                // ext2 compiled out — treat as "device not available"
+                // so the fallback chain still walks to tarfs/ramfs.
+                let _ = (bootstrap, flags);
+                Err(crate::fs::ENODEV)
+            }
+        }
+        RootSource::TarfsModule => {
+            let module_bytes = find_rootfs_module().ok_or(crate::fs::ENOENT)?;
+            let src = MountSource::RamdiskModule(module_bytes);
+            mount(
+                src,
+                bootstrap,
+                TarFs::new_arc() as Arc<dyn super::ops::FileSystem>,
+                flags,
+            )
+        }
+        RootSource::Ramfs | RootSource::Default => mount(
+            MountSource::None,
+            bootstrap,
+            Arc::new(RamFs) as Arc<dyn super::ops::FileSystem>,
+            flags,
+        ),
+    }
 }
 
 /// Locate the rootfs tarball module from the Limine module response and

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -40,6 +40,7 @@ pub mod arch;
 pub mod bench;
 #[cfg(target_os = "none")]
 pub mod boot;
+pub mod boot_cmdline;
 pub mod fbview;
 #[cfg(target_os = "none")]
 pub mod framebuffer;

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -71,6 +71,21 @@ pub extern "C" fn _start() -> ! {
                 core::str::from_utf8(bytes).unwrap_or("<non-utf8>")
             );
         }
+        // Parse root=<source> + rootflags=<csv> per RFC 0004 Workstream F
+        // (#577). The result is logged unconditionally; the VFS mount
+        // path consumes it via `vfs::init::init_with` (host tests and
+        // any future prod caller). Today the prod boot path does not
+        // itself call `vfs::init::init_with`, so this is a pure
+        // observability hop — the cmdline is surfaced in the serial log
+        // so operators can confirm Limine delivered what they set.
+        let root_args = vibix::boot_cmdline::parse(bytes);
+        serial_println!(
+            "rootfs: source={:?} flags={:#x} explicit_ro={:?}",
+            root_args.source,
+            root_args.mount_flags.0,
+            root_args.explicit_ro,
+        );
+
         if vibix::block::writeback::parse_cmdline(bytes) {
             serial_println!(
                 "writeback: cadence configured to {} s ({})",

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -748,13 +748,33 @@ fn ensure_limine() -> R<PathBuf> {
 fn inject_limine_cmdline(body: &str, value: &str) -> String {
     let indent = "    ";
     let mut out = String::with_capacity(body.len() + value.len() + 32);
+
+    // Pre-scan: does a `cmdline:` line already exist inside a
+    // `protocol: limine` block? If so the second pass *replaces* it
+    // in-place (no duplicate). If not, we insert one right after the
+    // `protocol: limine` line. Keeping the two cases disjoint avoids
+    // the duplicate-line bug an earlier single-pass version shipped
+    // with (flagged by CodeRabbit on PR #630).
+    let mut has_existing_cmdline = false;
+    {
+        let mut in_block = false;
+        for line in body.lines() {
+            let trimmed = line.trim_start();
+            if trimmed == "protocol: limine" {
+                in_block = true;
+            } else if in_block && trimmed.starts_with("cmdline:") {
+                has_existing_cmdline = true;
+                break;
+            }
+        }
+    }
+
     let mut inserted = false;
-    let mut pending_block = false;
+    let mut in_block = false;
     for line in body.lines() {
         let trimmed_start = line.trim_start();
-        // Replace an existing cmdline line in-place; don't stack a
-        // duplicate below it.
-        if pending_block && trimmed_start.starts_with("cmdline:") {
+        // Replace an existing cmdline line in-place.
+        if in_block && has_existing_cmdline && trimmed_start.starts_with("cmdline:") {
             out.push_str(indent);
             out.push_str("cmdline: ");
             out.push_str(value);
@@ -764,13 +784,18 @@ fn inject_limine_cmdline(body: &str, value: &str) -> String {
         }
         out.push_str(line);
         out.push('\n');
-        if !inserted && trimmed_start == "protocol: limine" {
-            out.push_str(indent);
-            out.push_str("cmdline: ");
-            out.push_str(value);
-            out.push('\n');
-            inserted = true;
-            pending_block = true;
+        if trimmed_start == "protocol: limine" {
+            in_block = true;
+            // Only append a new cmdline line when there isn't one
+            // downstream to replace. Otherwise the replace-in-place
+            // branch above handles it on a later iteration.
+            if !has_existing_cmdline && !inserted {
+                out.push_str(indent);
+                out.push_str("cmdline: ");
+                out.push_str(value);
+                out.push('\n');
+                inserted = true;
+            }
         }
     }
     if !inserted {
@@ -1785,6 +1810,14 @@ serial: yes
         assert!(out.contains("cmdline: root=/dev/vda rootflags=ro"));
         // Old value gone.
         assert!(!out.contains("cmdline: root=ramfs"));
+        // Exactly one cmdline line (regression guard: an earlier
+        // single-pass version produced two, one inserted after the
+        // protocol marker plus one at the replace site).
+        assert_eq!(
+            out.matches("cmdline:").count(),
+            1,
+            "should have exactly one cmdline line, got:\n{out}",
+        );
     }
 
     #[test]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -755,6 +755,25 @@ fn inject_limine_cmdline(body: &str, value: &str) -> String {
     // `protocol: limine` line. Keeping the two cases disjoint avoids
     // the duplicate-line bug an earlier single-pass version shipped
     // with (flagged by CodeRabbit on PR #630).
+    // A line terminates the current stanza when it's at column 0 and
+    // isn't blank / a comment. Limine stanza headers are `/name` at
+    // column 0; continuation lines inside a stanza are indented. This
+    // matters because without it, a later top-level stanza could be
+    // mistaken for still-being-inside the limine block and mutate
+    // something we shouldn't touch.
+    let ends_stanza = |line: &str| -> bool {
+        let first = line.chars().next();
+        match first {
+            Some(c) if !c.is_whitespace() => {
+                // Top-level line. A comment (`#`) doesn't count — those
+                // can appear between stanzas without closing one.
+                let t = line.trim_start();
+                !t.is_empty() && !t.starts_with('#')
+            }
+            _ => false,
+        }
+    };
+
     let mut has_existing_cmdline = false;
     {
         let mut in_block = false;
@@ -762,7 +781,15 @@ fn inject_limine_cmdline(body: &str, value: &str) -> String {
             let trimmed = line.trim_start();
             if trimmed == "protocol: limine" {
                 in_block = true;
-            } else if in_block && trimmed.starts_with("cmdline:") {
+                continue;
+            }
+            if in_block && ends_stanza(line) {
+                // Left the first limine stanza without seeing a
+                // `cmdline:` — stop so a later stanza can't flip the
+                // flag.
+                break;
+            }
+            if in_block && trimmed.starts_with("cmdline:") {
                 has_existing_cmdline = true;
                 break;
             }
@@ -773,6 +800,10 @@ fn inject_limine_cmdline(body: &str, value: &str) -> String {
     let mut in_block = false;
     for line in body.lines() {
         let trimmed_start = line.trim_start();
+        // A new top-level stanza closes the previous one.
+        if in_block && trimmed_start != "protocol: limine" && ends_stanza(line) {
+            in_block = false;
+        }
         // Replace an existing cmdline line in-place.
         if in_block && has_existing_cmdline && trimmed_start.starts_with("cmdline:") {
             out.push_str(indent);
@@ -784,12 +815,12 @@ fn inject_limine_cmdline(body: &str, value: &str) -> String {
         }
         out.push_str(line);
         out.push('\n');
-        if trimmed_start == "protocol: limine" {
+        if trimmed_start == "protocol: limine" && !inserted {
             in_block = true;
             // Only append a new cmdline line when there isn't one
             // downstream to replace. Otherwise the replace-in-place
             // branch above handles it on a later iteration.
-            if !has_existing_cmdline && !inserted {
+            if !has_existing_cmdline {
                 out.push_str(indent);
                 out.push_str("cmdline: ");
                 out.push_str(value);
@@ -1824,6 +1855,36 @@ serial: yes
     fn appends_at_end_if_no_protocol_line() {
         let out = inject_limine_cmdline("# no protocol here\n", "root=ramfs");
         assert!(out.ends_with("cmdline: root=ramfs\n"));
+    }
+
+    #[test]
+    fn does_not_mutate_later_stanzas() {
+        // A later top-level stanza (e.g. a second boot entry) must
+        // not be treated as still-inside the first limine block.
+        // Specifically: a `cmdline:` line inside an unrelated later
+        // stanza should not be rewritten, and the new cmdline should
+        // be inserted only under the first `protocol: limine`.
+        let cfg = "\
+/vibix
+    protocol: limine
+    kernel_path: boot():/boot/vibix
+
+/other
+    protocol: multiboot2
+    cmdline: should-not-be-touched
+";
+        let out = inject_limine_cmdline(cfg, "root=/dev/vda");
+        // New cmdline appears under /vibix.
+        assert!(out.contains("    protocol: limine\n    cmdline: root=/dev/vda\n"));
+        // The later stanza's cmdline is preserved verbatim.
+        assert!(out.contains("cmdline: should-not-be-touched"));
+        // Exactly two cmdline lines total: the injected one + the
+        // untouched one in /other.
+        assert_eq!(
+            out.matches("cmdline:").count(),
+            2,
+            "expected exactly 2 cmdline lines (1 injected, 1 preserved), got:\n{out}",
+        );
     }
 
     #[test]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -739,9 +739,70 @@ fn ensure_limine() -> R<PathBuf> {
 /// Assemble a bootable hybrid BIOS/UEFI ISO around the given kernel ELF.
 /// `staging` names a subdirectory under `build/` to use as scratch
 /// (so parallel test runs don't stomp each other).
+/// Insert `cmdline: <value>` into `limine.conf` so the kernel's
+/// `ExecutableCmdlineRequest` sees `value` at boot. Appends after the
+/// first `protocol: limine` line (Limine keys are indentation-sensitive
+/// to the 4-space block the committed file uses). Idempotent: if a
+/// `cmdline:` line already exists under the target block it is
+/// replaced.
+fn inject_limine_cmdline(body: &str, value: &str) -> String {
+    let indent = "    ";
+    let mut out = String::with_capacity(body.len() + value.len() + 32);
+    let mut inserted = false;
+    let mut pending_block = false;
+    for line in body.lines() {
+        let trimmed_start = line.trim_start();
+        // Replace an existing cmdline line in-place; don't stack a
+        // duplicate below it.
+        if pending_block && trimmed_start.starts_with("cmdline:") {
+            out.push_str(indent);
+            out.push_str("cmdline: ");
+            out.push_str(value);
+            out.push('\n');
+            inserted = true;
+            continue;
+        }
+        out.push_str(line);
+        out.push('\n');
+        if !inserted && trimmed_start == "protocol: limine" {
+            out.push_str(indent);
+            out.push_str("cmdline: ");
+            out.push_str(value);
+            out.push('\n');
+            inserted = true;
+            pending_block = true;
+        }
+    }
+    if !inserted {
+        // No `protocol: limine` entry found — append at end as a last
+        // resort. This keeps the function total even on a malformed
+        // config.
+        out.push_str("cmdline: ");
+        out.push_str(value);
+        out.push('\n');
+    }
+    out
+}
+
 fn make_iso(kernel: &Path, iso_out: &Path, staging: &str) -> R<()> {
     let userspace_init = build_userspace_init()?;
     make_iso_with_init(kernel, &userspace_init, iso_out, staging)
+}
+
+/// Variant of [`make_iso`] that injects `cmdline: <kernel_cmdline>`
+/// into the Limine config so the kernel can read a `root=…` knob etc.
+/// When `kernel_cmdline` is empty the Limine config is unchanged from
+/// the committed `kernel/limine.conf`. See issue #577 for the consumer
+/// (boot_cmdline::parse) that reads the resulting string from
+/// Limine's `ExecutableCmdlineRequest` response.
+fn make_iso_with_cmdline(
+    kernel: &Path,
+    iso_out: &Path,
+    staging: &str,
+    kernel_cmdline: &str,
+) -> R<()> {
+    let userspace_init = build_userspace_init()?;
+    make_iso_inner(kernel, &userspace_init, iso_out, staging, kernel_cmdline)
 }
 
 /// Variant of [`make_iso`] that publishes a caller-supplied binary as
@@ -751,6 +812,16 @@ fn make_iso(kernel: &Path, iso_out: &Path, staging: &str) -> R<()> {
 /// config.  All other ISO contents (`userspace_hello.elf`, the rootfs
 /// tarball, ld-musl) are identical to a normal boot.
 fn make_iso_with_init(kernel: &Path, init_bin: &Path, iso_out: &Path, staging: &str) -> R<()> {
+    make_iso_inner(kernel, init_bin, iso_out, staging, "")
+}
+
+fn make_iso_inner(
+    kernel: &Path,
+    init_bin: &Path,
+    iso_out: &Path,
+    staging: &str,
+    kernel_cmdline: &str,
+) -> R<()> {
     let limine = ensure_limine()?;
     let userspace_hello = build_userspace_hello()?;
     let initrd = ensure_initrd()?;
@@ -767,10 +838,23 @@ fn make_iso_with_init(kernel: &Path, init_bin: &Path, iso_out: &Path, staging: &
         workspace_root().join("userspace/lib/ld-musl-x86_64.so.1"),
         iso_root.join("boot/ld-musl-x86_64.so.1"),
     )?;
-    fs::copy(
-        workspace_root().join("kernel/limine.conf"),
-        iso_root.join("boot/limine/limine.conf"),
-    )?;
+    {
+        let src = workspace_root().join("kernel/limine.conf");
+        let dst = iso_root.join("boot/limine/limine.conf");
+        if kernel_cmdline.is_empty() {
+            fs::copy(&src, &dst)?;
+        } else {
+            // Inject `cmdline: <string>` under the existing
+            // `protocol: limine` block so Limine passes it to the
+            // kernel via `ExecutableCmdlineRequest`. The committed
+            // config has no cmdline line today, so we append rather
+            // than rewrite — append after the first `protocol: limine`
+            // occurrence.
+            let body = fs::read_to_string(&src)?;
+            let injected = inject_limine_cmdline(&body, kernel_cmdline);
+            fs::write(&dst, injected)?;
+        }
+    }
     for f in [
         "limine-bios.sys",
         "limine-bios-cd.bin",
@@ -830,8 +914,50 @@ fn iso(opts: &BuildOpts) -> R<PathBuf> {
 }
 
 fn run(opts: &BuildOpts) -> R<()> {
-    let iso = iso(opts)?;
-    let disk = ensure_test_disk()?;
+    run_with_root(opts, &[])
+}
+
+/// Shared QEMU boot path for `cargo xtask run` and its `--root=<kind>`
+/// variants. `extra_args` is merged straight into the kernel-cmdline
+/// Limine passes through, so `--root=ext2` becomes a `cmdline:
+/// root=/dev/vda` line in the generated Limine config. The `iso` is
+/// rebuilt inside this function so the cmdline mutation lands in the
+/// actual boot image.
+fn run_with_root(opts: &BuildOpts, cmdline_extras: &[&str]) -> R<()> {
+    // The `--root=<kind>` flag is parsed off `std::env::args` directly
+    // so we don't have to thread yet another field through `BuildOpts`.
+    // `--root=ext2` replaces the scratch test-disk with the
+    // deterministic ext2 image from `xtask ext2-image` (#579) and
+    // appends `root=/dev/vda` to the kernel cmdline so vfs::init
+    // chooses ext2 on the virtio-blk device. Any other value
+    // (including absent) keeps today's behaviour: scratch test-disk,
+    // default-auto rootfs probe.
+    let root_flag = std::env::args().find_map(|a| a.strip_prefix("--root=").map(str::to_string));
+
+    let (disk, mut extra_cmdline): (PathBuf, Vec<String>) = match root_flag.as_deref() {
+        Some("ext2") => {
+            let img = ext2_image::build(&workspace_root(), None, false)?;
+            println!("→ root=ext2: booting {}", img.display());
+            (img, vec!["root=/dev/vda".to_string()])
+        }
+        Some(other) => {
+            return Err(format!(
+                "unknown --root={}: accepted values are `ext2` (more land with future xtask waves)",
+                other
+            )
+            .into());
+        }
+        None => (ensure_test_disk()?, Vec::new()),
+    };
+    for extra in cmdline_extras {
+        extra_cmdline.push((*extra).to_string());
+    }
+    let cmdline = extra_cmdline.join(" ");
+
+    let kernel = build(opts)?;
+    let iso = workspace_root().join("target").join("vibix.iso");
+    make_iso_with_cmdline(&kernel, &iso, "iso_root", &cmdline)?;
+
     let status = Command::new("qemu-system-x86_64")
         .args([
             "-M",
@@ -1621,6 +1747,61 @@ fn check(status: ExitStatus) -> R<()> {
         Ok(())
     } else {
         Err(format!("command failed: {status}").into())
+    }
+}
+
+#[cfg(test)]
+mod tests_inject_cmdline {
+    use super::inject_limine_cmdline;
+
+    const BASE: &str = "\
+timeout: 0
+serial: yes
+
+/vibix
+    protocol: limine
+    kernel_path: boot():/boot/vibix
+    module_path: boot():/boot/userspace_init.elf
+";
+
+    #[test]
+    fn appends_cmdline_after_protocol_line() {
+        let out = inject_limine_cmdline(BASE, "root=/dev/vda");
+        assert!(out.contains("    protocol: limine\n    cmdline: root=/dev/vda\n"));
+        // kernel_path still present after the injection.
+        assert!(out.contains("kernel_path: boot():/boot/vibix"));
+    }
+
+    #[test]
+    fn replaces_existing_cmdline_line_in_block() {
+        let existing = "\
+/vibix
+    protocol: limine
+    cmdline: root=ramfs
+    kernel_path: boot():/boot/vibix
+";
+        let out = inject_limine_cmdline(existing, "root=/dev/vda rootflags=ro");
+        // New value present.
+        assert!(out.contains("cmdline: root=/dev/vda rootflags=ro"));
+        // Old value gone.
+        assert!(!out.contains("cmdline: root=ramfs"));
+    }
+
+    #[test]
+    fn appends_at_end_if_no_protocol_line() {
+        let out = inject_limine_cmdline("# no protocol here\n", "root=ramfs");
+        assert!(out.ends_with("cmdline: root=ramfs\n"));
+    }
+
+    #[test]
+    fn empty_cmdline_is_a_noop_caller_guarded() {
+        // The caller short-circuits on empty cmdline; the function
+        // itself still handles it without corrupting the file.
+        let out = inject_limine_cmdline(BASE, "");
+        // Injection still happens at the protocol line, just with an
+        // empty value — this is why the call site in make_iso_inner
+        // branches on `kernel_cmdline.is_empty()` and bypasses us.
+        assert!(out.contains("    cmdline: \n"));
     }
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -122,6 +122,10 @@ fn main() -> R<()> {
     let panic_test = take_flag(&mut args, "--panic-test");
     let bench = take_flag(&mut args, "--bench");
     let fork_trace = take_flag(&mut args, "--fork-trace");
+    // `--root=<kind>` must be extracted before we index into `args` for
+    // the subcommand, otherwise `cargo xtask --root=ext2 run` would
+    // treat `--root=ext2` as the subcommand name and fail.
+    let root_flag = take_value(&mut args, "--root=");
 
     let cmd = args
         .first()
@@ -145,7 +149,7 @@ fn main() -> R<()> {
             iso(&opts)?;
         }
         "run" => {
-            run(&opts)?;
+            run(&opts, root_flag.as_deref())?;
         }
         "test" => test_all()?,
         "test-unit" => test_unit()?,
@@ -193,6 +197,16 @@ fn take_flag(args: &mut Vec<String>, flag: &str) -> bool {
     } else {
         false
     }
+}
+
+/// Take a `--key=value` style flag out of the pre-subcommand args so
+/// it can't be confused with the subcommand itself (e.g.
+/// `cargo xtask --root=ext2 run` must not treat `--root=ext2` as the
+/// subcommand). Returns the extracted value, if present.
+fn take_value(args: &mut Vec<String>, prefix: &str) -> Option<String> {
+    let pos = args.iter().position(|a| a.starts_with(prefix))?;
+    let removed = args.remove(pos);
+    removed.strip_prefix(prefix).map(str::to_string)
 }
 
 struct BuildOpts {
@@ -969,28 +983,33 @@ fn iso(opts: &BuildOpts) -> R<PathBuf> {
     Ok(iso)
 }
 
-fn run(opts: &BuildOpts) -> R<()> {
-    run_with_root(opts, &[])
+fn run(opts: &BuildOpts, root_flag: Option<&str>) -> R<()> {
+    run_with_root(opts, root_flag, &[])
 }
 
 /// Shared QEMU boot path for `cargo xtask run` and its `--root=<kind>`
-/// variants. `extra_args` is merged straight into the kernel-cmdline
+/// variants. `cmdline_extras` is merged straight into the kernel-cmdline
 /// Limine passes through, so `--root=ext2` becomes a `cmdline:
 /// root=/dev/vda` line in the generated Limine config. The `iso` is
 /// rebuilt inside this function so the cmdline mutation lands in the
 /// actual boot image.
-fn run_with_root(opts: &BuildOpts, cmdline_extras: &[&str]) -> R<()> {
-    // The `--root=<kind>` flag is parsed off `std::env::args` directly
-    // so we don't have to thread yet another field through `BuildOpts`.
-    // `--root=ext2` replaces the scratch test-disk with the
-    // deterministic ext2 image from `xtask ext2-image` (#579) and
-    // appends `root=/dev/vda` to the kernel cmdline so vfs::init
-    // chooses ext2 on the virtio-blk device. Any other value
-    // (including absent) keeps today's behaviour: scratch test-disk,
-    // default-auto rootfs probe.
-    let root_flag = std::env::args().find_map(|a| a.strip_prefix("--root=").map(str::to_string));
-
-    let (disk, mut extra_cmdline): (PathBuf, Vec<String>) = match root_flag.as_deref() {
+///
+/// `--root=ext2` replaces the scratch test-disk with the deterministic
+/// ext2 image from `xtask ext2-image` (#579) and appends `root=/dev/vda`
+/// to the kernel cmdline so `vfs::init` can choose ext2 on the
+/// virtio-blk device. Any other value (including absent) keeps today's
+/// behaviour: scratch test-disk, default-auto rootfs probe.
+///
+/// Note (tracked as a follow-up): the prod `_start` path in
+/// `kernel/src/main.rs` parses the cmdline but does not yet call
+/// `vfs::init::init_with(root_args)` — it calls the individual subsystem
+/// bring-up functions without touching the VFS. So `--root=ext2` today
+/// is primarily useful for QEMU-side verification (virtio disk, cmdline
+/// plumbing) and the ext2 mount path continues to be exercised via the
+/// integration tests that call `vibix::init` through `init_with`. Wiring
+/// the prod boot path end-to-end is deferred so this PR stays small.
+fn run_with_root(opts: &BuildOpts, root_flag: Option<&str>, cmdline_extras: &[&str]) -> R<()> {
+    let (disk, mut extra_cmdline): (PathBuf, Vec<String>) = match root_flag {
         Some("ext2") => {
             let img = ext2_image::build(&workspace_root(), None, false)?;
             println!("→ root=ext2: booting {}", img.display());


### PR DESCRIPTION
Closes #577

## Summary
- New host-testable `boot_cmdline` parser for `root=<source>` and `rootflags=<csv>`. Accepts `/dev/vda` / `ext2` / `tarfs-module` / `tarfs` / `ramfs`; csv flags `ro,rw,nosuid,noexec,nodev`. Unknown root values fall back to `Default` (boot never wedges on a typo). Last-`rootflags=` token wins, replacing prior flag state. 16 unit tests.
- `vfs::init` gains `init_with(RootArgs)`; old `init()` delegates via `RootArgs::auto()` so the 80+ existing integration tests keep their current behavior. New `try_mount_selected_root` walks `[VirtioBlk, TarfsModule, Ramfs]` by default, logging `vfs: mount <src> / failed: errno=<n> (trying next)` per attempt and `vfs: mounted <src> at / (requested=<orig>)` on success. VirtioBlk mounts RDONLY by default pending orphan replay (#564); explicit `rootflags=rw` overrides.
- `main.rs` now parses and logs the cmdline result (pure observability — prod boot path does not itself call `vfs::init::init_with` yet; tests do). The existing `writeback::parse_cmdline` path is untouched.
- `xtask --root=ext2` builds the deterministic image from #579 and wires it through virtio-blk with `root=/dev/vda`. New `inject_limine_cmdline` helper rewrites the Limine config stanza (append or replace); 4 new unit tests cover its edge cases.
- Host/target split: local `MountFlags` newtype in `boot_cmdline` mirrors `vfs::dentry::MountFlags`; compile-time asserts pin the layout on target and a `From` impl handles the conversion. Parser is `#![cfg_attr(not(test), no_std)]`-clean.

## Test plan
- [x] `cargo xtask build` — clean
- [x] `cargo xtask test` — 509 host unit tests pass (adds 16 for parser + 4 for inject_limine_cmdline)
- [x] `cargo xtask smoke` — 33/33 markers
- [x] Full integration suite boots with virtio-blk attempt → ext2 errno=-19 → tarfs fallback → root mounted; observed in kernel serial log: `vfs: mount ext2 (virtio-blk) / failed: errno=-19 (trying next)` → `vfs: mounted tarfs (module) at / (requested=Default)`
