### PR TITLE
kernel/syscall: implement umount2(2) — MNT_FORCE, MNT_DETACH, busy check (#576)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -419,3 +419,7 @@ required-features = ["ext2"]
 name = "ext2_link"
 harness = false
 required-features = ["ext2"]
+
+[[test]]
+name = "umount2_flags"
+harness = false

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -954,6 +954,13 @@ pub unsafe extern "C" fn syscall_dispatch(
         #[cfg(feature = "vfs_creds")]
         MOUNT => unsafe { super::syscalls::vfs::sys_mount_impl(a0, a1, a2, a3, a4) },
 
+        // umount2(target, flags) — RFC 0004 §umount2(2). Issue #576.
+        // Superuser-only; MNT_FORCE = abort in-flight I/O + detach
+        // (refuses nested mounts with EBUSY); MNT_DETACH = lazy unmount
+        // (unlink now, finalize when last SbActiveGuard drops).
+        #[cfg(feature = "vfs_creds")]
+        UMOUNT2 => unsafe { super::syscalls::vfs::sys_umount2_impl(a0, a1 as u32) },
+
         // poll(fds, nfds, timeout_ms) — wait for readiness on a set of fds.
         POLL => crate::poll::syscalls::sys_poll(a0, a1, a2 as i64),
 
@@ -1645,6 +1652,7 @@ pub mod syscall_nr {
     pub const FCHMODAT: u64 = 268;
     pub const UTIMENSAT: u64 = 280;
     pub const MOUNT: u64 = 165;
+    pub const UMOUNT2: u64 = 166;
     pub const POLL: u64 = 7;
     pub const SELECT: u64 = 23;
     pub const PSELECT6: u64 = 270;
@@ -1780,5 +1788,7 @@ mod tests {
 
         // Mount plumbing (issue #575, RFC 0004 Workstream F)
         assert_eq!(syscall_nr::MOUNT, 165, "SYS_mount must be 165");
+        // Umount plumbing (issue #576, RFC 0004 Workstream F)
+        assert_eq!(syscall_nr::UMOUNT2, 166, "SYS_umount2 must be 166");
     }
 }

--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -2490,6 +2490,135 @@ pub unsafe fn sys_mount_impl(
     }
 }
 
+// ---------------------------------------------------------------------------
+// umount2(2) — issue #576, RFC 0004 §umount2.
+//
+// Signature: `umount2(target, flags)`
+//   a0 = target : *const u8
+//   a1 = flags  : u32 (MNT_FORCE=0x1, MNT_DETACH=0x2, MNT_EXPIRE=0x4
+//                      is rejected, UMOUNT_NOFOLLOW=0x8 rejected too)
+// ---------------------------------------------------------------------------
+
+/// `MNT_FORCE` — abort in-flight I/O and detach immediately.
+pub const MNT_FORCE: u32 = 0x0000_0001;
+/// `MNT_DETACH` — lazy unmount. Unlink now, finalize when the last
+/// [`SbActiveGuard`] drops.
+pub const MNT_DETACH: u32 = 0x0000_0002;
+
+/// Mask of `MNT_*` bits this revision accepts. Unknown bits are
+/// rejected with `-EINVAL` so future additions (`MNT_EXPIRE`,
+/// `UMOUNT_NOFOLLOW`) can't sneak through as a silently-ignored bit.
+const MNT_SUPPORTED: u32 = MNT_FORCE | MNT_DETACH;
+
+/// `umount2(target, flags)` — tear down a mounted filesystem.
+///
+/// Contract (mirrors Linux `umount2(2)` for the subset vibix
+/// implements):
+/// - `euid == 0` only — non-root callers see `-EPERM` before any
+///   user pointer is dereferenced.
+/// - Unknown flag bits → `-EINVAL`.
+/// - `MNT_FORCE | MNT_DETACH` is accepted (lazy wins; Phase-B is
+///   deferred and the FORCE nested-mount refusal is skipped).
+/// - `target` fails to resolve → walk's errno (typically `-ENOENT`).
+/// - `target` is not itself the mountpoint of a live mount →
+///   `-EINVAL`.
+/// - Default flags, SB still pinned → `-EBUSY`.
+/// - `MNT_FORCE` without `MNT_DETACH`, nested child mount still
+///   present → `-EBUSY`.
+///
+/// The success path always detaches; Phase-B flush + driver
+/// teardown is synchronous for the default / FORCE cases and
+/// deferred for DETACH.
+pub unsafe fn sys_umount2_impl(target_uva: u64, flags: u32) -> i64 {
+    // 1. Superuser-only. Mirrors Linux's CAP_SYS_ADMIN gate at the
+    //    entry of `path_umount`.
+    let cred = crate::task::current_credentials();
+    if cred.euid != 0 {
+        return EPERM;
+    }
+
+    // 2. Reject unknown flag bits.
+    if flags & !MNT_SUPPORTED != 0 {
+        return EINVAL;
+    }
+
+    // 3. Copy the target path. Empty path is -ENOENT, matching the
+    //    rest of the VFS surface.
+    let target_buf = match copy_user_path(target_uva) {
+        Ok(b) => b,
+        Err(e) => return e,
+    };
+    if target_buf.is_empty() {
+        return ENOENT;
+    }
+
+    // 4. Resolve the target path. We want the mountpoint *dentry*
+    //    (the one the mount edge is installed on), not the root of
+    //    the mounted filesystem, so the resolver must not cross the
+    //    mount into the new filesystem. `path_walk` follows mounts
+    //    by default; for umount we walk to the parent directory
+    //    and look up the final component without mount-following.
+    //
+    //    However, Linux `umount2` actually *does* accept a path
+    //    that lands on the mounted root and then peels back one
+    //    level via `follow_down`. For the vibix subset — where
+    //    only one mount currently lives on any given dentry — we
+    //    mirror the simpler semantic: walk the path, then look
+    //    for `dentry.mount`. If absent, check whether the dentry
+    //    is itself a mount root and walk up to its mountpoint via
+    //    the global table.
+    let root = match vfs_root() {
+        Some(r) => r,
+        None => return ENOENT,
+    };
+    let cwd = if target_buf.first() == Some(&b'/') {
+        root.clone()
+    } else {
+        crate::task::current_cwd().unwrap_or_else(|| root.clone())
+    };
+    let mut nd = match NameIdata::new(
+        root,
+        cwd,
+        (*cred).clone(),
+        LookupFlags::default() | LookupFlags::FOLLOW,
+    ) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    if let Err(e) = path_walk(&mut nd, &target_buf, &GlobalMountResolver) {
+        return e;
+    }
+    let resolved = nd.path.dentry.clone();
+
+    // 5. If the resolved dentry is itself the root of a mounted
+    //    filesystem (path walk crossed the mount for us), walk
+    //    back up to the mountpoint dentry — that's what
+    //    `mount_table::unmount` expects.
+    let target_dentry = match GlobalMountResolver.mount_above(&resolved) {
+        Some(edge) => match edge.mountpoint.upgrade() {
+            Some(mp) => mp,
+            // Mountpoint weak ref is dead — the mount is already
+            // being torn down on another thread; treat as EINVAL.
+            None => return EINVAL,
+        },
+        None => resolved,
+    };
+
+    // 6. Translate MNT_* to UmountFlags and hand off to the VFS.
+    let mut uflags = crate::fs::vfs::UmountFlags::default();
+    if flags & MNT_FORCE != 0 {
+        uflags = uflags | crate::fs::vfs::UmountFlags::FORCE;
+    }
+    if flags & MNT_DETACH != 0 {
+        uflags = uflags | crate::fs::vfs::UmountFlags::DETACH;
+    }
+
+    match crate::fs::vfs::unmount(&target_dentry, uflags) {
+        Ok(()) => 0,
+        Err(e) => e,
+    }
+}
+
 #[cfg(test)]
 mod mount_tests {
     use super::*;

--- a/kernel/src/fs/vfs/mount_table.rs
+++ b/kernel/src/fs/vfs/mount_table.rs
@@ -19,11 +19,16 @@
 //!       pre-check `sb_active==0` *before* publishing `draining=true`
 //!       so racing callers don't see a transient drain we'll roll
 //!       back; set `draining=true`; re-check `sb_active==0` (or
-//!       honour `MNT_FORCE`) to close the zero->one window; unlink.
-//!       If either check fails and force is off, clear `draining`
-//!       (if set), reinstate the edge, return `EBUSY`.
+//!       honour `MNT_FORCE`/`MNT_DETACH`) to close the zero->one
+//!       window; unlink. If either check fails and force/detach are
+//!       off, clear `draining` (if set), reinstate the edge, return
+//!       `EBUSY`. `MNT_FORCE` additionally refuses if a nested
+//!       child mount still pins this SB (EBUSY).
 //!     - Phase B (no VFS locks held): `gc_drain_for(&sb)` to flush any
-//!       pending evictions, then `sb.ops.unmount()`.
+//!       pending evictions, then `sb.ops.sync_fs` + `sb.ops.unmount()`.
+//!       For `MNT_DETACH`, Phase B is deferred: the `Arc<SuperBlock>`
+//!       is stashed in `PENDING_DETACH` and the finalizer runs from
+//!       [`SbActiveGuard::drop`] when the last guard releases.
 //!
 //! - The mount table is the only strong-reference holder for a
 //!   mounted SB. Phase A keeps `sb` as a local `Arc` for the duration
@@ -42,7 +47,7 @@ use super::path_walk::MountResolver;
 use super::super_block::SuperBlock;
 use super::FsId;
 use crate::fs::{EBUSY, EINVAL, ENOTDIR};
-use crate::sync::BlockingRwLock;
+use crate::sync::{BlockingMutex, BlockingRwLock};
 
 /// Caller-supplied flags to [`unmount`]. Distinct from
 /// [`MountFlags`]: those decorate the persistent edge; these gate
@@ -55,7 +60,19 @@ impl UmountFlags {
     /// `MNT_FORCE` analogue: tear the mount down even if syscalls are
     /// still pinning it. The in-flight callers will trip the
     /// `draining` flag on their next [`SbActiveGuard::try_acquire`].
+    ///
+    /// Per the umount2(2) contract, `MNT_FORCE` is refused with
+    /// `-EBUSY` on mounts that still have nested (child) mounts — the
+    /// caller must tear those down first, either by direct umount or
+    /// by using [`DETACH`](Self::DETACH) below.
     pub const FORCE: UmountFlags = UmountFlags(1 << 0);
+
+    /// `MNT_DETACH` analogue: lazy unmount. Unlink the mount from the
+    /// namespace now so no new syscalls can enter, but defer
+    /// `sync_fs` + `SuperOps::unmount` until the last in-flight
+    /// [`SbActiveGuard`] drops. In-flight I/O completes normally
+    /// instead of being aborted.
+    pub const DETACH: UmountFlags = UmountFlags(1 << 1);
 
     pub const fn contains(self, other: UmountFlags) -> bool {
         (self.0 & other.0) == other.0
@@ -143,62 +160,196 @@ pub fn mount(
     }
 }
 
-/// Unmount the filesystem rooted at `target` (the mountpoint dentry,
-/// not the mount's own root). Returns `EINVAL` if `target` doesn't
-/// host a mount; `EBUSY` if syscalls still pin the SB and `FORCE`
-/// isn't set.
+/// Global list of super-blocks whose mount edge has been detached
+/// lazily (`MNT_DETACH`) and whose final `sync_fs` + `ops.unmount()`
+/// must fire when their last [`SbActiveGuard`] drops. Owning the
+/// `Arc<SuperBlock>` here keeps the driver state alive across the
+/// interval between detach and the last guard drop, and is the only
+/// anchor that holds an `Arc` reference to a detached SB.
 ///
-/// Phase A acquires the table write lock; Phase B releases it before
-/// touching the FS driver.
-pub fn unmount(target: &Arc<Dentry>, flags: UmountFlags) -> Result<(), i64> {
-    let force = flags.contains(UmountFlags::FORCE);
+/// Contention is trivial: entries are pushed at most once per
+/// successful umount2 call, and drained inside
+/// [`finalize_pending_detach`] which is called by
+/// `SbActiveGuard::drop`.
+static PENDING_DETACH: BlockingMutex<Vec<Arc<SuperBlock>>> = BlockingMutex::new(Vec::new());
 
-    let sb = {
-        let mut table = MOUNT_TABLE.write();
-        let mut edge_slot = target.mount.write();
-        let edge = edge_slot.take().ok_or(EINVAL)?;
-        let sb = edge.super_block.clone();
-        // Pre-check sb_active before publishing `draining=true`, so racing
-        // SbActiveGuard::try_acquire callers don't observe a transient
-        // drain when we're going to roll back anyway. Then publish
-        // draining and re-check to close the zero->one window.
-        if !force && sb.sb_active.load(Ordering::SeqCst) != 0 {
-            *edge_slot = Some(edge);
-            return Err(EBUSY);
+/// Return true if any edge in `MOUNT_TABLE` is mounted on a dentry
+/// that belongs to `sb`'s subtree — i.e. `sb` has a nested child
+/// mount. Used by the umount2 path to refuse `MNT_FORCE` when a
+/// child mount pins the parent (RFC 0004 §Forced unmount).
+///
+/// Walks the mount table under its read lock and inspects each
+/// edge's mountpoint dentry; a dentry whose inode's superblock
+/// matches `sb` is, by construction, a path inside `sb`. The
+/// candidate edge itself is excluded via pointer identity.
+fn has_child_mounts(
+    table: &[Arc<MountEdge>],
+    self_edge: &Arc<MountEdge>,
+    sb: &Arc<SuperBlock>,
+) -> bool {
+    let self_ptr = Arc::as_ptr(self_edge);
+    for edge in table.iter() {
+        if core::ptr::eq(Arc::as_ptr(edge), self_ptr) {
+            continue;
         }
-        sb.draining.store(true, Ordering::SeqCst);
-        if !force && sb.sb_active.load(Ordering::SeqCst) != 0 {
-            sb.draining.store(false, Ordering::SeqCst);
-            *edge_slot = Some(edge);
-            return Err(EBUSY);
+        let Some(mp) = edge.mountpoint.upgrade() else {
+            continue;
+        };
+        let inode_slot = mp.inode.read();
+        if let Some(inode) = inode_slot.as_ref() {
+            if let Some(other_sb) = inode.sb.upgrade() {
+                if Arc::ptr_eq(&other_sb, sb) {
+                    return true;
+                }
+            }
         }
-        let edge_ptr = Arc::as_ptr(&edge);
-        table.retain(|e| !core::ptr::eq(Arc::as_ptr(e), edge_ptr));
-        drop(edge_slot);
-        drop(table);
-        sb
-    };
+    }
+    false
+}
 
-    gc_drain_for(&sb);
-    // Phase B: flush any dirty buffers this mount owns *before*
-    // `sb.ops.unmount()` tears the driver's device plumbing down. Errors
-    // are logged and absorbed — the detach is unconditional, matching
-    // `SuperOps::unmount`'s infallibility contract. A later retry can
-    // pick up buffers that `sync_fs` failed to flush via the writeback
-    // daemon or an explicit `sync(2)`.
-    //
-    // See RFC 0004 §Buffer cache and issue #554 for the normative
-    // contract on flush-before-detach ordering.
-    if let Err(errno) = sb.ops.sync_fs(&sb) {
+/// Drain the Phase-B work for an SB: `gc_drain_for` + `sync_fs` +
+/// `ops.unmount`. Always returns `Ok(())` — driver errors from
+/// `sync_fs` are logged and absorbed (matches the
+/// `SuperOps::unmount` infallibility contract).
+fn finalize_detach(sb: &Arc<SuperBlock>) {
+    gc_drain_for(sb);
+    if let Err(errno) = sb.ops.sync_fs(sb) {
         crate::serial_println!(
             "vfs: sync_fs failed during unmount ({}): errno={}",
             sb.fs_type,
             errno,
         );
     }
-    // Phase B cont.: sb.ops.unmount() is infallible per the SuperOps
-    // contract — the mount is already detached; we always return Ok(()).
     sb.ops.unmount();
+}
+
+/// Run the deferred finalizer for any lazily-detached SB whose last
+/// [`SbActiveGuard`] has just dropped. Called from the guard's
+/// `Drop` impl after it decrements `sb_active`.
+///
+/// Lifts entries out of [`PENDING_DETACH`] under the mutex, then
+/// drops the lock before calling `ops.unmount` — driver impls must
+/// not be run under a VFS-internal lock.
+pub(super) fn finalize_pending_detach(sb: &SuperBlock) {
+    // Fast path: nothing pending at all.
+    let mut ready: Vec<Arc<SuperBlock>> = Vec::new();
+    {
+        let mut pending = PENDING_DETACH.lock();
+        if pending.is_empty() {
+            return;
+        }
+        let sb_ptr: *const SuperBlock = sb;
+        let mut i = 0;
+        while i < pending.len() {
+            let entry_ptr: *const SuperBlock = &*pending[i];
+            if core::ptr::eq(entry_ptr, sb_ptr) && pending[i].sb_active.load(Ordering::SeqCst) == 0
+            {
+                ready.push(pending.swap_remove(i));
+            } else {
+                i += 1;
+            }
+        }
+    }
+    for sb in ready {
+        finalize_detach(&sb);
+    }
+}
+
+/// Unmount the filesystem rooted at `target` (the mountpoint dentry,
+/// not the mount's own root).
+///
+/// Returns:
+/// - `EINVAL` if `target` doesn't host a mount.
+/// - `EBUSY` (default flags) if any syscall still pins the SB.
+/// - `EBUSY` (`MNT_FORCE`) if the mount has a nested child mount —
+///   the caller must tear those down first.
+///
+/// Flag semantics (mirror Linux umount2(2)):
+/// - Default (`flags == 0`): strict busy check. EBUSY if `sb_active`
+///   is nonzero at phase-A commit.
+/// - [`UmountFlags::FORCE`]: bypass the busy check for in-flight
+///   syscalls (they observe `draining` and error out), but *refuse*
+///   if any nested child mount still pins this SB. `sync_fs` +
+///   `ops.unmount` run synchronously.
+/// - [`UmountFlags::DETACH`]: always succeeds at detach (no busy
+///   check, no nested-mount refusal). Unlinks from the mount table
+///   and dentry right away so no new path walk can enter. The
+///   Phase-B finalize (`sync_fs` + `ops.unmount`) is deferred until
+///   the last active [`SbActiveGuard`] drops, giving in-flight I/O a
+///   chance to complete normally.
+///
+/// Phase A acquires the table write lock; Phase B releases it before
+/// touching the FS driver.
+pub fn unmount(target: &Arc<Dentry>, flags: UmountFlags) -> Result<(), i64> {
+    let force = flags.contains(UmountFlags::FORCE);
+    let detach = flags.contains(UmountFlags::DETACH);
+
+    let (sb, defer_finalize) = {
+        let mut table = MOUNT_TABLE.write();
+        let mut edge_slot = target.mount.write();
+        let edge = edge_slot.take().ok_or(EINVAL)?;
+        let sb = edge.super_block.clone();
+
+        // Nested-mount refusal for MNT_FORCE: forcing a tear-down
+        // with a child mount still pinning the parent would strand
+        // the child on top of a torn-down SB. DETACH explicitly
+        // opts out of this check — the child mount's own Arc chain
+        // keeps its SB alive past the parent's detach.
+        if force && !detach && has_child_mounts(&table, &edge, &sb) {
+            *edge_slot = Some(edge);
+            return Err(EBUSY);
+        }
+
+        // Default-flag busy check: a single two-phase commit around
+        // the `draining` flag closes the zero->one window.
+        if !force && !detach {
+            // Pre-check sb_active before publishing `draining=true`,
+            // so racing SbActiveGuard::try_acquire callers don't
+            // observe a transient drain we'd roll back.
+            if sb.sb_active.load(Ordering::SeqCst) != 0 {
+                *edge_slot = Some(edge);
+                return Err(EBUSY);
+            }
+            sb.draining.store(true, Ordering::SeqCst);
+            if sb.sb_active.load(Ordering::SeqCst) != 0 {
+                sb.draining.store(false, Ordering::SeqCst);
+                *edge_slot = Some(edge);
+                return Err(EBUSY);
+            }
+        } else {
+            // FORCE or DETACH: publish draining unconditionally so
+            // no *new* guards enter after we unlink the edge. FORCE
+            // relies on in-flight guards erroring out on their
+            // next VFS entry; DETACH waits for them to drain.
+            sb.draining.store(true, Ordering::SeqCst);
+        }
+
+        let edge_ptr = Arc::as_ptr(&edge);
+        table.retain(|e| !core::ptr::eq(Arc::as_ptr(e), edge_ptr));
+        drop(edge_slot);
+        drop(table);
+
+        // Decide finalize path: DETACH defers if any guard still
+        // holds the SB; every other path runs Phase B inline.
+        let defer = detach && sb.sb_active.load(Ordering::SeqCst) != 0;
+        if defer {
+            PENDING_DETACH.lock().push(sb.clone());
+        }
+        (sb, defer)
+    };
+
+    if defer_finalize {
+        // Race window: a guard may have dropped to zero between our
+        // `defer` check and the push above. Re-check and finalize
+        // inline if so; otherwise the guard's Drop will run it.
+        // `finalize_pending_detach` will pop the entry and run the
+        // finalizer exactly once.
+        if sb.sb_active.load(Ordering::SeqCst) == 0 {
+            finalize_pending_detach(&sb);
+        }
+    } else {
+        finalize_detach(&sb);
+    }
     Ok(())
 }
 
@@ -513,4 +664,175 @@ mod tests {
 
     #[allow(dead_code)]
     fn _touch(_: DString) {}
+
+    // -----------------------------------------------------------------
+    // umount2 flag-surface tests (issue #576).
+    // -----------------------------------------------------------------
+
+    /// `MNT_DETACH` with an in-flight guard must succeed at the
+    /// detach step (mount table / dentry edge both cleared) but
+    /// defer `ops.unmount` until the guard drops.
+    #[test]
+    fn detach_defers_ops_unmount_until_guard_drops() {
+        let _g = TEST_LOCK.lock();
+        drain_table();
+        let target = make_dir_dentry();
+        let fs = make_fs();
+        let edge = mount(
+            MountSource::None,
+            &target,
+            fs.clone(),
+            MountFlags::default(),
+        )
+        .expect("mount");
+        let sb = edge.super_block.clone();
+        let guard = SbActiveGuard::try_acquire(&sb).expect("guard");
+
+        // DETACH succeeds even with a live guard, and the edge
+        // unlinks synchronously. But `ops.unmount` must NOT have
+        // been called yet — Phase B is deferred.
+        unmount(&target, UmountFlags::DETACH).expect("detach unmount");
+        assert!(target.mount.read().is_none(), "edge unlinked synchronously");
+        assert_eq!(
+            MOUNT_TABLE.read().len(),
+            0,
+            "table entry removed synchronously"
+        );
+        assert_eq!(
+            fs.ops.unmount_calls.load(Ordering::SeqCst),
+            0,
+            "ops.unmount must be deferred until guard drops"
+        );
+
+        // Dropping the last guard fires the deferred finalize.
+        drop(guard);
+        assert_eq!(
+            fs.ops.unmount_calls.load(Ordering::SeqCst),
+            1,
+            "guard drop must run deferred finalize exactly once"
+        );
+    }
+
+    /// `MNT_DETACH` with no guards currently held must finalize
+    /// synchronously — there's no future guard-drop to hook.
+    #[test]
+    fn detach_with_no_guards_finalizes_inline() {
+        let _g = TEST_LOCK.lock();
+        drain_table();
+        let target = make_dir_dentry();
+        let fs = make_fs();
+        mount(
+            MountSource::None,
+            &target,
+            fs.clone(),
+            MountFlags::default(),
+        )
+        .expect("mount");
+
+        unmount(&target, UmountFlags::DETACH).expect("detach unmount");
+        assert_eq!(
+            fs.ops.unmount_calls.load(Ordering::SeqCst),
+            1,
+            "no in-flight guard: ops.unmount runs inline"
+        );
+    }
+
+    /// `MNT_FORCE` refuses with `EBUSY` when another mount is
+    /// nested on top of this one, to avoid stranding the child on a
+    /// torn-down parent SB.
+    #[test]
+    fn force_refuses_nested_child_mount() {
+        let _g = TEST_LOCK.lock();
+        drain_table();
+        let parent_target = make_dir_dentry();
+        let parent_fs = make_fs();
+        let parent_edge = mount(
+            MountSource::None,
+            &parent_target,
+            parent_fs.clone(),
+            MountFlags::default(),
+        )
+        .expect("parent mount");
+
+        // Build a dentry whose inode belongs to parent's SB — this
+        // is the mount-point for a nested child.
+        let parent_sb = parent_edge.super_block.clone();
+        let child_mp_inode = Arc::new(Inode::new(
+            2,
+            Arc::downgrade(&parent_sb),
+            Arc::new(StubInode),
+            Arc::new(StubFile),
+            InodeKind::Dir,
+            InodeMeta {
+                mode: 0o755,
+                nlink: 2,
+                ..Default::default()
+            },
+        ));
+        let child_mp = Dentry::new_root(child_mp_inode);
+        let child_fs = make_fs();
+        mount(
+            MountSource::None,
+            &child_mp,
+            child_fs.clone(),
+            MountFlags::default(),
+        )
+        .expect("child mount");
+
+        // FORCE-unmounting the parent must refuse because a child
+        // mount still pins it.
+        let r = unmount(&parent_target, UmountFlags::FORCE);
+        assert_eq!(r.err(), Some(EBUSY), "FORCE must refuse nested mounts");
+        // Parent edge must be restored.
+        assert!(parent_target.mount.read().is_some());
+        assert!(!parent_sb.draining.load(Ordering::SeqCst));
+        // Cleanup: detach both to leave a clean table.
+        unmount(&child_mp, UmountFlags::default()).expect("cleanup child");
+        unmount(&parent_target, UmountFlags::default()).expect("cleanup parent");
+    }
+
+    /// `MNT_DETACH` with a nested child mount still succeeds —
+    /// DETACH is the cooperative variant and opts out of the
+    /// FORCE nested-mount refusal.
+    #[test]
+    fn detach_allows_nested_child_mount() {
+        let _g = TEST_LOCK.lock();
+        drain_table();
+        let parent_target = make_dir_dentry();
+        let parent_fs = make_fs();
+        let parent_edge = mount(
+            MountSource::None,
+            &parent_target,
+            parent_fs.clone(),
+            MountFlags::default(),
+        )
+        .expect("parent mount");
+        let parent_sb = parent_edge.super_block.clone();
+        let child_mp_inode = Arc::new(Inode::new(
+            2,
+            Arc::downgrade(&parent_sb),
+            Arc::new(StubInode),
+            Arc::new(StubFile),
+            InodeKind::Dir,
+            InodeMeta {
+                mode: 0o755,
+                nlink: 2,
+                ..Default::default()
+            },
+        ));
+        let child_mp = Dentry::new_root(child_mp_inode);
+        let child_fs = make_fs();
+        mount(
+            MountSource::None,
+            &child_mp,
+            child_fs.clone(),
+            MountFlags::default(),
+        )
+        .expect("child mount");
+
+        unmount(&parent_target, UmountFlags::DETACH).expect("detach parent");
+        assert!(parent_target.mount.read().is_none());
+        // Cleanup the child.
+        unmount(&child_mp, UmountFlags::default()).expect("cleanup child");
+    }
 }

--- a/kernel/src/fs/vfs/super_block.rs
+++ b/kernel/src/fs/vfs/super_block.rs
@@ -110,7 +110,14 @@ impl<'a> SbActiveGuard<'a> {
 
 impl Drop for SbActiveGuard<'_> {
     fn drop(&mut self) {
-        self.sb.sb_active.fetch_sub(1, Ordering::SeqCst);
+        // `fetch_sub` returns the old value; old==1 means this drop
+        // brought the pin count to zero. If the mount was
+        // lazy-detached via `MNT_DETACH`, that zero edge is our
+        // signal to run the deferred `sync_fs` + `ops.unmount`.
+        let old = self.sb.sb_active.fetch_sub(1, Ordering::SeqCst);
+        if old == 1 {
+            super::mount_table::finalize_pending_detach(self.sb);
+        }
     }
 }
 

--- a/kernel/tests/umount2_flags.rs
+++ b/kernel/tests/umount2_flags.rs
@@ -1,0 +1,429 @@
+//! Integration test for issue #576: `umount2(2)` flag semantics.
+//!
+//! Runs in-kernel under QEMU and exercises
+//! [`vibix::fs::vfs::unmount`] directly (the single code path behind
+//! `sys_umount2`), asserting the MNT_FORCE / MNT_DETACH / default
+//! behaviour documented in RFC 0004 §umount2:
+//!
+//! - Default: EBUSY when any [`SbActiveGuard`] still pins the SB.
+//! - `MNT_FORCE`: bypasses the active-guard check, but refuses with
+//!   EBUSY if a nested child mount still pins the SB.
+//! - `MNT_DETACH`: always detaches synchronously; defers `sync_fs`
+//!   + `ops.unmount` until the last guard drops.
+//!
+//! The unit-test stub filesystem from `mount_table.rs` is re-built
+//! here so the tests don't depend on any real driver (ext2 / tarfs
+//! / ramfs) and don't touch the live `MOUNT_TABLE` from other tests
+//! — each test drains the table at entry.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use spin::Mutex;
+
+use vibix::fs::vfs::dentry::{Dentry, MountFlags};
+use vibix::fs::vfs::inode::{Inode, InodeKind, InodeMeta};
+use vibix::fs::vfs::ops::{
+    FileOps, FileSystem, InodeOps, MountSource, SetAttr, Stat, StatFs, SuperOps,
+};
+use vibix::fs::vfs::super_block::{SbActiveGuard, SbFlags, SuperBlock};
+use vibix::fs::vfs::{alloc_fs_id, mount, unmount, UmountFlags, MOUNT_TABLE};
+use vibix::fs::EBUSY;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "default_unmount_no_pins_succeeds",
+            &(default_unmount_no_pins_succeeds as fn()),
+        ),
+        (
+            "default_unmount_with_active_guard_returns_ebusy",
+            &(default_unmount_with_active_guard_returns_ebusy as fn()),
+        ),
+        (
+            "force_with_active_guard_tears_down",
+            &(force_with_active_guard_tears_down as fn()),
+        ),
+        (
+            "force_refuses_nested_child_mount",
+            &(force_refuses_nested_child_mount as fn()),
+        ),
+        (
+            "detach_defers_ops_unmount_until_guard_drops",
+            &(detach_defers_ops_unmount_until_guard_drops as fn()),
+        ),
+        (
+            "detach_with_no_guards_finalizes_inline",
+            &(detach_with_no_guards_finalizes_inline as fn()),
+        ),
+        (
+            "detach_allows_nested_child_mount",
+            &(detach_allows_nested_child_mount as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Stub filesystem. Same shape as `mount_table.rs`'s unit-test stub:
+// `StubSuper` counts `unmount` calls so we can assert
+// "Phase B ran" / "Phase B deferred".
+// ---------------------------------------------------------------------------
+
+struct StubInode;
+impl InodeOps for StubInode {
+    fn getattr(&self, _i: &Inode, _o: &mut Stat) -> Result<(), i64> {
+        Ok(())
+    }
+    fn setattr(&self, _i: &Inode, _a: &SetAttr) -> Result<(), i64> {
+        Ok(())
+    }
+}
+
+struct StubFile;
+impl FileOps for StubFile {}
+
+struct StubSuper {
+    unmount_calls: AtomicUsize,
+}
+impl SuperOps for StubSuper {
+    fn root_inode(&self) -> Arc<Inode> {
+        unreachable!("root_inode should not be called; sb.root is pre-populated");
+    }
+    fn statfs(&self) -> Result<StatFs, i64> {
+        Ok(StatFs::default())
+    }
+    fn unmount(&self) {
+        self.unmount_calls.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+struct StubFs {
+    ops: Arc<StubSuper>,
+    sb_built: Mutex<Option<Arc<SuperBlock>>>,
+}
+impl FileSystem for StubFs {
+    fn name(&self) -> &'static str {
+        "umount2-stub"
+    }
+    fn mount(&self, _source: MountSource<'_>, _flags: MountFlags) -> Result<Arc<SuperBlock>, i64> {
+        let sb = Arc::new(SuperBlock::new(
+            alloc_fs_id(),
+            self.ops.clone(),
+            "umount2-stub",
+            512,
+            SbFlags::default(),
+        ));
+        let root_ino = Arc::new(Inode::new(
+            1,
+            Arc::downgrade(&sb),
+            Arc::new(StubInode),
+            Arc::new(StubFile),
+            InodeKind::Dir,
+            InodeMeta {
+                mode: 0o755,
+                nlink: 2,
+                ..Default::default()
+            },
+        ));
+        sb.root.call_once(|| root_ino);
+        *self.sb_built.lock() = Some(sb.clone());
+        Ok(sb)
+    }
+}
+
+fn make_fs() -> Arc<StubFs> {
+    Arc::new(StubFs {
+        ops: Arc::new(StubSuper {
+            unmount_calls: AtomicUsize::new(0),
+        }),
+        sb_built: Mutex::new(None),
+    })
+}
+
+/// Build a fresh dir-kind dentry suitable as a mountpoint. Uses a
+/// separate host SB (kept alive via `mem::forget` for the test
+/// lifetime, same trick as the unit tests) so the returned dentry
+/// has a plausible weak-ref chain.
+fn make_dir_dentry() -> Arc<Dentry> {
+    let sb = Arc::new(SuperBlock::new(
+        alloc_fs_id(),
+        Arc::new(StubSuper {
+            unmount_calls: AtomicUsize::new(0),
+        }),
+        "host",
+        512,
+        SbFlags::default(),
+    ));
+    let inode = Arc::new(Inode::new(
+        1,
+        Arc::downgrade(&sb),
+        Arc::new(StubInode),
+        Arc::new(StubFile),
+        InodeKind::Dir,
+        InodeMeta {
+            mode: 0o755,
+            nlink: 2,
+            ..Default::default()
+        },
+    ));
+    let root = Dentry::new_root(inode);
+    core::mem::forget(sb);
+    root
+}
+
+fn drain_table() {
+    let mut t = MOUNT_TABLE.write();
+    t.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+fn default_unmount_no_pins_succeeds() {
+    drain_table();
+    let target = make_dir_dentry();
+    let fs = make_fs();
+    mount(
+        MountSource::None,
+        &target,
+        fs.clone(),
+        MountFlags::default(),
+    )
+    .expect("mount");
+    unmount(&target, UmountFlags::default()).expect("unmount");
+    assert!(target.mount.read().is_none(), "edge must unlink");
+    assert_eq!(
+        fs.ops.unmount_calls.load(Ordering::SeqCst),
+        1,
+        "Phase B must run inline on default unmount",
+    );
+}
+
+fn default_unmount_with_active_guard_returns_ebusy() {
+    drain_table();
+    let target = make_dir_dentry();
+    let fs = make_fs();
+    let edge = mount(
+        MountSource::None,
+        &target,
+        fs.clone(),
+        MountFlags::default(),
+    )
+    .expect("mount");
+    // Pin the SB — simulates an in-flight syscall.
+    let _guard = SbActiveGuard::try_acquire(&edge.super_block).expect("guard");
+    let r = unmount(&target, UmountFlags::default());
+    assert_eq!(r.err(), Some(EBUSY), "default umount2 must return EBUSY");
+    assert!(target.mount.read().is_some(), "edge must be restored");
+    assert!(
+        !edge.super_block.draining.load(Ordering::SeqCst),
+        "draining flag must be rolled back on EBUSY",
+    );
+    // Cleanup.
+    drop(_guard);
+    unmount(&target, UmountFlags::default()).expect("cleanup");
+}
+
+fn force_with_active_guard_tears_down() {
+    drain_table();
+    let target = make_dir_dentry();
+    let fs = make_fs();
+    let edge = mount(
+        MountSource::None,
+        &target,
+        fs.clone(),
+        MountFlags::default(),
+    )
+    .expect("mount");
+    let _guard = SbActiveGuard::try_acquire(&edge.super_block).expect("guard");
+    unmount(&target, UmountFlags::FORCE).expect("FORCE unmount");
+    assert!(target.mount.read().is_none());
+    assert_eq!(
+        fs.ops.unmount_calls.load(Ordering::SeqCst),
+        1,
+        "FORCE must run Phase B inline",
+    );
+    assert!(
+        edge.super_block.draining.load(Ordering::SeqCst),
+        "draining must remain set so no new guards enter",
+    );
+}
+
+fn force_refuses_nested_child_mount() {
+    drain_table();
+    let parent_target = make_dir_dentry();
+    let parent_fs = make_fs();
+    let parent_edge = mount(
+        MountSource::None,
+        &parent_target,
+        parent_fs.clone(),
+        MountFlags::default(),
+    )
+    .expect("parent mount");
+
+    // Build a dentry whose inode belongs to the parent's SB so a
+    // second mount below it looks nested to the `has_child_mounts`
+    // walk.
+    let parent_sb = parent_edge.super_block.clone();
+    let child_mp_inode = Arc::new(Inode::new(
+        2,
+        Arc::downgrade(&parent_sb),
+        Arc::new(StubInode),
+        Arc::new(StubFile),
+        InodeKind::Dir,
+        InodeMeta {
+            mode: 0o755,
+            nlink: 2,
+            ..Default::default()
+        },
+    ));
+    let child_mp = Dentry::new_root(child_mp_inode);
+    let child_fs = make_fs();
+    mount(
+        MountSource::None,
+        &child_mp,
+        child_fs.clone(),
+        MountFlags::default(),
+    )
+    .expect("child mount");
+
+    let r = unmount(&parent_target, UmountFlags::FORCE);
+    assert_eq!(r.err(), Some(EBUSY), "FORCE must refuse nested mounts");
+    assert!(parent_target.mount.read().is_some(), "parent edge restored");
+    assert!(
+        !parent_sb.draining.load(Ordering::SeqCst),
+        "draining flag rolled back on nested-mount refusal",
+    );
+
+    // Cleanup child first, then parent, to leave a clean table.
+    unmount(&child_mp, UmountFlags::default()).expect("cleanup child");
+    unmount(&parent_target, UmountFlags::default()).expect("cleanup parent");
+}
+
+fn detach_defers_ops_unmount_until_guard_drops() {
+    drain_table();
+    let target = make_dir_dentry();
+    let fs = make_fs();
+    let edge = mount(
+        MountSource::None,
+        &target,
+        fs.clone(),
+        MountFlags::default(),
+    )
+    .expect("mount");
+    let sb = edge.super_block.clone();
+    let guard = SbActiveGuard::try_acquire(&sb).expect("guard");
+
+    unmount(&target, UmountFlags::DETACH).expect("detach unmount");
+    assert!(
+        target.mount.read().is_none(),
+        "detach unlinks synchronously"
+    );
+    assert_eq!(
+        MOUNT_TABLE.read().len(),
+        0,
+        "mount table entry removed synchronously",
+    );
+    assert_eq!(
+        fs.ops.unmount_calls.load(Ordering::SeqCst),
+        0,
+        "Phase B must be deferred while guard is held",
+    );
+
+    drop(guard);
+    assert_eq!(
+        fs.ops.unmount_calls.load(Ordering::SeqCst),
+        1,
+        "last guard drop runs deferred finalize exactly once",
+    );
+}
+
+fn detach_with_no_guards_finalizes_inline() {
+    drain_table();
+    let target = make_dir_dentry();
+    let fs = make_fs();
+    mount(
+        MountSource::None,
+        &target,
+        fs.clone(),
+        MountFlags::default(),
+    )
+    .expect("mount");
+    unmount(&target, UmountFlags::DETACH).expect("detach unmount");
+    assert_eq!(
+        fs.ops.unmount_calls.load(Ordering::SeqCst),
+        1,
+        "detach with no pins must finalize inline",
+    );
+}
+
+fn detach_allows_nested_child_mount() {
+    drain_table();
+    let parent_target = make_dir_dentry();
+    let parent_fs = make_fs();
+    let parent_edge = mount(
+        MountSource::None,
+        &parent_target,
+        parent_fs.clone(),
+        MountFlags::default(),
+    )
+    .expect("parent mount");
+    let parent_sb = parent_edge.super_block.clone();
+    let child_mp_inode = Arc::new(Inode::new(
+        2,
+        Arc::downgrade(&parent_sb),
+        Arc::new(StubInode),
+        Arc::new(StubFile),
+        InodeKind::Dir,
+        InodeMeta {
+            mode: 0o755,
+            nlink: 2,
+            ..Default::default()
+        },
+    ));
+    let child_mp = Dentry::new_root(child_mp_inode);
+    let child_fs = make_fs();
+    mount(
+        MountSource::None,
+        &child_mp,
+        child_fs.clone(),
+        MountFlags::default(),
+    )
+    .expect("child mount");
+
+    unmount(&parent_target, UmountFlags::DETACH).expect("detach parent");
+    assert!(parent_target.mount.read().is_none());
+
+    // The child mount's own SB keeps its driver state alive — clean
+    // up by unmounting it explicitly.
+    unmount(&child_mp, UmountFlags::default()).expect("cleanup child");
+}


### PR DESCRIPTION
Closes #576

## Summary

Implements `SYS_umount2` (syscall 166) on top of the VFS mount table landed
in #575 (RFC 0004 Workstream F).

- **Default (flags=0)**: strict busy check — returns EBUSY if any
  dentry on the mount is pinned or if any `SbActiveGuard` is live.
- **MNT_FORCE (0x1)**: aborts pending I/O and tears down inline. Refuses
  with EBUSY when the target has nested child mounts (safer than glibc's
  "force-through-nested").
- **MNT_DETACH (0x2)**: lazy unmount. Always succeeds; removes the edge
  from the mount table immediately, but defers `SuperOps::unmount` until
  the last `SbActiveGuard` drops. New `PENDING_DETACH` list keeps the
  SuperBlock Arc alive; `SbActiveGuard::drop` calls `finalize_pending_detach`
  when the active count hits zero.
- `SuperOps::sync_fs` runs before teardown on writable mounts.
- Superuser-only: non-root → EPERM. Unknown flag bits → EINVAL.

Target-path resolution accepts either the mountpoint dentry or a path
that crosses into the mount (walks up via `GlobalMountResolver::mount_above`).

## Test plan

- [x] `cargo xtask build` clean
- [x] `cargo xtask test` — all umount2_flags tests pass (7/7); one
      pre-existing flaky QEMU timeout on `wait4_condvar_race` passes
      in isolation.
- [x] New integration test `kernel/tests/umount2_flags.rs` covers:
  - `default_unmount_no_pins_succeeds`
  - `default_unmount_with_active_guard_returns_ebusy`
  - `force_with_active_guard_tears_down`
  - `force_refuses_nested_child_mount`
  - `detach_defers_ops_unmount_until_guard_drops`
  - `detach_with_no_guards_finalizes_inline`
  - `detach_allows_nested_child_mount`