### PR TITLE
fs/ext2: orphan-list final-close — truncate, free, unchain (#573)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -423,3 +423,8 @@ required-features = ["ext2"]
 [[test]]
 name = "umount2_flags"
 harness = false
+
+[[test]]
+name = "ext2_orphan_finalize"
+harness = false
+required-features = ["ext2"]

--- a/kernel/src/fs/ext2/fs.rs
+++ b/kernel/src/fs/ext2/fs.rs
@@ -631,9 +631,11 @@ impl SuperOps for Ext2Super {
     ///
     /// If `ino` is present in [`Ext2Super::orphan_list`], run the
     /// RFC 0004 §Final-close sequence via
-    /// [`super::orphan_finalize::finalize`]: truncate-to-zero, free
-    /// the inode, unchain from the on-disk orphan list, drop the
-    /// in-memory pin. A non-orphan ino (a normal inode falling out of
+    /// [`super::orphan_finalize::finalize`]: truncate-to-zero,
+    /// unchain from the on-disk orphan list (stamp `i_dtime` tombstone),
+    /// free the inode in the bitmap, then drop the in-memory pin.
+    /// Ordering note: unchain-before-free is load-bearing — see the
+    /// `orphan_finalize` module docs. A non-orphan ino (a normal inode falling out of
     /// the VFS cache) is a no-op — ext2 has no dirty-inode writeback
     /// yet; that lives behind the future `sync` path.
     ///

--- a/kernel/src/fs/ext2/fs.rs
+++ b/kernel/src/fs/ext2/fs.rs
@@ -625,6 +625,54 @@ impl SuperOps for Ext2Super {
         })
     }
 
+    /// VFS eviction hook: the last `Arc<Inode>` for `ino` (excluding
+    /// any orphan-list pin) just dropped, and the `gc_queue` drainer
+    /// is calling us to finalize.
+    ///
+    /// If `ino` is present in [`Ext2Super::orphan_list`], run the
+    /// RFC 0004 §Final-close sequence via
+    /// [`super::orphan_finalize::finalize`]: truncate-to-zero, free
+    /// the inode, unchain from the on-disk orphan list, drop the
+    /// in-memory pin. A non-orphan ino (a normal inode falling out of
+    /// the VFS cache) is a no-op — ext2 has no dirty-inode writeback
+    /// yet; that lives behind the future `sync` path.
+    ///
+    /// Errors are swallowed with a `kwarn!`: the VFS drainer has no
+    /// useful fallback and leaving the orphan-list pin in place means
+    /// the next mount-time replay (#564) will see the entry and retry
+    /// the sequence.
+    fn evict_inode(&self, ino: u64) -> Result<(), i64> {
+        // ino comes in as u64 from the VFS; ext2's ino space is u32.
+        // Values above u32::MAX can't reference a real on-disk inode.
+        let Ok(ext2_ino) = u32::try_from(ino) else {
+            return Ok(());
+        };
+        // Fast path: non-orphan cache eviction. Nothing to do.
+        let is_orphan = { self.orphan_list.lock().contains_key(&ext2_ino) };
+        if !is_orphan {
+            return Ok(());
+        }
+        // Upgrade the self_ref to a strong Arc<Ext2Super> so the
+        // finalize free-function can be called. The Arc is live because
+        // `gc_queue` upgraded its own Weak<SuperBlock> before calling
+        // us, and that SuperBlock holds an Arc<dyn SuperOps> = Arc of
+        // this very Ext2Super.
+        let Some(super_arc) = self.self_ref.upgrade() else {
+            return Ok(());
+        };
+        match super::orphan_finalize::finalize(&super_arc, ext2_ino) {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                crate::kwarn!(
+                    "ext2: orphan finalize ino {}: errno={}, leaving pin for replay",
+                    ext2_ino,
+                    e,
+                );
+                Ok(())
+            }
+        }
+    }
+
     fn sync_fs(&self, _sb: &SuperBlock) -> Result<(), i64> {
         // Scope the flush to just this mount's DeviceId — shared-device
         // concurrent mounts (RFC 0004 §Buffer cache) must not leak.

--- a/kernel/src/fs/ext2/mod.rs
+++ b/kernel/src/fs/ext2/mod.rs
@@ -140,3 +140,13 @@ pub mod link;
 
 #[cfg(all(feature = "ext2", target_os = "none"))]
 pub use link::{link, symlink};
+
+// Orphan-list final-close sequence (#573). Runs the four-step
+// truncate → free_inode → unchain → unpin pipeline for an unlinked-
+// but-closed inode. Same feature gate as the rest of the write-path
+// modules; the integration test lives in `kernel/tests/ext2_orphan_finalize.rs`.
+#[cfg(all(feature = "ext2", target_os = "none"))]
+pub mod orphan_finalize;
+
+#[cfg(all(feature = "ext2", target_os = "none"))]
+pub use orphan_finalize::finalize as finalize_orphan;

--- a/kernel/src/fs/ext2/orphan_finalize.rs
+++ b/kernel/src/fs/ext2/orphan_finalize.rs
@@ -158,7 +158,6 @@ pub fn finalize(super_ref: &Arc<Ext2Super>, ino: u32) -> Result<(), i64> {
         }
     }
 
-    let _kind = pinned.kind;
     // `free_inode`'s `was_dir` flag drives a `bg_used_dirs_count`
     // decrement. The unlink path (#569) already decrements that counter
     // inside `rmdir` via `decrement_used_dirs`, *before* it hands the

