### PR TITLE
fs/ext2: InodeOps link and symlink (inline fast-symlink + slow-symlink paths)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -414,3 +414,8 @@ required-features = ["ext2"]
 name = "ext2_create"
 harness = false
 required-features = ["ext2"]
+
+[[test]]
+name = "ext2_link"
+harness = false
+required-features = ["ext2"]

--- a/kernel/src/fs/ext2/create.rs
+++ b/kernel/src/fs/ext2/create.rs
@@ -397,7 +397,11 @@ fn create_common(
 /// fields of `disk`. Preserves the tail (on-disk rev-1 images store a
 /// larger slot that carries fields we don't decode) via
 /// [`DiskInode::encode_to_slot`].
-fn write_new_inode(super_: &Arc<Ext2Super>, ino: u32, disk: &DiskInode) -> Result<(), i64> {
+pub(super) fn write_new_inode(
+    super_: &Arc<Ext2Super>,
+    ino: u32,
+    disk: &DiskInode,
+) -> Result<(), i64> {
     if ino == 0 {
         return Err(EINVAL);
     }
@@ -470,7 +474,7 @@ fn write_new_inode(super_: &Arc<Ext2Super>, ino: u32, disk: &DiskInode) -> Resul
 /// Only uses the inode's direct pointers (`i_block[0..12]`) in this
 /// wave; directories that outgrow 12 blocks need the indirect-block
 /// walker's write path, which is Workstream F scope.
-fn add_link(
+pub(super) fn add_link(
     super_: &Arc<Ext2Super>,
     parent: &Ext2Inode,
     name: &[u8],
@@ -816,7 +820,10 @@ fn bump_parent_links(
 /// preserving the tail by construction). Shared with `write_new_inode`;
 /// kept as a helper so the RMW discipline in the module docs stays
 /// honest.
-fn read_inode_slot(super_: &Arc<Ext2Super>, ino: u32) -> Result<alloc::vec::Vec<u8>, i64> {
+pub(super) fn read_inode_slot(
+    super_: &Arc<Ext2Super>,
+    ino: u32,
+) -> Result<alloc::vec::Vec<u8>, i64> {
     if ino == 0 {
         return Err(EINVAL);
     }
@@ -872,7 +879,7 @@ fn read_inode_slot(super_: &Arc<Ext2Super>, ino: u32) -> Result<alloc::vec::Vec<
 /// - Not `.` or `..` (these are synthesised by `mkdir` / the iterator,
 ///   not creatable by userspace).
 /// - Contains no NUL bytes or `/` separators.
-fn validate_name(name: &[u8]) -> Result<(), i64> {
+pub(super) fn validate_name(name: &[u8]) -> Result<(), i64> {
     if name.is_empty() {
         return Err(EINVAL);
     }

--- a/kernel/src/fs/ext2/inode.rs
+++ b/kernel/src/fs/ext2/inode.rs
@@ -297,6 +297,32 @@ impl InodeOps for Ext2Inode {
         let sb = dir.sb.upgrade().ok_or(EIO)?;
         super::create::mknod(&super_ref, self, dir, &sb, name, InodeKind::Fifo, mode, 0)
     }
+
+    /// Create a hard link `name` under `dir` pointing at `target`.
+    ///
+    /// Dispatches to [`super::link::link`]. Bumps the target inode's
+    /// `i_links_count`, flushes the slot, then splices a new dirent
+    /// into the parent's directory block. Directory targets are
+    /// refused with `EPERM`; cross-superblock links with `EXDEV`.
+    fn link(&self, dir: &Inode, name: &[u8], target: &Inode) -> Result<(), i64> {
+        let super_ref = self.super_ref.upgrade().ok_or(EIO)?;
+        super::link::link(&super_ref, self, dir, target, name)
+    }
+
+    /// Create a symbolic link `name` under `dir` whose target path is
+    /// `target`.
+    ///
+    /// Dispatches to [`super::link::symlink`]. Targets ≤ 60 bytes are
+    /// stored inline in `i_block[]` (fast symlink); longer targets
+    /// allocate one data block via [`super::balloc::alloc_block`] and
+    /// write the bytes there (slow symlink). `i_mode` is `S_IFLNK |
+    /// 0o777` regardless of any caller-supplied mode — POSIX mandates
+    /// 0777 for symlinks.
+    fn symlink(&self, dir: &Inode, name: &[u8], target: &[u8]) -> Result<Arc<Inode>, i64> {
+        let super_ref = self.super_ref.upgrade().ok_or(EIO)?;
+        let sb = dir.sb.upgrade().ok_or(EIO)?;
+        super::link::symlink(&super_ref, self, dir, &sb, name, target)
+    }
 }
 
 /// Zero-sized marker type re-exported from wave 2 as the `FileOps`

--- a/kernel/src/fs/ext2/link.rs
+++ b/kernel/src/fs/ext2/link.rs
@@ -1,0 +1,438 @@
+//! ext2 `InodeOps::link` + `InodeOps::symlink` — hard-link and
+//! symbolic-link creation on the write path.
+//!
+//! RFC 0004 (`docs/RFC/0004-ext2-filesystem-driver.md`) §Hard links,
+//! §Symbolic links, §Fast symlink format. Workstream E, issue #570.
+//!
+//! # Hard link (`link`)
+//!
+//! A hard link is a second dirent pointing at an already-existing
+//! inode. The on-disk change is:
+//!
+//! 1. Bump the **target** inode's `i_links_count` and rewrite its
+//!    inode-table slot. Sync the slot block so a crash between step 1
+//!    and step 2 leaves the inode with a slightly-inflated link count,
+//!    which `e2fsck` trims back on next mount.
+//! 2. Insert a new dirent in the parent directory block pointing at
+//!    the target's ino with the correct `file_type` byte.
+//!
+//! POSIX (`link(2)`) forbids linking a directory — we always refuse
+//! with `EPERM` regardless of credential (the traditional superuser
+//! exception is an operational footgun that ext2's RFC explicitly
+//! disables). Cross-superblock links return `EXDEV`.
+//!
+//! If the link count is already at its on-disk ceiling (`u16::MAX`) the
+//! request fails with `EMLINK` — bumping would overflow and corrupt
+//! the count.
+//!
+//! # Symbolic link (`symlink`)
+//!
+//! A symlink is a new inode whose body is the target path string.
+//! The `i_mode` is `S_IFLNK | 0o777` (POSIX §4.10 mandates 0777 for
+//! symlink permission bits — they're never consulted; the permission
+//! check happens on the link's target during path resolution).
+//!
+//! Two on-disk shapes, picked by target length:
+//!
+//! - **Fast symlink** (target ≤ 60 bytes): the bytes live inline in
+//!   `i_block[0..15]` (15 × 4 = 60 bytes). `i_blocks = 0`, no data
+//!   block is allocated. The read path's gate in [`super::symlink`]
+//!   keys off `is_symlink && i_blocks == 0 && i_size <= 60`.
+//! - **Slow symlink** (target > 60 bytes, ≤ `PATH_MAX = 4095`): we
+//!   allocate one data block via [`super::balloc::alloc_block`],
+//!   write the target bytes into it, and stamp `i_block[0]` with the
+//!   block number. `i_blocks = block_size / 512` (the single
+//!   allocated block in 512-byte sectors).
+//!
+//! Write ordering mirrors [`super::create`]'s regular-file pipeline:
+//! `alloc_inode` → (slow only: `alloc_block` + write target) → encode
+//! inode + flush → insert dirent → flush. A crash at any step leaves
+//! either an orphan inode (if the dirent never landed) or a valid
+//! symlink — never a dangling dirent.
+//!
+//! # What this module does *not* do
+//!
+//! - `readlink` — covered by [`super::symlink`] (#563) on the read
+//!   side.
+//! - Permission checks. The generic VFS layer runs
+//!   `permission(parent, MAY_WRITE | MAY_EXEC, cred)` before
+//!   dispatching; we assume the caller has already done so.
+//! - Credential-aware owner/group stamping. Like `create.rs`, the new
+//!   inode's uid/gid are both `0` until the `Credential` threading
+//!   from RFC 0004 §Credentials lands.
+
+use alloc::sync::Arc;
+
+use super::create::{add_link, read_inode_slot, validate_name, write_new_inode};
+use super::disk::{Ext2Inode as DiskInode, EXT2_FT_SYMLINK, EXT2_N_BLOCKS};
+use super::fs::{Ext2MountFlags, Ext2Super};
+use super::ialloc::{alloc_inode, free_inode};
+use super::inode::{iget, Ext2Inode};
+use super::symlink::EXT2_FAST_SYMLINK_MAX;
+
+use crate::fs::vfs::inode::{Inode, InodeKind};
+use crate::fs::vfs::super_block::SuperBlock;
+use crate::fs::vfs::Timespec;
+use crate::fs::{EEXIST, EINVAL, EIO, ENAMETOOLONG, ENOENT, ENOTDIR, EPERM, EROFS};
+
+/// `PATH_MAX` for symlink targets. POSIX caps a path at 4096 including
+/// the trailing NUL; the stored-target length excludes the NUL, so a
+/// symlink target may be up to 4095 bytes. Larger targets return
+/// `ENAMETOOLONG`.
+pub const EXT2_SYMLINK_TARGET_MAX: usize = 4095;
+
+/// ext2 ceiling on `i_links_count`. The field is a `u16` on disk.
+/// Hitting the ceiling makes further `link(2)` calls against the inode
+/// return `EMLINK` (per POSIX). Ext3+ raises this via the
+/// `DIR_NLINK` feature; ext2's cap is hard.
+pub const EXT2_LINK_MAX: u16 = u16::MAX;
+
+/// `link(2)` errno for "too many links". Defined here to keep the
+/// link-specific errno gathered in one place — the kernel's canonical
+/// errno table in `kernel/src/fs/mod.rs` doesn't yet re-export `EMLINK`
+/// because no caller before this module needed it.
+pub const EMLINK: i64 = -31;
+
+// ---------------------------------------------------------------------------
+// Hard link — InodeOps::link
+// ---------------------------------------------------------------------------
+
+/// Insert a new dirent `name` in `parent` that points at the existing
+/// inode `target`. Bumps the target's `i_links_count` first, then
+/// inserts the dirent. See the module docs for the full ordering story.
+pub fn link(
+    super_: &Arc<Ext2Super>,
+    parent: &Ext2Inode,
+    parent_vfs: &Inode,
+    target: &Inode,
+    name: &[u8],
+) -> Result<(), i64> {
+    if super_.ext2_flags.contains(Ext2MountFlags::RDONLY)
+        || super_.ext2_flags.contains(Ext2MountFlags::FORCED_RDONLY)
+    {
+        return Err(EROFS);
+    }
+    validate_name(name)?;
+    if parent_vfs.kind != InodeKind::Dir {
+        return Err(ENOTDIR);
+    }
+    // POSIX: link(2) against a directory is refused unconditionally on
+    // this driver. Linux historically allowed it for root-with-
+    // CAP_DAC_READ_SEARCH, but the RFC rules it out because a linked
+    // directory breaks `..` invariant assumptions across the tree.
+    if target.kind == InodeKind::Dir {
+        return Err(EPERM);
+    }
+
+    // Cross-superblock links are a hard EXDEV. The VFS layer already
+    // filters most of these at the `linkat` entry point but a
+    // user-mode-driver test could call us directly; keep the check so
+    // the driver alone is sufficient.
+    let parent_sb = parent_vfs.sb.upgrade().ok_or(EIO)?;
+    let target_sb = target.sb.upgrade().ok_or(EIO)?;
+    if !Arc::ptr_eq(&parent_sb, &target_sb) {
+        return Err(crate::fs::EXDEV);
+    }
+
+    // Serialise directory mutations on the parent, same as create_common.
+    let _parent_guard = parent_vfs.dir_rwsem.write();
+
+    // Refuse duplicate name up front; anything other than ENOENT
+    // propagates.
+    match super::dir::lookup(super_, parent, name) {
+        Ok(_) => return Err(EEXIST),
+        Err(e) if e == ENOENT => {}
+        Err(e) => return Err(e),
+    }
+
+    let target_ino = target.ino as u32;
+    if target_ino == 0 {
+        return Err(EINVAL);
+    }
+
+    // Step 1: bump the target's i_links_count on disk (and detect
+    // ceiling). Re-read through the buffer cache so any concurrent
+    // setattr/unlink observation is coherent.
+    let slot = read_inode_slot(super_, target_ino)?;
+    let mut disk = DiskInode::decode(&slot);
+    if disk.i_links_count == EXT2_LINK_MAX {
+        return Err(EMLINK);
+    }
+    // Also guard against the inode having hit `i_dtime != 0` (tombstone
+    // — on the orphan list awaiting final-close reclaim). Linking into
+    // such an inode would revive a half-freed object.
+    if disk.i_dtime != 0 {
+        return Err(ENOENT);
+    }
+    disk.i_links_count = disk.i_links_count.saturating_add(1);
+    // Touch i_ctime — POSIX mandates that link(2) updates ctime on the
+    // target inode.
+    let now = Timespec::now().sec as u32;
+    disk.i_ctime = now;
+    write_new_inode(super_, target_ino, &disk)?;
+
+    // Step 2: splice a new dirent into the parent directory block. If
+    // add_link fails, unwind the link-count bump so we don't leak a
+    // phantom reference.
+    let file_type = filetype_from_mode(disk.i_mode);
+    if let Err(e) = add_link(super_, parent, name, target_ino, file_type) {
+        // Revert the link count. If the re-write fails the on-disk
+        // count is inflated by 1; `e2fsck` trims it. Intentionally log-
+        // and-drop the secondary error — we already have an error to
+        // propagate.
+        disk.i_links_count = disk.i_links_count.saturating_sub(1);
+        let _ = write_new_inode(super_, target_ino, &disk);
+        return Err(e);
+    }
+
+    // Mirror the bump in the target Inode's in-memory VFS meta so
+    // subsequent `stat()` calls (which read through `InodeOps::getattr`
+    // or the cached `Inode::meta`) see the new nlink without a fresh
+    // iget.
+    {
+        let mut meta = target.meta.write();
+        meta.nlink = meta.nlink.saturating_add(1);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Symbolic link — InodeOps::symlink
+// ---------------------------------------------------------------------------
+
+/// Create a new symlink `name` in `parent` whose target is `target`.
+/// Picks fast vs. slow layout by length. Returns the freshly-published
+/// `Arc<Inode>` for the new symlink.
+pub fn symlink(
+    super_: &Arc<Ext2Super>,
+    parent: &Ext2Inode,
+    parent_vfs: &Inode,
+    sb: &Arc<SuperBlock>,
+    name: &[u8],
+    target: &[u8],
+) -> Result<Arc<Inode>, i64> {
+    if super_.ext2_flags.contains(Ext2MountFlags::RDONLY)
+        || super_.ext2_flags.contains(Ext2MountFlags::FORCED_RDONLY)
+    {
+        return Err(EROFS);
+    }
+    validate_name(name)?;
+    if parent_vfs.kind != InodeKind::Dir {
+        return Err(ENOTDIR);
+    }
+    // Empty target is nonsensical — POSIX `symlink(2)` with an empty
+    // `oldpath` returns ENOENT.
+    if target.is_empty() {
+        return Err(ENOENT);
+    }
+    if target.len() > EXT2_SYMLINK_TARGET_MAX {
+        return Err(ENAMETOOLONG);
+    }
+
+    let _parent_guard = parent_vfs.dir_rwsem.write();
+
+    match super::dir::lookup(super_, parent, name) {
+        Ok(_) => return Err(EEXIST),
+        Err(e) if e == ENOENT => {}
+        Err(e) => return Err(e),
+    }
+
+    let inodes_per_group = super_.sb_disk.lock().s_inodes_per_group;
+    let parent_group = if inodes_per_group == 0 {
+        None
+    } else {
+        Some((parent.ino - 1) / inodes_per_group)
+    };
+
+    // Step 1: ialloc.
+    let new_ino = alloc_inode(super_, parent_group, false)?;
+
+    // Mirror create_common's unwind gate. `linked = true` after
+    // add_link succeeds; after that point a failure must NOT free the
+    // inode (a dirent on disk points at it). `data_block` tracks a
+    // slow-symlink data block so pre-link failures can free it too.
+    let mut data_block: Option<u32> = None;
+    let mut linked = false;
+
+    let outcome: Result<Arc<Inode>, i64> = (|| {
+        let now = Timespec::now().sec as u32;
+        let fast = target.len() <= EXT2_FAST_SYMLINK_MAX as usize;
+        let block_size = super_.block_size;
+
+        // Build the initial on-disk inode with the inline target (fast
+        // path). For slow symlinks this just zero-stamps i_block[]; we
+        // re-emit below with the allocated block number.
+        let mut i_block = [0u32; EXT2_N_BLOCKS];
+        if fast {
+            // Inline encoding: concatenate target bytes into the 60-byte
+            // i_block[] region as little-endian u32s. See the matching
+            // decoder in `super::symlink::inline_bytes`.
+            let mut raw = [0u8; 60];
+            raw[..target.len()].copy_from_slice(target);
+            for (i, slot) in i_block.iter_mut().enumerate() {
+                let off = 4 * i;
+                *slot = u32::from_le_bytes([raw[off], raw[off + 1], raw[off + 2], raw[off + 3]]);
+            }
+        }
+
+        let i_mode: u16 = 0o120_000 | 0o777; // S_IFLNK | 0o777
+        let i_blocks_sectors: u32 = if fast { 0 } else { block_size / 512 };
+
+        let mut disk = DiskInode {
+            i_mode,
+            i_uid: 0,
+            i_size: target.len() as u32,
+            i_atime: now,
+            i_ctime: now,
+            i_mtime: now,
+            i_dtime: 0,
+            i_gid: 0,
+            i_links_count: 1,
+            i_blocks: i_blocks_sectors,
+            i_flags: 0,
+            i_block,
+            i_dir_acl_or_size_high: 0,
+            l_i_uid_high: 0,
+            l_i_gid_high: 0,
+        };
+
+        // Slow path: allocate a data block, write the target into it,
+        // then stamp i_block[0] before the first on-disk encode.
+        if !fast {
+            let blk = super::balloc::alloc_block(super_, parent_group)?;
+            data_block = Some(blk);
+            write_slow_symlink_target(super_, blk, target, block_size)?;
+            disk.i_block[0] = blk;
+        }
+
+        // Step 2: encode the inode + flush.
+        write_new_inode(super_, new_ino, &disk)?;
+
+        // Step 3: insert the dirent.
+        add_link(super_, parent, name, new_ino, EXT2_FT_SYMLINK)?;
+        linked = true;
+
+        // Publish the fresh inode via the per-mount cache.
+        iget(super_, sb, new_ino)
+    })();
+
+    match outcome {
+        Ok(inode) => Ok(inode),
+        Err(e) => {
+            if !linked {
+                if let Some(blk) = data_block {
+                    let _ = super::balloc::free_block(super_, blk);
+                }
+                let _ = free_inode(super_, new_ino, false);
+            }
+            // If linked == true the dirent points at the inode; the
+            // e2fsck path reconciles any leaked resources if a later
+            // step (currently only `iget`) fails.
+            Err(e)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Map the inode's `i_mode` S_IFMT bits to the ext2 `file_type` byte
+/// used in dirents when `INCOMPAT_FILETYPE` is on (the golden image
+/// plus every modern ext2 image does carry this flag). Unknown modes
+/// round-trip to `EXT2_FT_UNKNOWN`; the dirent walker treats that as
+/// the "check via ino->mode" fallback.
+fn filetype_from_mode(mode: u16) -> u8 {
+    use super::disk::{
+        EXT2_FT_BLKDEV, EXT2_FT_CHRDEV, EXT2_FT_DIR, EXT2_FT_FIFO, EXT2_FT_REG_FILE, EXT2_FT_SOCK,
+        EXT2_FT_UNKNOWN,
+    };
+    match mode & 0o170_000 {
+        0o100_000 => EXT2_FT_REG_FILE,
+        0o040_000 => EXT2_FT_DIR,
+        0o120_000 => EXT2_FT_SYMLINK,
+        0o020_000 => EXT2_FT_CHRDEV,
+        0o060_000 => EXT2_FT_BLKDEV,
+        0o010_000 => EXT2_FT_FIFO,
+        0o140_000 => EXT2_FT_SOCK,
+        _ => EXT2_FT_UNKNOWN,
+    }
+}
+
+/// Write the slow-symlink target into `blk`, zeroing any trailing
+/// bytes inside the block so readers don't observe stale data. The
+/// buffer-cache page for a freshly-allocated data block may carry
+/// whatever bytes the slot held in its previous incarnation — zero
+/// the whole block first.
+fn write_slow_symlink_target(
+    super_: &Arc<Ext2Super>,
+    blk: u32,
+    target: &[u8],
+    block_size: u32,
+) -> Result<(), i64> {
+    if target.len() > block_size as usize {
+        // Shouldn't happen — the caller already clamped to
+        // EXT2_SYMLINK_TARGET_MAX (4095), and every ext2 `block_size`
+        // (1 KiB … 4 KiB) is ≥ 4095 except the 1 KiB case. On a 1 KiB
+        // FS with a >1024-byte target we'd need multi-block slow
+        // symlinks, which this wave doesn't implement; surface as
+        // ENAMETOOLONG so the caller can report it cleanly.
+        return Err(ENAMETOOLONG);
+    }
+    let bh = super_
+        .cache
+        .bread(super_.device_id, blk as u64)
+        .map_err(|_| EIO)?;
+    {
+        let mut data = bh.data.write();
+        if (block_size as usize) > data.len() {
+            return Err(EIO);
+        }
+        for b in data[..block_size as usize].iter_mut() {
+            *b = 0;
+        }
+        data[..target.len()].copy_from_slice(target);
+    }
+    super_.cache.mark_dirty(&bh);
+    super_.cache.sync_dirty_buffer(&bh).map_err(|_| EIO)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filetype_from_mode_covers_all_ifmts() {
+        use super::super::disk::{
+            EXT2_FT_BLKDEV, EXT2_FT_CHRDEV, EXT2_FT_DIR, EXT2_FT_FIFO, EXT2_FT_REG_FILE,
+            EXT2_FT_SOCK, EXT2_FT_UNKNOWN,
+        };
+        assert_eq!(filetype_from_mode(0o100_644), EXT2_FT_REG_FILE);
+        assert_eq!(filetype_from_mode(0o040_755), EXT2_FT_DIR);
+        assert_eq!(filetype_from_mode(0o120_777), EXT2_FT_SYMLINK);
+        assert_eq!(filetype_from_mode(0o020_666), EXT2_FT_CHRDEV);
+        assert_eq!(filetype_from_mode(0o060_600), EXT2_FT_BLKDEV);
+        assert_eq!(filetype_from_mode(0o010_644), EXT2_FT_FIFO);
+        assert_eq!(filetype_from_mode(0o140_600), EXT2_FT_SOCK);
+        // Unknown S_IFMT → EXT2_FT_UNKNOWN.
+        assert_eq!(filetype_from_mode(0o000_644), EXT2_FT_UNKNOWN);
+    }
+
+    #[test]
+    fn fast_symlink_bound_is_60_bytes() {
+        // Matches the read-path gate in super::symlink.
+        assert_eq!(EXT2_FAST_SYMLINK_MAX, 60);
+    }
+
+    #[test]
+    fn link_max_is_u16_max() {
+        assert_eq!(EXT2_LINK_MAX, u16::MAX);
+    }
+
+    #[test]
+    fn symlink_target_max_matches_path_max_minus_nul() {
+        // PATH_MAX = 4096 including trailing NUL.
+        assert_eq!(EXT2_SYMLINK_TARGET_MAX, 4095);
+    }
+}

--- a/kernel/src/fs/ext2/mod.rs
+++ b/kernel/src/fs/ext2/mod.rs
@@ -130,3 +130,13 @@ pub mod create;
 
 #[cfg(all(feature = "ext2", target_os = "none"))]
 pub use create::{create_dir, create_file, mknod};
+
+// InodeOps::link + InodeOps::symlink (#570). Same feature gate — the
+// module reuses create.rs's `add_link` / `write_new_inode` /
+// `read_inode_slot` helpers and touches the buffer cache directly for
+// slow-symlink target writes.
+#[cfg(all(feature = "ext2", target_os = "none"))]
+pub mod link;
+
+#[cfg(all(feature = "ext2", target_os = "none"))]
+pub use link::{link, symlink};

--- a/kernel/tests/ext2_link.rs
+++ b/kernel/tests/ext2_link.rs
@@ -1,0 +1,563 @@
+//! Integration test for issue #570: ext2 `InodeOps::link` +
+//! `InodeOps::symlink`.
+//!
+//! Mounts the 64 KiB golden image RW and exercises the two write-side
+//! entry points on `Ext2Inode`:
+//!
+//! - `link`: bumps target's `i_links_count`, inserts a dirent in the
+//!   parent, refuses directory targets with `EPERM`, refuses
+//!   `u16::MAX` link counts with `EMLINK`.
+//! - `symlink`: fast-path (≤ 60 bytes, inline in `i_block[]`, zero
+//!   `i_blocks`) and slow-path (> 60 bytes, single data block). Verify
+//!   the target reads back byte-for-byte through the existing
+//!   `read_symlink` helper.
+//!
+//! Shares the RamDisk / mount plumbing with `ext2_create.rs`.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+use spin::Mutex;
+
+use vibix::block::{BlockDevice, BlockError};
+use vibix::fs::ext2::symlink::{is_fast_symlink, is_symlink, read_symlink, EXT2_FAST_SYMLINK_MAX};
+use vibix::fs::ext2::{
+    create_dir, create_file, dir, iget, link as ext2_link, symlink as ext2_symlink, Ext2Fs,
+    Ext2Inode, Ext2InodeMeta, Ext2Super,
+};
+use vibix::fs::vfs::inode::InodeKind;
+use vibix::fs::vfs::ops::{FileSystem as _, MountSource};
+use vibix::fs::vfs::MountFlags;
+use vibix::fs::{EEXIST, ENAMETOOLONG, ENOTDIR, EPERM, EROFS};
+use vibix::sync::BlockingRwLock;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+const GOLDEN_IMG: &[u8; 65_536] = include_bytes!("../src/fs/ext2/fixtures/golden.img");
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "link_bumps_nlink_and_inserts_dirent",
+            &(link_bumps_nlink_and_inserts_dirent as fn()),
+        ),
+        (
+            "link_refuses_directory_target",
+            &(link_refuses_directory_target as fn()),
+        ),
+        (
+            "link_refuses_duplicate_name",
+            &(link_refuses_duplicate_name as fn()),
+        ),
+        ("link_ro_mount_refuses", &(link_ro_mount_refuses as fn())),
+        (
+            "symlink_fast_inline_60_bytes",
+            &(symlink_fast_inline_60_bytes as fn()),
+        ),
+        ("symlink_slow_61_bytes", &(symlink_slow_61_bytes as fn())),
+        (
+            "symlink_boundary_60_vs_61",
+            &(symlink_boundary_60_vs_61 as fn()),
+        ),
+        (
+            "symlink_rejects_oversize",
+            &(symlink_rejects_oversize as fn()),
+        ),
+        (
+            "symlink_rejects_bad_name",
+            &(symlink_rejects_bad_name as fn()),
+        ),
+        (
+            "symlink_ro_mount_refuses",
+            &(symlink_ro_mount_refuses as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RamDisk — identical shape to ext2_create.rs / ext2_unlink.rs.
+// ---------------------------------------------------------------------------
+
+struct RamDisk {
+    block_size: u32,
+    storage: Mutex<Vec<u8>>,
+    writes: AtomicU32,
+    read_only: AtomicBool,
+}
+
+impl RamDisk {
+    fn from_image(bytes: &[u8], block_size: u32) -> Arc<Self> {
+        assert!(bytes.len() % block_size as usize == 0);
+        Arc::new(Self {
+            block_size,
+            storage: Mutex::new(bytes.to_vec()),
+            writes: AtomicU32::new(0),
+            read_only: AtomicBool::new(false),
+        })
+    }
+    fn set_read_only(&self, ro: bool) {
+        self.read_only.store(ro, Ordering::Relaxed);
+    }
+    fn writes(&self) -> u32 {
+        self.writes.load(Ordering::Relaxed)
+    }
+}
+
+impl BlockDevice for RamDisk {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
+        let bs = self.block_size as u64;
+        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
+            return Err(BlockError::BadAlign);
+        }
+        let storage = self.storage.lock();
+        let end = offset
+            .checked_add(buf.len() as u64)
+            .ok_or(BlockError::OutOfRange)?;
+        if end > storage.len() as u64 {
+            return Err(BlockError::OutOfRange);
+        }
+        let off = offset as usize;
+        buf.copy_from_slice(&storage[off..off + buf.len()]);
+        Ok(())
+    }
+    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
+        if self.read_only.load(Ordering::Relaxed) {
+            return Err(BlockError::ReadOnly);
+        }
+        let bs = self.block_size as u64;
+        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
+            return Err(BlockError::BadAlign);
+        }
+        let mut storage = self.storage.lock();
+        let end = offset
+            .checked_add(buf.len() as u64)
+            .ok_or(BlockError::Enospc)?;
+        if end > storage.len() as u64 {
+            return Err(BlockError::Enospc);
+        }
+        let off = offset as usize;
+        storage[off..off + buf.len()].copy_from_slice(buf);
+        self.writes.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+    fn block_size(&self) -> u32 {
+        self.block_size
+    }
+    fn capacity(&self) -> u64 {
+        self.storage.lock().len() as u64
+    }
+}
+
+fn mount_golden_rw() -> (
+    Arc<vibix::fs::vfs::super_block::SuperBlock>,
+    Arc<Ext2Fs>,
+    Arc<Ext2Super>,
+    Arc<RamDisk>,
+) {
+    let disk = RamDisk::from_image(GOLDEN_IMG.as_slice(), 512);
+    let fs = Ext2Fs::new_with_device(disk.clone() as Arc<dyn BlockDevice>);
+    let sb = fs
+        .mount(MountSource::None, MountFlags(0))
+        .expect("RW mount must succeed");
+    let super_arc = fs.current_super().expect("current_super must upgrade");
+    (sb, fs, super_arc, disk)
+}
+
+fn mount_golden_ro() -> (
+    Arc<vibix::fs::vfs::super_block::SuperBlock>,
+    Arc<Ext2Fs>,
+    Arc<Ext2Super>,
+    Arc<RamDisk>,
+) {
+    let disk = RamDisk::from_image(GOLDEN_IMG.as_slice(), 512);
+    let fs = Ext2Fs::new_with_device(disk.clone() as Arc<dyn BlockDevice>);
+    let sb = fs
+        .mount(MountSource::None, MountFlags::RDONLY)
+        .expect("RO mount must succeed");
+    disk.set_read_only(true);
+    let super_arc = fs.current_super().expect("current_super must upgrade");
+    (sb, fs, super_arc, disk)
+}
+
+fn make_ext2_inode_from_disk(
+    super_arc: &Arc<Ext2Super>,
+    sb: &Arc<vibix::fs::vfs::super_block::SuperBlock>,
+    ino: u32,
+) -> Ext2Inode {
+    let _ = iget(super_arc, sb, ino).expect("iget live ino");
+
+    let inodes_per_group = super_arc.sb_disk.lock().s_inodes_per_group;
+    let group = (ino - 1) / inodes_per_group;
+    let index_in_group = (ino - 1) % inodes_per_group;
+    let bg_inode_table = {
+        let bgdt = super_arc.bgdt.lock();
+        bgdt[group as usize].bg_inode_table
+    };
+    let byte_offset = (index_in_group as u64) * (super_arc.inode_size as u64);
+    let block_in_table = byte_offset / (super_arc.block_size as u64);
+    let offset_in_block = (byte_offset % (super_arc.block_size as u64)) as usize;
+    let absolute_block = bg_inode_table as u64 + block_in_table;
+
+    let bh = super_arc
+        .cache
+        .bread(super_arc.device_id, absolute_block)
+        .expect("bread inode table");
+    let data = bh.data.read();
+    let mut slot = [0u8; 128];
+    slot.copy_from_slice(&data[offset_in_block..offset_in_block + 128]);
+    drop(data);
+    let disk_inode = vibix::fs::ext2::disk::Ext2Inode::decode(&slot);
+
+    let meta = Ext2InodeMeta {
+        mode: disk_inode.i_mode,
+        uid: disk_inode.uid(),
+        gid: disk_inode.gid(),
+        size: disk_inode.i_size as u64,
+        atime: disk_inode.i_atime,
+        ctime: disk_inode.i_ctime,
+        mtime: disk_inode.i_mtime,
+        dtime: disk_inode.i_dtime,
+        links_count: disk_inode.i_links_count,
+        i_blocks: disk_inode.i_blocks,
+        flags: disk_inode.i_flags,
+        i_block: disk_inode.i_block,
+    };
+
+    Ext2Inode {
+        super_ref: Arc::downgrade(super_arc),
+        ino,
+        meta: BlockingRwLock::new(meta),
+        block_map: BlockingRwLock::new(None),
+        unlinked: AtomicBool::new(false),
+    }
+}
+
+/// Re-decode the raw on-disk inode (`disk::Ext2Inode`) for a given
+/// ino. The `read_symlink` helper needs this shape, not the driver-
+/// level `Ext2Inode`.
+fn read_disk_inode(super_arc: &Arc<Ext2Super>, ino: u32) -> vibix::fs::ext2::disk::Ext2Inode {
+    let inodes_per_group = super_arc.sb_disk.lock().s_inodes_per_group;
+    let group = (ino - 1) / inodes_per_group;
+    let index_in_group = (ino - 1) % inodes_per_group;
+    let bg_inode_table = {
+        let bgdt = super_arc.bgdt.lock();
+        bgdt[group as usize].bg_inode_table
+    };
+    let byte_offset = (index_in_group as u64) * (super_arc.inode_size as u64);
+    let block_in_table = byte_offset / (super_arc.block_size as u64);
+    let offset_in_block = (byte_offset % (super_arc.block_size as u64)) as usize;
+    let absolute_block = bg_inode_table as u64 + block_in_table;
+
+    let bh = super_arc
+        .cache
+        .bread(super_arc.device_id, absolute_block)
+        .expect("bread inode table");
+    let data = bh.data.read();
+    let mut slot = [0u8; 128];
+    slot.copy_from_slice(&data[offset_in_block..offset_in_block + 128]);
+    vibix::fs::ext2::disk::Ext2Inode::decode(&slot)
+}
+
+// ---------------------------------------------------------------------------
+// Tests — hard link
+// ---------------------------------------------------------------------------
+
+fn link_bumps_nlink_and_inserts_dirent() {
+    let (sb, _fs, super_arc, _disk) = mount_golden_rw();
+    let parent_vfs = iget(&super_arc, &sb, 2).expect("iget root");
+    let parent = make_ext2_inode_from_disk(&super_arc, &sb, 2);
+
+    // First create a regular file we'll hard-link.
+    let src = create_file(&super_arc, &parent, &parent_vfs, &sb, b"target", 0o644)
+        .expect("create_file target");
+    let src_ino = src.ino as u32;
+    let nlink_before = {
+        let d = read_disk_inode(&super_arc, src_ino);
+        d.i_links_count
+    };
+
+    // Re-read parent meta — add_link may have extended the dir.
+    let parent = make_ext2_inode_from_disk(&super_arc, &sb, 2);
+
+    ext2_link(&super_arc, &parent, &parent_vfs, &src, b"alias").expect("link must succeed");
+
+    // On-disk nlink must have bumped by 1.
+    let d_after = read_disk_inode(&super_arc, src_ino);
+    assert_eq!(
+        d_after.i_links_count,
+        nlink_before + 1,
+        "target i_links_count must bump by 1"
+    );
+
+    // Fresh dirent `alias` resolves to the same ino.
+    let parent_after = make_ext2_inode_from_disk(&super_arc, &sb, 2);
+    let found = dir::lookup(&super_arc, &parent_after, b"alias").expect("lookup alias");
+    assert_eq!(found, src_ino, "alias must resolve to src ino");
+    let found_orig = dir::lookup(&super_arc, &parent_after, b"target").expect("lookup target");
+    assert_eq!(found_orig, src_ino);
+
+    // In-memory VFS nlink also bumped.
+    assert_eq!(
+        src.meta.read().nlink as u16,
+        nlink_before + 1,
+        "VFS meta nlink mirrors on-disk bump"
+    );
+
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn link_refuses_directory_target() {
+    let (sb, _fs, super_arc, _disk) = mount_golden_rw();
+    let parent_vfs = iget(&super_arc, &sb, 2).expect("iget root");
+    let parent = make_ext2_inode_from_disk(&super_arc, &sb, 2);
+
+    // Create a subdir.
+    let subdir =
+        create_dir(&super_arc, &parent, &parent_vfs, &sb, b"subd", 0o755).expect("create_dir");
+
+    let parent = make_ext2_inode_from_disk(&super_arc, &sb, 2);
+
+    // Linking a directory must fail with EPERM.
+    let err = ext2_link(&super_arc, &parent, &parent_vfs, &subdir, b"dalias")
+        .err()
+        .expect("link to dir must fail");
+    assert_eq!(err, EPERM);
+
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn link_refuses_duplicate_name() {
+    let (sb, _fs, super_arc, _disk) = mount_golden_rw();
+    let parent_vfs = iget(&super_arc, &sb, 2).expect("iget root");
+    let parent = make_ext2_inode_from_disk(&super_arc, &sb, 2);
+
+    let src =
+        create_file(&super_arc, &parent, &parent_vfs, &sb, b"src", 0o644).expect("create_file src");
+    let parent = make_ext2_inode_from_disk(&super_arc, &sb, 2);
+
+    // `lost+found` already exists on the golden image; linking to that
+    // name must surface EEXIST.
+    let err = ext2_link(&super_arc, &parent, &parent_vfs, &src, b"lost+found")
+        .err()
+        .expect("duplicate name must fail");
+    assert_eq!(err, EEXIST);
+
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn link_ro_mount_refuses() {
+    let (sb, _fs, super_arc, disk) = mount_golden_ro();
+    let parent_vfs = iget(&super_arc, &sb, 2).expect("iget root");
+    let parent = make_ext2_inode_from_disk(&super_arc, &sb, 2);
+
+    // Use the root inode itself (dir) as the "target" — the RO check
+    // fires before the directory-target refusal, so EROFS wins. We
+    // pass `parent_vfs` as the target too (it happens to be the only
+    // Arc<Inode> in hand, and the check is ordered correctly).
+    let err = ext2_link(&super_arc, &parent, &parent_vfs, &parent_vfs, b"nope")
+        .err()
+        .expect("RO mount must refuse link");
+    assert_eq!(err, EROFS);
+    assert_eq!(disk.writes(), 0, "no writes on a refused RO link");
+
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+// ---------------------------------------------------------------------------
+// Tests — symbolic link
+// ---------------------------------------------------------------------------
+
+fn symlink_fast_inline_60_bytes() {
+    let (sb, _fs, super_arc, _disk) = mount_golden_rw();
+    let parent_vfs = iget(&super_arc, &sb, 2).expect("iget root");
+    let parent = make_ext2_inode_from_disk(&super_arc, &sb, 2);
+
+    let target: &[u8] = b"/bin/sh";
+    let sl =
+        ext2_symlink(&super_arc, &parent, &parent_vfs, &sb, b"sh", target).expect("symlink fast");
+    let sl_ino = sl.ino as u32;
+    assert_eq!(sl.kind, InodeKind::Link);
+
+    let d = read_disk_inode(&super_arc, sl_ino);
+    assert!(is_symlink(&d));
+    assert!(
+        is_fast_symlink(&d),
+        "target ≤ 60 bytes must land in the inline fast path"
+    );
+    assert_eq!(d.i_size as usize, target.len());
+    assert_eq!(d.i_blocks, 0, "fast symlink has zero allocated blocks");
+
+    // Target reads back byte-for-byte via the existing readlink helper.
+    let mut buf = [0xffu8; 128];
+    let n = read_symlink(&d, &super_arc, &mut buf).expect("read back fast symlink");
+    assert_eq!(n, target.len());
+    assert_eq!(&buf[..n], target);
+
+    // Dirent resolves to the symlink ino.
+    let parent_after = make_ext2_inode_from_disk(&super_arc, &sb, 2);
+    let found = dir::lookup(&super_arc, &parent_after, b"sh").expect("lookup sh");
+    assert_eq!(found, sl_ino);
+
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn symlink_slow_61_bytes() {
+    let (sb, _fs, super_arc, _disk) = mount_golden_rw();
+    let parent_vfs = iget(&super_arc, &sb, 2).expect("iget root");
+    let parent = make_ext2_inode_from_disk(&super_arc, &sb, 2);
+
+    // 64-byte target is > 60, forcing the slow path.
+    let target: [u8; 64] = core::array::from_fn(|i| b'a' + (i % 26) as u8);
+    let sl = ext2_symlink(&super_arc, &parent, &parent_vfs, &sb, b"long", &target)
+        .expect("symlink slow");
+    let sl_ino = sl.ino as u32;
+
+    let d = read_disk_inode(&super_arc, sl_ino);
+    assert!(is_symlink(&d));
+    assert!(
+        !is_fast_symlink(&d),
+        "target > 60 bytes must land in the slow path"
+    );
+    assert_eq!(d.i_size as usize, target.len());
+    assert_ne!(d.i_blocks, 0, "slow symlink allocates a data block");
+    assert_ne!(
+        d.i_block[0], 0,
+        "slow symlink i_block[0] is the target block"
+    );
+
+    let mut buf = [0u8; 128];
+    let n = read_symlink(&d, &super_arc, &mut buf).expect("read back slow symlink");
+    assert_eq!(n, target.len());
+    assert_eq!(&buf[..n], &target);
+
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn symlink_boundary_60_vs_61() {
+    let (sb, _fs, super_arc, _disk) = mount_golden_rw();
+    let parent_vfs = iget(&super_arc, &sb, 2).expect("iget root");
+    let parent = make_ext2_inode_from_disk(&super_arc, &sb, 2);
+
+    // Exactly 60 bytes must still be inline.
+    let t60: [u8; 60] = core::array::from_fn(|i| b'0' + (i % 10) as u8);
+    assert_eq!(EXT2_FAST_SYMLINK_MAX as usize, 60);
+    let sl60 =
+        ext2_symlink(&super_arc, &parent, &parent_vfs, &sb, b"s60", &t60).expect("60-byte symlink");
+    let d60 = read_disk_inode(&super_arc, sl60.ino as u32);
+    assert!(is_fast_symlink(&d60), "60 bytes is the inline boundary");
+    let mut buf = [0u8; 64];
+    let n = read_symlink(&d60, &super_arc, &mut buf).expect("readback 60");
+    assert_eq!(n, 60);
+    assert_eq!(&buf[..60], &t60);
+
+    // Re-read parent between calls to pick up freshly-added dirents /
+    // possibly-grown block pointer.
+    let parent = make_ext2_inode_from_disk(&super_arc, &sb, 2);
+
+    // 61 bytes flips to the slow path.
+    let t61: [u8; 61] = core::array::from_fn(|i| b'A' + (i % 26) as u8);
+    let sl61 =
+        ext2_symlink(&super_arc, &parent, &parent_vfs, &sb, b"s61", &t61).expect("61-byte symlink");
+    let d61 = read_disk_inode(&super_arc, sl61.ino as u32);
+    assert!(
+        !is_fast_symlink(&d61),
+        "61 bytes is one past the inline boundary"
+    );
+    let mut buf = [0u8; 128];
+    let n = read_symlink(&d61, &super_arc, &mut buf).expect("readback 61");
+    assert_eq!(n, 61);
+    assert_eq!(&buf[..61], &t61);
+
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn symlink_rejects_oversize() {
+    let (sb, _fs, super_arc, _disk) = mount_golden_rw();
+    let parent_vfs = iget(&super_arc, &sb, 2).expect("iget root");
+    let parent = make_ext2_inode_from_disk(&super_arc, &sb, 2);
+
+    // 4096-byte target — one past PATH_MAX-minus-NUL. Must fail
+    // ENAMETOOLONG before any allocation.
+    let huge = [b'x'; 4096];
+    let err = ext2_symlink(&super_arc, &parent, &parent_vfs, &sb, b"huge", &huge)
+        .err()
+        .expect("oversize target must fail");
+    assert_eq!(err, ENAMETOOLONG);
+
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn symlink_rejects_bad_name() {
+    let (sb, _fs, super_arc, _disk) = mount_golden_rw();
+    let parent_vfs = iget(&super_arc, &sb, 2).expect("iget root");
+    let parent = make_ext2_inode_from_disk(&super_arc, &sb, 2);
+
+    // Reserved names surface as EEXIST (same reason as create_common's
+    // validate_name path).
+    let err = ext2_symlink(&super_arc, &parent, &parent_vfs, &sb, b".", b"/bin")
+        .err()
+        .expect("`.` name must fail");
+    assert_eq!(err, EEXIST);
+
+    // Parent inode must actually be a dir.
+    let reg =
+        create_file(&super_arc, &parent, &parent_vfs, &sb, b"reg", 0o644).expect("create reg");
+    let reg_ext2 = make_ext2_inode_from_disk(&super_arc, &sb, reg.ino as u32);
+    let err = ext2_symlink(&super_arc, &reg_ext2, &reg, &sb, b"bad", b"/bin")
+        .err()
+        .expect("non-dir parent must fail");
+    assert_eq!(err, ENOTDIR);
+
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn symlink_ro_mount_refuses() {
+    let (sb, _fs, super_arc, disk) = mount_golden_ro();
+    let parent_vfs = iget(&super_arc, &sb, 2).expect("iget root");
+    let parent = make_ext2_inode_from_disk(&super_arc, &sb, 2);
+
+    let err = ext2_symlink(&super_arc, &parent, &parent_vfs, &sb, b"sl", b"/bin/sh")
+        .err()
+        .expect("RO mount must refuse symlink");
+    assert_eq!(err, EROFS);
+    assert_eq!(disk.writes(), 0, "no writes on a refused RO symlink");
+
+    sb.ops.unmount();
+    drop(super_arc);
+}


### PR DESCRIPTION
## Summary

Implements `InodeOps::link` and `InodeOps::symlink` for ext2 (RFC 0004 Workstream E, issue #570). Reuses the create-path's write ordering and dirent-insert helpers from #568.

- Hard link: inode-table RMW bumps target's `i_links_count` + `i_ctime`, then `add_link` splices a new dirent. Directory targets → `EPERM`; cross-superblock → `EXDEV`; `u16::MAX` nlink → `EMLINK`; `i_dtime != 0` tombstones → `ENOENT`. `add_link` failure reverts the bump.
- Symbolic link: `ialloc::alloc_inode` → fast (≤ 60 bytes inline in `i_block[]`) or slow (> 60 bytes, `balloc::alloc_block` + zero + write) → encode + flush → `add_link` → flush. `i_mode = S_IFLNK | 0o777` per POSIX §4.10.
- Promotes `add_link` / `write_new_inode` / `read_inode_slot` / `validate_name` from `create.rs` to `pub(super)` so `link.rs` shares the exact same duplicate-name gate, dirent-split logic, and rev-1 inode-slot preservation.
- Wires `InodeOps::{link, symlink}` on `Ext2Inode` to dispatch into the new free functions.

Closes #570

## Test plan

- [x] `cargo xtask build` green.
- [x] New `kernel/tests/ext2_link.rs` (10 QEMU integration tests) all pass:
  - `link_bumps_nlink_and_inserts_dirent` — on-disk `i_links_count` +1, VFS meta mirrors, both names resolve to the same ino.
  - `link_refuses_directory_target` → `EPERM`.
  - `link_refuses_duplicate_name` → `EEXIST`.
  - `link_ro_mount_refuses` → `EROFS` with zero backing-disk writes.
  - `symlink_fast_inline_60_bytes` — fast-path gate (`is_fast_symlink`), readback via existing `read_symlink`.
  - `symlink_slow_61_bytes` — slow-path data block allocated, `i_blocks != 0`, byte-for-byte readback.
  - `symlink_boundary_60_vs_61` — exactly 60 bytes still inline; 61 flips to slow.
  - `symlink_rejects_oversize` — 4096-byte target → `ENAMETOOLONG`.
  - `symlink_rejects_bad_name` — reserved name `.` → `EEXIST`; non-dir parent → `ENOTDIR`.
  - `symlink_ro_mount_refuses` → `EROFS` with zero writes.
- [x] Host unit tests for `filetype_from_mode` and the constants.