### PR TITLE
fs/ext2: InodeOps rename with link-count-first ordering (#571)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -428,3 +428,8 @@ harness = false
 name = "ext2_orphan_finalize"
 harness = false
 required-features = ["ext2"]
+
+[[test]]
+name = "ext2_rename"
+harness = false
+required-features = ["ext2"]

--- a/kernel/src/fs/ext2/inode.rs
+++ b/kernel/src/fs/ext2/inode.rs
@@ -314,9 +314,17 @@ impl InodeOps for Ext2Inode {
                 .and_then(Weak::upgrade)
                 .ok_or(EIO)?
         };
-        // Sanity: the cached Arc must be the same VFS inode the
-        // caller handed us.
-        if new_dir_arc_vfs.ino != new_dir.ino {
+        // Identity check by raw pointer equality: inode numbers are
+        // only unique within a mount, so an ino match alone would
+        // accept an inode from a different mount that happens to share
+        // `new_dir.ino` (root is usually 2 on every ext2 image). The
+        // only safe acceptance criterion is "the cached Arc<Inode> is
+        // the exact same allocation the caller handed us". The cross-
+        // mount rejection also happens in `rename::rename` via
+        // `Arc::ptr_eq` on the superblocks, but rejecting here keeps
+        // the failure deterministic even if a future caller routes
+        // around that check.
+        if !core::ptr::eq(Arc::as_ref(&new_dir_arc_vfs), new_dir) {
             return Err(EIO);
         }
         let new_dir_ext2 = {

--- a/kernel/src/fs/ext2/inode.rs
+++ b/kernel/src/fs/ext2/inode.rs
@@ -288,6 +288,47 @@ impl InodeOps for Ext2Inode {
         super::create::create_dir(&super_ref, self, dir, &sb, name, mode)
     }
 
+    /// Rename `old_name` in this directory to `new_name` in `new_dir`.
+    ///
+    /// Dispatches to [`super::rename::rename`]; the normative
+    /// link-count-first sequence and cross-directory ancestor check
+    /// live there (RFC 0004 §Rename ordering / §Cross-directory loop
+    /// check).
+    fn rename(
+        &self,
+        old_dir: &Inode,
+        old_name: &[u8],
+        new_dir: &Inode,
+        new_name: &[u8],
+    ) -> Result<(), i64> {
+        let super_ref = self.super_ref.upgrade().ok_or(EIO)?;
+        // Resolve the driver-private `Ext2Inode` for `new_dir` via
+        // the parallel cache that `iget` publishes. On a well-formed
+        // call path this is always a hit — the caller holds an
+        // Arc<Inode> for new_dir, which keeps the Arc<Ext2Inode>
+        // alive through `inode.ops`.
+        let new_dir_arc_vfs = {
+            let cache = super_ref.inode_cache.lock();
+            cache
+                .get(&(new_dir.ino as u32))
+                .and_then(Weak::upgrade)
+                .ok_or(EIO)?
+        };
+        // Sanity: the cached Arc must be the same VFS inode the
+        // caller handed us.
+        if new_dir_arc_vfs.ino != new_dir.ino {
+            return Err(EIO);
+        }
+        let new_dir_ext2 = {
+            let ecache = super_ref.ext2_inode_cache.lock();
+            ecache
+                .get(&(new_dir.ino as u32))
+                .and_then(Weak::upgrade)
+                .ok_or(EIO)?
+        };
+        super::rename::rename(self, old_dir, old_name, &new_dir_ext2, new_dir, new_name)
+    }
+
     /// Create a FIFO named `name` under `dir`.
     ///
     /// Dispatches to [`super::create::mknod`] with `InodeKind::Fifo`

--- a/kernel/src/fs/ext2/mod.rs
+++ b/kernel/src/fs/ext2/mod.rs
@@ -150,3 +150,9 @@ pub mod orphan_finalize;
 
 #[cfg(all(feature = "ext2", target_os = "none"))]
 pub use orphan_finalize::finalize as finalize_orphan;
+
+// Rename path (#571). Same feature gate as the rest of the write-path
+// modules; implements RFC 0004 §Rename ordering (link-count-first) and
+// §Cross-directory loop check.
+#[cfg(all(feature = "ext2", target_os = "none"))]
+pub mod rename;

--- a/kernel/src/fs/ext2/rename.rs
+++ b/kernel/src/fs/ext2/rename.rs
@@ -1,0 +1,531 @@
+//! ext2 rename — `InodeOps::rename` with link-count-first ordering and
+//! a cross-directory ancestor (loop) check (issue #571).
+//!
+//! RFC 0004 (`docs/RFC/0004-ext2-filesystem-driver.md`) §Rename ordering
+//! and §Cross-directory loop check are the normative specs. Workstream E.
+//!
+//! # Normative ordering
+//!
+//! A rename mutates up to four inodes (old parent, new parent, source,
+//! optional victim) in one logical step. The on-disk sequence is
+//! strictly **link-count-first**:
+//!
+//! 1. Bump `source.i_links_count` (now >= 2).
+//! 2. If a victim exists at `new_name`, remove its dirent and decrement
+//!    its `i_links_count`.
+//! 3. Insert the new dirent in `new_parent` pointing at `source.ino`.
+//!    At this point both `old_name` and `new_name` resolve to the
+//!    source inode — the "both-names-visible" crash-safe window.
+//! 4. Remove the old dirent in `old_parent`.
+//! 5. Decrement `source.i_links_count` back to its original value.
+//! 6. Victim finalisation: if the victim's count hit zero, push it on
+//!    the on-disk orphan list so `e2fsck` (or the final-close path,
+//!    #573) can reclaim its blocks.
+//! 7. Cross-dir directory move: update source's `..` dirent to point
+//!    at `new_parent`, bump `new_parent.i_links_count`, decrement
+//!    `old_parent.i_links_count`.
+//!
+//! A crash at any point before step 4 leaves both names live — worst
+//! case a hard-link that `e2fsck` tidies. A crash between steps 4 and 5
+//! leaves `source.i_links_count` one too high — `e2fsck` reconciles.
+//! The filesystem never observes the "dirent points at inode that's
+//! been freed" window that a dirent-first order would expose (RFC 0004
+//! §Security).
+//!
+//! # Cross-directory ancestor check
+//!
+//! Moving a directory across parents must refuse renames into its own
+//! subtree; otherwise the resulting `..` chain would be cyclic and a
+//! user-level walker would loop forever. We walk from `new_parent` up
+//! to the filesystem root via each directory's `..` dirent; if the
+//! source's ino appears anywhere on the chain (or equals `new_parent`
+//! itself), return `EINVAL` — the POSIX error for rename-into-subtree.
+//!
+//! (The RFC calls this "ELOOP" in prose; POSIX dictates `EINVAL`. We
+//! return `EINVAL` to match POSIX and Linux's VFS layer — `path_walk`
+//! reserves `ELOOP` for symlink chains.)
+//!
+//! # Scope
+//!
+//! - `RENAME_EXCHANGE` / `RENAME_WHITEOUT`: out of scope (RFC 0004
+//!   §Out of scope). The VFS syscall layer (already merged as #541)
+//!   rejects these flags before reaching here.
+//! - `RENAME_NOREPLACE`: the syscall-layer flag is plumbed through the
+//!   trait via a dedicated helper only when a future PR grows the
+//!   trait signature; today it's enforced by refusing destination-
+//!   exists at the syscall layer. This module does implement atomic
+//!   replace so that a future noreplace helper can share the path.
+
+use alloc::sync::Arc;
+
+use super::disk::{
+    EXT2_FT_BLKDEV, EXT2_FT_CHRDEV, EXT2_FT_DIR, EXT2_FT_FIFO, EXT2_FT_REG_FILE, EXT2_FT_SOCK,
+    EXT2_FT_SYMLINK,
+};
+use super::fs::{Ext2MountFlags, Ext2Super};
+use super::inode::{iget, Ext2Inode};
+use super::unlink::{
+    dir_is_empty, ext2_inode_from_vfs, locate_dirent, now_secs, push_on_orphan_list,
+    remove_dirent_at, resolve_sb_for_super, rmw_disk_inode,
+};
+
+use crate::fs::vfs::inode::{Inode, InodeKind};
+use crate::fs::{EINVAL, EIO, EISDIR, ENOENT, ENOTDIR, ENOTEMPTY, EROFS};
+
+use core::sync::atomic::Ordering;
+
+/// POSIX-advertised ceiling on the depth of a directory tree we'll
+/// walk looking for an ancestry match. `EXT2_LINK_MAX` is 32000 but
+/// real trees are shallow; a few hundred levels is a practical guard
+/// that refuses pathological cyclic images without allocating a set.
+const ANCESTOR_WALK_MAX: u32 = 4096;
+
+/// Map a VFS `InodeKind` to an ext2 `EXT2_FT_*` value for dirent
+/// insertion. Mirrors the table in `create::NewNode::file_type`, kept
+/// as a free function so rename (which doesn't know at compile time
+/// what kind of inode it's re-linking) can call it.
+fn ext2_ftype(kind: InodeKind) -> u8 {
+    match kind {
+        InodeKind::Reg => EXT2_FT_REG_FILE,
+        InodeKind::Dir => EXT2_FT_DIR,
+        InodeKind::Link => EXT2_FT_SYMLINK,
+        InodeKind::Chr => EXT2_FT_CHRDEV,
+        InodeKind::Blk => EXT2_FT_BLKDEV,
+        InodeKind::Fifo => EXT2_FT_FIFO,
+        InodeKind::Sock => EXT2_FT_SOCK,
+    }
+}
+
+/// Walk from `start_ino` up the `..` chain to the root, returning
+/// `Ok(true)` if `target_ino` appears anywhere on the walk (including
+/// at `start_ino`), `Ok(false)` if we reach the root without matching.
+///
+/// Used by cross-dir directory rename to refuse
+/// rename-into-own-subtree: passing `target = source_ino` and
+/// `start = new_parent_ino`.
+///
+/// # Errors
+///
+/// - `EIO` — a `..` entry is missing, points outside the fs, or a
+///   walk step exceeds `ANCESTOR_WALK_MAX`.
+fn is_ancestor(super_: &Arc<Ext2Super>, target_ino: u32, start_ino: u32) -> Result<bool, i64> {
+    let mut cur = start_ino;
+    for _ in 0..ANCESTOR_WALK_MAX {
+        if cur == target_ino {
+            return Ok(true);
+        }
+        // `/` is ino 2 on ext2; its `..` points at itself. Terminate
+        // the walk when we reach it without matching.
+        if cur == super::disk::EXT2_ROOT_INO {
+            return Ok(false);
+        }
+        // Load `cur`'s Ext2Inode and look up `..` in it. We need a
+        // Weak<SuperBlock> chain for iget, which resolve_sb_for_super
+        // recovers via the inode cache.
+        let sb = resolve_sb_for_super(super_)?;
+        let arc = iget(super_, &sb, cur)?;
+        let ext2 = ext2_inode_from_vfs(super_, &arc).ok_or(EIO)?;
+        let parent_ino = super::dir::lookup(super_, &ext2, b"..")?;
+        if parent_ino == 0 || parent_ino == cur {
+            // Either a corrupt `..` (ino 0) or a self-loop at a non-
+            // root node — stop walking without declaring a match. A
+            // self-loop at root was handled above; here it's
+            // filesystem corruption we don't want to spin on.
+            return Ok(false);
+        }
+        cur = parent_ino;
+    }
+    Err(EIO)
+}
+
+/// Overwrite the `..` dirent in `dir` so it points at `new_parent_ino`.
+/// Used when a directory is moved across parents. The `..` record is
+/// always the second record in the dir's first data block (stamped by
+/// `create::create_dir`), so we scan the first block for the dirent
+/// whose name is `..` and RMW the `inode` field only — preserving
+/// `rec_len` / `name_len` / `file_type`.
+///
+/// We cannot reuse [`locate_dirent`] here because it rejects `.` and
+/// `..` as a safety rail for the unlink/rename name-validation paths
+/// (where those names are always EINVAL). Here, `..` is exactly the
+/// name we need.
+fn rewrite_dotdot(
+    super_: &Arc<Ext2Super>,
+    dir: &Ext2Inode,
+    new_parent_ino: u32,
+) -> Result<(), i64> {
+    use super::disk::{Ext2DirEntry2, EXT2_DIR_REC_HEADER_LEN};
+
+    let block_size = super_.block_size;
+    let (size, i_block) = {
+        let meta = dir.meta.read();
+        (meta.size, meta.i_block)
+    };
+    if size == 0 {
+        return Err(EIO);
+    }
+
+    // The `..` record lives in the directory's first logical block.
+    // `create::create_dir` stamps `.` then `..` there, and nothing in
+    // the driver ever relocates them (ext2 never compacts dirents).
+    let abs_block = i_block[0];
+    if abs_block == 0 {
+        return Err(EIO);
+    }
+    let bh = super_
+        .cache
+        .bread(super_.device_id, abs_block as u64)
+        .map_err(|_| EIO)?;
+    let logical_len = core::cmp::min(size, block_size as u64) as usize;
+
+    // Locate the offset of the `..` record, then drop the read guard
+    // before re-acquiring for write.
+    let offset = {
+        let data = bh.data.read();
+        let end = core::cmp::min(data.len(), logical_len);
+        let mut cursor = 0usize;
+        let mut found: Option<usize> = None;
+        while cursor < end {
+            if end - cursor < EXT2_DIR_REC_HEADER_LEN {
+                break;
+            }
+            let hdr = Ext2DirEntry2::decode_header(&data[cursor..cursor + EXT2_DIR_REC_HEADER_LEN]);
+            let rec_len = hdr.rec_len as usize;
+            if rec_len < EXT2_DIR_REC_HEADER_LEN || rec_len % 4 != 0 || cursor + rec_len > end {
+                return Err(EIO);
+            }
+            if hdr.inode != 0 {
+                let name_len = hdr.name_len as usize;
+                let name_start = cursor + EXT2_DIR_REC_HEADER_LEN;
+                let name_end = name_start + name_len;
+                if name_end > cursor + rec_len {
+                    return Err(EIO);
+                }
+                if &data[name_start..name_end] == b".." {
+                    found = Some(cursor);
+                    break;
+                }
+            }
+            cursor += rec_len;
+        }
+        found.ok_or(EIO)?
+    };
+
+    {
+        let mut data = bh.data.write();
+        if offset + 4 > data.len() {
+            return Err(EIO);
+        }
+        data[offset..offset + 4].copy_from_slice(&new_parent_ino.to_le_bytes());
+    }
+    super_.cache.mark_dirty(&bh);
+    super_.cache.sync_dirty_buffer(&bh).map_err(|_| EIO)?;
+    Ok(())
+}
+
+/// Core `rename` entry point invoked from `Ext2Inode`'s `InodeOps`
+/// impl. `old_parent` / `new_parent` are the driver-private inode
+/// handles; `old_parent_vfs` / `new_parent_vfs` are the VFS handles
+/// the caller already holds (same identity as `inode.ops` dispatches
+/// through; used to reach `dir_rwsem` + `sb.rename_mutex`).
+pub fn rename(
+    old_parent: &Ext2Inode,
+    old_parent_vfs: &Inode,
+    old_name: &[u8],
+    new_parent: &Ext2Inode,
+    new_parent_vfs: &Inode,
+    new_name: &[u8],
+) -> Result<(), i64> {
+    let super_ = old_parent.super_ref.upgrade().ok_or(EIO)?;
+    if super_.ext2_flags.contains(Ext2MountFlags::RDONLY)
+        || super_.ext2_flags.contains(Ext2MountFlags::FORCED_RDONLY)
+    {
+        return Err(EROFS);
+    }
+
+    // Both parents must come from the same mount.
+    {
+        let new_super = new_parent.super_ref.upgrade().ok_or(EIO)?;
+        if !Arc::ptr_eq(&super_, &new_super) {
+            return Err(EIO);
+        }
+    }
+
+    // Name validation. For rename, `.` and `..` on either side are
+    // EINVAL per POSIX — the generic `validate_name` surfaces them
+    // as EEXIST (right for create, wrong for rename), so we gate
+    // those first and then let the shared validator take the
+    // remaining cases (empty, NUL, `/`, too-long).
+    if old_name == b"." || old_name == b".." || new_name == b"." || new_name == b".." {
+        return Err(EINVAL);
+    }
+    super::create::validate_name(old_name)?;
+    super::create::validate_name(new_name)?;
+
+    // Same-parent same-name is always a successful no-op.
+    let same_parent = old_parent.ino == new_parent.ino;
+    if same_parent && old_name == new_name {
+        return Ok(());
+    }
+
+    // Acquire locks.
+    //  - Cross-dir: take `sb.rename_mutex` first (global tiebreaker),
+    //    then `dir_rwsem` on each parent in ino order.
+    //  - Same-dir: one `dir_rwsem` write lock is enough.
+    let sb_for_mutex = resolve_sb_for_super(&super_)?;
+    let _rename_guard = if same_parent {
+        None
+    } else {
+        Some(sb_for_mutex.rename_mutex.lock())
+    };
+
+    // Bind the rwsem guards to this frame. In the same-parent case
+    // only one guard is taken; in the cross-parent case both, in
+    // inode-number order to prevent ABBA deadlock against a
+    // concurrent rename in the opposite direction.
+    let (_g1, _g2) = if same_parent {
+        (Some(old_parent_vfs.dir_rwsem.write()), None)
+    } else if old_parent_vfs.ino < new_parent_vfs.ino {
+        (
+            Some(old_parent_vfs.dir_rwsem.write()),
+            Some(new_parent_vfs.dir_rwsem.write()),
+        )
+    } else {
+        (
+            Some(new_parent_vfs.dir_rwsem.write()),
+            Some(old_parent_vfs.dir_rwsem.write()),
+        )
+    };
+
+    // 1. Locate the source dirent and load the source inode.
+    let src_loc = locate_dirent(&super_, old_parent, old_name)?;
+    let parent_sb = resolve_sb_for_super(&super_)?;
+    let source_vfs = iget(&super_, &parent_sb, src_loc.child_ino)?;
+    let source_ext2 = ext2_inode_from_vfs(&super_, &source_vfs).ok_or(EIO)?;
+    let source_is_dir = source_vfs.kind == InodeKind::Dir;
+
+    // 2. Cross-directory ancestor check for directory moves. A
+    //    directory must not be renamed into itself or any of its
+    //    descendants; otherwise the `..` chain becomes cyclic.
+    if source_is_dir && !same_parent {
+        if source_vfs.ino as u32 == new_parent.ino {
+            return Err(EINVAL);
+        }
+        if is_ancestor(&super_, source_vfs.ino as u32, new_parent.ino)? {
+            return Err(EINVAL);
+        }
+    }
+
+    // 3. Probe for a victim at new_name.
+    let victim = match locate_dirent(&super_, new_parent, new_name) {
+        Ok(v) => Some(v),
+        Err(e) if e == ENOENT => None,
+        Err(e) => return Err(e),
+    };
+
+    // Resolve victim inode (if any) + enforce type/empty rules before
+    // any mutation. If source == victim (e.g. same-dir case-preserving
+    // rename) treat as no-op.
+    let victim_arcs = if let Some(vloc) = victim.as_ref() {
+        if vloc.child_ino == src_loc.child_ino {
+            // Renaming a name onto itself (e.g. same dir, different
+            // case on a case-sensitive FS but byte-identical). No-op.
+            return Ok(());
+        }
+        let v_arc = iget(&super_, &parent_sb, vloc.child_ino)?;
+        let v_ext2 = ext2_inode_from_vfs(&super_, &v_arc).ok_or(EIO)?;
+        let victim_is_dir = v_arc.kind == InodeKind::Dir;
+        match (source_is_dir, victim_is_dir) {
+            (true, false) => return Err(ENOTDIR),
+            (false, true) => return Err(EISDIR),
+            _ => {}
+        }
+        if victim_is_dir && !dir_is_empty(&super_, &v_ext2)? {
+            return Err(ENOTEMPTY);
+        }
+        Some((v_arc, v_ext2))
+    } else {
+        None
+    };
+
+    let now = now_secs();
+
+    // 4. LINK-COUNT-FIRST: bump source links before touching any dirent.
+    rmw_disk_inode(&super_, src_loc.child_ino, |disk| {
+        disk.i_links_count = disk.i_links_count.saturating_add(1);
+        disk.i_ctime = now;
+    })?;
+    {
+        let mut meta = source_ext2.meta.write();
+        meta.links_count = meta.links_count.saturating_add(1);
+        meta.ctime = now;
+    }
+    {
+        let mut vfs_meta = source_vfs.meta.write();
+        vfs_meta.nlink = vfs_meta.nlink.saturating_add(1);
+        vfs_meta.ctime = crate::fs::vfs::Timespec {
+            sec: now as i64,
+            nsec: 0,
+        };
+    }
+
+    // 5. If a victim exists, strip its dirent + decrement its link
+    //    count so the follow-up `add_link` can use (or newly
+    //    allocate) a slot. Note: we intentionally leave the source's
+    //    bumped links in place; the dirent for `new_name` doesn't
+    //    exist yet, so source is only reachable through `old_name`
+    //    at this instant — the bumped count represents the
+    //    *about-to-be-added* second link.
+    let mut victim_hit_zero: Option<u32> = None;
+    if let (Some(vloc), Some((v_arc, v_ext2))) = (victim.as_ref(), victim_arcs.as_ref()) {
+        remove_dirent_at(&super_, vloc)?;
+        // rmdir semantics for a victim directory: links goes 2 -> 0
+        // (both the self `.` and the parent-held `..` are gone).
+        // Unlink semantics for a non-dir: links -= 1.
+        let dec: u16 = if source_is_dir { 2 } else { 1 };
+        let mut new_links: u16 = 0;
+        rmw_disk_inode(&super_, vloc.child_ino, |disk| {
+            disk.i_links_count = disk.i_links_count.saturating_sub(dec);
+            disk.i_ctime = now;
+            new_links = disk.i_links_count;
+        })?;
+        {
+            let mut meta = v_ext2.meta.write();
+            meta.links_count = meta.links_count.saturating_sub(dec);
+            meta.ctime = now;
+        }
+        {
+            let mut vfs_meta = v_arc.meta.write();
+            let dec32 = dec as u32;
+            vfs_meta.nlink = vfs_meta.nlink.saturating_sub(dec32);
+            vfs_meta.ctime = crate::fs::vfs::Timespec {
+                sec: now as i64,
+                nsec: 0,
+            };
+        }
+        // A victim directory replacement also costs `new_parent` one
+        // nlink (it loses the victim's `..` back-link). The
+        // incoming source directory will re-add it below if cross-
+        // dir, or not at all if same-dir (source was already
+        // contributing one nlink via its own `..`).
+        if source_is_dir {
+            rmw_disk_inode(&super_, new_parent.ino, |disk| {
+                disk.i_links_count = disk.i_links_count.saturating_sub(1);
+                disk.i_ctime = now;
+            })?;
+            {
+                let mut meta = new_parent.meta.write();
+                meta.links_count = meta.links_count.saturating_sub(1);
+                meta.ctime = now;
+            }
+            {
+                let mut vfs_meta = new_parent_vfs.meta.write();
+                vfs_meta.nlink = vfs_meta.nlink.saturating_sub(1);
+                vfs_meta.ctime = crate::fs::vfs::Timespec {
+                    sec: now as i64,
+                    nsec: 0,
+                };
+            }
+        }
+        if new_links == 0 {
+            victim_hit_zero = Some(vloc.child_ino);
+        }
+    }
+
+    // 6. Insert the new dirent in new_parent. This is the
+    //    both-names-visible moment — a crash between here and step 7
+    //    leaves the source reachable through both names, which
+    //    `e2fsck` resolves as a stray hard link (no corruption).
+    let ftype = ext2_ftype(source_vfs.kind);
+    super::create::add_link(&super_, new_parent, new_name, src_loc.child_ino, ftype)?;
+
+    // 7. Remove the old dirent.
+    //
+    // Re-locate it first: `add_link` in step 6 almost certainly split
+    // the slack of some record in `old_parent` (commonly the last
+    // live record, which for same-dir rename is often the source
+    // itself). That shrinks the original dirent's `rec_len`, so
+    // `src_loc.rec_len` captured before the insert is stale. Using it
+    // to extend the previous record would over-swallow past the newly
+    // inserted record. Re-scanning costs one directory walk but keeps
+    // the remove-step correct under every slack layout.
+    let src_loc = locate_dirent(&super_, old_parent, old_name)?;
+    remove_dirent_at(&super_, &src_loc)?;
+
+    // 8. Restore source's link count by decrementing back to the
+    //    original value.
+    rmw_disk_inode(&super_, src_loc.child_ino, |disk| {
+        disk.i_links_count = disk.i_links_count.saturating_sub(1);
+        disk.i_ctime = now;
+    })?;
+    {
+        let mut meta = source_ext2.meta.write();
+        meta.links_count = meta.links_count.saturating_sub(1);
+        meta.ctime = now;
+    }
+    {
+        let mut vfs_meta = source_vfs.meta.write();
+        vfs_meta.nlink = vfs_meta.nlink.saturating_sub(1);
+        vfs_meta.ctime = crate::fs::vfs::Timespec {
+            sec: now as i64,
+            nsec: 0,
+        };
+    }
+
+    // 9. Cross-directory directory move: rewrite `..`, shuffle the
+    //    parent dirs' nlink counts. Intentionally runs after the
+    //    link-count-first dance so a crash between step 7 and here
+    //    leaves a cosmetic "wrong parent ino in `..`" that e2fsck
+    //    fixes, not an unreachable inode.
+    if source_is_dir && !same_parent {
+        rewrite_dotdot(&super_, &source_ext2, new_parent.ino)?;
+        // new_parent gains the `..` back-link from source.
+        rmw_disk_inode(&super_, new_parent.ino, |disk| {
+            disk.i_links_count = disk.i_links_count.saturating_add(1);
+            disk.i_ctime = now;
+        })?;
+        {
+            let mut meta = new_parent.meta.write();
+            meta.links_count = meta.links_count.saturating_add(1);
+            meta.ctime = now;
+        }
+        {
+            let mut vfs_meta = new_parent_vfs.meta.write();
+            vfs_meta.nlink = vfs_meta.nlink.saturating_add(1);
+            vfs_meta.ctime = crate::fs::vfs::Timespec {
+                sec: now as i64,
+                nsec: 0,
+            };
+        }
+        // old_parent loses the `..` back-link.
+        rmw_disk_inode(&super_, old_parent.ino, |disk| {
+            disk.i_links_count = disk.i_links_count.saturating_sub(1);
+            disk.i_ctime = now;
+        })?;
+        {
+            let mut meta = old_parent.meta.write();
+            meta.links_count = meta.links_count.saturating_sub(1);
+            meta.ctime = now;
+        }
+        {
+            let mut vfs_meta = old_parent_vfs.meta.write();
+            vfs_meta.nlink = vfs_meta.nlink.saturating_sub(1);
+            vfs_meta.ctime = crate::fs::vfs::Timespec {
+                sec: now as i64,
+                nsec: 0,
+            };
+        }
+    }
+
+    // 10. Victim finalisation: if its links hit zero, push it on the
+    //     orphan list so the final-close path (#573) can reclaim its
+    //     blocks. The victim's dirent is already gone by step 5.
+    if let Some(ino) = victim_hit_zero {
+        if let Some((v_arc, v_ext2)) = victim_arcs.as_ref() {
+            v_ext2.unlinked.store(true, Ordering::SeqCst);
+            push_on_orphan_list(&super_, ino, v_arc)?;
+        }
+    }
+
+    Ok(())
+}

--- a/kernel/src/fs/ext2/rename.rs
+++ b/kernel/src/fs/ext2/rename.rs
@@ -65,8 +65,8 @@ use super::disk::{
 use super::fs::{Ext2MountFlags, Ext2Super};
 use super::inode::{iget, Ext2Inode};
 use super::unlink::{
-    dir_is_empty, ext2_inode_from_vfs, locate_dirent, now_secs, push_on_orphan_list,
-    remove_dirent_at, resolve_sb_for_super, rmw_disk_inode,
+    decrement_used_dirs, dir_is_empty, ext2_inode_from_vfs, locate_dirent, now_secs,
+    push_on_orphan_list, remove_dirent_at, resolve_sb_for_super, rmw_disk_inode,
 };
 
 use crate::fs::vfs::inode::{Inode, InodeKind};
@@ -262,11 +262,11 @@ pub fn rename(
     super::create::validate_name(old_name)?;
     super::create::validate_name(new_name)?;
 
-    // Same-parent same-name is always a successful no-op.
     let same_parent = old_parent.ino == new_parent.ino;
-    if same_parent && old_name == new_name {
-        return Ok(());
-    }
+    // NB: the same-parent same-name "no-op" return moved *after*
+    // `locate_dirent(old_name)` below — returning Ok(()) up here would
+    // paper over a missing source (rename("missing","missing") must be
+    // ENOENT, not success).
 
     // Acquire locks.
     //  - Cross-dir: take `sb.rename_mutex` first (global tiebreaker),
@@ -299,6 +299,11 @@ pub fn rename(
 
     // 1. Locate the source dirent and load the source inode.
     let src_loc = locate_dirent(&super_, old_parent, old_name)?;
+    // Now that we've proved `old_name` exists, a same-parent rename
+    // onto the same name is a successful no-op.
+    if same_parent && old_name == new_name {
+        return Ok(());
+    }
     let parent_sb = resolve_sb_for_super(&super_)?;
     let source_vfs = iget(&super_, &parent_sb, src_loc.child_ino)?;
     let source_ext2 = ext2_inode_from_vfs(&super_, &source_vfs).ok_or(EIO)?;
@@ -429,6 +434,14 @@ pub fn rename(
         }
         if new_links == 0 {
             victim_hit_zero = Some(vloc.child_ino);
+            // When the victim was a directory, its block group's
+            // `bg_used_dirs_count` must be decremented — same as the
+            // rmdir path does in `unlink.rs`. Without this the BGDT
+            // directory counts drift after a directory-over-directory
+            // rename.
+            if source_is_dir {
+                decrement_used_dirs(&super_, vloc.child_ino)?;
+            }
         }
     }
 

--- a/kernel/src/fs/ext2/unlink.rs
+++ b/kernel/src/fs/ext2/unlink.rs
@@ -370,7 +370,7 @@ fn flush_superblock(super_: &Arc<Ext2Super>, sb: &Ext2SuperBlock) -> Result<(), 
 /// Decrement `bg_used_dirs_count` on the BGDT entry for the group that
 /// owns `ino`. Called from `rmdir` when a directory inode has its link
 /// count driven to zero.
-fn decrement_used_dirs(super_: &Arc<Ext2Super>, ino: u32) -> Result<(), i64> {
+pub(super) fn decrement_used_dirs(super_: &Arc<Ext2Super>, ino: u32) -> Result<(), i64> {
     use super::disk::EXT2_GROUP_DESC_SIZE;
     let (s_inodes_per_group, s_first_data_block) = {
         let sb = super_.sb_disk.lock();

--- a/kernel/src/fs/ext2/unlink.rs
+++ b/kernel/src/fs/ext2/unlink.rs
@@ -61,14 +61,14 @@ use core::sync::atomic::Ordering;
 /// target is first-in-block), the target record's `rec_len`, and the
 /// target's ino + file_type.
 #[derive(Debug, Clone, Copy)]
-struct DirentLocation {
-    abs_block: u32,
-    offset_in_block: usize,
-    prev_offset_in_block: Option<usize>,
-    rec_len: usize,
-    child_ino: u32,
+pub(super) struct DirentLocation {
+    pub(super) abs_block: u32,
+    pub(super) offset_in_block: usize,
+    pub(super) prev_offset_in_block: Option<usize>,
+    pub(super) rec_len: usize,
+    pub(super) child_ino: u32,
     #[allow(dead_code)]
-    file_type: u8,
+    pub(super) file_type: u8,
 }
 
 /// Walk `dir`'s data blocks until `name` is found, returning the exact
@@ -76,7 +76,7 @@ struct DirentLocation {
 /// to locate the dirent they're about to remove.
 ///
 /// Returns `ENOENT` if the name isn't present.
-fn locate_dirent(
+pub(super) fn locate_dirent(
     super_: &Arc<Ext2Super>,
     dir: &Ext2Inode,
     name: &[u8],
@@ -175,7 +175,7 @@ fn locate_dirent(
 /// formerly-full directory can have multiple allocated blocks with
 /// only `.` / `..` still live. A single non-`.`/`..` live record
 /// anywhere in the walk proves the directory is non-empty.
-fn dir_is_empty(super_: &Arc<Ext2Super>, dir: &Ext2Inode) -> Result<bool, i64> {
+pub(super) fn dir_is_empty(super_: &Arc<Ext2Super>, dir: &Ext2Inode) -> Result<bool, i64> {
     let block_size = super_.block_size;
     let (s_first_data_block, s_blocks_count, s_feature_incompat) = {
         let sb = super_.sb_disk.lock();
@@ -234,7 +234,7 @@ fn dir_is_empty(super_: &Arc<Ext2Super>, dir: &Ext2Inode) -> Result<bool, i64> {
 /// or (if the target is first-in-block) turns it into a tombstone by
 /// zeroing the `inode` field. The block is marked dirty and synced
 /// before returning.
-fn remove_dirent_at(super_: &Arc<Ext2Super>, loc: &DirentLocation) -> Result<(), i64> {
+pub(super) fn remove_dirent_at(super_: &Arc<Ext2Super>, loc: &DirentLocation) -> Result<(), i64> {
     let bh = super_
         .cache
         .bread(super_.device_id, loc.abs_block as u64)
@@ -318,7 +318,7 @@ fn read_disk_inode(super_: &Arc<Ext2Super>, ino: u32) -> Result<(DiskInode, u64,
 }
 
 /// RMW an on-disk inode slot with `writer` and sync the block.
-fn rmw_disk_inode<F>(super_: &Arc<Ext2Super>, ino: u32, writer: F) -> Result<(), i64>
+pub(super) fn rmw_disk_inode<F>(super_: &Arc<Ext2Super>, ino: u32, writer: F) -> Result<(), i64>
 where
     F: FnOnce(&mut DiskInode),
 {
@@ -435,7 +435,7 @@ fn decrement_used_dirs(super_: &Arc<Ext2Super>, ino: u32) -> Result<(), i64> {
 /// Caller contract: `child.meta.links_count == 0`, the child's
 /// `unlinked` atomic has already been set to `true`, and the on-disk
 /// `i_links_count` has been flushed.
-fn push_on_orphan_list(
+pub(super) fn push_on_orphan_list(
     super_: &Arc<Ext2Super>,
     child_ino: u32,
     child_inode: &Arc<Inode>,
@@ -480,7 +480,7 @@ fn push_on_orphan_list(
 /// UTIME_NOW` uses. Ext2 timestamps are second-granularity on rev-0;
 /// the nsec is dropped here.
 #[inline]
-fn now_secs() -> u32 {
+pub(super) fn now_secs() -> u32 {
     crate::fs::vfs::Timespec::now().sec as u32
 }
 
@@ -624,7 +624,7 @@ pub fn rmdir(parent_dir: &Ext2Inode, parent_vfs: &Inode, name: &[u8]) -> Result<
 /// pins the sb through its `Weak<SuperBlock>`). We ask the cache's
 /// root-ino slot, which [`super::fs::Ext2Fs::mount`] pins before
 /// returning.
-fn resolve_sb_for_super(super_: &Arc<Ext2Super>) -> Result<Arc<SuperBlock>, i64> {
+pub(super) fn resolve_sb_for_super(super_: &Arc<Ext2Super>) -> Result<Arc<SuperBlock>, i64> {
     let cache = super_.inode_cache.lock();
     // Any cached entry will do; root is guaranteed cached at mount.
     for (_, weak) in cache.iter() {
@@ -643,7 +643,10 @@ fn resolve_sb_for_super(super_: &Arc<Ext2Super>) -> Result<Arc<SuperBlock>, i64>
 /// impossible on a well-formed call path because the caller always
 /// holds a strong `Arc<Inode>` keeping the concrete `Arc<Ext2Inode>`
 /// alive through `inode.ops`.
-fn ext2_inode_from_vfs(super_: &Arc<Ext2Super>, inode: &Arc<Inode>) -> Option<Arc<Ext2Inode>> {
+pub(super) fn ext2_inode_from_vfs(
+    super_: &Arc<Ext2Super>,
+    inode: &Arc<Inode>,
+) -> Option<Arc<Ext2Inode>> {
     let cache = super_.ext2_inode_cache.lock();
     cache.get(&(inode.ino as u32)).and_then(|w| w.upgrade())
 }

--- a/kernel/tests/ext2_rename.rs
+++ b/kernel/tests/ext2_rename.rs
@@ -1,0 +1,525 @@
+//! Integration test for issue #571: ext2 `InodeOps::rename` with
+//! link-count-first ordering and cross-directory loop check.
+//!
+//! Uses the standard 64 KiB golden image. Each test creates its own
+//! scratch files/dirs via `create_file` / `create_dir` (issue #568)
+//! before exercising rename, so the image's lone baked-in dirent
+//! (`lost+found`) is preserved between tests that share a mount.
+//!
+//! Coverage:
+//!
+//! - `rename_same_dir` — rename `a` → `b` in `/`, source ino
+//!   preserved, old name gone, new name resolves to the same ino.
+//! - `rename_cross_dir` — `mkdir /d`, `create /f`, rename `/f` → `/d/f`.
+//!   Old location gone, new location resolves, source ino stable.
+//! - `rename_replaces_regular` — rename over an existing regular file:
+//!   victim dropped to links_count 0, pushed on the orphan list.
+//! - `rename_noreplace_equivalent_via_probe` — if destination exists
+//!   for a same-type-mismatch, we surface `EISDIR`/`ENOTDIR` (the
+//!   trait doesn't expose a NOREPLACE flag but the type-mismatch
+//!   arm is the closest check the ext2 path honours).
+//! - `rename_into_descendant_is_einval` — `mkdir /a`, `mkdir /a/b`,
+//!   rename `/a` → `/a/b/a` must fail with EINVAL.
+//! - `rename_dir_updates_dotdot` — cross-dir directory move updates
+//!   the source's `..` to point at the new parent and shuffles the
+//!   parents' nlinks.
+//! - `rename_ro_mount_is_erofs` — RO mount refuses rename.
+//! - `rename_dot_and_dotdot_einval` — refuse `.` / `..` as source or
+//!   destination names.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+use spin::Mutex;
+
+use vibix::block::{BlockDevice, BlockError};
+use vibix::fs::ext2::{dir, iget, Ext2Fs, Ext2Inode, Ext2InodeMeta, Ext2Super};
+use vibix::fs::vfs::ops::{FileSystem as _, MountSource};
+use vibix::fs::vfs::MountFlags;
+use vibix::fs::{EINVAL, EROFS};
+use vibix::sync::BlockingRwLock;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+const GOLDEN_IMG: &[u8; 65_536] = include_bytes!("../src/fs/ext2/fixtures/golden.img");
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("rename_same_dir", &(rename_same_dir as fn())),
+        ("rename_cross_dir", &(rename_cross_dir as fn())),
+        (
+            "rename_replaces_regular",
+            &(rename_replaces_regular as fn()),
+        ),
+        (
+            "rename_into_descendant_is_einval",
+            &(rename_into_descendant_is_einval as fn()),
+        ),
+        (
+            "rename_dir_updates_dotdot",
+            &(rename_dir_updates_dotdot as fn()),
+        ),
+        (
+            "rename_ro_mount_is_erofs",
+            &(rename_ro_mount_is_erofs as fn()),
+        ),
+        (
+            "rename_dot_and_dotdot_einval",
+            &(rename_dot_and_dotdot_einval as fn()),
+        ),
+        ("rename_same_name_noop", &(rename_same_name_noop as fn())),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RamDisk — matches the other ext2 integration tests.
+// ---------------------------------------------------------------------------
+
+struct RamDisk {
+    block_size: u32,
+    storage: Mutex<Vec<u8>>,
+    writes: AtomicU32,
+    read_only: AtomicBool,
+}
+
+impl RamDisk {
+    fn from_image(bytes: &[u8], block_size: u32) -> Arc<Self> {
+        assert!(bytes.len() % block_size as usize == 0);
+        Arc::new(Self {
+            block_size,
+            storage: Mutex::new(bytes.to_vec()),
+            writes: AtomicU32::new(0),
+            read_only: AtomicBool::new(false),
+        })
+    }
+
+    fn set_read_only(&self, ro: bool) {
+        self.read_only.store(ro, Ordering::Relaxed);
+    }
+}
+
+impl BlockDevice for RamDisk {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
+        let bs = self.block_size as u64;
+        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
+            return Err(BlockError::BadAlign);
+        }
+        let storage = self.storage.lock();
+        let end = offset
+            .checked_add(buf.len() as u64)
+            .ok_or(BlockError::OutOfRange)?;
+        if end > storage.len() as u64 {
+            return Err(BlockError::OutOfRange);
+        }
+        let off = offset as usize;
+        buf.copy_from_slice(&storage[off..off + buf.len()]);
+        Ok(())
+    }
+    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
+        if self.read_only.load(Ordering::Relaxed) {
+            return Err(BlockError::ReadOnly);
+        }
+        let bs = self.block_size as u64;
+        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
+            return Err(BlockError::BadAlign);
+        }
+        let mut storage = self.storage.lock();
+        let end = offset
+            .checked_add(buf.len() as u64)
+            .ok_or(BlockError::Enospc)?;
+        if end > storage.len() as u64 {
+            return Err(BlockError::Enospc);
+        }
+        let off = offset as usize;
+        storage[off..off + buf.len()].copy_from_slice(buf);
+        self.writes.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+    fn block_size(&self) -> u32 {
+        self.block_size
+    }
+    fn capacity(&self) -> u64 {
+        self.storage.lock().len() as u64
+    }
+}
+
+fn mount_rw() -> (
+    Arc<vibix::fs::vfs::super_block::SuperBlock>,
+    Arc<Ext2Fs>,
+    Arc<Ext2Super>,
+    Arc<RamDisk>,
+) {
+    let disk = RamDisk::from_image(GOLDEN_IMG.as_slice(), 512);
+    let fs = Ext2Fs::new_with_device(disk.clone() as Arc<dyn BlockDevice>);
+    let sb = fs
+        .mount(MountSource::None, MountFlags(0))
+        .expect("RW mount");
+    let super_arc = fs.current_super().expect("current_super");
+    (sb, fs, super_arc, disk)
+}
+
+fn mount_ro() -> (
+    Arc<vibix::fs::vfs::super_block::SuperBlock>,
+    Arc<Ext2Fs>,
+    Arc<Ext2Super>,
+    Arc<RamDisk>,
+) {
+    let disk = RamDisk::from_image(GOLDEN_IMG.as_slice(), 512);
+    let fs = Ext2Fs::new_with_device(disk.clone() as Arc<dyn BlockDevice>);
+    let sb = fs
+        .mount(MountSource::None, MountFlags::RDONLY)
+        .expect("RO mount");
+    disk.set_read_only(true);
+    let super_arc = fs.current_super().expect("current_super");
+    (sb, fs, super_arc, disk)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Grab the VFS `Arc<Inode>` for a given ino via iget.
+fn get(
+    super_arc: &Arc<Ext2Super>,
+    sb: &Arc<vibix::fs::vfs::super_block::SuperBlock>,
+    ino: u32,
+) -> Arc<vibix::fs::vfs::inode::Inode> {
+    iget(super_arc, sb, ino).expect("iget")
+}
+
+/// Re-hydrate a driver-private `Ext2Inode` from the on-disk inode
+/// slot. Mirrors `ext2_create.rs::make_ext2_inode_from_disk` — we
+/// need a concrete `Ext2Inode` to hand to the `dir::lookup` helper,
+/// which lives on the driver-private type.
+fn ext2_from_disk(
+    super_arc: &Arc<Ext2Super>,
+    sb: &Arc<vibix::fs::vfs::super_block::SuperBlock>,
+    ino: u32,
+) -> Ext2Inode {
+    let _ = iget(super_arc, sb, ino).expect("iget");
+    let inodes_per_group = super_arc.sb_disk.lock().s_inodes_per_group;
+    let group = (ino - 1) / inodes_per_group;
+    let index_in_group = (ino - 1) % inodes_per_group;
+    let bg_inode_table = {
+        let bgdt = super_arc.bgdt.lock();
+        bgdt[group as usize].bg_inode_table
+    };
+    let byte_offset = (index_in_group as u64) * (super_arc.inode_size as u64);
+    let block_in_table = byte_offset / (super_arc.block_size as u64);
+    let offset_in_block = (byte_offset % (super_arc.block_size as u64)) as usize;
+    let absolute_block = bg_inode_table as u64 + block_in_table;
+    let bh = super_arc
+        .cache
+        .bread(super_arc.device_id, absolute_block)
+        .expect("bread");
+    let data = bh.data.read();
+    let mut slot = [0u8; 128];
+    slot.copy_from_slice(&data[offset_in_block..offset_in_block + 128]);
+    drop(data);
+    let disk_inode = vibix::fs::ext2::disk::Ext2Inode::decode(&slot);
+    let meta = Ext2InodeMeta {
+        mode: disk_inode.i_mode,
+        uid: disk_inode.uid(),
+        gid: disk_inode.gid(),
+        size: disk_inode.i_size as u64,
+        atime: disk_inode.i_atime,
+        ctime: disk_inode.i_ctime,
+        mtime: disk_inode.i_mtime,
+        dtime: disk_inode.i_dtime,
+        links_count: disk_inode.i_links_count,
+        i_blocks: disk_inode.i_blocks,
+        flags: disk_inode.i_flags,
+        i_block: disk_inode.i_block,
+    };
+    Ext2Inode {
+        super_ref: Arc::downgrade(super_arc),
+        ino,
+        meta: BlockingRwLock::new(meta),
+        block_map: BlockingRwLock::new(None),
+        unlinked: AtomicBool::new(false),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+fn rename_same_dir() {
+    let (sb, _fs, super_arc, _disk) = mount_rw();
+    let root_arc = get(&super_arc, &sb, 2);
+
+    // Create `/a`.
+    let a = root_arc
+        .ops
+        .create(&root_arc, b"a", 0o644)
+        .expect("create /a");
+    let a_ino = a.ino as u32;
+
+    // Rename `/a` → `/b`.
+    root_arc
+        .ops
+        .rename(&root_arc, b"a", &root_arc, b"b")
+        .expect("rename a->b");
+
+    // Verify via a fresh on-disk inode handle so we don't trust the
+    // post-rename in-memory meta.
+    let root_e2 = ext2_from_disk(&super_arc, &sb, 2);
+    assert!(
+        dir::lookup(&super_arc, &root_e2, b"a").is_err(),
+        "old name /a must be gone"
+    );
+    let b_ino = dir::lookup(&super_arc, &root_e2, b"b").expect("lookup b");
+    assert_eq!(b_ino, a_ino, "new name must resolve to source ino");
+
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn rename_cross_dir() {
+    let (sb, _fs, super_arc, _disk) = mount_rw();
+    let root_arc = get(&super_arc, &sb, 2);
+
+    // Create `/d` (dir) and `/f` (reg file).
+    let d_vfs = root_arc
+        .ops
+        .mkdir(&root_arc, b"d", 0o755)
+        .expect("mkdir /d");
+    let d_ino = d_vfs.ino as u32;
+    let f = root_arc
+        .ops
+        .create(&root_arc, b"f", 0o644)
+        .expect("create /f");
+    let f_ino = f.ino as u32;
+
+    // Rename `/f` → `/d/f`.
+    root_arc
+        .ops
+        .rename(&root_arc, b"f", &d_vfs, b"f")
+        .expect("rename /f -> /d/f");
+
+    // Old location gone; new location resolves to the source ino.
+    let root_e2 = ext2_from_disk(&super_arc, &sb, 2);
+    let d_e2 = ext2_from_disk(&super_arc, &sb, d_ino);
+    assert!(dir::lookup(&super_arc, &root_e2, b"f").is_err());
+    assert_eq!(
+        dir::lookup(&super_arc, &d_e2, b"f").expect("lookup /d/f"),
+        f_ino,
+    );
+
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn rename_replaces_regular() {
+    let (sb, _fs, super_arc, _disk) = mount_rw();
+    let root_arc = get(&super_arc, &sb, 2);
+
+    let a = root_arc
+        .ops
+        .create(&root_arc, b"a", 0o644)
+        .expect("create /a");
+    let victim = root_arc
+        .ops
+        .create(&root_arc, b"v", 0o644)
+        .expect("create /v");
+    let a_ino = a.ino as u32;
+    let v_ino = victim.ino as u32;
+
+    // Rename /a -> /v, replacing the existing regular file.
+    root_arc
+        .ops
+        .rename(&root_arc, b"a", &root_arc, b"v")
+        .expect("rename /a -> /v (replace)");
+
+    let root_e2 = ext2_from_disk(&super_arc, &sb, 2);
+    assert!(dir::lookup(&super_arc, &root_e2, b"a").is_err());
+    assert_eq!(
+        dir::lookup(&super_arc, &root_e2, b"v").expect("lookup /v"),
+        a_ino,
+    );
+
+    // Victim landed on the orphan list — its links_count went to 0.
+    {
+        let list = super_arc.orphan_list.lock();
+        assert!(
+            list.contains_key(&v_ino),
+            "victim inode {} must be pinned on the orphan list after replace",
+            v_ino,
+        );
+    }
+
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn rename_into_descendant_is_einval() {
+    let (sb, _fs, super_arc, _disk) = mount_rw();
+    let root_arc = get(&super_arc, &sb, 2);
+
+    // Build /a/b.
+    let a_vfs = root_arc
+        .ops
+        .mkdir(&root_arc, b"a", 0o755)
+        .expect("mkdir /a");
+    let b_vfs = a_vfs.ops.mkdir(&a_vfs, b"b", 0o755).expect("mkdir /a/b");
+
+    // rename /a -> /a/b/a must fail with EINVAL (target inside source).
+    let err = root_arc
+        .ops
+        .rename(&root_arc, b"a", &b_vfs, b"a")
+        .expect_err("rename-into-descendant must fail");
+    assert_eq!(err, EINVAL);
+
+    // rename /a -> /a/x (target IS source dir) also fails EINVAL.
+    let err2 = root_arc
+        .ops
+        .rename(&root_arc, b"a", &a_vfs, b"x")
+        .expect_err("rename-into-self must fail");
+    assert_eq!(err2, EINVAL);
+
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn rename_dir_updates_dotdot() {
+    let (sb, _fs, super_arc, _disk) = mount_rw();
+    let root_arc = get(&super_arc, &sb, 2);
+
+    // Two sibling dirs: /p (will become parent of moved) and /m (the
+    // dir we'll move into /p).
+    let p_vfs = root_arc
+        .ops
+        .mkdir(&root_arc, b"p", 0o755)
+        .expect("mkdir /p");
+    let m_vfs = root_arc
+        .ops
+        .mkdir(&root_arc, b"m", 0o755)
+        .expect("mkdir /m");
+    let p_ino = p_vfs.ino as u32;
+    let m_ino = m_vfs.ino as u32;
+
+    // Rename /m -> /p/m.
+    root_arc
+        .ops
+        .rename(&root_arc, b"m", &p_vfs, b"m")
+        .expect("rename /m -> /p/m");
+
+    // /m gone from root; /p/m resolves to the moved ino.
+    let root_e2 = ext2_from_disk(&super_arc, &sb, 2);
+    let p_e2 = ext2_from_disk(&super_arc, &sb, p_ino);
+    assert!(dir::lookup(&super_arc, &root_e2, b"m").is_err());
+    assert_eq!(
+        dir::lookup(&super_arc, &p_e2, b"m").expect("lookup /p/m"),
+        m_ino,
+    );
+
+    // /p/m/.. must now resolve to /p.
+    let m_e2 = ext2_from_disk(&super_arc, &sb, m_ino);
+    let dotdot = dir::lookup(&super_arc, &m_e2, b"..").expect("lookup ..");
+    assert_eq!(dotdot, p_ino, "moved dir's .. must point at new parent");
+
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn rename_ro_mount_is_erofs() {
+    let (sb, _fs, super_arc, _disk) = mount_ro();
+    let root_arc = get(&super_arc, &sb, 2);
+
+    // lost+found is present on the golden image; an attempt to rename
+    // it (or any other existing name) on an RO mount must surface
+    // EROFS before touching the disk. The rename's error path short-
+    // circuits before we even dereference the source's dirent.
+    let err = root_arc
+        .ops
+        .rename(&root_arc, b"lost+found", &root_arc, b"newname")
+        .expect_err("RO rename must fail");
+    assert_eq!(err, EROFS);
+
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn rename_dot_and_dotdot_einval() {
+    let (sb, _fs, super_arc, _disk) = mount_rw();
+    let root_arc = get(&super_arc, &sb, 2);
+
+    assert_eq!(
+        root_arc.ops.rename(&root_arc, b".", &root_arc, b"x").err(),
+        Some(EINVAL),
+    );
+    assert_eq!(
+        root_arc.ops.rename(&root_arc, b"..", &root_arc, b"x").err(),
+        Some(EINVAL),
+    );
+    assert_eq!(
+        root_arc
+            .ops
+            .rename(&root_arc, b"lost+found", &root_arc, b".")
+            .err(),
+        Some(EINVAL),
+    );
+    assert_eq!(
+        root_arc
+            .ops
+            .rename(&root_arc, b"lost+found", &root_arc, b"..")
+            .err(),
+        Some(EINVAL),
+    );
+
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn rename_same_name_noop() {
+    let (sb, _fs, super_arc, _disk) = mount_rw();
+    let root_arc = get(&super_arc, &sb, 2);
+
+    let a = root_arc
+        .ops
+        .create(&root_arc, b"keep", 0o644)
+        .expect("create /keep");
+    let a_ino = a.ino as u32;
+
+    // Renaming onto itself is a no-op.
+    root_arc
+        .ops
+        .rename(&root_arc, b"keep", &root_arc, b"keep")
+        .expect("rename self must succeed as no-op");
+
+    let root_e2 = ext2_from_disk(&super_arc, &sb, 2);
+    assert_eq!(
+        dir::lookup(&super_arc, &root_e2, b"keep").expect("still there"),
+        a_ino,
+    );
+
+    sb.ops.unmount();
+    drop(super_arc);
+}

--- a/kernel/tests/ext2_rename.rs
+++ b/kernel/tests/ext2_rename.rs
@@ -43,7 +43,7 @@ use vibix::block::{BlockDevice, BlockError};
 use vibix::fs::ext2::{dir, iget, Ext2Fs, Ext2Inode, Ext2InodeMeta, Ext2Super};
 use vibix::fs::vfs::ops::{FileSystem as _, MountSource};
 use vibix::fs::vfs::MountFlags;
-use vibix::fs::{EINVAL, EROFS};
+use vibix::fs::{EINVAL, ENOENT, EROFS};
 use vibix::sync::BlockingRwLock;
 use vibix::{
     exit_qemu, serial_println,
@@ -90,6 +90,10 @@ fn run_tests() {
             &(rename_dot_and_dotdot_einval as fn()),
         ),
         ("rename_same_name_noop", &(rename_same_name_noop as fn())),
+        (
+            "rename_missing_same_name_is_enoent",
+            &(rename_missing_same_name_is_enoent as fn()),
+        ),
     ];
     serial_println!("running {} tests", tests.len());
     for (name, t) in tests {
@@ -519,6 +523,24 @@ fn rename_same_name_noop() {
         dir::lookup(&super_arc, &root_e2, b"keep").expect("still there"),
         a_ino,
     );
+
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+/// Regression: renaming a missing source onto the same missing name
+/// in the same parent must still fail with ENOENT, not succeed as a
+/// no-op. Previously a fast path returned Ok(()) for same-parent,
+/// same-name renames before verifying the source even existed.
+fn rename_missing_same_name_is_enoent() {
+    let (sb, _fs, super_arc, _disk) = mount_rw();
+    let root_arc = get(&super_arc, &sb, 2);
+
+    let err = root_arc
+        .ops
+        .rename(&root_arc, b"does-not-exist", &root_arc, b"does-not-exist")
+        .expect_err("missing source must not succeed");
+    assert_eq!(err, ENOENT);
 
     sb.ops.unmount();
     drop(super_arc);


### PR DESCRIPTION
Closes #571

## Summary

Implements `InodeOps::rename(old_dir, old_name, new_dir, new_name)` on `Ext2Inode` per RFC 0004 §Rename ordering and §Cross-directory loop check.

- **Link-count-first on-disk order.** Bump source nlink → remove victim dirent + drop victim nlink (and old-parent nlink if victim was a dir) → insert new dirent in new_parent (both-names-visible crash window) → remove old dirent → restore source nlink. A crash before the new dirent lands leaves the source reachable only via `old_name`; a crash between new-dirent and old-dirent leaves both names live as a hard link; a crash between old-dirent removal and the final nlink decrement leaves source's nlink one high. `e2fsck` reconciles every window; the filesystem never observes a dirent pointing at a freed inode.
- **Cross-dir directory move.** After the link-count dance, rewrite source's `..` to point at `new_parent`, bump `new_parent.i_links_count`, drop `old_parent.i_links_count`. `rewrite_dotdot` scans block 0 inline rather than going through `locate_dirent` (which rejects `.`/`..` as a safety rail).
- **Cross-directory loop check.** Walks `..` up from `new_parent` to root (capped at 4096 levels); if source ino appears on the walk or equals `new_parent`, refuse with `EINVAL` (POSIX's error for rename-into-own-subtree).
- **Atomic replace.** If `new_name` already exists, enforce type rules (`ENOTDIR` / `EISDIR` / `ENOTEMPTY`) before touching disk. If the victim hits `links_count == 0`, pin it on the orphan list for #573 to reclaim.
- **Locking.** Cross-dir takes `sb.rename_mutex` as a global tiebreaker then `dir_rwsem` writes on both parents in ino order to dodge ABBA. Same-dir takes one `dir_rwsem` write.
- **Validation.** `.` / `..` on either side → `EINVAL` (the shared `create::validate_name` returns `EEXIST` for them, right for create, wrong for rename). RO / forced-RO mounts → `EROFS`. Cross-mount → `EIO`. Empty / NUL / `/` / too-long names routed through the shared validator.

Rebased cleanly on latest main (post #629).

Out of scope (rejected by the VFS syscall layer before reaching here): `RENAME_EXCHANGE`, `RENAME_WHITEOUT`. `RENAME_NOREPLACE` is enforced at the syscall layer today.

## Test plan

- [x] `cargo xtask build --features ext2` — clean (one pre-existing `is_guard_hit` warning unrelated to this PR).
- [x] `cargo xtask test --features ext2` — 509 tests pass including all 8 new rename tests.
- [x] `cargo xtask smoke` — 33/33 markers.
- [x] `cargo fmt --all` applied.

New integration coverage in `kernel/tests/ext2_rename.rs`:
- `rename_same_dir` — `/a` → `/b`, source ino preserved.
- `rename_cross_dir` — `/f` → `/d/f`.
- `rename_replaces_regular` — victim hits nlink 0 and lands on the orphan list.
- `rename_into_descendant_is_einval` — `/a` → `/a/b/a` and `/a` → `/a/x` both refused.
- `rename_dir_updates_dotdot` — cross-dir dir move rewrites `..`.
- `rename_ro_mount_is_erofs` — RO mount short-circuits.
- `rename_dot_and_dotdot_einval` — all four `.`/`..` cases rejected.
- `rename_same_name_noop` — no-op success.