--- a/kernel/src/fs/ext2/orphan_finalize.rs
+++ b/kernel/src/fs/ext2/orphan_finalize.rs
@@ -1,0 +1,410 @@
+//! ext2 orphan-list final-close sequence (issue #573).
+//!
+//! RFC 0004 (`docs/RFC/0004-ext2-filesystem-driver.md`) §Orphan list,
+//! §Final-close sequence is the normative spec. Workstream E.
+//!
+//! # What this wave does
+//!
+//! When an unlinked-but-still-open inode reaches its last close (the
+//! last non-orphan-list strong reference drops), the driver must run
+//! the four-step finalize sequence:
+//!
+//! 1. **Truncate-to-zero**: free every data + indirect block via
+//!    [`super::balloc::free_block`]; matches the shrinking-SIZE path in
+//!    [`super::setattr::truncate_free`] (#572). Runs even for
+//!    directories (which `setattr` refuses with `EISDIR`) — an orphaned
+//!    empty directory may still own its data block until finalize
+//!    releases it.
+//! 2. **Free the inode**: call [`super::ialloc::free_inode`] to clear
+//!    the inode bitmap bit and bump `s_free_inodes_count`.
+//! 3. **Remove from the on-disk orphan chain**: update the predecessor
+//!    that points at this ino (via `s_last_orphan` or another orphan's
+//!    `i_dtime`) to skip over it. Then stamp this inode's `i_dtime`
+//!    with the current wall-clock time so an `e2fsck` / remount sees it
+//!    as fully deleted rather than as an orphan-chain terminator.
+//! 4. **Drop the `Arc<Inode>` pin** from
+//!    [`super::inode::OrphanList`]. This releases the residency root;
+//!    any still-live cache `Weak<Inode>` will upgrade to `None` on the
+//!    next `iget` and the cache slot gets swept out.
+//!
+//! # Atomicity
+//!
+//! If the driver crashes (or power cuts) mid-sequence, the on-mount
+//! orphan-chain validator (#564) re-discovers the inode and pins it
+//! into [`super::inode::OrphanList`]; a subsequent explicit
+//! [`finalize`] call (or the equivalent userspace `fsck`) then re-runs
+//! the sequence. The steps are ordered so each individual write leaves
+//! the filesystem in a re-runnable state:
+//!
+//! - After step 1, blocks that were freed back to the allocator won't
+//!   be double-freed on replay because step 1 rereads the current
+//!   on-disk `i_block[]` each time — already-cleared slots are no-ops.
+//! - Step 2 (`free_inode`) tolerates a second call only if the bitmap
+//!   bit is still set; a second call from replay would see a cleared
+//!   bit and return `EIO`. The mount-replay (#564) orphan-chain walker
+//!   already gates the finalize on `i_links_count == 0` — after step 2
+//!   the inode's on-disk `i_links_count` is still 0 (we never clear the
+//!   inode-slot; `free_inode` only flips the bitmap), so replay
+//!   proceeds. The double-free is avoided because step 3's `i_dtime`
+//!   stamp (a nonzero wall-clock) is what the replay validator checks
+//!   to decide "this is fully deleted, skip."
+//! - Step 3 finally unchains the inode and stamps a real `i_dtime`. At
+//!   this point the mount-replay walker would observe
+//!   `i_dtime != 0 && i_links_count == 0` — the canonical "fully
+//!   deleted" state — and would not re-enlist the inode.
+//! - Step 4 is in-memory only; a crash here costs nothing beyond the
+//!   pin until the next mount.
+//!
+//! # Out of scope
+//!
+//! - The production trigger (wiring the last-fd-close event to this
+//!   finalize call). In the current ext2 driver, the orphan list holds
+//!   `Arc<Inode>` strong refs — the last `OpenFile` drop doesn't cause
+//!   the `Inode` to hit zero while an orphan-list entry exists.
+//!   [`Ext2Super::evict_inode`](super::fs::Ext2Super) is the hook site
+//!   the VFS `gc_queue` drives, but it only fires when the VFS drops
+//!   the last `Arc<Inode>` it holds, which only happens after the
+//!   orphan-list pin is explicitly released. Until the production
+//!   trigger is wired (follow-up issue; see "Wiring the production
+//!   trigger" below), callers invoke [`finalize`] directly — this is
+//!   sufficient for the mount-time replay path (#564) and for the
+//!   integration tests that exercise the sequence end-to-end.
+//!
+//! # Wiring the production trigger
+//!
+//! The RFC 0004 design envisions a per-`OpenFile` drop that, after
+//! decrementing a driver-side refcount, calls this module's [`finalize`]
+//! when the count hits zero for an unlinked inode. That refcount hook
+//! doesn't exist yet on `OpenFile`; adding it is a separate VFS surface
+//! change and will be handled in a follow-up. Until then, mount-time
+//! replay (#564) and explicit calls (from tests, or a future background
+//! orphan-sweep) are the two callers.
+
+use alloc::sync::Arc;
+
+use super::disk::{
+    Ext2Inode as DiskInode, Ext2SuperBlock, EXT2_INODE_SIZE_V0, EXT2_N_BLOCKS, EXT2_SUPERBLOCK_SIZE,
+};
+use super::fs::{Ext2MountFlags, Ext2Super, SUPERBLOCK_BYTE_OFFSET};
+use super::inode::Ext2Inode;
+use super::setattr::{locate_inode_slot, truncate_free};
+
+use crate::fs::{EIO, ENOENT, EROFS};
+
+/// Run the RFC 0004 §Final-close sequence for orphan inode `ino` on
+/// the given mount.
+///
+/// Preconditions (enforced by returns, not panic):
+///
+/// - The mount is writable (`EROFS` if `RDONLY` / `FORCED_RDONLY`).
+/// - `ino` is present in [`super::inode::OrphanList`] (`ENOENT`
+///   otherwise — an idempotent sentinel for "already finalized").
+/// - The on-disk inode slot is still in the "orphan" state —
+///   `i_links_count == 0`. A nonzero `i_links_count` means someone
+///   relinked the inode while it was orphaned (e.g. `linkat(2)` against
+///   an orphan, which ext2 does not currently permit but should reject
+///   gracefully anyway); `EIO` is returned.
+///
+/// On success, the `Arc<Inode>` pin is removed from
+/// [`super::inode::OrphanList`] and all of the on-disk bookkeeping is
+/// flushed through the buffer cache.
+///
+/// On any mid-sequence error, the in-memory `orphan_list` pin is left
+/// in place so the next finalize attempt (explicit re-call, or
+/// mount-time replay) can retry.
+pub fn finalize(super_ref: &Arc<Ext2Super>, ino: u32) -> Result<(), i64> {
+    if super_ref.ext2_flags.contains(Ext2MountFlags::RDONLY)
+        || super_ref.ext2_flags.contains(Ext2MountFlags::FORCED_RDONLY)
+    {
+        return Err(EROFS);
+    }
+
+    // 0. Pull the pinned Arc<Inode> out of the orphan list as a clone
+    //    so we can resolve the Ext2Inode + kind while the sequence
+    //    runs. Do NOT remove the entry yet — keep the pin until step 4
+    //    so a mid-sequence failure leaves the inode still recoverable.
+    let pinned = {
+        let list = super_ref.orphan_list.lock();
+        list.get(&ino).cloned()
+    };
+    let pinned = pinned.ok_or(ENOENT)?;
+
+    // Recover the driver-private Ext2Inode via the parallel cache.
+    let ext2_inode = {
+        let cache = super_ref.ext2_inode_cache.lock();
+        cache.get(&ino).and_then(|w| w.upgrade()).ok_or(EIO)?
+    };
+
+    let _kind = pinned.kind;
+    // `free_inode`'s `was_dir` flag drives a `bg_used_dirs_count`
+    // decrement. The unlink path (#569) already decrements that counter
+    // inside `rmdir` via `decrement_used_dirs`, *before* it hands the
+    // inode to the orphan list. Passing `was_dir = true` here would
+    // double-decrement and leave the BGDT slot underflowed. The counter
+    // is maintained at unlink time in this driver, not at finalize time.
+    let was_dir = false;
+
+    // 1. Truncate to zero: free all data + indirect blocks. Reuse the
+    //    setattr shrinking path; it already walks reverse-logical so a
+    //    crash mid-walk leaves a prefix reachable (not a suffix past
+    //    EOF). `truncate_free` returns the updated i_block[] and the
+    //    count of freed blocks; we commit both to disk via an RMW of
+    //    the inode slot so that a crash between here and step 2 leaves
+    //    the inode cleanly truncated (i_size=0, i_blocks=0, i_block[]
+    //    all zero) — mount-replay (#564) will then re-run steps 2-4.
+    truncate_inode_to_zero(super_ref, &ext2_inode)?;
+
+    // 2. Free the inode number in the inode bitmap and bump
+    //    `s_free_inodes_count`. `was_dir` decrements
+    //    `bg_used_dirs_count` for the owning group.
+    super::ialloc::free_inode(super_ref, ino, was_dir)?;
+
+    // 3. Remove this ino from the on-disk orphan chain: patch the
+    //    predecessor (either `s_last_orphan` or another orphan's
+    //    `i_dtime`) to point at our `i_dtime` (next-pointer), then
+    //    stamp *our* `i_dtime` with the current wall-clock seconds so
+    //    a subsequent mount-time walker sees us as fully deleted
+    //    (`i_links_count == 0 && i_dtime != 0 && i_dtime < some-chain-head`
+    //    — the linkage is dead and only the dtime-tombstone remains).
+    unchain_orphan(super_ref, ino)?;
+
+    // 4. Drop the in-memory Arc<Inode> pin. After this the inode cache's
+    //    Weak<Inode> will no longer upgrade; a racing `iget` that
+    //    started before step 4 may still hold a live Arc through its
+    //    own local, and the tail of its walk will simply find a
+    //    fully-deleted on-disk inode — which it should already tolerate
+    //    via the `i_mode == 0` / `i_dtime != 0` decode check.
+    {
+        let mut list = super_ref.orphan_list.lock();
+        let _ = list.remove(&ino);
+    }
+
+    drop(pinned);
+    Ok(())
+}
+
+/// Step 1 of the finalize sequence: free every data + indirect block
+/// on `ext2_inode`, zero out `i_block[]` / `i_blocks` / `i_size` in the
+/// in-memory meta, and RMW-flush the on-disk inode slot.
+///
+/// A separate entry point (instead of invoking `setattr` with
+/// `SIZE = 0`) because `setattr` refuses SIZE on directories (`EISDIR`)
+/// — orphaned directories reach this path through rmdir's hit-zero,
+/// and their data block (the last dirent page) must still be released.
+/// This helper bypasses the kind-guard; it trusts the caller's
+/// orphan-state proof.
+fn truncate_inode_to_zero(
+    super_ref: &Arc<Ext2Super>,
+    ext2_inode: &Arc<Ext2Inode>,
+) -> Result<(), i64> {
+    // Snapshot the current i_block[] under the read lock; we pass it
+    // into `truncate_free` without holding the lock across the (many)
+    // buffer-cache writes the free walk will drive.
+    let cur_i_block = { ext2_inode.meta.read().i_block };
+
+    // new_size = 0 → free everything; `truncate_free` returns the
+    // updated pointer array (all zeros on success) and a freed count.
+    let (_freed, new_i_block) = truncate_free(super_ref, &cur_i_block, 0)?;
+
+    // Apply to the in-memory meta.
+    {
+        let mut meta = ext2_inode.meta.write();
+        meta.size = 0;
+        meta.i_blocks = 0;
+        meta.i_block = new_i_block;
+    }
+
+    // RMW the on-disk inode slot so a later mount-replay sees a
+    // consistent zero-length orphan. We preserve `i_links_count` (must
+    // stay 0 — the orphan invariant) and `i_dtime` (still the orphan-
+    // chain next-pointer at this point; step 3 will overwrite it).
+    let (block_in_dev, offset_in_block) = locate_inode_slot(super_ref, ext2_inode.ino)?;
+    let bh = super_ref
+        .cache
+        .bread(super_ref.device_id, block_in_dev)
+        .map_err(|_| EIO)?;
+    {
+        let mut data = bh.data.write();
+        if offset_in_block + EXT2_INODE_SIZE_V0 > data.len() {
+            return Err(EIO);
+        }
+        let slot = &mut data[offset_in_block..offset_in_block + EXT2_INODE_SIZE_V0];
+        let mut disk = DiskInode::decode(slot);
+        disk.i_size = 0;
+        // On regular files with RO_COMPAT_LARGE_FILE, i_dir_acl_or_size_high
+        // is the high 32 bits of size; clear it so size reads back as 0.
+        let is_reg = (disk.i_mode & 0o170_000) == 0o100_000;
+        if is_reg {
+            disk.i_dir_acl_or_size_high = 0;
+        }
+        disk.i_blocks = 0;
+        disk.i_block = [0u32; EXT2_N_BLOCKS];
+        disk.encode_to_slot(slot);
+    }
+    super_ref.cache.mark_dirty(&bh);
+    super_ref.cache.sync_dirty_buffer(&bh).map_err(|_| EIO)?;
+    Ok(())
+}
+
+/// Step 3: remove `ino` from the on-disk orphan chain.
+///
+/// The chain is a singly-linked list threaded through on-disk
+/// `i_dtime` fields, with the head in `s_last_orphan`. To remove
+/// `ino`:
+///
+/// - Read `ino`'s `i_dtime` — this is the *next* pointer in the chain.
+/// - Walk from the head; find the predecessor whose next-pointer is
+///   `ino` (or notice that `s_last_orphan == ino`).
+/// - Patch the predecessor to point at `ino`'s next.
+/// - Stamp `ino`'s on-disk `i_dtime` with the current wall-clock time
+///   — converting the orphan-chain next-pointer into a real deletion
+///   timestamp, which is what `e2fsck` and mount-replay (#564) use to
+///   distinguish "fully deleted" from "still on the orphan list."
+fn unchain_orphan(super_ref: &Arc<Ext2Super>, ino: u32) -> Result<(), i64> {
+    let _guard = super_ref.alloc_mutex.lock();
+
+    // Read `ino`'s current i_dtime (= next-pointer in the chain).
+    let next_ptr = {
+        let (disk, _, _) = read_disk_inode(super_ref, ino)?;
+        disk.i_dtime
+    };
+
+    // Walk from the head to find the predecessor.
+    let head = super_ref.sb_disk.lock().s_last_orphan;
+    if head == 0 {
+        // Chain is empty but caller claims `ino` is on it — the
+        // in-memory orphan_list disagrees with the on-disk state.
+        // Return EIO; the finalize call site will leave the pin and
+        // a future replay can re-assess.
+        return Err(EIO);
+    }
+
+    if head == ino {
+        // `ino` is the head. Update `s_last_orphan := next_ptr` and
+        // flush the superblock.
+        let mut sb = super_ref.sb_disk.lock();
+        sb.s_last_orphan = next_ptr;
+        flush_superblock(super_ref, &sb)?;
+    } else {
+        // Walk forward. Bound by `s_inodes_count` to reject any
+        // cycle a racing corruption might have introduced; in a
+        // well-behaved chain the bound is never hit.
+        let s_inodes_count = super_ref.sb_disk.lock().s_inodes_count;
+        let mut cur = head;
+        let mut steps: u32 = 0;
+        loop {
+            if steps > s_inodes_count {
+                return Err(EIO);
+            }
+            steps += 1;
+            // Fetch cur's next-pointer.
+            let (cur_disk, _, _) = read_disk_inode(super_ref, cur)?;
+            let cur_next = cur_disk.i_dtime;
+            if cur_next == ino {
+                // Predecessor: patch its i_dtime to `next_ptr`.
+                rmw_disk_inode(super_ref, cur, |d| {
+                    d.i_dtime = next_ptr;
+                })?;
+                break;
+            }
+            if cur_next == 0 {
+                // End of chain without finding `ino` — inconsistent
+                // state between the in-memory pin and the on-disk
+                // chain. Return EIO; the pin is preserved for a
+                // later retry.
+                return Err(EIO);
+            }
+            cur = cur_next;
+        }
+    }
+
+    // Finally, stamp `ino`'s own i_dtime with the wall-clock. The
+    // on-disk inode slot was previously zeroed of its data pointers in
+    // step 1 and of its bitmap bit in step 2 — this write is the last
+    // on-disk mutation for this inode and marks it as fully deleted to
+    // any subsequent mount-replay walker.
+    let now = crate::fs::vfs::Timespec::now().sec as u32;
+    // `now == 0` would look like "still on orphan list" to the
+    // mount-replay walker. Defend against a clock-at-epoch situation
+    // (e.g. an early-boot RTC read returning 0) by substituting 1.
+    let dtime_stamp = if now == 0 { 1 } else { now };
+    rmw_disk_inode(super_ref, ino, |d| {
+        d.i_dtime = dtime_stamp;
+    })?;
+
+    Ok(())
+}
+
+/// Mirrors the unlink.rs helper of the same name. Reads the 128-byte
+/// rev-0 prefix of `ino`'s inode-table slot and returns the decoded
+/// `DiskInode` plus the (block, offset_in_block) locating it for the
+/// subsequent RMW.
+fn read_disk_inode(super_: &Arc<Ext2Super>, ino: u32) -> Result<(DiskInode, u64, usize), i64> {
+    let (block_in_dev, offset_in_block) = locate_inode_slot(super_, ino)?;
+    let bh = super_
+        .cache
+        .bread(super_.device_id, block_in_dev)
+        .map_err(|_| EIO)?;
+    let data = bh.data.read();
+    if offset_in_block + EXT2_INODE_SIZE_V0 > data.len() {
+        return Err(EIO);
+    }
+    let mut slot = [0u8; EXT2_INODE_SIZE_V0];
+    slot.copy_from_slice(&data[offset_in_block..offset_in_block + EXT2_INODE_SIZE_V0]);
+    Ok((DiskInode::decode(&slot), block_in_dev, offset_in_block))
+}
+
+/// RMW an on-disk inode slot with `writer` and sync the block. Mirrors
+/// `unlink::rmw_disk_inode` — kept as a module-local so each mutator
+/// owns its own flush boundary.
+fn rmw_disk_inode<F>(super_: &Arc<Ext2Super>, ino: u32, writer: F) -> Result<(), i64>
+where
+    F: FnOnce(&mut DiskInode),
+{
+    let (mut disk, block_in_dev, offset_in_block) = read_disk_inode(super_, ino)?;
+    writer(&mut disk);
+    let bh = super_
+        .cache
+        .bread(super_.device_id, block_in_dev)
+        .map_err(|_| EIO)?;
+    {
+        let mut data = bh.data.write();
+        if offset_in_block + EXT2_INODE_SIZE_V0 > data.len() {
+            return Err(EIO);
+        }
+        disk.encode_to_slot(&mut data[offset_in_block..offset_in_block + EXT2_INODE_SIZE_V0]);
+    }
+    super_.cache.mark_dirty(&bh);
+    super_.cache.sync_dirty_buffer(&bh).map_err(|_| EIO)?;
+    Ok(())
+}
+
+/// Flush the in-memory `sb_disk` snapshot back to its on-disk slot.
+/// Mirrors `unlink::flush_superblock` — each module owns its own copy
+/// so mutators don't depend on sibling-module visibility.
+fn flush_superblock(super_: &Arc<Ext2Super>, sb: &Ext2SuperBlock) -> Result<(), i64> {
+    let block_size = super_.block_size as u64;
+    if block_size == 0 {
+        return Err(EIO);
+    }
+    let sb_block = SUPERBLOCK_BYTE_OFFSET / block_size;
+    let sb_offset_in_block = (SUPERBLOCK_BYTE_OFFSET % block_size) as usize;
+    let bh = super_
+        .cache
+        .bread(super_.device_id, sb_block)
+        .map_err(|_| EIO)?;
+    {
+        let mut data = bh.data.write();
+        if sb_offset_in_block + EXT2_SUPERBLOCK_SIZE > data.len() {
+            return Err(EIO);
+        }
+        sb.encode_to_slot(&mut data[sb_offset_in_block..sb_offset_in_block + EXT2_SUPERBLOCK_SIZE]);
+    }
+    super_.cache.mark_dirty(&bh);
+    super_.cache.sync_dirty_buffer(&bh).map_err(|_| EIO)?;
+    Ok(())
+}
+
+// Host-side tests would need a full BlockCache + Ext2Super fixture; the
+// end-to-end coverage lives in `kernel/tests/ext2_orphan_finalize.rs`
+// under the ext2 integration harness.

--- a/kernel/src/fs/ext2/orphan_finalize.rs
+++ b/kernel/src/fs/ext2/orphan_finalize.rs
@@ -15,13 +15,21 @@
 //!    directories (which `setattr` refuses with `EISDIR`) — an orphaned
 //!    empty directory may still own its data block until finalize
 //!    releases it.
-//! 2. **Free the inode**: call [`super::ialloc::free_inode`] to clear
-//!    the inode bitmap bit and bump `s_free_inodes_count`.
-//! 3. **Remove from the on-disk orphan chain**: update the predecessor
-//!    that points at this ino (via `s_last_orphan` or another orphan's
-//!    `i_dtime`) to skip over it. Then stamp this inode's `i_dtime`
-//!    with the current wall-clock time so an `e2fsck` / remount sees it
-//!    as fully deleted rather than as an orphan-chain terminator.
+//! 2. **Unchain from the on-disk orphan list and stamp the tombstone**:
+//!    update the predecessor that points at this ino (via
+//!    `s_last_orphan` or another orphan's `i_dtime`) to skip over it,
+//!    then stamp this inode's `i_dtime` with the current wall-clock
+//!    time. This step **must** land before step 3 — see below.
+//! 3. **Free the inode**: call [`super::ialloc::free_inode`] to clear
+//!    the inode bitmap bit and bump `s_free_inodes_count`. Ordering
+//!    unchain-before-free is load-bearing: once the bitmap bit is
+//!    cleared, a concurrent `create(2)` can reallocate the ino. If
+//!    unchain ran after free, the allocator could hand the ino to a new
+//!    inode before the tombstone `i_dtime` write landed — and the
+//!    orphan-chain walk would then either rewrite the new inode's
+//!    `i_dtime` or leave `s_last_orphan` transiently pointing at a
+//!    reallocated, non-orphan inode. Doing unchain first keeps those
+//!    two worlds (orphan chain vs. live allocation) disjoint.
 //! 4. **Drop the `Arc<Inode>` pin** from
 //!    [`super::inode::OrphanList`]. This releases the residency root;
 //!    any still-live cache `Weak<Inode>` will upgrade to `None` on the
@@ -39,19 +47,20 @@
 //! - After step 1, blocks that were freed back to the allocator won't
 //!   be double-freed on replay because step 1 rereads the current
 //!   on-disk `i_block[]` each time — already-cleared slots are no-ops.
-//! - Step 2 (`free_inode`) tolerates a second call only if the bitmap
-//!   bit is still set; a second call from replay would see a cleared
-//!   bit and return `EIO`. The mount-replay (#564) orphan-chain walker
-//!   already gates the finalize on `i_links_count == 0` — after step 2
-//!   the inode's on-disk `i_links_count` is still 0 (we never clear the
-//!   inode-slot; `free_inode` only flips the bitmap), so replay
-//!   proceeds. The double-free is avoided because step 3's `i_dtime`
-//!   stamp (a nonzero wall-clock) is what the replay validator checks
-//!   to decide "this is fully deleted, skip."
-//! - Step 3 finally unchains the inode and stamps a real `i_dtime`. At
-//!   this point the mount-replay walker would observe
-//!   `i_dtime != 0 && i_links_count == 0` — the canonical "fully
-//!   deleted" state — and would not re-enlist the inode.
+//! - Step 2 unchains the inode and stamps a real `i_dtime`. The bitmap
+//!   bit is still set at this point, so the ino is not reusable; if we
+//!   crash between step 2 and step 3, mount-replay (#564) observes
+//!   `i_links_count == 0 && i_dtime != 0` — the canonical "fully
+//!   deleted" state — and skips it. The orphan chain has already been
+//!   patched, so the inode is no longer on any orphan-list walk.
+//! - Step 3 (`free_inode`) tolerates a second call only if the bitmap
+//!   bit is still set. A crash between the tombstone and this step
+//!   leaves the bit set; mount-replay re-runs `free_inode` (the ino is
+//!   not on the chain anymore, so replay finds it via a separate scan
+//!   of the bitmap or via userspace `fsck`). The double-free is
+//!   avoided because step 2's `i_dtime` stamp (a nonzero wall-clock)
+//!   is what the replay validator checks to decide "this is fully
+//!   deleted, skip."
 //! - Step 4 is in-memory only; a crash here costs nothing beyond the
 //!   pin until the next mount.
 //!
@@ -135,6 +144,20 @@ pub fn finalize(super_ref: &Arc<Ext2Super>, ino: u32) -> Result<(), i64> {
         cache.get(&ino).and_then(|w| w.upgrade()).ok_or(EIO)?
     };
 
+    // Guard: the on-disk slot must still be in the orphan state —
+    // `i_links_count == 0`. A racing relink (currently rejected by the
+    // driver, but defense in depth) would leave a positive link count;
+    // freeing the inode underneath a live dirent would silently corrupt
+    // the filesystem. Read-only check, no lock held across it; the
+    // orphan-list pin (cloned above) keeps the ino from being concurrently
+    // finalized elsewhere.
+    {
+        let (disk, _, _) = read_disk_inode(super_ref, ino)?;
+        if disk.i_links_count != 0 {
+            return Err(EIO);
+        }
+    }
+
     let _kind = pinned.kind;
     // `free_inode`'s `was_dir` flag drives a `bg_used_dirs_count`
     // decrement. The unlink path (#569) already decrements that counter
@@ -154,19 +177,20 @@ pub fn finalize(super_ref: &Arc<Ext2Super>, ino: u32) -> Result<(), i64> {
     //    all zero) — mount-replay (#564) will then re-run steps 2-4.
     truncate_inode_to_zero(super_ref, &ext2_inode)?;
 
-    // 2. Free the inode number in the inode bitmap and bump
+    // 2. Remove this ino from the on-disk orphan chain and stamp the
+    //    deletion tombstone. This **must** happen before step 3: once
+    //    the inode bitmap bit is cleared, a concurrent `create(2)` can
+    //    re-allocate this ino. Doing unchain-then-stamp first keeps the
+    //    ino off the orphan chain and durably tombstoned while the bit
+    //    is still set, so there's no window where `s_last_orphan` or a
+    //    predecessor's `i_dtime` could transiently point at a reallocated,
+    //    non-orphan inode.
+    unchain_orphan(super_ref, ino)?;
+
+    // 3. Free the inode number in the inode bitmap and bump
     //    `s_free_inodes_count`. `was_dir` decrements
     //    `bg_used_dirs_count` for the owning group.
     super::ialloc::free_inode(super_ref, ino, was_dir)?;
-
-    // 3. Remove this ino from the on-disk orphan chain: patch the
-    //    predecessor (either `s_last_orphan` or another orphan's
-    //    `i_dtime`) to point at our `i_dtime` (next-pointer), then
-    //    stamp *our* `i_dtime` with the current wall-clock seconds so
-    //    a subsequent mount-time walker sees us as fully deleted
-    //    (`i_links_count == 0 && i_dtime != 0 && i_dtime < some-chain-head`
-    //    — the linkage is dead and only the dtime-tombstone remains).
-    unchain_orphan(super_ref, ino)?;
 
     // 4. Drop the in-memory Arc<Inode> pin. After this the inode cache's
     //    Weak<Inode> will no longer upgrade; a racing `iget` that
@@ -217,7 +241,7 @@ fn truncate_inode_to_zero(
     // RMW the on-disk inode slot so a later mount-replay sees a
     // consistent zero-length orphan. We preserve `i_links_count` (must
     // stay 0 — the orphan invariant) and `i_dtime` (still the orphan-
-    // chain next-pointer at this point; step 3 will overwrite it).
+    // chain next-pointer at this point; step 2 will overwrite it).
     let (block_in_dev, offset_in_block) = locate_inode_slot(super_ref, ext2_inode.ino)?;
     let bh = super_ref
         .cache
@@ -246,7 +270,8 @@ fn truncate_inode_to_zero(
     Ok(())
 }
 
-/// Step 3: remove `ino` from the on-disk orphan chain.
+/// Step 2: remove `ino` from the on-disk orphan chain and stamp its
+/// `i_dtime` tombstone.
 ///
 /// The chain is a singly-linked list threaded through on-disk
 /// `i_dtime` fields, with the head in `s_last_orphan`. To remove
@@ -320,9 +345,11 @@ fn unchain_orphan(super_ref: &Arc<Ext2Super>, ino: u32) -> Result<(), i64> {
 
     // Finally, stamp `ino`'s own i_dtime with the wall-clock. The
     // on-disk inode slot was previously zeroed of its data pointers in
-    // step 1 and of its bitmap bit in step 2 — this write is the last
-    // on-disk mutation for this inode and marks it as fully deleted to
-    // any subsequent mount-replay walker.
+    // step 1 — this write converts the orphan-chain next-pointer into
+    // a real deletion timestamp. Step 3 (`free_inode`) runs after this
+    // to release the bitmap bit; at that point mount-replay sees
+    // `i_links_count == 0 && i_dtime != 0` and knows the inode is
+    // fully deleted.
     let now = crate::fs::vfs::Timespec::now().sec as u32;
     // `now == 0` would look like "still on orphan list" to the
     // mount-replay walker. Defend against a clock-at-epoch situation

--- a/kernel/src/fs/ext2/setattr.rs
+++ b/kernel/src/fs/ext2/setattr.rs
@@ -298,7 +298,7 @@ pub fn setattr(ext2_inode: &Ext2Inode, inode: &Inode, attr: &SetAttr) -> Result<
 /// Compute the (absolute block, offset-in-block) location of the
 /// inode-table slot for `ino`. Mirrors the arithmetic in
 /// [`super::inode::iget`].
-fn locate_inode_slot(super_ref: &Arc<Ext2Super>, ino: u32) -> Result<(u64, usize), i64> {
+pub(super) fn locate_inode_slot(super_ref: &Arc<Ext2Super>, ino: u32) -> Result<(u64, usize), i64> {
     if ino == 0 {
         return Err(EINVAL);
     }
@@ -340,7 +340,7 @@ fn locate_inode_slot(super_ref: &Arc<Ext2Super>, ino: u32) -> Result<(u64, usize
 /// The walk is reverse-logical: highest logical block first, so a
 /// crash mid-walk leaves a prefix of the file intact and no "past
 /// EOF" block pointer still reachable from the inode.
-fn truncate_free(
+pub(super) fn truncate_free(
     super_ref: &Arc<Ext2Super>,
     cur_i_block: &[u32; EXT2_N_BLOCKS],
     new_size: u64,

--- a/kernel/tests/ext2_orphan_finalize.rs
+++ b/kernel/tests/ext2_orphan_finalize.rs
@@ -178,6 +178,28 @@ fn mount_ro() -> (Arc<SuperBlock>, Arc<Ext2Fs>, Arc<Ext2Super>, Arc<RamDisk>) {
 // Tests
 // ---------------------------------------------------------------------------
 
+// On-disk offsets for the tombstone-state assertion. Duplicated from
+// the ext2_orphan_chain test — the offsets are pinned against the real
+// mkfs.ext2 layout rather than consuming crate-private constants.
+const BGDT_BYTE_OFFSET_1K: usize = 2048;
+const BGD_OFF_INODE_TABLE: usize = 8;
+const INODE_SIZE: usize = 128;
+const INODE_OFF_DTIME: usize = 20;
+const INODE_OFF_LINKS_COUNT: usize = 26;
+const BLOCK_SIZE_BYTES: usize = 1024;
+
+fn u32_le(image: &[u8], off: usize) -> u32 {
+    u32::from_le_bytes(image[off..off + 4].try_into().unwrap())
+}
+fn u16_le(image: &[u8], off: usize) -> u16 {
+    u16::from_le_bytes(image[off..off + 2].try_into().unwrap())
+}
+fn inode_slot_offset(image: &[u8], ino: u32) -> usize {
+    let itab_block = u32_le(image, BGDT_BYTE_OFFSET_1K + BGD_OFF_INODE_TABLE) as usize;
+    let slot_in_table = (ino as usize) - 1;
+    itab_block * BLOCK_SIZE_BYTES + slot_in_table * INODE_SIZE
+}
+
 fn finalize_rmdir_orphan_frees_blocks_and_chain_head() {
     let (sb, _fs, super_arc, _disk) = mount_rw();
 
@@ -259,6 +281,26 @@ fn finalize_rmdir_orphan_frees_blocks_and_chain_head() {
         free_blocks_after > free_blocks_before,
         "finalize must free lost+found's dir data block back to the allocator (before={free_blocks_before}, after={free_blocks_after})",
     );
+    // 6. Tombstone state. The on-disk inode slot for ino 11 must show
+    //    `i_links_count == 0 && i_dtime != 0` — the canonical "fully
+    //    deleted" signature mount-replay (#564) uses to distinguish
+    //    finalized inodes from still-orphan ones. Read the block
+    //    directly off the RamDisk storage so we bypass any in-memory
+    //    cache of the Ext2Inode.
+    {
+        let storage = _disk.storage.lock();
+        let slot_off = inode_slot_offset(&storage, 11);
+        let links = u16_le(&storage, slot_off + INODE_OFF_LINKS_COUNT);
+        let dtime = u32_le(&storage, slot_off + INODE_OFF_DTIME);
+        assert_eq!(
+            links, 0,
+            "finalize must leave i_links_count == 0 (orphan invariant preserved)"
+        );
+        assert_ne!(
+            dtime, 0,
+            "finalize must stamp a nonzero i_dtime — mount-replay uses i_dtime != 0 as the 'fully deleted' marker"
+        );
+    }
 
     sb.ops.unmount();
     drop(super_arc);

--- a/kernel/tests/ext2_orphan_finalize.rs
+++ b/kernel/tests/ext2_orphan_finalize.rs
@@ -1,0 +1,297 @@
+//! Integration test for issue #573: ext2 orphan-list final-close
+//! sequence — truncate-to-zero, free inode, unchain from the on-disk
+//! orphan list.
+//!
+//! RFC 0004 (`docs/RFC/0004-ext2-filesystem-driver.md`) §Orphan list
+//! and §Final-close sequence are the normative spec. This test drives
+//! the sequence in two entry configurations:
+//!
+//! 1. **Single-entry chain**: rmdir `lost+found` → orphan_list + chain
+//!    head both carry ino 11. Call [`finalize_orphan`] → blocks freed,
+//!    inode freed in the bitmap, `s_last_orphan` reverts to 0, in-memory
+//!    orphan_list empty.
+//! 2. **RO mount rejects**: mounting RO and invoking the finalize
+//!    free function returns `EROFS`, preserving the pin.
+//! 3. **No-op on non-orphan**: calling finalize for a ino that isn't
+//!    in orphan_list returns `ENOENT`.
+//!
+//! A "mid-sequence crash and replay" test isn't wired here because the
+//! replay path (mount-time orphan-chain validator, #564) already has
+//! independent coverage in `kernel/tests/ext2_orphan_chain.rs`; the
+//! interesting property for *this* PR is that finalize itself is the
+//! round-trip the replay path eventually drives.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+use spin::Mutex;
+
+use vibix::block::{BlockDevice, BlockError};
+use vibix::fs::ext2::{finalize_orphan, iget, Ext2Fs, Ext2Super};
+use vibix::fs::vfs::ops::{FileSystem as _, MountSource};
+use vibix::fs::vfs::super_block::SuperBlock;
+use vibix::fs::vfs::MountFlags;
+use vibix::fs::{ENOENT, EROFS};
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+const GOLDEN_IMG: &[u8; 65_536] = include_bytes!("../src/fs/ext2/fixtures/golden.img");
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "finalize_rmdir_orphan_frees_blocks_and_chain_head",
+            &(finalize_rmdir_orphan_frees_blocks_and_chain_head as fn()),
+        ),
+        (
+            "finalize_on_non_orphan_is_enoent",
+            &(finalize_on_non_orphan_is_enoent as fn()),
+        ),
+        (
+            "finalize_ro_mount_is_erofs",
+            &(finalize_ro_mount_is_erofs as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RamDisk — matches ext2_unlink.rs.
+// ---------------------------------------------------------------------------
+
+struct RamDisk {
+    block_size: u32,
+    storage: Mutex<Vec<u8>>,
+    writes: AtomicU32,
+    read_only: AtomicBool,
+}
+
+impl RamDisk {
+    fn from_image(bytes: &[u8], block_size: u32) -> Arc<Self> {
+        assert!(bytes.len() % block_size as usize == 0);
+        Arc::new(Self {
+            block_size,
+            storage: Mutex::new(bytes.to_vec()),
+            writes: AtomicU32::new(0),
+            read_only: AtomicBool::new(false),
+        })
+    }
+
+    fn set_read_only(&self, ro: bool) {
+        self.read_only.store(ro, Ordering::Relaxed);
+    }
+}
+
+impl BlockDevice for RamDisk {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
+        let bs = self.block_size as u64;
+        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
+            return Err(BlockError::BadAlign);
+        }
+        let storage = self.storage.lock();
+        let end = offset
+            .checked_add(buf.len() as u64)
+            .ok_or(BlockError::OutOfRange)?;
+        if end > storage.len() as u64 {
+            return Err(BlockError::OutOfRange);
+        }
+        let off = offset as usize;
+        buf.copy_from_slice(&storage[off..off + buf.len()]);
+        Ok(())
+    }
+    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
+        if self.read_only.load(Ordering::Relaxed) {
+            return Err(BlockError::ReadOnly);
+        }
+        let bs = self.block_size as u64;
+        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
+            return Err(BlockError::BadAlign);
+        }
+        let mut storage = self.storage.lock();
+        let end = offset
+            .checked_add(buf.len() as u64)
+            .ok_or(BlockError::Enospc)?;
+        if end > storage.len() as u64 {
+            return Err(BlockError::Enospc);
+        }
+        let off = offset as usize;
+        storage[off..off + buf.len()].copy_from_slice(buf);
+        self.writes.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+    fn block_size(&self) -> u32 {
+        self.block_size
+    }
+    fn capacity(&self) -> u64 {
+        self.storage.lock().len() as u64
+    }
+}
+
+fn mount_rw() -> (Arc<SuperBlock>, Arc<Ext2Fs>, Arc<Ext2Super>, Arc<RamDisk>) {
+    let disk = RamDisk::from_image(GOLDEN_IMG.as_slice(), 512);
+    let fs = Ext2Fs::new_with_device(disk.clone() as Arc<dyn BlockDevice>);
+    let sb = fs
+        .mount(MountSource::None, MountFlags(0))
+        .expect("RW mount");
+    let super_arc = fs.current_super().expect("current_super");
+    (sb, fs, super_arc, disk)
+}
+
+fn mount_ro() -> (Arc<SuperBlock>, Arc<Ext2Fs>, Arc<Ext2Super>, Arc<RamDisk>) {
+    let disk = RamDisk::from_image(GOLDEN_IMG.as_slice(), 512);
+    let fs = Ext2Fs::new_with_device(disk.clone() as Arc<dyn BlockDevice>);
+    let sb = fs
+        .mount(MountSource::None, MountFlags::RDONLY)
+        .expect("RO mount");
+    disk.set_read_only(true);
+    let super_arc = fs.current_super().expect("current_super");
+    (sb, fs, super_arc, disk)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+fn finalize_rmdir_orphan_frees_blocks_and_chain_head() {
+    let (sb, _fs, super_arc, _disk) = mount_rw();
+
+    // Snapshot baselines.
+    let (free_inodes_before, free_blocks_before) = {
+        let d = super_arc.sb_disk.lock();
+        (d.s_free_inodes_count, d.s_free_blocks_count)
+    };
+    let used_dirs_before_mount = super_arc.bgdt.lock()[0].bg_used_dirs_count;
+
+    // Drive the rmdir half: this populates orphan_list + s_last_orphan.
+    let root = iget(&super_arc, &sb, 2).expect("iget root");
+    // Pre-load ino 11 into the ext2-inode cache so finalize can upgrade
+    // its Weak<Ext2Inode>. rmdir itself already performs the iget, but
+    // binding a local here makes the ext2_inode_cache insertion visible
+    // for the rest of this test even after rmdir returns.
+    let _lf = iget(&super_arc, &sb, 11).expect("iget lost+found");
+    root.ops
+        .rmdir(&root, b"lost+found")
+        .expect("rmdir(lost+found)");
+
+    // Confirm rmdir's postconditions (mirror ext2_unlink.rs expectations).
+    assert_eq!(
+        super_arc.sb_disk.lock().s_last_orphan,
+        11,
+        "rmdir must leave chain head at ino 11"
+    );
+    assert!(
+        super_arc.orphan_list.lock().contains_key(&11),
+        "rmdir must pin ino 11 in the orphan_list"
+    );
+
+    // Drop the explicit Arc<Inode> so only the orphan_list pin +
+    // inode-cache Weak remain live for ino 11. `finalize` should still
+    // succeed — it reaches the Ext2Inode via the parallel ext2 inode
+    // cache, which shares the pinned Arc through `inode.ops`.
+    drop(_lf);
+
+    // Now run the final-close sequence.
+    finalize_orphan(&super_arc, 11).expect("finalize");
+
+    // Postconditions.
+    // 1. Orphan chain head reverts to 0 (we were the sole entry).
+    assert_eq!(
+        super_arc.sb_disk.lock().s_last_orphan,
+        0,
+        "finalize must clear the on-disk chain head for the last entry"
+    );
+    // 2. Orphan list is empty.
+    assert!(
+        super_arc.orphan_list.lock().is_empty(),
+        "finalize must drop the in-memory pin"
+    );
+    // 3. Free-inode counter incremented by 1.
+    let free_inodes_after = super_arc.sb_disk.lock().s_free_inodes_count;
+    assert_eq!(
+        free_inodes_after,
+        free_inodes_before + 1,
+        "free_inode must bump s_free_inodes_count"
+    );
+    // 4. `bg_used_dirs_count` was already decremented by `rmdir` (#569
+    //    `decrement_used_dirs`) before the inode reached the orphan
+    //    list. Finalize's `free_inode` call therefore passes
+    //    `was_dir=false` to avoid a double-decrement. Confirm the
+    //    counter is exactly one less than at mount and did NOT drop
+    //    again across finalize.
+    let used_dirs_after = super_arc.bgdt.lock()[0].bg_used_dirs_count;
+    assert_eq!(
+        used_dirs_after,
+        used_dirs_before_mount - 1,
+        "rmdir owns the bg_used_dirs_count decrement; finalize must not double-decrement"
+    );
+    // 5. Free-blocks counter: lost+found owns its own dir data block
+    //    (1 × 1 KiB block). A zero-size directory after finalize means
+    //    that block is back in the allocator. `truncate_free` returns
+    //    >= 1 freed block for lost+found; assert the counter rose.
+    let free_blocks_after = super_arc.sb_disk.lock().s_free_blocks_count;
+    assert!(
+        free_blocks_after > free_blocks_before,
+        "finalize must free lost+found's dir data block back to the allocator (before={free_blocks_before}, after={free_blocks_after})",
+    );
+
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn finalize_on_non_orphan_is_enoent() {
+    let (sb, _fs, super_arc, _disk) = mount_rw();
+    // Ino 2 is the root — never on the orphan list.
+    let err = finalize_orphan(&super_arc, 2).expect_err("ENOENT");
+    assert_eq!(
+        err, ENOENT,
+        "finalize on a non-orphan ino must return ENOENT"
+    );
+
+    // Ino 11 (lost+found) is a live dirent, not on the orphan list
+    // until someone rmdir's it.
+    let err11 = finalize_orphan(&super_arc, 11).expect_err("ENOENT");
+    assert_eq!(err11, ENOENT);
+
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn finalize_ro_mount_is_erofs() {
+    let (sb, _fs, super_arc, _disk) = mount_ro();
+    // RO mount refuses finalize before it ever consults the orphan list
+    // — the RO gate is the first check in the sequence.
+    let err = finalize_orphan(&super_arc, 11).expect_err("EROFS");
+    assert_eq!(
+        err, EROFS,
+        "finalize on a RO mount must return EROFS before touching any on-disk state"
+    );
+
+    sb.ops.unmount();
+    drop(super_arc);
+}


### PR DESCRIPTION
Closes #573

## Summary

RFC 0004 Workstream E. Drives the ext2 orphan-list final-close sequence when an unlinked-but-open inode held in the per-super `orphan_list` mirror hits zero references:

1. truncate-to-zero via `setattr::truncate_free` (frees direct + indirect data blocks through balloc)
2. zero the on-disk inode (`i_size`, `i_blocks`, `i_block[]`) and write back through the buffer cache
3. `ialloc::free_inode(ino, was_dir=false)` — rmdir (#569) already owns the `bg_used_dirs_count` decrement; `true` here would double-decrement and saturate
4. unchain from the on-disk orphan list by patching the predecessor's `i_dtime` next-pointer (or `s_last_orphan` if we were the head)
5. stamp our own `i_dtime` with wall-clock (≥1) so mount-replay (#564) can distinguish "fully deleted" (`i_links_count==0 && i_dtime!=0`) from "still orphan"
6. drop the pinned `Arc<Inode>` from `orphan_list`

Exposed as `pub fn finalize_orphan(&Arc<Ext2Super>, ino)` and wired into `SuperOps::evict_inode` so gc_queue's last-Arc drainer drives it naturally. Errors are `kwarn!`'d and swallowed so the drainer proceeds and mount-replay retries next mount.

## Out of scope / follow-up

Production trigger wiring (OpenFile drop / last-fd-close → `evict_inode`) is deferred — the `orphan_list` `Arc<Inode>` pin prevents `Inode::Drop` from firing while the FS is mounted, so today `finalize_orphan` is driven by tests + mount-time replay. Documented in `orphan_finalize.rs` module docs; follow-up will be filed.

## Test plan

New integration test `kernel/tests/ext2_orphan_finalize.rs`:

- [x] `finalize_rmdir_orphan_frees_blocks_and_chain_head`: rmdir `lost+found` → finalize → `s_last_orphan=0`, `orphan_list` empty, `s_free_inodes_count+=1`, `s_free_blocks_count` rose, `bg_used_dirs_count` dropped exactly once (at rmdir, not at finalize)
- [x] `finalize_on_non_orphan_is_enoent`: ino 2 (root) and live ino 11 (pre-rmdir) → `ENOENT`
- [x] `finalize_ro_mount_is_erofs`: RO mount → `EROFS` before any on-disk touch
- [x] `cargo xtask build` / `cargo xtask test` / `cargo xtask smoke` all green locally