### PR TITLE
tests/pjdfstest: vendor saidsay-so/pjdfstest (2-clause BSD) and strip host-only ops (#580)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,11 @@ members = [
     "userspace/init",
     "userspace/repro_fork",
 ]
+# tests/pjdfstest is a vendored copy of saidsay-so/pjdfstest (2-clause BSD). It
+# is intentionally kept outside the workspace until #581 wires it into xtask —
+# its nightly target, dep versions, and unstable features must not leak into
+# the kernel build graph.
+exclude = ["tests/pjdfstest"]
 resolver = "2"
 
 [workspace.package]

--- a/docs/attribution/pjdfstest.md
+++ b/docs/attribution/pjdfstest.md
@@ -1,0 +1,50 @@
+# pjdfstest — vendored attribution
+
+`tests/pjdfstest/` contains a vendored copy of the Rust rewrite of
+[pjdfstest](https://github.com/saidsay-so/pjdfstest), a POSIX filesystem
+conformance suite originally written in C by Paweł Jakub Dawidek (2006–2012)
+and rewritten in Rust during Google Summer of Code 2022 by Sayafdine Said.
+
+## Upstream
+
+- Repository: <https://github.com/saidsay-so/pjdfstest>
+- Vendored commit: `a53a2103ff86a1cf1643f3d075e7478725cab879` ("build: update deps (#160)")
+- Vendored path: only the `rust/` subtree was imported (the top-level
+  autotools-era C harness is not used).
+
+## License
+
+The upstream suite is distributed under the 2-clause BSD license
+(see `tests/pjdfstest/LICENSE`, copied verbatim from upstream `COPYING`).
+The vendored tree preserves that notice; downstream vibix contributions under
+`tests/pjdfstest/` are offered under the same 2-clause BSD terms so the
+directory remains license-consistent with upstream.
+
+## Scope of local modifications
+
+This commit strips test ops whose syscalls vibix does not implement, so the
+suite compiles cleanly on the Linux host even though the vibix userspace
+target is narrower than FreeBSD/Linux.
+
+Removed test modules (see `tests/pjdfstest/src/tests/mod.rs` and
+`tests/pjdfstest/src/tests/errors.rs`):
+
+| Removed                                | Reason                                                |
+| -------------------------------------- | ----------------------------------------------------- |
+| `src/tests/chflags.rs`                 | BSD-only `chflags(2)`; vibix has no file-flag syscall |
+| `src/tests/mkfifo.rs`                  | vibix has no FIFO support                             |
+| `src/tests/mknod.rs`                   | vibix has no userspace device-node creation          |
+| `src/tests/nfsv4acl/`                  | vibix has no ACL support                              |
+| `src/tests/posix_fallocate.rs`         | vibix has no `fallocate` / `posix_fallocate`          |
+| `src/tests/errors/etxtbsy.rs`          | vibix does not enforce ETXTBSY on running binaries    |
+
+Call-sites that previously imported the stripped helpers
+(`src/tests/open.rs`, `src/tests/truncate.rs`) are commented out with a
+pointer back to this file. BSD-gated code paths (`chflags`, `lchflags`,
+`nfsv4acl` in `src/context.rs` / `src/utils.rs`) were left in place because
+they are already `cfg`-gated off on Linux and will be needed if we ever
+re-port the suite to a BSD-flavored vibix target.
+
+The upstream workspace (`tests/pjdfstest/Cargo.toml`) is intentionally kept
+out of the top-level Rust workspace via `exclude = ["tests/pjdfstest"]` in the
+repo-root `Cargo.toml`. Wiring into xtask and CI is tracked by #581 and #582.

--- a/tests/pjdfstest/.gitignore
+++ b/tests/pjdfstest/.gitignore
@@ -1,0 +1,4 @@
+target/
+**/*.rs.bk
+*.pdb
+.tmp*

--- a/tests/pjdfstest/AUTHORS
+++ b/tests/pjdfstest/AUTHORS
@@ -1,0 +1,3 @@
+* Alan Somers <asomers@FreeBSD.org>		- contributor/co-maintainer
+* Ngie Cooper <ngie@FreeBSD.org>		- contributor/co-maintainer
+* Pawel Jakub Dawidek <pawel@dawidek.net>	- pjdfstest author/maintainer

--- a/tests/pjdfstest/Cargo.toml
+++ b/tests/pjdfstest/Cargo.toml
@@ -1,0 +1,40 @@
+# The vendored pjdfstest crate is intentionally its own standalone workspace so
+# it does not inherit the kernel's nightly target, panic=abort profile, or
+# rust-toolchain constraints. The outer vibix workspace excludes this path; see
+# docs/attribution/pjdfstest.md. Wiring into xtask is tracked by #581.
+[workspace]
+
+[package]
+name = "pjdfstest"
+version = "0.1.0"
+edition = "2021"
+resolver = "2"
+
+[dependencies]
+exacl = "0.12.0"
+tempfile = "3.14.0"
+rand = { version = "0.8.5", features = ["min_const_gen"] }
+strum = { version = "0.26.3", features = ["derive"] }
+strum_macros = "0.26.4"
+anyhow = "1.0.93"
+paste = "1.0.7"
+gumdrop = "0.8.1"
+figment = { version = "0.10.6", features = ["toml"] }
+nix = { version = "0.29", features = ["fs", "socket", "mount", "user"] }
+serde = { version = "1.0.214", features = ["derive"] }
+inventory = "0.3.0"
+walkdir = "2.3.2"
+sysctl = "0.6.0"
+
+[target.'cfg(target_os = "freebsd")'.dependencies]
+jail = "0.3.0"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+caps = "0.5.4"
+
+[[bin]]
+name = "pjdfstest"
+path = "src/main.rs"
+
+[build-dependencies]
+cfg_aliases = "0.2.1"

--- a/tests/pjdfstest/LICENSE
+++ b/tests/pjdfstest/LICENSE
@@ -1,0 +1,27 @@
+$FreeBSD: head/tools/regression/pjdfstest/LICENSE 211354 2010-08-15 21:29:03Z pjd $
+
+License for all regression tests available with pjdfstest:
+
+Copyright (c) 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHORS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/tests/pjdfstest/build.rs
+++ b/tests/pjdfstest/build.rs
@@ -1,0 +1,16 @@
+use cfg_aliases::cfg_aliases;
+
+fn main() {
+    // Setup cfg aliases
+    cfg_aliases! {
+        // OS-exclusive syscalls
+        chflags: { file_flags },
+        lchmod: { any(target_os = "netbsd", target_os = "freebsd", target_os = "dragonfly") },
+        lchflags: { any(target_os = "openbsd", target_os = "netbsd", target_os = "freebsd",
+                    target_os = "dragonfly", target_os = "macos", target_os = "ios") },
+        // OS-exclusive features
+        file_flags: { any(target_os = "openbsd", target_os = "netbsd", target_os = "freebsd",
+                    target_os = "dragonfly", target_os = "macos", target_os = "ios") },
+        birthtime: { any(target_os = "freebsd", target_os = "ios", target_os = "macos", target_os = "netbsd", target_os = "openbsd") }
+    }
+}

--- a/tests/pjdfstest/pjdfstest.toml
+++ b/tests/pjdfstest/pjdfstest.toml
@@ -1,0 +1,35 @@
+# Configuration for the pjdfstest runner
+
+# This section allows enabling file system specific features.
+# Please see the book for more details.
+# A list of these features is provided when executing the runner with `-l`.
+[features]
+# File flags can be specified for OS which supports them.
+# file_flags = ["UF_IMMUTABLE"]
+
+# Here is an example with the `posix_fallocate` syscall.
+posix_fallocate = {}
+
+# Might use the key notation as well.
+# [features.posix_fallocate]
+
+[settings]
+# naptime is the duration of various short sleeps.  It should be greater than
+# the timestamp granularity of the file system under test.
+naptime = 0.001
+# Allow to run the EROFS tests, which require to remount the file system on which
+# pjdsfstest is run as read-only.
+allow_remount = false
+
+# This section allows to modify the mechanism for switching users, which is required by some tests.
+# [dummy_auth]
+# An entry is the name of a user and its associated group.
+# For now, the array requires exactly 3 entries.
+# Please see the book for more details.
+# entries = [
+#   ["nobody", "nobody"],
+#   nogroup instead for some Linux distros
+#   ["nobody", "nogroup"],
+#   ["tests", "tests"],
+#   ["pjdfstest", "pjdfstest"],
+# ]

--- a/tests/pjdfstest/src/config.rs
+++ b/tests/pjdfstest/src/config.rs
@@ -1,0 +1,77 @@
+//! Configuration for the test suite.
+//!
+//! This module contains the configuration for the test suite. It is used to configure the test suite
+//! and to define which tests should be run on which file systems.
+//!
+//! The configuration is loaded from a TOML file, which is passed as a command line argument to the test suite.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use crate::test::FileFlags;
+use crate::test::FileSystemFeature;
+use serde::{Deserialize, Serialize};
+
+mod auth;
+pub use auth::*;
+
+/// Configuration for dummy authentication.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct CommonFeatureConfig {}
+
+/// Configuration for file-system specific features.
+/// Please see the book for more details.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct FeaturesConfig {
+    /// File flags available in the file system.
+    #[serde(default)]
+    pub file_flags: HashSet<FileFlags>,
+    /// Secondary file system to use for cross-file-system tests.
+    // TODO: Move to another part of the configuration when refactoring
+    #[serde(default)]
+    pub secondary_fs: Option<PathBuf>,
+    /// File-system specific features which are enabled
+    /// and do not require any additional configuration.
+    #[serde(flatten)]
+    pub fs_features: HashMap<FileSystemFeature, CommonFeatureConfig>,
+}
+
+/// Adjustable file-system specific settings.
+/// Please see the book for more details.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SettingsConfig {
+    /// Time to sleep within tests (in seconds)
+    /// between modifications to the file system.
+    /// It should be set to a value that is at least greater than
+    /// the timestamp granularity of the file system under test.
+    #[serde(default = "default_naptime")]
+    pub naptime: f64,
+    /// Allow remounting the file system with different settings during tests
+    /// (required for example by the `erofs` tests).
+    pub allow_remount: bool,
+}
+
+impl Default for SettingsConfig {
+    fn default() -> Self {
+        SettingsConfig {
+            naptime: default_naptime(),
+            allow_remount: false,
+        }
+    }
+}
+
+const fn default_naptime() -> f64 {
+    1.0
+}
+
+/// Configuration for the test suite.
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct Config {
+    /// File-system features.
+    pub features: FeaturesConfig,
+    /// File-system specific settings.
+    pub settings: SettingsConfig,
+    /// Dummy authentication configuration.
+    pub dummy_auth: DummyAuthConfig,
+}

--- a/tests/pjdfstest/src/config/auth.rs
+++ b/tests/pjdfstest/src/config/auth.rs
@@ -1,0 +1,157 @@
+use std::error::Error;
+use std::process::exit;
+use std::{borrow::Cow, fmt::Display};
+
+use nix::unistd::{Group, User};
+use serde::{de::Visitor, ser::SerializeTuple, Deserialize, Serialize};
+
+#[derive(Debug)]
+pub enum AuthEntrySerdeError {
+    UserNotFound(String),
+    GroupNotFound(String),
+    UserNotInGroup(String, String),
+}
+
+impl Display for AuthEntrySerdeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AuthEntrySerdeError::UserNotFound(user) => write!(f, "No user found for '{user}'"),
+            AuthEntrySerdeError::GroupNotFound(group) => write!(f, "No group found for '{group}'"),
+            AuthEntrySerdeError::UserNotInGroup(user, group) => {
+                write!(f, "User '{user}' is not part of group '{group}'")
+            }
+        }
+    }
+}
+
+impl Error for AuthEntrySerdeError {}
+
+/// A struct to deserialize user/group names
+/// into [`User`]/[`Group`].
+#[derive(Debug)]
+pub struct DummyAuthEntry {
+    pub user: User,
+    pub group: Group,
+}
+
+struct AuthEntryVisitor;
+
+impl<'de> Visitor<'de> for AuthEntryVisitor {
+    type Value = DummyAuthEntry;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("a tuple of user and group")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::SeqAccess<'de>,
+    {
+        let user: Cow<str> = seq
+            .next_element()?
+            .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+        let user = User::from_name(&user)
+            .map_err(serde::de::Error::custom)?
+            .ok_or_else(|| {
+                serde::de::Error::custom(
+                    AuthEntrySerdeError::UserNotFound(user.to_string()).to_string(),
+                )
+            })?;
+
+        let group: Cow<str> = seq
+            .next_element()?
+            .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?;
+        let group = Group::from_name(&group)
+            .map_err(serde::de::Error::custom)?
+            .ok_or_else(|| {
+                serde::de::Error::custom(
+                    AuthEntrySerdeError::GroupNotFound(group.to_string()).to_string(),
+                )
+            })?;
+
+        if user.gid != group.gid {
+            return Err(serde::de::Error::custom(
+                AuthEntrySerdeError::UserNotInGroup(user.name, group.name).to_string(),
+            ));
+        }
+
+        Ok(DummyAuthEntry { user, group })
+    }
+}
+
+impl<'de> Deserialize<'de> for DummyAuthEntry {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_tuple(2, AuthEntryVisitor)
+    }
+}
+
+impl Serialize for DummyAuthEntry {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut tup = serializer.serialize_tuple(2)?;
+        tup.serialize_element(&self.user.name)?;
+        tup.serialize_element(&self.group.name)?;
+        tup.end()
+    }
+}
+
+/// Stores configuration for authentication.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DummyAuthConfig {
+    /// Auth entries, which are composed of a [`User`] and its associated [`Group`].
+    /// The user should be part of the associated group.
+    /// They are used when a test requires switching to different users.
+    pub entries: [DummyAuthEntry; 3],
+}
+
+impl Default for DummyAuthConfig {
+    fn default() -> Self {
+        let unobody = User::from_name("nobody").unwrap().unwrap_or_else(|| {
+            eprintln!("error: nobody: no such user");
+            exit(1);
+        });
+        let gnobody = Group::from_gid(unobody.gid).unwrap().unwrap_or_else(|| {
+            eprintln!("error: {}: no such group", unobody.gid);
+            exit(1);
+        });
+        let upjdfstest = User::from_name("pjdfstest").unwrap().unwrap_or_else(|| {
+            eprintln!("error: pjdfstest: no such user");
+            exit(1);
+        });
+        let gpjdfstest = Group::from_gid(upjdfstest.gid).unwrap().unwrap_or_else(|| {
+            eprintln!("error: {}: no such group", upjdfstest.gid);
+            exit(1);
+        });
+        let utests = User::from_name("tests").unwrap().unwrap_or_else(|| {
+            eprintln!("error: tests: no such user");
+            exit(1);
+        });
+        let gtests = Group::from_gid(utests.gid).unwrap().unwrap_or_else(|| {
+            eprintln!("error: {}: no such group", utests.gid);
+            exit(1);
+        });
+        Self {
+            entries: [
+                {
+                    DummyAuthEntry {
+                        user: unobody,
+                        group: gnobody,
+                    }
+                },
+                DummyAuthEntry {
+                    user: upjdfstest,
+                    group: gpjdfstest,
+                },
+                DummyAuthEntry {
+                    user: utests,
+                    group: gtests,
+                },
+            ],
+        }
+    }
+}

--- a/tests/pjdfstest/src/context.rs
+++ b/tests/pjdfstest/src/context.rs
@@ -1,0 +1,662 @@
+//! Provides a context for tests through the [`TestContext`] and [`SerializedTestContext`] structs.
+//!
+//! The [`TestContext`] struct allows to create files, directories, get auth entries, and sleep for the amount of time specified in the configuration.
+//! Its [`SerializedTestContext`] counterpart allows to execute functions as another user/group(s) and with another umask.
+
+use nix::{
+    fcntl::OFlag,
+    sys::{
+        socket::{bind, socket, SockFlag, UnixAddr},
+        stat::{lstat, mknod, mode_t, umask, Mode, SFlag},
+    },
+    unistd::{
+        getgroups, mkdir, mkfifo, pathconf, setegid, seteuid, setgroups, Gid, Group, Uid, User,
+    },
+};
+
+use rand::distributions::{Alphanumeric, DistString};
+use std::{
+    cell::Cell,
+    fs::create_dir_all,
+    ops::{Deref, DerefMut},
+    os::fd::{AsRawFd, OwnedFd},
+    panic::{catch_unwind, resume_unwind, AssertUnwindSafe},
+    path::{Path, PathBuf},
+    thread,
+    time::Duration,
+};
+use strum_macros::EnumIter;
+
+use crate::{
+    config::{Config, DummyAuthEntry, FeaturesConfig},
+    utils::{chmod, lchmod, open, symlink},
+};
+
+/// File type, mainly used with [TestContext::create] and parameterized tests.
+#[derive(Debug, Clone, Eq, PartialEq, EnumIter)]
+pub enum FileType {
+    Regular,
+    Dir,
+    Fifo,
+    Block,
+    Char,
+    Socket,
+    Symlink(Option<PathBuf>),
+}
+
+impl FileType {
+    pub const fn privileged(&self) -> bool {
+        matches!(self, FileType::Block | FileType::Char)
+    }
+}
+
+const NUM_RAND_CHARS: usize = 32;
+
+/// Auth entries which are composed of a [`User`] and its associated [`Group`].
+/// Allows to retrieve the auth entries.
+#[derive(Debug)]
+pub struct DummyAuthEntries<'a> {
+    entries: &'a [DummyAuthEntry],
+    index: Cell<usize>,
+}
+
+impl<'a> DummyAuthEntries<'a> {
+    pub fn new(entries: &'a [DummyAuthEntry]) -> Self {
+        Self {
+            entries,
+            index: Cell::new(0),
+        }
+    }
+
+    /// Returns a new entry.
+    pub fn get_new_entry(&self) -> (&User, &Group) {
+        let entry = self.entries.get(self.index.get()).unwrap();
+        self.index.set(self.index.get() + 1);
+
+        (&entry.user, &entry.group)
+    }
+}
+
+/// Test context which allows to create files, directories, get auth entries,
+/// and sleep for the amount of time specified in the configuration.
+///
+/// # Note
+///
+/// The context will automatically remove all files and directories created during the test.
+///
+/// # Example
+///
+/// ```ignore
+/// use nix::sys::stat::Mode;
+/// use tempfile::TempDir;
+///
+/// use crate::{
+///    config::{Config, DummyAuthEntry},
+///    context::{FileType, TestContext},
+/// };
+///
+/// let config = Config::default();
+/// let temp_dir = TempDir::new().unwrap();
+/// let entries = vec![DummyAuthEntry::new("user", "group")];
+/// let ctx = TestContext::new(&config, &entries, temp_dir.path());
+///
+/// let (user, group) = ctx.get_new_entry();
+/// assert_eq!(user.name, "user");
+/// assert_eq!(group.name, "group");
+///
+/// let file = ctx.create(FileType::Regular).unwrap();
+/// let file_stat = nix::sys::stat::stat(&file).unwrap();
+/// assert_eq!(file_stat.st_mode & Mode::S_IFMT.bits(), nix::libc::S_IFREG);
+/// ```
+///
+pub struct TestContext<'a> {
+    /// Duration to sleep, used to wait for file system timestamps to change.
+    naptime: Duration,
+    /// Temporary directory where the test will be executed and files will be created.
+    temp_dir: &'a Path,
+    /// Features configuration, used to determine which features are enabled.
+    features_config: &'a FeaturesConfig,
+    /// Auth entries which are composed of a [`User`] and its associated [`Group`].
+    auth_entries: DummyAuthEntries<'a>,
+    /// Jail, used to isolate the test environment on FreeBSD.
+    #[cfg(target_os = "freebsd")]
+    jail: Option<jail::RunningJail>,
+}
+
+/// Serialized test context which allows to execute functions as another user/group(s) and with another umask.
+///
+/// # Example
+///
+/// ```ignore
+/// use nix::sys::stat::Mode;
+/// use tempfile::TempDir;
+///
+/// use crate::{
+///   config::{Config, DummyAuthEntry},
+///   context::{FileType, SerializedTestContext},
+/// };
+///
+/// let config = Config::default();
+/// let temp_dir = TempDir::new().unwrap();
+/// let entries = vec![DummyAuthEntry::new("user", "group")];
+/// let ctx = SerializedTestContext::new(&config, &entries, temp_dir.path());
+///
+/// let (user, group) = ctx.get_new_entry();
+/// assert_eq!(user.name, "user");
+/// assert_eq!(group.name, "group");
+///
+/// ctx.as_user(user, None, || {
+///    let file = ctx.create(FileType::Regular).unwrap();
+///    let file_stat = nix::sys::stat::stat(&file).unwrap();
+///    assert_eq!(file_stat.st_mode & Mode::S_IFMT.bits(), nix::libc::S_IFREG);
+/// });
+/// ```
+///
+pub struct SerializedTestContext<'a> {
+    ctx: TestContext<'a>,
+}
+
+impl<'a> Deref for SerializedTestContext<'a> {
+    type Target = TestContext<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.ctx
+    }
+}
+
+impl<'a> DerefMut for SerializedTestContext<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.ctx
+    }
+}
+
+impl<'a> SerializedTestContext<'a> {
+    pub fn new(config: &'a Config, entries: &'a [DummyAuthEntry], base_dir: &'a Path) -> Self {
+        Self {
+            ctx: TestContext::new(config, entries, base_dir),
+        }
+    }
+
+    /// Execute the function as another user/group(s).
+    /// If `groups` is set to `None`, only the default group associated to the user will be used
+    /// and the effective [`Gid`] will be this one.
+    /// Otherwise, the first provided [`Gid`] will be the effective one
+    /// and the others will be added with `setgroups`.
+    pub fn as_user<F>(&self, user: &User, groups: Option<&[Gid]>, f: F)
+    where
+        F: FnOnce(),
+    {
+        let original_euid = Uid::effective();
+        let original_egid = Gid::effective();
+        let original_groups = getgroups().unwrap();
+
+        let groups: Vec<_> = groups
+            .unwrap_or_else(|| std::slice::from_ref(&user.gid))
+            .to_vec();
+        setgroups(&groups).unwrap();
+
+        setegid(groups[0]).unwrap();
+        seteuid(user.uid).unwrap();
+
+        let res = catch_unwind(AssertUnwindSafe(f));
+
+        seteuid(original_euid).unwrap();
+        setegid(original_egid).unwrap();
+        setgroups(&original_groups).unwrap();
+
+        if let Err(e) = res {
+            resume_unwind(e)
+        }
+    }
+
+    /// Execute the function with another umask.
+    pub fn with_umask<F>(&self, mask: mode_t, f: F)
+    where
+        F: FnOnce(),
+    {
+        let previous_mask = umask(Mode::from_bits_truncate(mask));
+
+        let res = catch_unwind(AssertUnwindSafe(f));
+
+        umask(previous_mask);
+
+        if let Err(e) = res {
+            resume_unwind(e)
+        }
+    }
+}
+
+impl<'a> Drop for SerializedTestContext<'a> {
+    fn drop(&mut self) {
+        umask(Mode::empty());
+    }
+}
+
+impl<'a> TestContext<'a> {
+    /// Create a new test context.
+    pub fn new(config: &'a Config, entries: &'a [DummyAuthEntry], temp_dir: &'a Path) -> Self {
+        let naptime = Duration::from_secs_f64(config.settings.naptime);
+        TestContext {
+            naptime,
+            temp_dir,
+            features_config: &config.features,
+            auth_entries: DummyAuthEntries::new(entries),
+            #[cfg(target_os = "freebsd")]
+            jail: None,
+        }
+    }
+
+    /// Return the base path for this context.
+    pub fn base_path(&self) -> &Path {
+        self.temp_dir
+    }
+
+    pub fn features_config(&self) -> &FeaturesConfig {
+        self.features_config
+    }
+
+    /// Generate a random path.
+    pub fn gen_path(&self) -> PathBuf {
+        self.base_path()
+            .join(Alphanumeric.sample_string(&mut rand::thread_rng(), NUM_RAND_CHARS))
+    }
+
+    /// Create a regular file and open it.
+    pub fn create_file(
+        &self,
+        oflag: OFlag,
+        mode: Option<nix::sys::stat::mode_t>,
+    ) -> Result<(PathBuf, OwnedFd), nix::Error> {
+        let mut file = self.new_file(FileType::Regular);
+        if let Some(mode) = mode {
+            file = file.mode(mode);
+        }
+        file.open(oflag)
+    }
+
+    /// Return a file builder.
+    pub fn new_file(&self, ft: FileType) -> FileBuilder {
+        FileBuilder::new(ft, &self.base_path())
+    }
+
+    /// Create a file with a random name.
+    pub fn create(&self, f_type: FileType) -> Result<PathBuf, nix::Error> {
+        self.new_file(f_type).create()
+    }
+
+    /// Create a file whose name length is _PC_NAME_MAX.
+    pub fn create_name_max(&self, f_type: FileType) -> Result<PathBuf, nix::Error> {
+        let max_name_len =
+            pathconf(self.base_path(), nix::unistd::PathconfVar::NAME_MAX)?.unwrap() as usize;
+
+        let file = self
+            .new_file(f_type)
+            .name(Alphanumeric.sample_string(&mut rand::thread_rng(), max_name_len));
+
+        file.create()
+    }
+
+    /// Create a file whose path length is _PC_PATH_MAX.
+    pub fn create_path_max(&self, f_type: FileType) -> Result<PathBuf, nix::Error> {
+        let max_name_len =
+            pathconf(self.base_path(), nix::unistd::PathconfVar::NAME_MAX)?.unwrap() as usize;
+        let component_len = max_name_len / 2;
+
+        // - 1 for null char
+        let max_path_len =
+            pathconf(self.base_path(), nix::unistd::PathconfVar::PATH_MAX)?.unwrap() as usize - 1;
+
+        let mut path = self.base_path().to_owned();
+        let initial_path_len = path.to_string_lossy().len();
+        let remaining_chars = max_path_len - initial_path_len;
+
+        let parts: Vec<_> = (0..remaining_chars / component_len)
+            .map(|_| Alphanumeric.sample_string(&mut rand::thread_rng(), component_len - 1))
+            .collect();
+
+        let remaining_chars = remaining_chars % component_len - 1;
+        if remaining_chars > 0 {
+            path.extend(parts);
+
+            create_dir_all(&path).unwrap();
+
+            path.push(Alphanumeric.sample_string(&mut rand::thread_rng(), remaining_chars));
+        } else {
+            path.extend(&parts[..parts.len() - 1]);
+
+            create_dir_all(&path).unwrap();
+
+            path.push(&parts[parts.len() - 1]);
+        }
+
+        self.new_file(f_type).name(&path).create()?;
+
+        Ok(path)
+    }
+
+    /// Returns a new entry.
+    pub fn get_new_entry(&self) -> (&User, &Group) {
+        self.auth_entries.get_new_entry()
+    }
+
+    /// Returns a new user.
+    /// Alias of `get_new_entry`.
+    pub fn get_new_user(&self) -> &User {
+        self.get_new_entry().0
+    }
+
+    /// Returns a new group.
+    /// Alias of `get_new_entry`.
+    pub fn get_new_group(&self) -> &Group {
+        self.get_new_entry().1
+    }
+
+    /// A short sleep, long enough for file system timestamps to change.
+    pub fn nap(&self) {
+        thread::sleep(self.naptime)
+    }
+
+    /// Set this Context's jail, so it will be destroyed during teardown.
+    #[cfg(target_os = "freebsd")]
+    pub fn set_jail(&mut self, jail: jail::RunningJail) {
+        self.jail = Some(jail)
+    }
+}
+
+// We implement Drop to circumvent the errors which arise from unlinking a directory for which
+// search or write permission is denied, or a flag denying delete for a file.
+impl<'a> Drop for TestContext<'a> {
+    fn drop(&mut self) {
+        let iter = walkdir::WalkDir::new(self.base_path()).into_iter();
+        for entry in iter {
+            let entry = match entry {
+                Ok(e) => e,
+                _ => continue,
+            };
+
+            if cfg!(lchflags) || entry.file_type().is_dir() {
+                let file_stat = match lstat(entry.path()) {
+                    Ok(s) => s,
+                    _ => continue,
+                };
+
+                let mode = Mode::S_IRWXU;
+                if (file_stat.st_mode & mode.bits()) != mode.bits() {
+                    let _ = lchmod(entry.path(), mode);
+                }
+
+                // We remove all flags
+                // TODO: Some platforms do not support lchflags, write chflagsat alternative for those (openbsd, macos, ios?)
+                #[cfg(lchflags)]
+                {
+                    use crate::utils::lchflags;
+                    use nix::{libc::fflags_t, sys::stat::FileFlag};
+
+                    if file_stat.st_flags != FileFlag::empty().bits() as fflags_t {
+                        let _ = lchflags(entry.path(), FileFlag::empty());
+                    }
+                }
+
+                // Shut down any jails
+                #[cfg(target_os = "freebsd")]
+                if let Some(jail) = self.jail.take() {
+                    let _ = jail.kill();
+                }
+            }
+        }
+    }
+}
+
+/// Allows to create a file using builder pattern.
+#[derive(Debug)]
+pub struct FileBuilder {
+    file_type: FileType,
+    path: PathBuf,
+    random_name: bool,
+    mode: Option<Mode>,
+}
+
+impl FileBuilder {
+    /// Create a file builder.
+    pub fn new<P: AsRef<Path>>(file_type: FileType, base_path: &P) -> Self {
+        Self {
+            path: base_path.as_ref().to_path_buf(),
+            random_name: true,
+            mode: None,
+            file_type,
+        }
+    }
+
+    /// [`Take`](std::mem::take) and return the path final form.
+    fn final_path(&mut self) -> PathBuf {
+        if self.random_name {
+            self.path
+                .push(Alphanumeric.sample_string(&mut rand::thread_rng(), NUM_RAND_CHARS))
+        }
+
+        std::mem::take(&mut self.path)
+    }
+
+    /// Create the file according to the provided information.
+    pub fn create(mut self) -> nix::Result<PathBuf> {
+        let mode = self.mode.unwrap_or_else(|| match self.file_type {
+            FileType::Dir => Mode::from_bits_truncate(0o755),
+            _ => Mode::from_bits_truncate(0o644),
+        });
+        let path = self.final_path();
+
+        match self.file_type {
+            FileType::Regular => open(&path, OFlag::O_CREAT, mode).map(drop),
+            FileType::Dir => mkdir(&path, mode),
+            FileType::Fifo => mkfifo(&path, mode),
+            FileType::Block => mknod(&path, SFlag::S_IFBLK, mode, 0),
+            FileType::Char => mknod(&path, SFlag::S_IFCHR, mode, 0),
+            FileType::Socket => {
+                let fd = socket(
+                    nix::sys::socket::AddressFamily::Unix,
+                    nix::sys::socket::SockType::Stream,
+                    SockFlag::empty(),
+                    None,
+                )?;
+                let sockaddr = UnixAddr::new(&path)?;
+                bind(fd.as_raw_fd(), &sockaddr)?;
+                if let Some(mode) = self.mode {
+                    chmod(&path, mode)?;
+                }
+                Ok(())
+            }
+            FileType::Symlink(target) => {
+                symlink(
+                    target.as_deref().unwrap_or_else(|| Path::new("test")),
+                    &path,
+                )?;
+
+                #[cfg(lchmod)]
+                if let Some(mode) = self.mode {
+                    lchmod(&path, mode)?;
+                }
+
+                Ok(())
+            }
+        }?;
+
+        Ok(path)
+    }
+
+    /// Create the file according to the provided information and open it.
+    /// This function automatically adds [`O_CREAT`](nix::fcntl::OFlag::O_CREAT) to the [`open`] flags when creating a regular file.
+    pub fn open(mut self, oflags: OFlag) -> nix::Result<(PathBuf, OwnedFd)> {
+        match self.file_type {
+            FileType::Regular => {
+                let path = self.final_path();
+                open(
+                    &path,
+                    OFlag::O_CREAT | oflags,
+                    self.mode.unwrap_or_else(|| Mode::from_bits_truncate(0o644)),
+                )
+                .map(|fd| (path, fd))
+            }
+            _ => self
+                .create()
+                .and_then(|p| open(&p, oflags, Mode::empty()).map(|fd| (p, fd))),
+        }
+    }
+
+    /// Change file mode.
+    pub fn mode(mut self, mode: nix::sys::stat::mode_t) -> Self {
+        self.mode = Some(Mode::from_bits_truncate(mode));
+        self
+    }
+
+    /// Join `name` to the base path.
+    /// An absolute path can also be provided, in this case it completely replaces the path.
+    pub fn name<P: AsRef<Path>>(mut self, name: P) -> Self {
+        self.path.push(name.as_ref());
+        self.random_name = false;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nix::{errno::Errno, fcntl::OFlag, sys::stat::Mode, unistd::pathconf};
+    use tempfile::TempDir;
+    use walkdir::WalkDir;
+
+    use crate::{
+        config::Config,
+        utils::{chmod, ALLPERMS},
+    };
+
+    use super::{FileType, TestContext};
+
+    #[test]
+    fn create() {
+        for ft in [
+            FileType::Regular,
+            FileType::Dir,
+            FileType::Fifo,
+            FileType::Socket,
+            FileType::Symlink(None),
+        ] {
+            let config = Config::default();
+            let tempdir = TempDir::new().unwrap();
+            let ctx = TestContext::new(&config, &[], tempdir.path());
+
+            assert!(ctx.base_path().starts_with(tempdir.path()));
+
+            let file = ctx.create(ft.clone()).unwrap();
+            let content: Vec<_> = WalkDir::new(ctx.base_path())
+                .min_depth(1)
+                .max_depth(1)
+                .into_iter()
+                .filter_map(|e| e.ok())
+                .collect();
+            assert_eq!(content.len(), 1);
+            assert_eq!(content[0].path(), &file);
+
+            let file_stat = nix::sys::stat::lstat(&file).unwrap();
+            assert_eq!(
+                file_stat.st_mode & nix::libc::S_IFMT,
+                match ft {
+                    FileType::Dir => nix::libc::S_IFDIR,
+                    FileType::Fifo => nix::libc::S_IFIFO,
+                    FileType::Regular => nix::libc::S_IFREG,
+                    FileType::Socket => nix::libc::S_IFSOCK,
+                    FileType::Symlink(..) => nix::libc::S_IFLNK,
+                    _ => unimplemented!(),
+                }
+            )
+        }
+    }
+
+    #[test]
+    fn name_max() {
+        let tmpdir = TempDir::new().unwrap();
+        let config = Config::default();
+        let ctx = TestContext::new(&config, &[], tmpdir.path());
+        let file = ctx.create_name_max(FileType::Regular).unwrap();
+        let name_len = file.file_name().unwrap().to_string_lossy().len();
+
+        let max_len = pathconf(ctx.base_path(), nix::unistd::PathconfVar::NAME_MAX)
+            .unwrap()
+            .unwrap();
+        assert_eq!(name_len, max_len as usize);
+        let mut invalid = file;
+        invalid.set_file_name(invalid.file_name().unwrap().to_string_lossy().into_owned() + "x");
+
+        assert_eq!(
+            chmod(&invalid, Mode::empty()).unwrap_err(),
+            Errno::ENAMETOOLONG
+        );
+    }
+
+    #[test]
+    fn path_max() {
+        let tmpdir = TempDir::new().unwrap();
+        let config = Config::default();
+        let ctx = TestContext::new(&config, &[], tmpdir.path());
+        let file = ctx.create_path_max(FileType::Regular).unwrap();
+        let path_len = file.to_string_lossy().len();
+
+        // including null char
+        let max_len = pathconf(ctx.base_path(), nix::unistd::PathconfVar::PATH_MAX)
+            .unwrap()
+            .unwrap()
+            - 1;
+        assert_eq!(path_len, max_len as usize);
+        let mut invalid = file;
+        invalid.set_file_name(invalid.file_name().unwrap().to_string_lossy().into_owned() + "x");
+
+        assert_eq!(
+            chmod(&invalid, Mode::empty()).unwrap_err(),
+            Errno::ENAMETOOLONG
+        );
+    }
+
+    #[test]
+    fn new_file() {
+        let current_umask = nix::sys::stat::umask(Mode::from_bits_truncate(ALLPERMS));
+        nix::sys::stat::umask(current_umask);
+
+        for ft in [
+            FileType::Regular,
+            FileType::Dir,
+            // TODO: Test other file types
+            // FileType::Fifo,
+            // FileType::Socket,
+            // FileType::Symlink(None),
+        ] {
+            let tmpdir = TempDir::new().unwrap();
+            let config = Config::default();
+            let ctx = TestContext::new(&config, &[], tmpdir.path());
+            let name = "testing";
+            let expected_mode = 0o725;
+            let (path, _file) = ctx
+                .new_file(ft)
+                .mode(expected_mode)
+                .name(name)
+                .open(OFlag::O_RDONLY)
+                .unwrap();
+
+            assert_eq!(path.file_name().unwrap().to_string_lossy(), name);
+
+            let file_stat = nix::sys::stat::stat(&path).unwrap();
+            let actual_mode = file_stat.st_mode & ALLPERMS;
+            assert_eq!(actual_mode, expected_mode & (!current_umask.bits()));
+        }
+    }
+
+    #[test]
+    fn regular_unique_syscall() {
+        let tmpdir = TempDir::new().unwrap();
+        let config = Config::default();
+        let ctx = TestContext::new(&config, &[], tmpdir.path());
+
+        assert!(ctx
+            .new_file(FileType::Regular)
+            .mode(0o000)
+            .open(OFlag::O_RDWR)
+            .is_ok());
+    }
+}

--- a/tests/pjdfstest/src/features.rs
+++ b/tests/pjdfstest/src/features.rs
@@ -1,0 +1,40 @@
+//! File-system features which are not available on every file system and can be tested for.
+//!
+//! This module defines an enum which represents features which are not available on every file system,
+//! but can be tested for. The features are used to define which tests should be run on which file systems.
+
+use serde::{Deserialize, Serialize};
+
+/// Features which are not available for every file system.
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    strum::Display,
+    strum::EnumIter,
+    strum::EnumMessage,
+    Serialize,
+    Deserialize,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum FileSystemFeature {
+    /// The [`chflags`](https://man.freebsd.org/cgi/man.cgi?chflags(1)) syscall is available
+    Chflags,
+    /// NFSv4 style Access Control Lists are available
+    Nfsv4Acls,
+    /// The [`posix_fallocate`](https://pubs.opengroup.org/onlinepubs/007904975/functions/posix_fallocate.html) syscall is available
+    PosixFallocate,
+    /// [`rename`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/rename.html) changes `st_ctime` on success (POSIX does not require a file system to update a file's ctime when it gets renamed, but some file systems choose to do it anyway)
+    RenameCtime,
+    /// `struct stat` contains an [`st_birthtime`](https://man.freebsd.org/cgi/man.cgi?stat(2)) field
+    StatStBirthtime,
+    /// The [`SF_SNAPSHOT`](https://man.freebsd.org/cgi/man.cgi?chflags(2)) flag can be set with `chflags`
+    ChflagsSfSnapshot,
+    /// The [`UTIME_NOW`](https://pubs.opengroup.org/onlinepubs/9699919799.orig/functions/futimens.html) constant is available
+    UtimeNow,
+    /// The [`utimensat`](https://pubs.opengroup.org/onlinepubs/9699919799.orig/functions/utimensat.html) syscall is available
+    Utimensat,
+}

--- a/tests/pjdfstest/src/flags.rs
+++ b/tests/pjdfstest/src/flags.rs
@@ -1,0 +1,190 @@
+//! File flags (see <https://docs.freebsd.org/en/books/handbook/basics/#permissions>).
+
+use serde::{Deserialize, Serialize};
+
+/// Define a set of flags for a given enum and implement `From` for `nix::sys::stat::FileFlag`.
+macro_rules! flags {
+    ( $( #[$enum_attrs: meta] )* pub enum $enum: ident { $(#[cfg($cfg: meta)] $(#[$attr: meta])* $flag: ident ),* $(,)?} ) => {
+        $(#[$enum_attrs])*
+        pub enum $enum {
+            $(#[cfg($cfg)]
+            $(#[$attr])*
+                $flag),*
+        }
+
+        #[cfg(file_flags)]
+        impl From<$enum> for nix::sys::stat::FileFlag {
+            fn from(flag: $enum) -> Self {
+                match flag {
+                $(
+                    #[cfg($cfg)]
+                    $enum::$flag => nix::sys::stat::FileFlag::$flag,
+                )*
+                }
+            }
+        }
+    };
+}
+
+flags! {
+#[allow(non_camel_case_types)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    strum::EnumString,
+    strum::Display,
+    strum::EnumIter,
+    Serialize,
+    Deserialize,
+)]
+/// File flags (see <https://docs.freebsd.org/en/books/handbook/basics/#permissions>).
+pub enum FileFlags {
+    #[cfg(any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+    ))]
+    UF_SETTABLE,
+    #[cfg(any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+    ))]
+    UF_NODUMP,
+    #[cfg(any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+    ))]
+    UF_IMMUTABLE,
+    #[cfg(any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+    ))]
+    UF_APPEND,
+    #[cfg(any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+    ))]
+    UF_OPAQUE,
+
+    #[cfg(any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+    ))]
+    SF_SETTABLE,
+    #[cfg(any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+    ))]
+    SF_ARCHIVED,
+    #[cfg(any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+    ))]
+    SF_IMMUTABLE,
+    #[cfg(any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+    ))]
+    SF_APPEND,
+
+    #[cfg(any(target_os = "dragonfly"))]
+    UF_NOHISTORY,
+    #[cfg(any(target_os = "dragonfly"))]
+    UF_CACHE,
+    #[cfg(any(target_os = "dragonfly"))]
+    UF_XLINK,
+    #[cfg(any(target_os = "dragonfly"))]
+    SF_NOHISTORY,
+    #[cfg(any(target_os = "dragonfly"))]
+    SF_CACHE,
+    #[cfg(any(target_os = "dragonfly"))]
+    SF_XLINK,
+
+    #[cfg(any(target_os = "freebsd"))]
+    UF_SYSTEM,
+    #[cfg(any(target_os = "freebsd"))]
+    UF_SPARSE,
+    #[cfg(any(target_os = "freebsd"))]
+    UF_OFFLINE,
+    #[cfg(any(target_os = "freebsd"))]
+    UF_REPARSE,
+    #[cfg(any(target_os = "freebsd"))]
+    UF_ARCHIVE,
+    #[cfg(any(target_os = "freebsd"))]
+    UF_READONLY,
+
+    #[cfg(any(target_os = "freebsd", target_os = "netbsd"))]
+    SF_SNAPSHOT,
+
+    #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+    UF_NOUNLINK,
+    #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+    SF_NOUNLINK,
+
+    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "watchos"))]
+    UF_COMPRESSED,
+    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "watchos"))]
+    UF_TRACKED,
+
+    #[cfg(any(
+        target_os = "freebsd",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos"
+    ))]
+    UF_HIDDEN,
+
+    #[cfg(any(target_os = "netbsd"))]
+    SF_LOG,
+    #[cfg(any(target_os = "netbsd"))]
+    SF_SNAPINVAL,
+}
+}

--- a/tests/pjdfstest/src/macros.rs
+++ b/tests/pjdfstest/src/macros.rs
@@ -1,0 +1,267 @@
+//! Macros for defining test cases.
+//!
+//! The `test_case` macro is used to define test cases for a test suite.
+
+/// Macro for defining test cases, which are automatically registered with the test suite.
+///
+/// A test case can be serialized or non-serialized, require root privileges, and be run on specific file types.
+/// It can also require specific features to be enabled, and have guards which are run before the test case is executed to determine if conditions are met.
+///
+/// The macro supports mutiple parameters which can be combined in a specific order,
+/// for example:
+///
+/// ```rust
+/// // Non-serialized test case
+/// test_case! {
+///    /// description
+///   basic
+/// }
+/// fn basic(_: &mut crate::test::TestContext) {}
+/// ```
+///
+/// ```rust
+/// // Non-serialized test case with required features, guards, and root privileges
+/// test_case! {
+///   /// description
+///  features, root, FileSystemFeature::Chflags, FileSystemFeature::PosixFallocate; guard_example
+/// }
+/// fn features(_: &mut crate::test::TestContext) {}
+/// ```
+///
+/// ```rust
+/// // Serialized test case with root privileges
+/// test_case! {
+///  /// description
+/// serialized, serialized, root
+/// }
+/// fn serialized(_: &mut crate::test::SerializedTestContext) {}
+/// ```
+///
+/// ```rust
+/// // Serialized test case with required features
+/// test_case! {
+/// /// description
+/// serialized_features, serialized, FileSystemFeature::Chflags, FileSystemFeature::PosixFallocate
+/// }
+/// fn serialized_features(_: &mut crate::test::SerializedTestContext) {}
+/// ```
+///
+/// ```rust
+/// // Serialized test case with required features, guards, root privileges, and file types
+/// test_case! {
+/// /// description
+/// serialized_types, serialized, root, FileSystemFeature::Chflags, FileSystemFeature::PosixFallocate; guard_example, root => [Regular, Fifo]
+/// }
+/// fn serialized_types(_: &mut crate::test::SerializedTestContext, _: crate::context::FileType) {}
+/// ```
+macro_rules! test_case {
+    ($(#[doc = $docs:expr])*
+        $f:ident, serialized, root $(,)* $( $features:expr ),* $(,)* $(; $( $flags:expr ),+)? $(=> $guards: tt )?) => {
+        $crate::test_case! {@serialized $f, &[$( $features ),*], &[$( $( $flags ),+ )?], concat!($($docs),*), true $(=> $guards)?}
+    };
+    ($(#[doc = $docs:expr])*
+        $f:ident, serialized $(,)* $( $features:expr ),* $(,)* $(; $( $flags:expr ),+)? $(=> $guards: tt )?) => {
+        $crate::test_case! {@serialized $f, &[$( $features ),*], &[$( $( $flags ),+ )?], concat!($($docs),*), false $(=> $guards)?}
+    };
+    ($(#[doc = $docs:expr])*
+        $f:ident, root $(,)* $( $features:expr ),* $(,)* $(; $( $flags:expr ),+)? $(=> $guards: tt )?) => {
+        $crate::test_case! {@ $f, &[$( $features ),*], &[$( $( $flags ),+ )?], true, concat!($($docs),*) $(=> $guards)?}
+    };
+    ($(#[doc = $docs:expr])*
+        $f:ident $(,)* $( $features:expr ),* $(,)* $(; $( $flags:expr ),+)? $(=> $guards: tt )?) => {
+        $crate::test_case! {@ $f, &[$( $features ),*], &[$( $( $flags ),+ )?], false, concat!($($docs),*) $(=> $guards)?}
+    };
+
+
+
+    (@serialized $f:ident, $features:expr, $guards:expr, $desc:expr, $require_root:expr ) => {
+        ::inventory::submit! {
+            $crate::test::TestCase {
+                name: concat!(module_path!(), "::", stringify!($f)),
+                description: $desc,
+                required_features: $features,
+                guards: $guards,
+                require_root: $require_root,
+                fun: $crate::test::TestFn::Serialized($f),
+            }
+        }
+    };
+    (@serialized $f:ident, $features:expr, $guards:expr, $desc:expr, $require_root:expr => [$( $file_type:tt $( ($ft_args: tt) )? ),+ $(,)*]) => {
+        $(
+            paste::paste! {
+                ::inventory::submit! {
+                    $crate::test::TestCase {
+                        name: concat!(module_path!(), "::", stringify!($f), "::", stringify!([<$file_type:lower>])),
+                        description: $desc,
+                        required_features: $features,
+                        guards: $guards,
+                        require_root: $require_root || $crate::context::FileType::$file_type $( ($ft_args) )?.privileged(),
+                        fun: $crate::test::TestFn::Serialized(|ctx| $f(ctx, $crate::context::FileType::$file_type $( ($ft_args) )?)),
+                    }
+                }
+            }
+        )+
+    };
+
+    (@ $f:ident, $features:expr, $guards:expr, $require_root:expr, $desc:expr ) => {
+        ::inventory::submit! {
+            $crate::test::TestCase {
+                name: concat!(module_path!(), "::", stringify!($f)),
+                description: $desc,
+                required_features: $features,
+                guards: $guards,
+                require_root: $require_root,
+                fun: $crate::test::TestFn::NonSerialized($f),
+            }
+        }
+    };
+    (@ $f:ident, $features:expr, $guards:expr, $require_root:expr, $desc:expr => [$( $file_type:tt $( ($ft_args: tt) )? ),+ $(,)*]) => {
+        $(
+            paste::paste! {
+                ::inventory::submit! {
+                    $crate::test::TestCase {
+                        name: concat!(module_path!(), "::", stringify!($f), "::", stringify!([<$file_type:lower>])),
+                        description: $desc,
+                        required_features: $features,
+                        guards: $guards,
+                        require_root: $require_root || $crate::context::FileType::$file_type $( ($ft_args) )?.privileged(),
+                        fun: $crate::test::TestFn::NonSerialized(|ctx| $f(ctx, $crate::context::FileType::$file_type $( ($ft_args) )?)),
+                    }
+                }
+            }
+        )+
+    };
+}
+
+pub(crate) use test_case;
+
+#[cfg(test)]
+mod t {
+    use crate::context::FileType;
+    use crate::test::FileSystemFeature;
+    use crate::{SerializedTestContext, TestCase, TestContext, TestFn};
+    use std::path::Path;
+
+    crate::test_case! {
+        /// description
+        basic
+    }
+    fn basic(_: &mut TestContext) {}
+    #[test]
+    fn basic_test() {
+        let tc = inventory::iter::<TestCase>()
+            .find(|tc| tc.name == "pjdfstest::macros::t::basic")
+            .unwrap();
+        assert_eq!(" description", tc.description);
+        assert!(!tc.require_root);
+        assert!(tc.required_features.is_empty());
+        assert!(matches!(tc.fun, TestFn::NonSerialized(f) if f as usize == basic as usize));
+        assert!(tc.guards.is_empty());
+    }
+
+    crate::test_case! {
+        /// description
+        features, FileSystemFeature::Chflags, FileSystemFeature::PosixFallocate
+    }
+    fn features(_: &mut TestContext) {}
+    #[test]
+    fn features_test() {
+        let tc = inventory::iter::<TestCase>()
+            .find(|tc| tc.name == "pjdfstest::macros::t::features")
+            .unwrap();
+        assert_eq!(" description", tc.description);
+        assert!(!tc.require_root);
+        assert_eq!(
+            tc.required_features,
+            &[
+                FileSystemFeature::Chflags,
+                FileSystemFeature::PosixFallocate
+            ]
+        );
+        assert!(matches!(tc.fun, TestFn::NonSerialized(f) if f as usize == features as usize));
+        assert!(tc.guards.is_empty());
+    }
+
+    fn guard_example(_: &crate::config::Config, _: &Path) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    crate::test_case! {
+        /// description
+        guard; guard_example
+    }
+    fn guard(_: &mut TestContext) {}
+    #[test]
+    fn guard_test() {
+        let tc = inventory::iter::<TestCase>()
+            .find(|tc| tc.name == "pjdfstest::macros::t::guard")
+            .unwrap();
+        assert_eq!(" description", tc.description);
+        assert!(!tc.require_root);
+        assert_eq!(
+            tc.guards.iter().map(|&g| g as usize).collect::<Vec<_>>(),
+            vec![guard_example as usize]
+        );
+        assert!(matches!(tc.fun, TestFn::NonSerialized(f) if f as usize == guard as usize));
+    }
+
+    crate::test_case! {
+        /// description
+        root, root
+    }
+    fn root(_: &mut TestContext) {}
+    #[test]
+    fn root_test() {
+        let tc = inventory::iter::<TestCase>()
+            .find(|tc| tc.name == "pjdfstest::macros::t::root")
+            .unwrap();
+        assert_eq!(" description", tc.description);
+        assert!(tc.require_root);
+        assert!(tc.required_features.is_empty());
+        assert!(matches!(tc.fun, TestFn::NonSerialized(f) if f as usize == root as usize));
+        assert!(tc.guards.is_empty());
+    }
+
+    crate::test_case! {
+        /// description
+        file_types => [Regular, Fifo]
+    }
+    fn file_types(_: &mut TestContext, _: FileType) {}
+    #[test]
+    fn file_types_test() {
+        let tc = inventory::iter::<TestCase>()
+            .find(|tc| tc.name == "pjdfstest::macros::t::file_types::fifo")
+            .unwrap();
+        assert_eq!(" description", tc.description);
+        assert!(!tc.require_root);
+        assert!(tc.required_features.is_empty());
+        assert!(tc.guards.is_empty());
+        // Can't check fun because it's a closure
+
+        let tc = inventory::iter::<TestCase>()
+            .find(|tc| tc.name == "pjdfstest::macros::t::file_types::regular")
+            .unwrap();
+        assert_eq!(" description", tc.description);
+        assert!(!tc.require_root);
+        assert!(tc.required_features.is_empty());
+        assert!(tc.guards.is_empty());
+        // Can't check fun because it's a closure
+    }
+
+    crate::test_case! {
+        /// description
+        serialized, serialized
+    }
+    fn serialized(_: &mut SerializedTestContext) {}
+    #[test]
+    fn serialized_test() {
+        let tc = inventory::iter::<TestCase>()
+            .find(|tc| tc.name == "pjdfstest::macros::t::serialized")
+            .unwrap();
+        assert_eq!(" description", tc.description);
+        assert!(!tc.require_root);
+        assert!(tc.required_features.is_empty());
+        assert!(matches!(tc.fun, TestFn::Serialized(f) if f as usize == serialized as usize));
+        assert!(tc.guards.is_empty());
+    }
+}

--- a/tests/pjdfstest/src/main.rs
+++ b/tests/pjdfstest/src/main.rs
@@ -1,0 +1,286 @@
+//! This is the main entry point for the test suite. It is responsible for parsing
+//! command line arguments, reading the configuration file, and running the tests.
+//! The test suite is composed of a set of test cases, each of which is a function
+//! that takes a [`TestContext`] as an argument. The [`TestContext`] provides access to
+//! the configuration, the dummy authentication entries, and a temporary directory
+//! for the test to use.
+//!
+//! The test suite is built using the `inventory` crate, which
+//! allows test cases to be registered at compile time. The test suite is run by
+//! iterating over the registered test cases and running each one in turn.
+//!
+//! The [`TestContext`] is created for each test case, and the test case function is called
+//! with the [`TestContext`] as an argument. The test case function can then use the
+//! [`TestContext`] to access the configuration, the dummy authentication entries, and
+//! the temporary directory. The test case function can perform whatever tests are
+//! necessary, and panic if the test fails. The test suite catches the panic, prints
+//! an error message, and continues running the remaining test cases. At the end of
+//! the test suite, the number of failed, skipped, and passed tests is printed.
+
+use std::{
+    backtrace::{Backtrace, BacktraceStatus},
+    collections::HashSet,
+    env::current_dir,
+    io::{stdout, Write},
+    panic::{catch_unwind, set_hook},
+    path::PathBuf,
+    sync::Mutex,
+};
+
+use config::Config;
+use figment::{
+    providers::{Format, Serialized, Toml},
+    Figment,
+};
+use gumdrop::Options;
+use nix::{
+    sys::stat::{umask, Mode},
+    unistd::Uid,
+};
+use strum::{EnumMessage, IntoEnumIterator};
+
+use tempfile::{tempdir_in, TempDir};
+
+mod config;
+mod context;
+mod features;
+mod flags;
+
+mod macros;
+pub(crate) use macros::*;
+
+mod test;
+mod tests;
+mod utils;
+
+use test::{FileSystemFeature, SerializedTestContext, TestCase, TestContext, TestFn};
+
+use crate::utils::chmod;
+
+static BACKTRACE: Mutex<Option<Backtrace>> = Mutex::new(None);
+
+#[derive(Debug, Options)]
+struct ArgOptions {
+    #[options(help = "print help message")]
+    help: bool,
+
+    #[options(help = "Path of the configuration file")]
+    configuration_file: Option<PathBuf>,
+
+    #[options(help = "List opt-in features")]
+    list_features: bool,
+
+    #[options(help = "Match names exactly")]
+    exact: bool,
+
+    #[options(help = "Verbose mode")]
+    verbose: bool,
+
+    #[options(help = "Path where the test suite will be executed")]
+    path: Option<PathBuf>,
+
+    #[options(free, help = "Filter test names")]
+    test_patterns: Vec<String>,
+
+    #[options(help = "Path to a secondary file system")]
+    secondary_fs: Option<PathBuf>,
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = ArgOptions::parse_args_default_or_exit();
+
+    if args.list_features {
+        for feature in FileSystemFeature::iter() {
+            println!("{feature}: {}", feature.get_documentation().unwrap());
+        }
+        return Ok(());
+    }
+
+    let config: Config = {
+        let mut figment = Figment::from(Serialized::defaults(Config::default()));
+        if let Some(path) = args.configuration_file.as_deref() {
+            figment = figment.merge(Toml::file(path))
+        }
+
+        let mut config: Config = figment.extract()?;
+        config.features.secondary_fs = args.secondary_fs;
+        config
+    };
+
+    let path = args
+        .path
+        .ok_or_else(|| anyhow::anyhow!("cannot get current dir"))
+        .or_else(|_| current_dir())?;
+    let base_dir = tempdir_in(path)?;
+
+    set_hook(Box::new(|_| {
+        *BACKTRACE.lock().unwrap() = Some(Backtrace::capture());
+    }));
+
+    let test_cases = inventory::iter::<TestCase>;
+    let test_cases: Vec<_> = test_cases
+        .into_iter()
+        .filter(|case| {
+            args.test_patterns.is_empty()
+                || args.test_patterns.iter().any(|pat| {
+                    if args.exact {
+                        case.name == pat
+                    } else {
+                        case.name.contains(pat)
+                    }
+                })
+        })
+        .map(|tc: &TestCase| TestCase {
+            // Ideally trim_start_matches could be done in test_case!, but only
+            // const functions are allowed there.
+            name: tc.name.trim_start_matches("pjdfstest::tests::"),
+            description: tc.description,
+            require_root: tc.require_root,
+            fun: tc.fun,
+            required_features: tc.required_features,
+            guards: tc.guards,
+        })
+        .collect();
+
+    umask(Mode::empty());
+
+    let (failed_count, skipped_count, success_count) =
+        run_test_cases(&test_cases, args.verbose, &config, base_dir)?;
+
+    println!(
+        "\nTests: {} failed, {} skipped, {} passed, {} total",
+        failed_count,
+        skipped_count,
+        success_count,
+        failed_count + skipped_count + success_count,
+    );
+
+    if failed_count > 0 {
+        Err(anyhow::anyhow!("Some tests have failed"))
+    } else {
+        Ok(())
+    }
+}
+
+/// Run provided test cases and filter according to features and flags availability.
+//TODO: Refactor this function
+fn run_test_cases(
+    test_cases: &[TestCase],
+    verbose: bool,
+    config: &Config,
+    base_dir: TempDir,
+) -> Result<(usize, usize, usize), anyhow::Error> {
+    let mut failed_tests_count: usize = 0;
+    let mut succeeded_tests_count: usize = 0;
+    let mut skipped_tests_count: usize = 0;
+
+    let is_root = Uid::current().is_root();
+
+    let enabled_features: HashSet<_> = config.features.fs_features.keys().collect();
+
+    let entries = &config.dummy_auth.entries;
+
+    for test_case in test_cases {
+        //TODO: There's probably a better way to do this...
+        let mut should_skip = test_case.require_root && !is_root;
+        let mut skip_reasons = Vec::<String>::new();
+
+        if should_skip {
+            skip_reasons.push(String::from("requires root privileges"));
+        }
+
+        let features: HashSet<_> = test_case.required_features.iter().collect();
+        let missing_features: Vec<_> = features.difference(&enabled_features).collect();
+        if !missing_features.is_empty() {
+            should_skip = true;
+
+            let features = &missing_features
+                .iter()
+                .map(|feature| format!("{}", feature))
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            skip_reasons.push(format!("requires features: {}", features));
+        }
+
+        let temp_dir = tempdir_in(base_dir.path()).unwrap();
+        // FIX: some tests need a 0o755 base dir
+        chmod(temp_dir.path(), Mode::from_bits_truncate(0o755)).unwrap();
+
+        if test_case
+            .guards
+            .iter()
+            .any(|guard| guard(config, temp_dir.path()).is_err())
+        {
+            should_skip = true;
+            skip_reasons.extend(
+                test_case
+                    .guards
+                    .iter()
+                    .filter_map(|guard| guard(config, base_dir.path()).err())
+                    .map(|err| err.to_string()),
+            );
+        }
+
+        // TODO: ;decide what to do about verbose
+        if verbose && !test_case.description.is_empty() {
+            print!("\n\t{}\t\t", test_case.description);
+        }
+
+        stdout().lock().flush()?;
+
+        if should_skip {
+            println!("{:72} skipped", test_case.name);
+            for reason in &skip_reasons {
+                println!("\t{}", reason);
+            }
+            skipped_tests_count += 1;
+            continue;
+        }
+
+        let result = catch_unwind(|| match test_case.fun {
+            TestFn::NonSerialized(fun) => {
+                let mut context = TestContext::new(config, entries, temp_dir.path());
+
+                (fun)(&mut context)
+            }
+            TestFn::Serialized(fun) => {
+                let mut context = SerializedTestContext::new(config, entries, temp_dir.path());
+
+                (fun)(&mut context)
+            }
+        });
+
+        match result {
+            Ok(_) => {
+                println!("{:77} ok", test_case.name);
+                succeeded_tests_count += 1;
+            }
+            Err(e) => {
+                let backtrace = BACKTRACE
+                    .lock()
+                    .unwrap()
+                    .take()
+                    .filter(|bt| bt.status() == BacktraceStatus::Captured);
+                let panic_information = match e.downcast::<String>() {
+                    Ok(v) => *v,
+                    Err(e) => match e.downcast::<&str>() {
+                        Ok(v) => v.to_string(),
+                        _ => "Unknown Source of Error".to_owned(),
+                    },
+                };
+                println!("{:73} FAILED\n\t{}", test_case.name, panic_information);
+                if let Some(backtrace) = backtrace {
+                    println!("Backtrace:\n{}", backtrace);
+                }
+                failed_tests_count += 1;
+            }
+        }
+    }
+
+    Ok((
+        failed_tests_count,
+        skipped_tests_count,
+        succeeded_tests_count,
+    ))
+}

--- a/tests/pjdfstest/src/test.rs
+++ b/tests/pjdfstest/src/test.rs
@@ -1,0 +1,31 @@
+//! Test framework for testing the filesystem implementation.
+
+use std::path::Path;
+
+use crate::config::Config;
+pub use crate::context::{SerializedTestContext, TestContext};
+pub use crate::features::*;
+pub use crate::flags::*;
+
+/// Function which indicates if the test should be skipped by returning an error.
+pub type Guard = fn(&Config, &Path) -> Result<(), anyhow::Error>;
+
+/// Function which runs the test.
+/// The function is passed a context object which can be used to interact with the filesystem.
+#[derive(Clone, Copy)]
+pub enum TestFn {
+    Serialized(fn(&mut SerializedTestContext)),
+    NonSerialized(fn(&mut TestContext)),
+}
+
+/// A single minimal test case.
+pub struct TestCase {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub require_root: bool,
+    pub fun: TestFn,
+    pub required_features: &'static [FileSystemFeature],
+    pub guards: &'static [Guard],
+}
+
+inventory::collect!(TestCase);

--- a/tests/pjdfstest/src/tests/chmod.rs
+++ b/tests/pjdfstest/src/tests/chmod.rs
@@ -1,0 +1,226 @@
+use crate::{
+    context::{FileType, SerializedTestContext},
+    test::TestContext,
+    tests::{assert_ctime_changed, assert_ctime_unchanged},
+    utils::{chmod, ALLPERMS},
+};
+
+#[cfg(lchmod)]
+use crate::utils::lchmod;
+
+use nix::{
+    sys::stat::{lstat, stat, Mode},
+    unistd::chown,
+};
+
+use super::errors::{
+    efault::efault_path_test_case,
+    eloop::{eloop_comp_test_case, eloop_final_comp_test_case},
+    enametoolong::{enametoolong_comp_test_case, enametoolong_path_test_case},
+    enoent::{
+        enoent_comp_test_case, enoent_named_file_test_case, enoent_symlink_named_file_test_case,
+    },
+    enotdir::enotdir_comp_test_case,
+    erofs::erofs_named_test_case,
+};
+
+#[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+const ALLPERMS_STICKY: nix::libc::mode_t = ALLPERMS | Mode::S_ISVTX.bits();
+
+// chmod/00.t:L24
+crate::test_case! {
+    /// chmod successfully change permissions
+    change_perm => [Regular, Dir, Fifo, Block, Char, Socket]
+}
+fn change_perm(ctx: &mut TestContext, f_type: FileType) {
+    let path = ctx.create(f_type).unwrap();
+    let expected_mode = Mode::from_bits_truncate(0o111);
+
+    assert!(chmod(&path, expected_mode).is_ok());
+
+    let actual_mode = stat(&path).unwrap().st_mode;
+
+    assert_eq!(actual_mode & ALLPERMS, expected_mode.bits());
+
+    // We test if it applies through symlinks
+    let symlink_path = ctx.create(FileType::Symlink(Some(path.clone()))).unwrap();
+    let link_mode = lstat(&symlink_path).unwrap().st_mode;
+    let expected_mode = Mode::from_bits_truncate(0o222);
+
+    assert!(chmod(&symlink_path, expected_mode).is_ok());
+
+    let actual_mode = stat(&path).unwrap().st_mode;
+    let actual_sym_mode = stat(&symlink_path).unwrap().st_mode;
+    assert_eq!(actual_mode & ALLPERMS, expected_mode.bits());
+    assert_eq!(actual_sym_mode & ALLPERMS, expected_mode.bits());
+
+    let actual_link_mode = lstat(&symlink_path).unwrap().st_mode;
+    assert_eq!(link_mode & ALLPERMS, actual_link_mode & ALLPERMS);
+}
+
+// chmod/00.t:L58
+crate::test_case! {
+    /// chmod updates ctime when it succeeds
+    update_ctime => [Regular, Dir, Fifo, Block, Char, Socket]
+}
+fn update_ctime(ctx: &mut TestContext, f_type: FileType) {
+    let path = ctx.create(f_type).unwrap();
+    assert_ctime_changed(ctx, &path, || {
+        assert!(chmod(&path, Mode::from_bits_truncate(0o111)).is_ok());
+    });
+}
+
+// chmod/00.t:L89
+crate::test_case! {
+    /// chmod does not update ctime when it fails
+    failed_chmod_unchanged_ctime, serialized, root => [Regular, Dir, Fifo, Block, Char, Socket]
+}
+fn failed_chmod_unchanged_ctime(ctx: &mut SerializedTestContext, f_type: FileType) {
+    let path = ctx.create(f_type).unwrap();
+    let user = ctx.get_new_user();
+    assert_ctime_unchanged(ctx, &path, || {
+        ctx.as_user(user, None, || {
+            assert!(chmod(&path, Mode::from_bits_truncate(0o111)).is_err());
+        });
+    });
+}
+
+// chmod/00.t:L119
+crate::test_case! {
+    /// S_ISGID bit shall be cleared upon successful return from chmod of a regular file
+    /// if the calling process does not have appropriate privileges, and if
+    /// the group ID of the file does not match the effective group ID or one of the
+    /// supplementary group IDs
+    clear_isgid_bit, serialized, root
+}
+fn clear_isgid_bit(ctx: &mut SerializedTestContext) {
+    let path = ctx.create(FileType::Regular).unwrap();
+    assert!(chmod(&path, Mode::from_bits_truncate(0o0755)).is_ok());
+
+    let user = ctx.get_new_user();
+
+    chown(&path, Some(user.uid), Some(user.gid)).unwrap();
+
+    let expected_mode = Mode::from_bits_truncate(0o2755);
+    ctx.as_user(user, None, || {
+        chmod(&path, expected_mode).unwrap();
+    });
+
+    let actual_mode = stat(&path).unwrap().st_mode;
+    assert_eq!(actual_mode & 0o7777, expected_mode.bits());
+
+    let expected_mode = Mode::from_bits_truncate(0o0755);
+    ctx.as_user(user, None, || {
+        assert!(chmod(&path, expected_mode).is_ok());
+    });
+
+    let actual_mode = stat(&path).unwrap().st_mode;
+    assert_eq!(actual_mode & 0o7777, expected_mode.bits());
+    //TODO: FreeBSD "S_ISGID should be removed and chmod(2) should success and FreeBSD returns EPERM."
+}
+
+// chmod/01.t
+enotdir_comp_test_case!(chmod(~path, Mode::empty()));
+
+// chmod/02.t
+enametoolong_comp_test_case!(chmod(~path, Mode::empty()));
+
+// chmod/03.t
+enametoolong_path_test_case!(chmod(~path, Mode::empty()));
+
+// chmod/04.t
+enoent_named_file_test_case!(chmod(~path, Mode::empty()));
+enoent_comp_test_case!(chmod(~path, Mode::empty()));
+enoent_symlink_named_file_test_case!(chmod(~path, Mode::empty()));
+
+// chmod/06.t
+eloop_comp_test_case!(chmod(~path, Mode::empty()));
+
+// chmod/06.t
+eloop_final_comp_test_case!(chmod(~path, Mode::empty()));
+
+// chmod/09.t
+erofs_named_test_case!(chmod(~path, Mode::empty()));
+
+// chmod/10.t
+efault_path_test_case!(chmod, |ptr| nix::libc::chmod(ptr, 0));
+
+#[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+crate::test_case! {
+    /// chmod returns EFTYPE if the effective user ID is not the super-user,
+    /// the mode includes the sticky bit (S_ISVTX),
+    /// and path does not refer to a directory
+    // chmod/11.t
+    eftype, serialized, root => [Regular, Fifo, Block, Char, Socket]
+}
+#[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+fn eftype(ctx: &mut SerializedTestContext, ft: FileType) {
+    use nix::errno::Errno;
+
+    let user = ctx.get_new_user();
+
+    let original_mode = Mode::from_bits_truncate(0o640);
+    let file = ctx
+        .new_file(ft)
+        .mode(original_mode.bits())
+        .create()
+        .unwrap();
+    chown(&file, Some(user.uid), Some(user.gid)).unwrap();
+    let new_mode = Mode::from_bits_truncate(0o644);
+    let link = ctx.create(FileType::Symlink(Some(file.clone()))).unwrap();
+
+    ctx.as_user(user, None, || {
+        assert_eq!(chmod(&file, new_mode | Mode::S_ISVTX), Err(Errno::EFTYPE));
+    });
+    let file_stat = stat(&file).unwrap();
+    assert_eq!(file_stat.st_mode & ALLPERMS_STICKY, original_mode.bits());
+
+    ctx.as_user(user, None, || {
+        assert_eq!(
+            chmod(&link, original_mode | Mode::S_ISVTX),
+            Err(Errno::EFTYPE)
+        );
+    });
+    let file_stat = stat(&link).unwrap();
+    assert_eq!(file_stat.st_mode & ALLPERMS_STICKY, original_mode.bits());
+
+    // lchmod
+
+    let mode = Mode::from_bits_truncate(0o621) | Mode::S_ISVTX;
+    ctx.as_user(user, None, || {
+        assert_eq!(lchmod(&file, mode), Err(Errno::EFTYPE));
+    });
+
+    let file_stat = lstat(&file).unwrap();
+    assert_eq!(file_stat.st_mode & ALLPERMS_STICKY, original_mode.bits());
+}
+
+#[cfg(lchmod)]
+mod lchmod {
+    use super::*;
+
+    // chmod/01.t
+    enotdir_comp_test_case!(lchmod(~path, Mode::empty()));
+
+    // chmod/04.t
+    enoent_named_file_test_case!(lchmod(~path, Mode::empty()));
+    enoent_comp_test_case!(lchmod(~path, Mode::empty()));
+
+    // chmod/06.t#L25
+    eloop_comp_test_case!(lchmod(~path, Mode::empty()));
+
+    enametoolong_comp_test_case!(lchmod(~path, Mode::empty()));
+    enametoolong_path_test_case!(lchmod(~path, Mode::empty()));
+
+    // chmod/09.t
+    erofs_named_test_case!(lchmod(~path, Mode::empty()));
+
+    // chmod/10.t
+    // TODO: lchmod is missing in libc
+    efault_path_test_case!(lchmod, |ptr| nix::libc::fchmodat(
+        0,
+        ptr,
+        0,
+        nix::libc::AT_SYMLINK_NOFOLLOW
+    ));
+}

--- a/tests/pjdfstest/src/tests/chown.rs
+++ b/tests/pjdfstest/src/tests/chown.rs
@@ -1,0 +1,81 @@
+use nix::unistd::chown;
+
+use crate::{context::TestContext, utils::lchown};
+
+use super::errors::efault::efault_path_test_case;
+use super::errors::eloop::{eloop_comp_test_case, eloop_final_comp_test_case};
+use super::errors::enametoolong::{enametoolong_comp_test_case, enametoolong_path_test_case};
+use super::errors::enoent::{
+    enoent_comp_test_case, enoent_named_file_test_case, enoent_symlink_named_file_test_case,
+};
+use super::errors::enotdir::enotdir_comp_test_case;
+use super::errors::erofs::erofs_named_test_case;
+
+fn chown_wrapper(ctx: &mut TestContext, path: &std::path::Path) -> nix::Result<()> {
+    let user = ctx.get_new_user();
+    chown(path, Some(user.uid), None)
+}
+
+// chown/01.t
+enotdir_comp_test_case!(chown, chown_wrapper);
+
+// chown/02.t
+enametoolong_comp_test_case!(chown, chown_wrapper);
+
+// chown/03.t
+enametoolong_path_test_case!(chown, chown_wrapper);
+
+// chown/04.t
+enoent_named_file_test_case!(chown, chown_wrapper);
+
+// chown/04.t
+enoent_comp_test_case!(chown, chown_wrapper);
+
+// chown/04.t
+enoent_symlink_named_file_test_case!(chown, chown_wrapper);
+
+// chown/06.t
+eloop_comp_test_case!(chown, chown_wrapper);
+
+// chown/06.t
+eloop_final_comp_test_case!(chown, chown_wrapper);
+
+// chown/09.t
+erofs_named_test_case!(chown, chown_wrapper);
+
+// chown/10.t
+efault_path_test_case!(chown, |ptr| nix::libc::chown(ptr, 0, 0));
+
+mod lchown {
+    use std::path::Path;
+
+    use super::*;
+
+    fn lchown_wrapper<P: AsRef<Path>>(ctx: &mut TestContext, path: P) -> nix::Result<()> {
+        let path = path.as_ref();
+        let user = ctx.get_new_user();
+        lchown(path, Some(user.uid), Some(user.gid))
+    }
+
+    // chown/01.t
+    enotdir_comp_test_case!(lchown, lchown_wrapper);
+
+    // chown/04.t
+    enoent_named_file_test_case!(lchown, lchown_wrapper);
+    enoent_comp_test_case!(lchown, lchown_wrapper);
+
+    // chown/06.t#L25
+    eloop_comp_test_case!(lchown, lchown_wrapper);
+
+    // chown/02.t
+    enametoolong_comp_test_case!(lchown, lchown_wrapper);
+
+    // chown/03.t
+    enametoolong_path_test_case!(lchown, lchown_wrapper);
+
+    // chown/09.t
+    erofs_named_test_case!(lchown, lchown_wrapper);
+
+    // chown/10.t
+    efault_path_test_case!(lchown, |ptr| nix::libc::lchown(ptr, 0, 0));
+}

--- a/tests/pjdfstest/src/tests/errors.rs
+++ b/tests/pjdfstest/src/tests/errors.rs
@@ -1,0 +1,11 @@
+//! Helper functions for testing error handling.
+
+pub(super) mod eexist;
+pub(super) mod efault;
+pub(super) mod eloop;
+pub(super) mod enametoolong;
+pub(super) mod enoent;
+pub(super) mod enotdir;
+pub(super) mod erofs;
+// etxtbsy: stripped — vibix has no ETXTBSY semantics (no dynamic-exec write protection).
+pub(super) mod exdev;

--- a/tests/pjdfstest/src/tests/errors/eexist.rs
+++ b/tests/pjdfstest/src/tests/errors/eexist.rs
@@ -1,0 +1,49 @@
+/// Create a test case which asserts that the sycall
+/// returns EEXIST if the named file exists.
+/// There are multiple forms for this macro:
+///
+/// - A basic form which takes the syscall, and optionally a `~path` argument
+///   to indicate where the `path` argument should be substituted if the path
+///   is not the only argument taken by the syscall.
+///
+/// ```
+/// // `unlink` accepts only a path as argument.
+/// eloop_comp_test_case!(unlink);
+/// // `chflags` takes a path and the flags to set as arguments.
+/// // We need to add `~path` where the path argument should normally be taken.
+/// eloop_comp_test_case!(chflags(~path, FileFlags::empty()));
+/// ```
+///
+/// - A more complex form which takes multiple functions
+///   with the context and the path as arguments, for syscalls
+///   requiring to compute other arguments.
+///
+/// ```
+/// eloop_comp_test_case!(chown, |ctx: &mut TestContext, path: &Path| {
+///   let user = ctx.get_new_user();
+///   chown(path, Some(user.uid), None)
+/// })
+/// ````
+macro_rules! eexist_file_exists_test_case {
+    ($syscall: ident, $($f: expr),+ $(; $attrs:tt )?) => {
+        crate::test_case! {
+            #[doc = concat!(stringify!($syscall),
+            " returns EEXIST if the named file exists")]
+            eexist_file_exists $(, $attrs )? => [Regular, Dir, Fifo, Block, Char, Socket, Symlink(None)]
+        }
+        fn eexist_file_exists(ctx: &mut crate::context::TestContext,
+            ft: crate::context::FileType) {
+            let path = ctx.create(ft).unwrap();
+            $( assert_eq!($f(ctx, &path), Err(nix::errno::Errno::EEXIST)); )+
+        }
+    };
+
+    ($syscall: ident $( ($( $($before:expr),* ,)? ~path $(, $($after:expr),*)?) )?) => {
+        eexist_file_exists_test_case!($syscall, |_: &mut $crate::context::TestContext,
+            path: &std::path::Path| {
+            $syscall($( $($($before),* ,)? )? path $( $(, $($after),*)? )?)
+        });
+    };
+}
+
+pub(crate) use eexist_file_exists_test_case;

--- a/tests/pjdfstest/src/tests/errors/efault.rs
+++ b/tests/pjdfstest/src/tests/errors/efault.rs
@@ -1,0 +1,106 @@
+/// Create a test case which asserts that the sycall
+/// returns EFAULT if the path argument points
+/// outside the process's allocated address space.
+/// It takes a function with the path pointer as argument.
+///
+/// ```ignore
+/// efault_path_test_case!(|ptr| nix::libc::mkdir(ptr, 0o755))
+/// ````
+macro_rules! efault_path_test_case {
+    ($syscall: ident, $fn: expr) => {
+        crate::test_case! {
+            #[doc = concat!(stringify!($syscall),
+            " returns EFAULT if the path argument points",
+            " outside the process's allocated address space"
+            )]
+            efault_path
+        }
+        fn efault_path(_: &mut crate::context::TestContext) {
+            let f = |ptr| unsafe { $fn(ptr) };
+
+            let null_ptr = std::ptr::null();
+            // TODO: This theorically could be a valid pointer, but
+            // it's unlikely to be the case in practice. Should we
+            // use a more robust way to get a pointer outside the
+            // process's allocated address space, though?
+            let invalid_ptr = usize::MAX as *const _;
+
+            assert_eq!(
+                nix::errno::Errno::result(f(null_ptr)),
+                Err(nix::errno::Errno::EFAULT)
+            );
+            assert_eq!(
+                nix::errno::Errno::result(f(invalid_ptr)),
+                Err(nix::errno::Errno::EFAULT)
+            );
+        }
+    };
+}
+
+pub(crate) use efault_path_test_case;
+
+/// Create a test case which asserts that the sycall
+/// returns EFAULT if one of the pathnames specified
+/// is outside the process's allocated address space.
+///
+/// ```ignore
+/// efault_error_test_case!(link, nix::libc::link)
+/// ```
+macro_rules! efault_either_test_case {
+    ($syscall:ident, $fn: expr) => {
+        crate::test_case! {
+            #[doc = concat!(stringify!($syscall),
+            " returns EFAULT if one of the pathnames specified",
+            " is outside the process's allocated address space"
+            )]
+            efault_either
+        }
+        fn efault_either(ctx: &mut crate::context::TestContext) {
+            use nix::NixPath;
+
+            let file = ctx.create(crate::context::FileType::Regular).unwrap();
+
+            let null_ptr = std::ptr::null();
+
+            // TODO: This theorically could be a valid pointer, but
+            // it's unlikely to be the case in practice. Should we
+            // use a more robust way to get a pointer outside the
+            // process's allocated address space, though?
+            let invalid_ptr = usize::MAX as *const _;
+
+            file.with_nix_path(|cstr| {
+                let ptr = cstr.as_ptr();
+
+                assert_eq!(
+                    nix::errno::Errno::result(unsafe { $fn(null_ptr, ptr) }),
+                    Err(nix::errno::Errno::EFAULT)
+                );
+                assert_eq!(
+                    nix::errno::Errno::result(unsafe { $fn(invalid_ptr, ptr) }),
+                    Err(nix::errno::Errno::EFAULT)
+                );
+
+                assert_eq!(
+                    nix::errno::Errno::result(unsafe { $fn(ptr, null_ptr) }),
+                    Err(nix::errno::Errno::EFAULT)
+                );
+                assert_eq!(
+                    nix::errno::Errno::result(unsafe { $fn(ptr, invalid_ptr) }),
+                    Err(nix::errno::Errno::EFAULT)
+                );
+            })
+            .unwrap();
+
+            assert_eq!(
+                nix::errno::Errno::result(unsafe { $fn(invalid_ptr, null_ptr) }),
+                Err(nix::errno::Errno::EFAULT)
+            );
+            assert_eq!(
+                nix::errno::Errno::result(unsafe { $fn(null_ptr, invalid_ptr) }),
+                Err(nix::errno::Errno::EFAULT)
+            );
+        }
+    };
+}
+
+pub(crate) use efault_either_test_case;

--- a/tests/pjdfstest/src/tests/errors/eloop.rs
+++ b/tests/pjdfstest/src/tests/errors/eloop.rs
@@ -1,0 +1,177 @@
+use std::path::PathBuf;
+
+use crate::context::{FileType, TestContext};
+
+/// Create a loop between two symbolic links and return them.
+pub fn create_loop_symlinks(ctx: &mut TestContext) -> (PathBuf, PathBuf) {
+    let loop1 = ctx.gen_path();
+    let loop2 = ctx.gen_path();
+
+    (
+        ctx.new_file(FileType::Symlink(Some(loop2.clone())))
+            .name(&loop1)
+            .create()
+            .unwrap(),
+        ctx.new_file(FileType::Symlink(Some(loop1)))
+            .name(&loop2)
+            .create()
+            .unwrap(),
+    )
+}
+
+/// Create a test case which asserts that the sycall
+/// returns ELOOP if too many symbolic links were encountered in translating
+/// a component of the pathname which is not the last one.
+/// There are multiple forms for this macro:
+///
+/// - A basic form which takes the syscall, and optionally a `~path` argument
+///   to indicate where the `path` argument should be substituted if the path
+///   is not the only argument taken by the syscall.
+///
+/// ```
+/// // `unlink` accepts only a path as argument.
+/// eloop_comp_test_case!(unlink);
+/// // `chflags` takes a path and the flags to set as arguments.
+/// // We need to add `~path` where the path argument should normally be taken.
+/// eloop_comp_test_case!(chflags(~path, FileFlags::empty()));
+/// ```
+///
+/// - A more complex form which takes multiple functions
+///   with the context and the path as arguments, for syscalls
+///   requiring to compute other arguments.
+///
+/// ```
+/// eloop_comp_test_case!(chown, |ctx: &mut TestContext, path: &Path| {
+///   let user = ctx.get_new_user();
+///   chown(path, Some(user.uid), None)
+/// })
+/// ````
+macro_rules! eloop_comp_test_case {
+    ($syscall: ident, $($f: expr),+) => {
+        crate::test_case! {
+            #[doc = concat!(stringify!($syscall),
+            " returns ELOOP if too many symbolic",
+            " links were encountered in translating a component of the pathname",
+            " which is not the last one")]
+            eloop_comp
+        }
+        fn eloop_comp(ctx: &mut crate::context::TestContext) {
+            let (mut loop1, mut loop2) = $crate::tests::errors::eloop::create_loop_symlinks(ctx);
+            loop1.push("test");
+            loop2.push("test");
+
+            $(
+                assert_eq!($f(ctx, &loop1).unwrap_err(), nix::errno::Errno::ELOOP);
+                assert_eq!($f(ctx, &loop2).unwrap_err(), nix::errno::Errno::ELOOP);
+            )+
+        }
+    };
+
+    ($syscall: ident $( ($( $($before:expr),* ,)? ~path $(, $($after:expr),*)?) )?) => {
+        eloop_comp_test_case!($syscall, |_: &mut $crate::context::TestContext,
+            path: &std::path::Path| {
+            $syscall($( $($($before),* ,)? )? path $( $(, $($after),*)? )?)
+        });
+    };
+}
+
+pub(crate) use eloop_comp_test_case;
+
+/// Create a test case which asserts that the sycall
+/// returns ELOOP if too many symbolic links were encountered in translating
+/// a component of either pathname which is not the last one.
+/// ```ignore
+/// eloop_either_test_case!(rename);
+/// ```
+macro_rules! eloop_either_test_case {
+    ($syscall: ident) => {
+        crate::test_case! {
+            #[doc = concat!(stringify!($syscall),
+            " returns ELOOP if too many symbolic",
+            " links were encountered in translating a component of either pathname",
+            " which is not the last one")]
+            eloop_comp
+        }
+        fn eloop_comp(ctx: &mut crate::context::TestContext) {
+            let (mut loop1, mut loop2) = $crate::tests::errors::eloop::create_loop_symlinks(ctx);
+            loop1.push("test");
+            loop2.push("test");
+            let valid_path = ctx.create(crate::context::FileType::Regular).unwrap();
+
+            assert_eq!(
+                $syscall(&loop1.join("test"), &valid_path).unwrap_err(),
+                Errno::ELOOP
+            );
+            assert_eq!(
+                $syscall(&loop2.join("test"), &valid_path).unwrap_err(),
+                Errno::ELOOP
+            );
+            assert_eq!(
+                $syscall(&valid_path, &loop1.join("test")).unwrap_err(),
+                Errno::ELOOP
+            );
+            assert_eq!(
+                $syscall(&valid_path, &loop2.join("test")).unwrap_err(),
+                Errno::ELOOP
+            );
+        }
+    };
+}
+
+pub(crate) use eloop_either_test_case;
+
+/// Create a test case which asserts that the sycall
+/// returns ELOOP if too many symbolic links were encountered in translating
+/// the last component of the pathname.
+/// There are multiple forms for this macro:
+///
+/// - A basic form which takes the syscall, and optionally a `~path` argument
+///   to indicate where the `path` argument should be substituted if the path
+///   is not the only argument taken by the syscall.
+///
+/// ```
+/// // `unlink` accepts only a path as argument.
+/// eloop_final_comp_test_case!(unlink);
+/// // `chflags` takes a path and the flags to set as arguments.
+/// // We need to add `~path` where the path argument should normally be taken.
+/// eloop_final_comp_test_case!(chflags(~path, FileFlags::empty()));
+/// ```
+///
+/// - A more complex form which can take multiple functions
+///   with the context and the path as arguments, for syscalls
+///   requring to compute other arguments.
+///
+/// ```
+/// eloop_final_comp_test_case!(chown, |ctx: &mut TestContext, path: &Path| {
+///   let user = ctx.get_new_user();
+///   chown(path, Some(user.uid), None)
+/// })
+/// ````
+macro_rules! eloop_final_comp_test_case {
+    ($syscall: ident, $($f: expr),+) => {
+        crate::test_case! {
+            #[doc = concat!(stringify!($syscall),
+            " returns ELOOP if too many symbolic",
+            " links were encountered in translating",
+            " the last component of the pathname")]
+            eloop_final_comp
+        }
+        fn eloop_final_comp(ctx: &mut crate::context::TestContext) {
+            let (loop1, loop2) = $crate::tests::errors::eloop::create_loop_symlinks(ctx);
+
+            $(
+                assert_eq!($f(ctx, &loop1).unwrap_err(), nix::errno::Errno::ELOOP);
+                assert_eq!($f(ctx, &loop2).unwrap_err(), nix::errno::Errno::ELOOP);
+            )+
+        }
+    };
+
+    ($syscall: ident $( ($( $($before:expr),* ,)? ~path $(, $($after:expr),*)?) )?) => {
+        eloop_final_comp_test_case!($syscall, |_: &mut $crate::context::TestContext,
+            path: &std::path::Path| {
+            $syscall($( $($($before),* ,)? )? path $( $(, $($after),*)? )?)
+        });
+    };
+}
+
+pub(crate) use eloop_final_comp_test_case;

--- a/tests/pjdfstest/src/tests/errors/enametoolong.rs
+++ b/tests/pjdfstest/src/tests/errors/enametoolong.rs
@@ -1,0 +1,181 @@
+/// Create a test case which asserts that the sycall
+/// returns `ENAMETOOLONG` if a component of a pathname
+/// exceeded `{NAME_MAX}` characters.
+/// There are multiple forms for this macro:
+///
+/// - A basic form which takes the syscall, and optionally a `~path` argument
+///   to indicate where the `path` argument should be substituted if the path
+///   is not the only argument taken by the syscall.
+///
+/// ```ignore
+/// // `unlink` accepts only a path as argument.
+/// enametoolong_comp_test_case!(unlink);
+/// // `chflags` takes a path and the flags to set as arguments.
+/// // We need to add `~path` where the path argument should normally be taken.
+/// enametoolong_comp_test_case!(chflags(~path, FileFlags::empty()));
+/// ```
+///
+/// - A more complex form which takes multiple functions
+///   with the context and the path as arguments for syscalls
+///   requring to compute other arguments.
+///
+/// ```ignore
+/// enametoolong_comp_test_case!(chown, |ctx: &mut TestContext, path: &Path| {
+///   let user = ctx.get_new_user();
+///   chown(path, Some(user.uid), None)
+/// })
+/// ````
+macro_rules! enametoolong_comp_test_case {
+    ($syscall: ident, $($f: expr),+ $(; $attrs:tt )?) => {
+        crate::test_case! {
+            #[doc = concat!(stringify!($syscall),
+                 " returns ENAMETOOLONG if a component of a pathname",
+                 " exceeded {NAME_MAX} characters")]
+            enametoolong_component $(, $attrs )?
+        }
+        fn enametoolong_component(ctx: &mut TestContext) {
+            use $crate::context::FileType;
+            use nix::errno::Errno;
+
+            let mut invalid_path = ctx.create_name_max(FileType::Regular).unwrap();
+            invalid_path.set_extension("x");
+            $(assert_eq!($f(ctx, &invalid_path), Err(Errno::ENAMETOOLONG));)+
+        }
+    };
+
+    ($syscall: ident $( ($( $($before:expr),* ,)? ~path $(, $($after:expr),*)?) )?) => {
+        enametoolong_comp_test_case!($syscall, |_ctx: &mut crate::context::TestContext,
+                                             path: &std::path::Path| {
+                $syscall($( $($($before),* ,)? )? path $( $(, $($after),*)? )?)
+        });
+    };
+}
+
+pub(crate) use enametoolong_comp_test_case;
+
+/// Create a test case which asserts that the sycall
+/// returns `ENAMETOOLONG` if a component of either pathname
+/// exceeds `{NAME_MAX}` characters.
+/// ```ignore
+/// // `rename` accepts two arguments.
+/// enametoolong_either_comp_test_case!(rename);
+/// ````
+macro_rules! enametoolong_either_comp_test_case {
+    ($syscall: ident) => {
+        crate::test_case! {
+            #[doc = concat!(stringify!($syscall),
+                 " returns ENAMETOOLONG if a component of either pathname",
+                 " exceeded {NAME_MAX} characters")]
+            enametoolong_component
+        }
+        fn enametoolong_component(ctx: &mut TestContext) {
+            use nix::errno::Errno;
+            use $crate::context::FileType;
+
+            let mut invalid_path = ctx.create_name_max(FileType::Regular).unwrap();
+            invalid_path.set_extension("x");
+            let valid_path = ctx.create_name_max(FileType::Regular).unwrap();
+            assert_eq!(
+                $syscall(&valid_path, &invalid_path),
+                Err(Errno::ENAMETOOLONG)
+            );
+            assert_eq!(
+                $syscall(&invalid_path, &valid_path),
+                Err(Errno::ENAMETOOLONG)
+            );
+        }
+    };
+}
+
+pub(crate) use enametoolong_either_comp_test_case;
+
+/// Create a test case which asserts that the sycall
+/// returns `ENAMETOOLONG` if an entire pathname
+/// exceeds `{PATH_MAX}` characters.
+/// There are multiple forms for this macro:
+///
+/// - A basic form which takes the syscall, and optionally a `~path` argument
+///   to indicate where the `path` argument should be substituted if the path
+///   is not the only argument taken by the syscall.
+///
+/// ```ignore
+/// // `unlink` accepts only a path as argument.
+/// enametoolong_path_test_case!(unlink);
+/// // `chflags` takes a path and the flags to set as arguments.
+/// // We need to add `~path` where the path argument should normally be taken.
+/// enametoolong_path_test_case!(chflags(~path, FileFlags::empty()));
+/// ```
+///
+/// - A more complex form which takes multiple functions
+///   with the context and the path as arguments for syscalls
+///   requring to compute other arguments.
+///
+/// ```ignore
+/// enametoolong_path_test_case!(chown, |ctx: &mut TestContext, path: &Path| {
+///   let user = ctx.get_new_user();
+///   chown(path, Some(user.uid), None)
+/// })
+/// ````
+macro_rules! enametoolong_path_test_case {
+    ($syscall: ident, $($f: expr),+ $(; $attrs:tt )?) => {
+        crate::test_case! {
+            #[doc = concat!(stringify!($syscall),
+                 " returns ENAMETOOLONG if an entire pathname",
+                 " exceeded {PATH_MAX} characters")]
+            enametoolong_path $(, $attrs )?
+        }
+        fn enametoolong_path(ctx: &mut TestContext) {
+            use $crate::context::FileType;
+            use nix::errno::Errno;
+
+            let mut invalid_path = ctx.create_path_max(FileType::Regular).unwrap();
+            invalid_path.set_extension("x");
+            $(assert_eq!($f(ctx, &invalid_path), Err(Errno::ENAMETOOLONG));)+
+        }
+    };
+
+    ($syscall: ident $( ($( $($before:expr),* ,)? ~path $(, $($after:expr),*)?) )?) => {
+        enametoolong_path_test_case!($syscall, |_ctx: &mut crate::context::TestContext,
+                                             path: &std::path::Path| {
+                $syscall($( $($($before),* ,)? )? path $( $(, $($after),*)? )?)
+        });
+    };
+}
+
+pub(crate) use enametoolong_path_test_case;
+
+/// Create a test case which asserts that the sycall
+/// returns `ENAMETOOLONG` if an entire pathname
+/// exceeds `{PATH_MAX}` characters.
+/// ```ignore
+/// // `rename` accepts two arguments.
+/// enametoolong_either_comp_test_case!(rename);
+/// ````
+macro_rules! enametoolong_either_path_test_case {
+    ($syscall: ident) => {
+        crate::test_case! {
+            #[doc = concat!(stringify!($syscall),
+                 " returns ENAMETOOLONG if an entire pathname",
+                 " exceeded {PATH_MAX} characters")]
+            enametoolong_path
+        }
+        fn enametoolong_path(ctx: &mut TestContext) {
+            use nix::errno::Errno;
+            use $crate::context::FileType;
+
+            let mut invalid_path = ctx.create_path_max(FileType::Regular).unwrap();
+            invalid_path.set_extension("x");
+            let valid_path = ctx.create_path_max(FileType::Regular).unwrap();
+            assert_eq!(
+                $syscall(&invalid_path, &valid_path),
+                Err(Errno::ENAMETOOLONG)
+            );
+            assert_eq!(
+                $syscall(&invalid_path, &valid_path),
+                Err(Errno::ENAMETOOLONG)
+            );
+        }
+    };
+}
+
+pub(crate) use enametoolong_either_path_test_case;

--- a/tests/pjdfstest/src/tests/errors/enoent.rs
+++ b/tests/pjdfstest/src/tests/errors/enoent.rs
@@ -1,0 +1,180 @@
+/// Create a test case which asserts that the sycall
+/// returns ENOENT if the named file does not exist.
+/// There are multiple forms for this macro:
+///
+/// - A basic form which takes the syscall, and optionally a `~path` argument
+///   to indicate where the `path` argument should be substituted if the path
+///   is not the only argument taken by the syscall.
+///
+/// ```
+/// // `unlink` accepts only a path as argument.
+/// enoent_named_file_test_case!(unlink);
+/// // `chflags` takes a path and the flags to set as arguments.
+/// // We need to add `~path` where the path argument should normally be taken.
+/// enoent_named_file_test_case!(chflags(~path, FileFlags::empty()));
+/// ```
+///
+/// - A more complex form which takes multiple functions
+///   with the context and the path as arguments for syscalls
+///   requring to compute other arguments.
+///
+/// ```
+/// enoent_named_file_test_case!(chown, |ctx: &mut TestContext, path: &Path| {
+///   let user = ctx.get_new_user();
+///   chown(path, Some(user.uid), None)
+/// })
+/// ````
+macro_rules! enoent_named_file_test_case {
+    ($syscall: ident, $($f: expr),+) => {
+        crate::test_case! {
+            #[doc = concat!(stringify!($syscall),
+                 " returns ENOENT if the named file does not exist")]
+           enoent_named_file
+        }
+        fn enoent_named_file(ctx: &mut crate::context::TestContext) {
+            let dir = ctx.create(crate::context::FileType::Dir).unwrap();
+            let path = dir.join("not_existent");
+
+            $( assert_eq!($f(ctx, &path).unwrap_err(), nix::errno::Errno::ENOENT) );+
+        }
+    };
+
+    ($syscall: ident $( ($( $($before:expr),* ,)? ~path $(, $($after:expr),*)?) )?) => {
+        enoent_named_file_test_case!($syscall, |_ctx: &mut crate::context::TestContext,
+                                             path: &std::path::Path| {
+                $syscall($( $($($before),* ,)? )? path $( $(, $($after),*)? )?)
+        });
+    };
+}
+
+pub(crate) use enoent_named_file_test_case;
+
+/// Create a test case which asserts that the sycall
+/// returns ENOENT if either of the named file does not exist.
+/// ```
+/// enoent_either_named_file_test_case!(rename);
+/// ```
+macro_rules! enoent_either_named_file_test_case {
+    ($syscall: ident) => {
+        $crate::tests::errors::enoent::enoent_named_file_test_case!(
+            $syscall,
+            |ctx: &mut crate::context::TestContext, path: &std::path::Path| {
+                let real_file = ctx.create(crate::context::FileType::Regular).unwrap();
+                let path = path.join("test");
+                $syscall(&path, &real_file)
+            },
+            |ctx: &mut crate::context::TestContext, path: &std::path::Path| {
+                let real_file = ctx.create(crate::context::FileType::Regular).unwrap();
+                let path = path.join("test");
+                $syscall(&*real_file, &path)
+            }
+        );
+    };
+}
+
+pub(crate) use enoent_either_named_file_test_case;
+
+/// Create a test case which asserts that the sycall
+/// returns ENOENT if the symlink target named file does not exist.
+/// There are multiple forms for this macro:
+///
+/// - A basic form which takes the syscall, and optionally a `~path` argument
+///   to indicate where the `path` argument should be substituted if the path
+///   is not the only argument taken by the syscall.
+///
+/// ```
+/// // `unlink` accepts only a path as argument.
+/// enoent_symlink_named_file_test_case!(unlink);
+/// // `chflags` takes a path and the flags to set as arguments.
+/// // We need to add `~path` where the path argument should normally be taken.
+/// enoent_symlink_named_file_test_case!(chflags(~path, FileFlags::empty()));
+/// ```
+///
+/// - A more complex form which takes multiple functions
+///   with the context and the path as arguments for syscalls
+///   requring to compute other arguments.
+///
+/// ```
+/// enoent_symlink_named_file_test_case!(chown, |ctx: &mut TestContext, path: &Path| {
+///   let user = ctx.get_new_user();
+///   chown(path, Some(user.uid), None)
+/// })
+/// ````
+macro_rules! enoent_symlink_named_file_test_case {
+    ($syscall: ident, $f: expr) => {
+        crate::test_case! {
+            #[doc = concat!(stringify!($syscall),
+                 " returns ENOENT if the symlink target named file does not exist")]
+           enoent_symlink
+        }
+        fn enoent_symlink(ctx: &mut crate::context::TestContext) {
+            let dir = ctx.create(crate::context::FileType::Dir).unwrap();
+            let path = dir.join("not_existent");
+            let link = ctx
+                .create(crate::context::FileType::Symlink(Some(path.to_path_buf())))
+                .unwrap();
+
+            assert_eq!($f(ctx, &link).unwrap_err(), nix::errno::Errno::ENOENT)
+        }
+    };
+
+    ($syscall: ident $( ($( $($before:expr),* ,)? ~path $(, $($after:expr),*)?) )?) => {
+        enoent_symlink_named_file_test_case!($syscall, |_ctx: &mut crate::context::TestContext,
+                                             path: &std::path::Path| {
+                $syscall($( $($($before),* ,)? )? path $( $(, $($after),*)? )?)
+        });
+    };
+}
+
+pub(crate) use enoent_symlink_named_file_test_case;
+
+/// Create a test case which asserts that the sycall
+/// returns ENOENT if a component of the path prefix does not exist.
+/// There are multiple forms for this macro:
+///
+/// - A basic form which takes the syscall, and optionally a `~path` argument
+///   to indicate where the `path` argument should be substituted if the path
+///   is not the only argument taken by the syscall.
+///
+/// ```
+/// // `unlink` accepts only a path as argument.
+/// enotdir_comp_test_case!(unlink);
+/// // `chflags` takes a path and the flags to set as arguments.
+/// // We need to add `~path` where the path argument should normally be taken.
+/// enotdir_comp_test_case!(chflags(~path, FileFlags::empty()));
+/// ```
+///
+/// - A more complex form which takes multiple functions
+///   with the context and the path as arguments for syscalls
+///   requring to compute other arguments.
+///
+/// ```
+/// enotdir_comp_test_case!(chown, |ctx: &mut TestContext, path: &Path| {
+///   let user = ctx.get_new_user();
+///   chown(path, Some(user.uid), None)
+/// })
+/// ````
+macro_rules! enoent_comp_test_case {
+    ($syscall: ident, $($f: expr),+) => {
+        crate::test_case! {
+            #[doc = concat!(stringify!($syscall),
+                 " returns ENOENT if a component of the path prefix does not exist")]
+           enoent_comp
+        }
+        fn enoent_comp(ctx: &mut crate::context::TestContext) {
+            let dir = ctx.create(crate::context::FileType::Dir).unwrap();
+            let path = dir.join("not_existent").join("test");
+
+            $( assert_eq!($f(ctx, &path).unwrap_err(), nix::errno::Errno::ENOENT) );+
+        }
+    };
+
+    ($syscall: ident $( ($( $($before:expr),* ,)? ~path $(, $($after:expr),*)?) )?) => {
+        enoent_comp_test_case!($syscall, |_ctx: &mut crate::context::TestContext,
+                                             path: &std::path::Path| {
+                $syscall($( $($($before),* ,)? )? path $( $(, $($after),*)? )?)
+        });
+    };
+}
+
+pub(crate) use enoent_comp_test_case;

--- a/tests/pjdfstest/src/tests/errors/enotdir.rs
+++ b/tests/pjdfstest/src/tests/errors/enotdir.rs
@@ -1,0 +1,83 @@
+/// Create a test case which asserts that the syscall returns ENOTDIR
+/// if a component of the path prefix is not a directory.
+/// There are multiple forms for this macro:
+///
+/// - A basic form which takes the syscall, and optionally a `~path` argument
+///   to indicate where the `path` argument should be substituted if the path
+///   is not the only argument taken by the syscall.
+///
+/// ```
+/// // `unlink` accepts only a path as argument.
+/// enotdir_comp_test_case!(unlink);
+/// // `chflags` takes a path and the flags to set as arguments.
+/// // We need to add `~path` where the path argument should normally be taken.
+/// enotdir_comp_test_case!(chflags(~path, FileFlags::empty()));
+/// ```
+///
+/// - A more complex form which takes multiple functions
+///   with the context and the path as arguments for syscalls
+///   requring to compute other arguments.
+///
+/// ```
+/// enotdir_comp_test_case!(chown, |ctx: &mut TestContext, path: &Path| {
+///   let user = ctx.get_new_user();
+///   chown(path, Some(user.uid), None)
+/// })
+/// ```
+macro_rules! enotdir_comp_test_case {
+    ($syscall: ident, $f: expr) => {
+        crate::test_case! {
+            #[doc = concat!(stringify!($syscall),
+                 " returns ENOTDIR if a component of the path prefix is not a directory")]
+            enotdir_component => [Regular, Fifo, Block, Char, Socket]
+        }
+        fn enotdir_component(ctx: &mut crate::context::TestContext,
+                            ft: crate::context::FileType) {
+            let base_path = ctx.create(ft.clone()).unwrap();
+            let path = base_path.join("previous_not_dir");
+
+            assert_eq!($f(ctx, &path).unwrap_err(), nix::errno::Errno::ENOTDIR)
+        }
+    };
+
+    ($syscall: ident $( ($( $($before:expr),* ,)? ~path $(, $($after:expr),*)?) )?) => {
+        enotdir_comp_test_case!($syscall, |_ctx: &mut crate::context::TestContext,
+                                             path: &std::path::Path| {
+                $syscall($( $($($before),* ,)? )? path $( $(, $($after),*)? )?)
+        });
+    };
+}
+
+/// Create a test case which asserts that the syscall returns ENOTDIR
+/// if a component of either path prefix is not a directory.
+/// It takes the syscall as its only argument.
+/// ```
+/// enotdir_comp_either_test_case!(rename);
+/// ```
+macro_rules! enotdir_comp_either_test_case {
+    ($syscall: ident) => {
+        crate::test_case! {
+            #[doc = concat!(stringify!($syscall),
+                 " returns ENOTDIR if a component of either path prefix is not a directory")]
+            enotdir_component_either => [Regular, Fifo, Block, Char, Socket]
+        }
+        fn enotdir_component_either(
+            ctx: &mut crate::context::TestContext,
+            ft: crate::context::FileType,
+        ) {
+            let file = ctx.create(ft.clone()).unwrap();
+            let path = file.join("previous_not_dir");
+            let new_path = ctx.gen_path();
+
+            assert_eq!($syscall(&*path, &*new_path).unwrap_err(), Errno::ENOTDIR);
+
+            let new_base_path = ctx.create(ft.clone()).unwrap();
+            let new_path = new_base_path.join("previous_not_dir");
+
+            assert_eq!($syscall(&*file, &*new_path).unwrap_err(), Errno::ENOTDIR);
+        }
+    };
+}
+
+pub(crate) use enotdir_comp_either_test_case;
+pub(crate) use enotdir_comp_test_case;

--- a/tests/pjdfstest/src/tests/errors/erofs.rs
+++ b/tests/pjdfstest/src/tests/errors/erofs.rs
@@ -1,0 +1,182 @@
+use std::{
+    panic::{catch_unwind, resume_unwind, AssertUnwindSafe},
+    path::Path,
+    process::Command,
+};
+
+use crate::utils::get_mountpoint;
+
+enum RemountOptions {
+    ReadOnly,
+    ReadWrite,
+}
+
+/// Guard to allow execution of this test only if it's allowed to run.
+pub(crate) fn can_run_erofs(conf: &crate::config::Config, _: &Path) -> anyhow::Result<()> {
+    if !conf.settings.allow_remount {
+        anyhow::bail!("Remounts (allow_remount) are not allowed in the configuration file")
+    }
+
+    Ok(())
+}
+
+/// Remount the file system mounted at `mountpoint` with the provided options.
+fn remount<P: AsRef<Path>>(mountpoint: P, options: RemountOptions) -> Result<(), anyhow::Error> {
+    if mountpoint.as_ref().parent().is_none() {
+        anyhow::bail!("Cannot remount root file system")
+    }
+
+    let opt = match options {
+        RemountOptions::ReadOnly => "ro",
+        RemountOptions::ReadWrite => "rw",
+    };
+
+    #[cfg(target_os = "linux")]
+    let opt = format!("remount,{opt}");
+
+    let mut cmd = Command::new("mount");
+
+    #[cfg(any(
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "dragonfly"
+    ))]
+    cmd.arg("-u");
+
+    // XXX: It is possible to do it directly with mount(2) but we use the CLI for now
+    let mount_result = cmd.arg("-o").arg(opt).arg(mountpoint.as_ref()).output()?;
+
+    if !mount_result.status.success() {
+        anyhow::bail!(
+            "Failed to remount: {}",
+            String::from_utf8_lossy(&mount_result.stderr)
+        )
+    }
+
+    Ok(())
+}
+
+/// Execute a function with a read-only file system and restore read/write flags after.
+// TODO: Get the original flags
+pub(crate) fn with_readonly_fs<F, P: AsRef<Path>>(path: P, f: F)
+where
+    F: FnOnce(),
+{
+    let mountpoint = get_mountpoint(path.as_ref()).unwrap();
+
+    remount(mountpoint, RemountOptions::ReadOnly).unwrap();
+
+    let res = catch_unwind(AssertUnwindSafe(f));
+
+    remount(mountpoint, RemountOptions::ReadWrite).unwrap();
+
+    if let Err(e) = res {
+        resume_unwind(e);
+    }
+}
+
+/// Create a test case which asserts that the syscall returns EROFS
+/// if the path resides on a read-only file system.
+/// There are multiple forms for this macro:
+///
+/// - A basic form which takes the syscall, and optionally a `~path` argument
+///   to indicate where the `path` argument should be substituted if the path
+///   is not the only argument taken by the syscall.
+///
+/// ```
+/// // `unlink` accepts only a path as argument.
+/// erofs_new_file_test_case!(unlink);
+/// // `chflags` takes a path and the flags to set as arguments.
+/// // We need to add `~path` where the path argument should normally be taken.
+/// erofs_new_file_test_case!(chflags(~path, FileFlags::empty()));
+/// ```
+///
+/// - A more complex form which takes multiple functions
+///   with the context and the path as arguments for syscalls
+///   requring to compute other arguments.
+///
+/// ```
+/// erofs_new_file_test_case!(chown, |ctx: &mut TestContext, path: &Path| {
+///   let user = ctx.get_new_user();
+///   chown(path, Some(user.uid), None)
+/// })
+/// ```
+macro_rules! erofs_new_file_test_case {
+    ($syscall: ident, $($f: expr),+) => {
+        crate::test_case! {
+            #[doc = concat!(stringify!($syscall),
+                 " returns EROFS if the path for the file to be created resides on a read-only file system")]
+            erofs_new_file, serialized, root; crate::tests::errors::erofs::can_run_erofs
+        }
+        fn erofs_new_file(ctx: &mut crate::context::SerializedTestContext) {
+            use crate::tests::errors::erofs::with_readonly_fs;
+            let path = ctx.base_path().to_owned();
+            let file = ctx.gen_path();
+            with_readonly_fs(path, || {
+                $( assert_eq!($f(ctx, &file), Err(nix::errno::Errno::EROFS)); )+
+            });
+        }
+    };
+
+    ($syscall: ident $( ($( $($before:expr),* ,)? ~path $(, $($after:expr),*)?) )?) => {
+        crate::tests::errors::erofs::erofs_new_file_test_case!($syscall, |_ctx, path: &std::path::Path| {
+                $syscall($( $($($before),* ,)? )? path $( $(, $($after),*)? )?)
+        });
+    };
+}
+
+pub(crate) use erofs_new_file_test_case;
+
+/// Create a test case which asserts that the syscall returns EROFS
+/// if the named file resides on a read-only file system.
+/// There are multiple forms for this macro:
+///
+/// - A basic form which takes the syscall, and optionally a `~path` argument
+///   to indicate where the `path` argument should be substituted if the path
+///   is not the only argument taken by the syscall.
+///
+/// ```
+/// // `unlink` accepts only a path as argument.
+/// erofs_test_case!(unlink);
+/// // `chflags` takes a path and the flags to set as arguments.
+/// // We need to add `~path` where the path argument should normally be taken.
+/// erofs_test_case!(chflags(~path, FileFlags::empty()));
+/// ```
+///
+/// - A more complex form which takes multiple functions
+///   with the context and the path as arguments for syscalls
+///   requring to compute other arguments.
+///
+/// ```
+/// erofs_test_case!(chown, |ctx: &mut TestContext, path: &Path| {
+///   let user = ctx.get_new_user();
+///   chown(path, Some(user.uid), None)
+/// })
+/// ```
+macro_rules! erofs_named_test_case {
+    ($syscall: ident, $($f: expr),+) => {
+        crate::test_case! {
+            #[doc = concat!(stringify!($syscall),
+                 " returns EROFS if the named file resides on a read-only file system")]
+            erofs_named, serialized, root; crate::tests::errors::erofs::can_run_erofs
+        }
+        fn erofs_named(ctx: &mut crate::context::SerializedTestContext) {
+            use crate::tests::errors::erofs::with_readonly_fs;
+            use crate::context::FileType;
+            let path = ctx.base_path().to_owned();
+            let file = ctx.new_file(FileType::Regular).name(path.join("file")).create().unwrap();
+            with_readonly_fs(path, || {
+                $( assert_eq!($f(ctx, &file), Err(nix::errno::Errno::EROFS)); )+
+            });
+        }
+    };
+
+    ($syscall: ident $( ($( $($before:expr),* ,)? ~path $(, $($after:expr),*)?) )?) => {
+        crate::tests::errors::erofs::erofs_named_test_case!($syscall, |_ctx, path: &std::path::Path| {
+                $syscall($( $($($before),* ,)? )? path $( $(, $($after),*)? )?)
+        });
+    };
+}
+
+pub(crate) use erofs_named_test_case;

--- a/tests/pjdfstest/src/tests/errors/exdev.rs
+++ b/tests/pjdfstest/src/tests/errors/exdev.rs
@@ -1,0 +1,44 @@
+use std::path::Path;
+
+use crate::config::Config;
+
+/// Guard which checks if a secondary file system has been configured.
+pub(crate) fn secondary_fs_available(config: &Config, _: &Path) -> anyhow::Result<()> {
+    config.features.secondary_fs.as_ref().map_or_else(
+        || {
+            Err(anyhow::anyhow!(
+                "No secondary file-system has been configured."
+            ))
+        },
+        |_| Ok(()),
+    )
+}
+
+/// Create a test-case for a syscall which returns `EXDEV` when the target is on a different file-system.
+/// The test-case will be skipped if no secondary file system has been configured.
+///
+/// ```rust,ignore
+/// exdev_target_test_case!(link);
+/// ```
+macro_rules! exdev_target_test_case {
+    ($syscall: ident) => {
+        crate::test_case! {
+            #[doc = concat!(stringify!($syscall),
+            " returns EXDEV when the target is on a different file-system")]
+            exdev_target; crate::tests::errors::exdev::secondary_fs_available
+        }
+        fn exdev_target(ctx: &mut crate::TestContext) {
+            let path = ctx.create(crate::context::FileType::Regular).unwrap();
+            let other_fs_path = ctx
+                .features_config()
+                .secondary_fs
+                .as_ref()
+                .unwrap()
+                .join("file");
+
+            assert_eq!($syscall(&path, &other_fs_path), Err(Errno::EXDEV));
+        }
+    };
+}
+
+pub(crate) use exdev_target_test_case;

--- a/tests/pjdfstest/src/tests/ftruncate.rs
+++ b/tests/pjdfstest/src/tests/ftruncate.rs
@@ -1,0 +1,129 @@
+use std::{fs::File, io::Write};
+
+use nix::{
+    errno::Errno,
+    fcntl::OFlag,
+    sys::stat::{lstat, Mode},
+    unistd::ftruncate,
+};
+use rand::random;
+
+use crate::{
+    context::FileType,
+    test::{SerializedTestContext, TestContext},
+    tests::{assert_ctime_changed, assert_ctime_unchanged},
+    utils::{chmod, open},
+};
+
+crate::test_case! {
+    /// ftruncate should extend a file, and shrink a sparse file
+    // ftruncate/00.t
+    extend_file_shrink_sparse
+}
+fn extend_file_shrink_sparse(ctx: &mut TestContext) {
+    let (path, file) = ctx.create_file(OFlag::O_RDWR, None).unwrap();
+    let size = 1234567;
+    assert!(ftruncate(file, size).is_ok());
+
+    let actual_size = lstat(&path).unwrap().st_size;
+    assert_eq!(actual_size, size);
+
+    let wronly_file = open(&path, OFlag::O_WRONLY, Mode::empty()).unwrap();
+    let size = 567;
+    assert!(ftruncate(wronly_file, size).is_ok());
+
+    let actual_size = lstat(&path).unwrap().st_size;
+    assert_eq!(actual_size, size);
+}
+
+crate::test_case! {
+    /// ftruncate should shrink the file if the specified size is less than the actual one
+    // ftruncate/00.t
+    shrink_not_empty
+}
+fn shrink_not_empty(ctx: &mut TestContext) {
+    let (path, file) = ctx.create_file(OFlag::O_RDWR, None).unwrap();
+    let size = 23456;
+    let random_data: [u8; 12345] = random();
+    File::create(&path)
+        .unwrap()
+        .write_all(&random_data)
+        .unwrap();
+
+    assert!(ftruncate(file, size).is_ok());
+    let actual_size = lstat(&path).unwrap().st_size;
+    assert_eq!(actual_size, size);
+
+    let wronly_file = open(&path, OFlag::O_WRONLY, Mode::empty()).unwrap();
+
+    let size = 1;
+    assert!(ftruncate(wronly_file, size).is_ok());
+    let actual_size = lstat(&path).unwrap().st_size;
+    assert_eq!(actual_size, size);
+}
+
+crate::test_case! {
+    /// ftruncate should update ctime if it succeeds
+    // ftruncate/00.t
+    update_ctime_success
+}
+fn update_ctime_success(ctx: &mut TestContext) {
+    let (path, file) = ctx.create_file(OFlag::O_RDWR, Some(0o644)).unwrap();
+
+    assert_ctime_changed(ctx, &path, || {
+        assert!(ftruncate(file, 123).is_ok());
+    });
+}
+
+crate::test_case! {
+    /// ftruncate should not update ctime if it fails
+    // ftruncate/00.t
+    unchanged_ctime_failed
+}
+fn unchanged_ctime_failed(ctx: &mut TestContext) {
+    let (path, file) = ctx.create_file(OFlag::O_RDONLY, Some(0o644)).unwrap();
+
+    assert_ctime_unchanged(ctx, &path, || {
+        assert_eq!(ftruncate(file, 123).unwrap_err(), Errno::EINVAL);
+    });
+}
+
+crate::test_case! {
+    /// The file mode of a newly created file should not affect whether ftruncate
+    /// will work, only the create args
+    /// https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=154873
+    // ftruncate/00.t
+    affected_create_flags_only, serialized, root
+}
+fn affected_create_flags_only(ctx: &mut SerializedTestContext) {
+    let subdir = ctx.create(FileType::Dir).unwrap();
+    let path = subdir.join("test");
+
+    let file = open(&path, OFlag::O_CREAT | OFlag::O_RDWR, Mode::empty()).unwrap();
+    assert!(ftruncate(file, 0).is_ok());
+
+    chmod(&subdir, Mode::from_bits_truncate(0o777)).unwrap();
+
+    let path = subdir.join("unprivileged");
+
+    let user = ctx.get_new_user();
+
+    ctx.as_user(user, None, || {
+        let file = open(&path, OFlag::O_CREAT | OFlag::O_RDWR, Mode::empty()).unwrap();
+        assert!(ftruncate(file, 0).is_ok());
+    });
+}
+
+crate::test_case! {
+    /// ftruncate returns EINVAL if the length argument was less than 0
+    // ftruncate/13.t
+    einval_negative_length
+}
+fn einval_negative_length(ctx: &mut TestContext) {
+    let path = ctx.create(FileType::Regular).unwrap();
+
+    let file = open(&path, OFlag::O_RDWR, Mode::empty()).unwrap();
+    assert_eq!(ftruncate(file, -1), Err(Errno::EINVAL));
+    let file = open(&path, OFlag::O_WRONLY, Mode::empty()).unwrap();
+    assert_eq!(ftruncate(file, nix::libc::off_t::MIN), Err(Errno::EINVAL));
+}

--- a/tests/pjdfstest/src/tests/link.rs
+++ b/tests/pjdfstest/src/tests/link.rs
@@ -1,0 +1,251 @@
+use nix::{
+    errno::Errno,
+    sys::stat::{lstat, Mode},
+    unistd::pathconf,
+    unistd::{chown, unlink},
+};
+
+use std::path::Path;
+
+use super::{
+    errors::{
+        efault::efault_either_test_case,
+        eloop::eloop_either_test_case,
+        enametoolong::{enametoolong_either_comp_test_case, enametoolong_either_path_test_case},
+        erofs::erofs_named_test_case,
+        exdev::exdev_target_test_case,
+    },
+    CTIME, MTIME,
+};
+
+use crate::config::Config;
+use crate::{
+    context::{FileType, SerializedTestContext, TestContext},
+    tests::{
+        assert_times_changed, assert_times_unchanged,
+        errors::enoent::enoent_either_named_file_test_case,
+        errors::enotdir::enotdir_comp_either_test_case, AsTimeInvariant,
+    },
+    utils::{chmod, link},
+};
+
+crate::test_case! {
+    /// link creates hardlinks which share the same metadata
+    // link/00.t#23-41
+    share_metadata, root => [Regular, Fifo, Block, Char, Socket]
+}
+fn share_metadata(ctx: &mut TestContext, ft: FileType) {
+    let file = ctx.create(ft).unwrap();
+    let file_stat = lstat(&file).unwrap();
+    assert_eq!(file_stat.st_nlink, 1);
+
+    let first_link = ctx.gen_path();
+    link(&file, &first_link).unwrap();
+    let file_stat = lstat(&file).unwrap();
+    let first_link_stat = lstat(&first_link).unwrap();
+    assert_eq!(file_stat.st_nlink, 2);
+    assert_eq!(file_stat.st_nlink, first_link_stat.st_nlink);
+    assert_eq!(
+        file_stat.as_time_invariant(),
+        first_link_stat.as_time_invariant()
+    );
+
+    let second_link = ctx.gen_path();
+    link(&first_link, &second_link).unwrap();
+
+    let file_stat = lstat(&file).unwrap();
+    let first_link_stat = lstat(&first_link).unwrap();
+    let second_link_stat = lstat(&second_link).unwrap();
+    assert_eq!(file_stat.st_nlink, 3);
+    assert_eq!(file_stat.st_nlink, first_link_stat.st_nlink);
+    assert_eq!(
+        file_stat.as_time_invariant(),
+        first_link_stat.as_time_invariant()
+    );
+    assert_eq!(
+        first_link_stat.as_time_invariant(),
+        second_link_stat.as_time_invariant()
+    );
+
+    chmod(&first_link, Mode::from_bits_truncate(0o201)).unwrap();
+    let user = ctx.get_new_user();
+    let group = ctx.get_new_group();
+    chown(&first_link, Some(user.uid), Some(group.gid)).unwrap();
+
+    let first_link_stat = lstat(&first_link).unwrap();
+    let file_stat = lstat(&file).unwrap();
+    let second_link_stat = lstat(&second_link).unwrap();
+    assert_eq!(
+        file_stat.as_time_invariant(),
+        first_link_stat.as_time_invariant()
+    );
+    assert_eq!(
+        first_link_stat.as_time_invariant(),
+        second_link_stat.as_time_invariant()
+    );
+}
+
+crate::test_case! {
+    /// Removing a link should only change the number of links
+    // link/00.t
+    remove_link => [Regular, Fifo, Block, Char, Socket]
+}
+fn remove_link(ctx: &mut TestContext, ft: FileType) {
+    let file = ctx.create(ft).unwrap();
+    let first_link = ctx.gen_path();
+    let second_link = ctx.gen_path();
+
+    link(&file, &first_link).unwrap();
+    link(&first_link, &second_link).unwrap();
+
+    unlink(&file).unwrap();
+    assert!(!file.exists());
+
+    let first_link_stat = lstat(&first_link).unwrap();
+    let second_link_stat = lstat(&second_link).unwrap();
+    assert_eq!(first_link_stat.st_nlink, 2);
+    assert_eq!(
+        first_link_stat.as_time_invariant(),
+        second_link_stat.as_time_invariant()
+    );
+
+    unlink(&second_link).unwrap();
+    assert!(!second_link.exists());
+
+    let first_link_stat = lstat(&first_link).unwrap();
+    assert_eq!(first_link_stat.st_nlink, 1);
+
+    unlink(&first_link).unwrap();
+    assert!(!first_link.exists());
+}
+
+crate::test_case! {
+    /// link changes ctime of file along with ctime and mtime of parent when sucessful
+    // link/00.t
+    changed_ctime_success => [Regular, Fifo, Block, Char, Socket]
+}
+fn changed_ctime_success(ctx: &mut TestContext, ft: FileType) {
+    let file = ctx.create(ft).unwrap();
+    let new_path = ctx.gen_path();
+
+    assert_times_changed()
+        .path(&file, CTIME)
+        .path(ctx.base_path(), CTIME | MTIME)
+        .execute(ctx, false, || {
+            assert!(link(&file, &new_path).is_ok());
+        });
+}
+crate::test_case! {
+    /// link changes neither ctime of file nor ctime or mtime of parent when it fails
+    // link/00.t#77
+    unchanged_ctime_fails, serialized, root => [Regular, Fifo, Block, Char, Socket]
+}
+fn unchanged_ctime_fails(ctx: &mut SerializedTestContext, ft: FileType) {
+    let file = ctx.create(ft).unwrap();
+    let new_path = ctx.gen_path();
+
+    let user = ctx.get_new_user();
+    assert_times_unchanged()
+        .path(&file, CTIME)
+        .path(ctx.base_path(), CTIME | MTIME)
+        .execute(ctx, false, || {
+            ctx.as_user(user, None, || {
+                assert!(matches!(
+                    link(&file, &new_path),
+                    Err(Errno::EPERM | Errno::EACCES)
+                ));
+            })
+        });
+}
+
+// link/01.t
+enotdir_comp_either_test_case!(link);
+
+const LINK_MAX_LIMIT: i64 = 65535;
+
+// BUG: Some systems return bogus value, and testing directories
+// might give different result than trying directly on the file
+fn has_reasonable_link_max(_: &Config, base_path: &Path) -> anyhow::Result<()> {
+    let link_max = pathconf(base_path, nix::unistd::PathconfVar::LINK_MAX)?
+        .ok_or_else(|| anyhow::anyhow!("Failed to get LINK_MAX value"))?;
+
+    // pathconf(_PC_LINK_MAX) on Linux returns 127 (LINUX_LINK_MAX) if the filesystem limit is unknown...
+    #[cfg(target_os = "linux")]
+    if link_max == 127 {
+        anyhow::bail!("Cannot get value for LINK_MAX: filesystem limit is unknown");
+    }
+
+    if link_max >= LINK_MAX_LIMIT {
+        anyhow::bail!(
+            "LINK_MAX value is too high ({link_max}, expected smaller than {LINK_MAX_LIMIT})"
+        );
+    }
+
+    Ok(())
+}
+
+crate::test_case! {
+    /// link returns EMLINK if the link count of the file named by name1 would exceed {LINK_MAX}
+    // link/05.t
+    link_count_max; has_reasonable_link_max
+}
+fn link_count_max(ctx: &mut TestContext) {
+    let file = ctx.create(FileType::Regular).unwrap();
+    let link_max = pathconf(&file, nix::unistd::PathconfVar::LINK_MAX)
+        .unwrap()
+        .unwrap();
+
+    for _ in 0..link_max - 1 {
+        link(&file, &ctx.gen_path()).unwrap();
+    }
+
+    assert_eq!(link(&file, &ctx.gen_path()), Err(Errno::EMLINK));
+}
+
+// link/02.t
+enametoolong_either_comp_test_case!(link);
+
+// link/03.t
+enametoolong_either_path_test_case!(link);
+
+// link/04.t
+enoent_either_named_file_test_case!(link);
+
+// link/08.t
+eloop_either_test_case!(link);
+
+// link/16.t
+erofs_named_test_case!(link, |ctx: &mut TestContext, file| {
+    let path = ctx.gen_path();
+    link(file, &path)
+});
+
+// link/09.t
+crate::test_case! {
+    /// link returns ENOENT if the source file does not exist
+    enoent_source_not_exists
+}
+fn enoent_source_not_exists(ctx: &mut TestContext) {
+    let source = ctx.gen_path();
+    let dest = ctx.gen_path();
+
+    assert_eq!(link(&source, &dest), Err(Errno::ENOENT));
+}
+
+crate::test_case! {
+    /// link returns EEXIST if the destination file exists
+    // link/10.t
+    eexist_dest_exists => [Regular, Dir, Fifo, Block, Char, Socket, Symlink(None)]
+}
+fn eexist_dest_exists(ctx: &mut TestContext, ft: FileType) {
+    let path = ctx.create(ft).unwrap();
+    let regular_file = ctx.create(FileType::Regular).unwrap();
+
+    assert_eq!(link(&regular_file, &path), Err(nix::errno::Errno::EEXIST));
+}
+
+// link/14.t
+exdev_target_test_case!(link);
+
+// link/17.t
+efault_either_test_case!(link, nix::libc::link);

--- a/tests/pjdfstest/src/tests/mkdir.rs
+++ b/tests/pjdfstest/src/tests/mkdir.rs
@@ -1,0 +1,79 @@
+use std::fs::FileType;
+
+use nix::{sys::stat::Mode, unistd::mkdir};
+
+use crate::context::{SerializedTestContext, TestContext};
+
+use super::errors::eexist::eexist_file_exists_test_case;
+use super::errors::efault::efault_path_test_case;
+use super::errors::eloop::eloop_comp_test_case;
+use super::errors::enametoolong::{enametoolong_comp_test_case, enametoolong_path_test_case};
+use super::errors::enoent::enoent_comp_test_case;
+use super::errors::erofs::erofs_new_file_test_case;
+use super::mksyscalls::{assert_perms_from_mode_and_umask, assert_uid_gid};
+use super::{assert_times_changed, errors::enotdir::enotdir_comp_test_case, ATIME, CTIME, MTIME};
+
+crate::test_case! {
+    /// POSIX: The file permission bits of the new directory shall be initialized from
+    /// mode. These file permission bits of the mode argument shall be modified by the
+    /// process' file creation mask.
+    // mkdir/00.t
+    permission_bits_from_mode, serialized
+}
+fn permission_bits_from_mode(ctx: &mut SerializedTestContext) {
+    assert_perms_from_mode_and_umask(ctx, mkdir, FileType::is_dir);
+}
+
+crate::test_case! {
+    /// POSIX: The directory's user ID shall be set to the process' effective user ID.
+    /// The directory's group ID shall be set to the group ID of the parent directory
+    /// or to the effective group ID of the process.
+    // mkdir/00.t
+    uid_gid_eq_euid_egid, serialized, root
+}
+fn uid_gid_eq_euid_egid(ctx: &mut SerializedTestContext) {
+    assert_uid_gid(ctx, mkdir);
+}
+
+crate::test_case! {
+    /// POSIX: Upon successful completion, mkdir() shall mark for update the st_atime,
+    /// st_ctime, and st_mtime fields of the directory. Also, the st_ctime and
+    /// st_mtime fields of the directory that contains the new entry shall be marked
+    /// for update.
+    // mkdir/00.t
+    changed_time_fields_success
+}
+fn changed_time_fields_success(ctx: &mut TestContext) {
+    let path = ctx.gen_path();
+
+    assert_times_changed()
+        .path(ctx.base_path(), CTIME | MTIME)
+        .paths(ctx.base_path(), &path, ATIME | CTIME | MTIME)
+        .execute(ctx, false, || {
+            mkdir(&path, Mode::from_bits_truncate(0o755)).unwrap();
+        });
+}
+
+// mkdir/01.t
+enotdir_comp_test_case!(mkdir(~path, Mode::empty()));
+
+// mkdir/02.t
+enametoolong_comp_test_case!(mkdir(~path, Mode::empty()));
+
+// mkdir/03.t
+enametoolong_path_test_case!(mkdir(~path, Mode::empty()));
+
+// mkdir/04.t
+enoent_comp_test_case!(mkdir(~path, Mode::empty()));
+
+// mkdir/07.t
+eloop_comp_test_case!(mkdir(~path, Mode::empty()));
+
+// mkdir/09.t
+erofs_new_file_test_case!(mkdir(~path, Mode::empty()));
+
+// mkdir/10.t
+eexist_file_exists_test_case!(mkdir(~path, Mode::empty()));
+
+// mkdir/12.t
+efault_path_test_case!(mkdir, |ptr| nix::libc::mkdir(ptr, 0o755));

--- a/tests/pjdfstest/src/tests/mksyscalls.rs
+++ b/tests/pjdfstest/src/tests/mksyscalls.rs
@@ -1,0 +1,120 @@
+//! Builder functions for `mk`-family syscalls tests.
+
+use std::{
+    fs::{metadata, FileType},
+    os::unix::prelude::PermissionsExt,
+    path::Path,
+};
+
+use nix::{
+    sys::stat::{lstat, mode_t, Mode},
+    unistd::{chown, Gid, Uid, User},
+};
+
+use crate::{
+    context::SerializedTestContext,
+    utils::{chmod, ALLPERMS},
+};
+
+/// Assert that the created entry gets its permission bits from the mode
+/// provided to the function negated by the process's file creation mask
+/// (umask), and its file type is equal to the expected one.
+pub(super) fn assert_perms_from_mode_and_umask<F, T, C>(
+    ctx: &mut SerializedTestContext,
+    f: F,
+    f_type_check: C,
+) where
+    F: Fn(&Path, Mode) -> nix::Result<T>,
+    C: Fn(&FileType) -> bool,
+{
+    fn assert_perm<F, T, C>(
+        ctx: &SerializedTestContext,
+        mode: mode_t,
+        expected_mode: mode_t,
+        f: F,
+        f_type_check: C,
+    ) where
+        F: Fn(&Path, Mode) -> nix::Result<T>,
+        C: Fn(&FileType) -> bool,
+    {
+        let path = ctx.gen_path();
+        assert!(f(&path, Mode::from_bits_truncate(mode)).is_ok());
+        let meta = metadata(&path).unwrap();
+        assert!(f_type_check(&meta.file_type()));
+        assert_eq!(
+            meta.permissions().mode() as mode_t & ALLPERMS,
+            expected_mode
+        );
+    }
+
+    /// Assert that the created entry permission bits equal `mode AND (NOT umask)`.
+    fn assert_perm_umask<F, T, C>(
+        ctx: &SerializedTestContext,
+        mode: mode_t,
+        umask: mode_t,
+        f: F,
+        check: C,
+    ) where
+        F: Fn(&Path, Mode) -> nix::Result<T>,
+        C: Fn(&FileType) -> bool,
+    {
+        ctx.with_umask(umask, || {
+            assert_perm(ctx, mode, mode & (!umask), f, check);
+        })
+    }
+
+    /// Assert that the created entry permission bits equal mode.
+    fn assert_perm_mode<F, T, C>(ctx: &SerializedTestContext, mode: mode_t, f: F, check: C)
+    where
+        F: Fn(&Path, Mode) -> nix::Result<T>,
+        C: Fn(&FileType) -> bool,
+    {
+        assert_perm(ctx, mode, mode, f, check);
+    }
+
+    assert_perm_mode(ctx, 0o755, &f, &f_type_check);
+    assert_perm_mode(ctx, 0o151, &f, &f_type_check);
+    assert_perm_umask(ctx, 0o151, 0o77, &f, &f_type_check);
+    assert_perm_umask(ctx, 0o345, 0o70, &f, &f_type_check);
+    assert_perm_umask(ctx, 0o501, 0o345, f, f_type_check);
+}
+
+/// Assert that the entry's user ID is set to the process' effective user ID and
+/// the entry's group ID should be set to the group ID of the parent directory
+/// or the effective group ID of the process.
+pub(super) fn assert_uid_gid<F, T>(ctx: &mut SerializedTestContext, f: F)
+where
+    F: Fn(&Path, Mode) -> nix::Result<T>,
+{
+    fn doit<F, T>(ctx: &SerializedTestContext, user: &User, gid: Option<Gid>, f: F)
+    where
+        F: Fn(&Path, Mode) -> nix::Result<T>,
+    {
+        let path = ctx.gen_path();
+        ctx.as_user(user, gid.map(|g| vec![g]).as_deref(), || {
+            f(&path, Mode::from_bits_truncate(0o755)).unwrap();
+        });
+
+        let filestat = lstat(&path).unwrap();
+        assert_eq!(filestat.st_uid, user.uid.as_raw());
+
+        let egid = gid.unwrap_or(user.gid).as_raw();
+        let dirstat = lstat(ctx.base_path()).unwrap();
+        assert!(filestat.st_gid == egid || filestat.st_gid == dirstat.st_gid);
+    }
+
+    let user = User::from_uid(Uid::effective()).unwrap().unwrap();
+    doit(ctx, &user, None, &f);
+
+    let user = ctx.get_new_user();
+    // To check that the entry gid is either parent gid or egid
+    chown(ctx.base_path(), Some(user.uid), Some(user.gid)).unwrap();
+
+    let (other_user, group) = ctx.get_new_entry();
+    doit(ctx, user, Some(group.gid), &f);
+
+    chmod(ctx.base_path(), Mode::from_bits_truncate(ALLPERMS)).unwrap();
+
+    let group = ctx.get_new_group();
+    doit(ctx, other_user, Some(group.gid), f);
+}

--- a/tests/pjdfstest/src/tests/mod.rs
+++ b/tests/pjdfstest/src/tests/mod.rs
@@ -1,0 +1,284 @@
+//! Where the tests are defined.
+//!
+//! This module contains the tests for the file system test suite. The tests are defined as functions
+//! which are then registered with the test suite.
+//!
+//! The tests are defined using the `test_case!` macro, which is used to define a test case for the test suite.
+//!
+//! It also contains some helper functions and macros which are used to define the tests.
+
+use std::fs::symlink_metadata;
+use std::ops::{BitAnd, BitOr};
+use std::os::unix::fs::MetadataExt as StdMetadataExt;
+
+use std::{fs::metadata, path::Path};
+
+use nix::sys::time::TimeSpec;
+
+use crate::test::TestContext;
+
+// chflags: stripped — BSD-only syscall, not present in vibix.
+pub mod chmod;
+pub mod chown;
+pub mod errors;
+pub mod ftruncate;
+pub mod link;
+pub mod mkdir;
+// mkfifo: stripped — vibix does not support FIFOs.
+// mknod: stripped — vibix does not support device-node creation from userspace.
+mod mksyscalls;
+// nfsv4acl: stripped — vibix has no ACL support.
+pub mod open;
+// posix_fallocate: stripped — vibix has no fallocate.
+pub mod rename;
+pub mod rmdir;
+pub mod symlink;
+pub mod truncate;
+pub mod unlink;
+pub mod utimensat;
+
+/// Argument to set which fields should be compared for [`TimeAssertion::path`].
+#[derive(Debug, Clone, Copy)]
+struct TimestampField(u32);
+
+const ATIME: TimestampField = TimestampField(0b001);
+const CTIME: TimestampField = TimestampField(0b010);
+const MTIME: TimestampField = TimestampField(0b100);
+
+impl PartialEq<u32> for TimestampField {
+    fn eq(&self, other: &u32) -> bool {
+        self.0 == *other
+    }
+}
+
+impl BitAnd for TimestampField {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        Self(self.0 & rhs.0)
+    }
+}
+
+impl BitOr for TimestampField {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+    }
+}
+
+/// A handy extention to std::os::unix::fs::MetadataExt
+trait MetadataExt: StdMetadataExt {
+    /// Return the file's last accessed time as a `TimeSpec`, including
+    /// fractional component.
+    fn atime_ts(&self) -> TimeSpec {
+        TimeSpec::new(self.atime(), self.atime_nsec())
+    }
+
+    /// Return the file's last changed time as a `TimeSpec`, including
+    /// fractional component.
+    fn ctime_ts(&self) -> TimeSpec {
+        TimeSpec::new(self.ctime(), self.ctime_nsec())
+    }
+
+    /// Return the file's last modified time as a `TimeSpec`, including
+    /// fractional component.
+    fn mtime_ts(&self) -> TimeSpec {
+        TimeSpec::new(self.mtime(), self.mtime_nsec())
+    }
+}
+
+impl<T: StdMetadataExt> MetadataExt for T {}
+
+/// Metadata which isn't related to time.
+#[derive(Debug, PartialEq)]
+struct InvariantTimeMetadata {
+    st_dev: nix::libc::dev_t,
+    st_ino: nix::libc::ino_t,
+    st_mode: nix::libc::mode_t,
+    st_nlink: nix::libc::nlink_t,
+    st_uid: nix::libc::uid_t,
+    st_gid: nix::libc::gid_t,
+    st_rdev: nix::libc::dev_t,
+    st_size: nix::libc::off_t,
+    st_blksize: nix::libc::blksize_t,
+    st_blocks: nix::libc::blkcnt_t,
+}
+
+trait AsTimeInvariant {
+    fn as_time_invariant(&self) -> InvariantTimeMetadata;
+}
+
+impl AsTimeInvariant for nix::sys::stat::FileStat {
+    fn as_time_invariant(&self) -> InvariantTimeMetadata {
+        InvariantTimeMetadata {
+            st_dev: self.st_dev,
+            st_ino: self.st_ino,
+            st_mode: self.st_mode,
+            st_nlink: self.st_nlink,
+            st_uid: self.st_uid,
+            st_gid: self.st_gid,
+            st_rdev: self.st_rdev,
+            st_size: self.st_size,
+            st_blksize: self.st_blksize,
+            st_blocks: self.st_blocks,
+        }
+    }
+}
+
+#[cfg(birthtime)]
+// Note: can't be a method of MetadataExt, because StdMetadataExt lacks a
+// birthtime() method.
+fn birthtime_ts(path: &Path) -> TimeSpec {
+    use nix::sys::stat::stat;
+
+    let sb = stat(path).unwrap();
+    TimeSpec::new(sb.st_birthtime, sb.st_birthtime_nsec)
+}
+
+#[derive(Debug)]
+#[must_use]
+/// Builder to create a time metadata assertion,
+/// which compares metadata between pairs of paths.
+struct TimeAssertion<'a> {
+    compared_paths: Vec<(&'a Path, &'a Path, TimestampField)>,
+    equal: bool,
+}
+
+impl<'a> TimeAssertion<'a> {
+    /// Return a new builder.
+    /// Comparison will be an equality check if `equal` is true, or an ordering one if it is false.
+    pub fn new(equal: bool) -> Self {
+        Self {
+            compared_paths: vec![],
+            equal,
+        }
+    }
+
+    /// Add a path that should compare with itself.
+    pub fn path(self, path: &'a Path, fields: TimestampField) -> Self {
+        self.paths(path, path, fields)
+    }
+
+    /// Add paths that should compare.
+    pub fn paths(
+        mut self,
+        path_before: &'a Path,
+        path_after: &'a Path,
+        fields: TimestampField,
+    ) -> Self {
+        self.compared_paths.push((path_before, path_after, fields));
+        self
+    }
+
+    /// Build the assertion and asserts that `before` metadata
+    /// is either equal to or different from the `after` metadata.
+    pub fn execute<F>(self, ctx: &TestContext, no_follow_symlink: bool, f: F)
+    where
+        F: FnOnce(),
+    {
+        let get_metadata = if no_follow_symlink {
+            symlink_metadata
+        } else {
+            metadata
+        };
+
+        let metas_before: Vec<_> = self
+            .compared_paths
+            .iter()
+            .map(|&(path, _, fields)| {
+                let meta = get_metadata(path).unwrap();
+                (
+                    (fields & ATIME != 0).then(|| meta.atime_ts()),
+                    (fields & CTIME != 0).then(|| meta.ctime_ts()),
+                    (fields & MTIME != 0).then(|| meta.mtime_ts()),
+                )
+            })
+            .collect();
+
+        ctx.nap();
+
+        f();
+
+        let metas_after: Vec<_> = self
+            .compared_paths
+            .into_iter()
+            .map(|(_, path, fields)| {
+                let meta = get_metadata(path).unwrap();
+                (
+                    (fields & ATIME != 0).then(|| meta.atime_ts()),
+                    (fields & CTIME != 0).then(|| meta.ctime_ts()),
+                    (fields & MTIME != 0).then(|| meta.mtime_ts()),
+                )
+            })
+            .collect();
+
+        if self.equal {
+            assert!(
+                metas_before
+                    .iter()
+                    .zip(metas_after.iter())
+                    .all(|(mb, ma)| mb == ma),
+                "Timestamps changed but shouldn't have"
+            );
+        } else {
+            assert!(
+                metas_before
+                    .iter()
+                    .zip(metas_after.iter())
+                    .all(|(mb, ma)| mb != ma),
+                "Timestamps did not change as expected"
+            );
+        }
+    }
+}
+
+/// Alias for `TimeAssertion::new(false)`.
+fn assert_times_changed<'a>() -> TimeAssertion<'a> {
+    TimeAssertion::new(false)
+}
+
+/// Alias for `TimeAssertion::new(true)`.
+fn assert_times_unchanged<'a>() -> TimeAssertion<'a> {
+    TimeAssertion::new(true)
+}
+
+/// Assert that a certain operation changes the ctime of a file.
+fn assert_ctime_changed<F>(ctx: &TestContext, path: &Path, f: F)
+where
+    F: FnOnce(),
+{
+    assert_times_changed()
+        .path(path, CTIME)
+        .execute(ctx, false, f)
+}
+
+/// Assert that a certain operation changes the mtime of a file.
+fn assert_mtime_changed<F>(ctx: &TestContext, path: &Path, f: F)
+where
+    F: FnOnce(),
+{
+    assert_times_changed()
+        .path(path, MTIME)
+        .execute(ctx, false, f)
+}
+
+/// Assert that a certain operation does not change the ctime of a file.
+fn assert_ctime_unchanged<F>(ctx: &TestContext, path: &Path, f: F)
+where
+    F: FnOnce(),
+{
+    assert_times_unchanged()
+        .path(path, CTIME)
+        .execute(ctx, false, f)
+}
+
+/// Assert that a certain operation does not change the ctime of a file without following symlinks.
+fn assert_symlink_ctime_unchanged<F>(ctx: &TestContext, path: &Path, f: F)
+where
+    F: FnOnce(),
+{
+    assert_times_unchanged()
+        .path(path, CTIME)
+        .execute(ctx, true, f)
+}

--- a/tests/pjdfstest/src/tests/open.rs
+++ b/tests/pjdfstest/src/tests/open.rs
@@ -1,0 +1,351 @@
+use std::fs::{metadata, symlink_metadata, FileType as StdFileType};
+use std::os::fd::{FromRawFd, IntoRawFd, OwnedFd};
+use std::os::unix::prelude::{MetadataExt, RawFd};
+use std::path::Path;
+
+use nix::errno::Errno;
+use nix::fcntl::{open, OFlag};
+use nix::sys::stat::Mode;
+use nix::sys::uio::pwrite;
+use nix::unistd::close;
+
+use crate::context::{FileType, SerializedTestContext, TestContext};
+
+use super::errors::eexist::eexist_file_exists_test_case;
+use super::errors::efault::efault_path_test_case;
+use super::errors::eloop::eloop_comp_test_case;
+use super::errors::enametoolong::{enametoolong_comp_test_case, enametoolong_path_test_case};
+use super::errors::enoent::{enoent_comp_test_case, enoent_named_file_test_case};
+use super::errors::erofs::{erofs_named_test_case, erofs_new_file_test_case};
+// etxtbsy: stripped — vibix has no ETXTBSY semantics.
+use super::mksyscalls::{assert_perms_from_mode_and_umask, assert_uid_gid};
+use super::{assert_times_changed, assert_times_unchanged, ATIME, CTIME, MTIME};
+
+fn open_wrapper(path: &Path, mode: Mode) -> nix::Result<()> {
+    open(path, OFlag::O_CREAT | OFlag::O_WRONLY, mode).and_then(close)
+}
+
+crate::test_case! {
+    /// POSIX: (If O_CREAT is specified and the file doesn't exist) [...] the access
+    /// permission bits of the file mode shall be set to the value of the third
+    /// argument taken as type mode_t modified as follows: a bitwise AND is performed
+    /// on the file-mode bits and the corresponding bits in the complement of the
+    /// process' file mode creation mask. Thus, all bits in the file mode whose
+    /// corresponding bit in the file mode creation mask is set are cleared.
+    // open/00.t
+    permission_bits_from_mode, serialized
+}
+fn permission_bits_from_mode(ctx: &mut SerializedTestContext) {
+    assert_perms_from_mode_and_umask(ctx, open_wrapper, StdFileType::is_file);
+}
+
+crate::test_case! {
+    /// POSIX: (If O_CREAT is specified and the file doesn't exist) [...] the user ID
+    /// of the file shall be set to the effective user ID of the process; the group ID
+    /// of the file shall be set to the group ID of the file's parent directory or to
+    /// the effective group ID of the process [...]
+    // open/00.t
+    uid_gid_eq_euid_egid, serialized, root
+}
+fn uid_gid_eq_euid_egid(ctx: &mut SerializedTestContext) {
+    assert_uid_gid(ctx, open_wrapper);
+}
+
+crate::test_case! {
+    /// POSIX: Upon successful completion, open(O_CREAT) shall mark for update the st_atime,
+    /// st_ctime, and st_mtime fields of the directory. Also, the st_ctime and
+    /// st_mtime fields of the directory that contains the new entry shall be marked
+    /// for update.
+    // open/00.t
+    changed_time_fields_success
+}
+fn changed_time_fields_success(ctx: &mut TestContext) {
+    let path = ctx.gen_path();
+
+    assert_times_changed()
+        .path(ctx.base_path(), CTIME | MTIME)
+        .paths(ctx.base_path(), &path, ATIME | CTIME | MTIME)
+        .execute(ctx, false, || {
+            open_wrapper(&path, Mode::from_bits_truncate(0o755)).unwrap();
+        });
+}
+
+crate::test_case! {
+    /// open do not update parent directory ctime and mtime fields if
+    /// the file previously existed.
+    // open/00.t
+    exists_no_update
+}
+fn exists_no_update(ctx: &mut TestContext) {
+    let file = ctx.create(FileType::Regular).unwrap();
+
+    assert_times_unchanged()
+        .path(ctx.base_path(), CTIME | MTIME)
+        .execute(ctx, false, || {
+            assert!(open_wrapper(&file, Mode::from_bits_truncate(0o755)).is_ok());
+        });
+}
+
+crate::test_case! {
+    /// open with O_TRUNC should truncate an exisiting file.
+    // open/00.t
+    open_trunc
+}
+fn open_trunc(ctx: &mut TestContext) {
+    let file = ctx.create(crate::context::FileType::Regular).unwrap();
+    std::fs::write(&file, "data".as_bytes()).unwrap();
+    assert_times_changed()
+        .path(&file, CTIME | MTIME)
+        .execute(ctx, false, || {
+            assert!(open(&file, OFlag::O_WRONLY | OFlag::O_TRUNC, Mode::empty())
+                .and_then(close)
+                .is_ok());
+        });
+    let size = metadata(&file).unwrap().size();
+    assert_eq!(size, 0);
+}
+
+crate::test_case! {
+    /// interact with > 2 GB files
+    // open/25.t
+    interact_2gb
+}
+fn interact_2gb(ctx: &mut TestContext) {
+    let (path, fd) = ctx.create_file(OFlag::O_WRONLY, Some(0o755)).unwrap();
+    const DATA: &str = "data";
+    const GB: usize = 1024usize.pow(3);
+    let offset = 2 * GB as i64 + 1;
+    pwrite(&fd, DATA.as_bytes(), offset).unwrap();
+    let expected_size = offset as u64 + DATA.len() as u64;
+    let size = symlink_metadata(&path).unwrap().size();
+    assert_eq!(size, expected_size);
+    close(fd.into_raw_fd()).unwrap();
+
+    let fd = unsafe { OwnedFd::from_raw_fd(open(&path, OFlag::O_RDONLY, Mode::empty()).unwrap()) };
+    let mut buf = [0; DATA.len()];
+    nix::sys::uio::pread(fd, &mut buf, offset).unwrap();
+    assert_eq!(buf, DATA.as_bytes());
+}
+
+// POSIX states that open should return ELOOP, but FreeBSD returns EMLINK instead
+// open/16.t
+#[cfg(not(target_os = "freebsd"))]
+crate::test_case! {
+    /// open returns ELOOP when O_NOFOLLOW was specified and the target is a symbolic link
+    open_nofollow
+}
+#[cfg(target_os = "freebsd")]
+crate::test_case! {
+    /// open returns EMLINK when O_NOFOLLOW was specified and the target is a symbolic link
+    open_nofollow
+}
+fn open_nofollow(ctx: &mut TestContext) {
+    let link = ctx.create(FileType::Symlink(None)).unwrap();
+
+    assert!(matches!(
+        open(
+            &link,
+            OFlag::O_RDONLY | OFlag::O_CREAT | OFlag::O_NOFOLLOW,
+            Mode::empty()
+        ),
+        Err(Errno::EMLINK | Errno::ELOOP)
+    ));
+    assert!(matches!(
+        open(&link, OFlag::O_RDONLY | OFlag::O_NOFOLLOW, Mode::empty()),
+        Err(Errno::EMLINK | Errno::ELOOP)
+    ));
+    assert!(matches!(
+        open(&link, OFlag::O_RDONLY | OFlag::O_NOFOLLOW, Mode::empty()),
+        Err(Errno::EMLINK | Errno::ELOOP)
+    ));
+    assert!(matches!(
+        open(&link, OFlag::O_RDWR | OFlag::O_NOFOLLOW, Mode::empty()),
+        Err(Errno::EMLINK | Errno::ELOOP)
+    ));
+}
+
+// POSIX now states that returned error should be EOPNOTSUPP, but Linux returns ENXIO
+#[cfg(not(target_os = "linux"))]
+crate::test_case! {
+    /// open returns EOPNOTSUPP when trying to open UNIX domain socket
+    socket_error
+}
+#[cfg(target_os = "linux")]
+crate::test_case! {
+    /// open returns ENXIO when trying to open UNIX domain socket
+    // open/24.t
+    socket_error
+}
+fn socket_error(ctx: &mut TestContext) {
+    let socket = ctx.create(FileType::Socket).unwrap();
+
+    assert!(matches!(
+        open(&socket, OFlag::O_RDONLY, Mode::empty()),
+        Err(Errno::EOPNOTSUPP | Errno::ENXIO)
+    ));
+    assert!(matches!(
+        open(&socket, OFlag::O_WRONLY, Mode::empty()),
+        Err(Errno::EOPNOTSUPP | Errno::ENXIO)
+    ));
+    assert!(matches!(
+        open(&socket, OFlag::O_RDWR, Mode::empty()),
+        Err(Errno::EOPNOTSUPP | Errno::ENXIO)
+    ));
+}
+
+crate::test_case! {
+    /// open returns ENXIO when O_NONBLOCK is set, the named file is a fifo, O_WRONLY is set,
+    /// and no process has the file open for reading
+    // open/17.t
+    fifo_nonblock_wronly
+}
+fn fifo_nonblock_wronly(ctx: &mut TestContext) {
+    let fifo = ctx.create(FileType::Fifo).unwrap();
+    assert_eq!(
+        open(&fifo, OFlag::O_WRONLY | OFlag::O_NONBLOCK, Mode::empty()),
+        Err(Errno::ENXIO)
+    );
+}
+
+// open/02.t
+enametoolong_comp_test_case!(open(~path, OFlag::O_CREAT, Mode::empty()));
+
+// open/03.t
+enametoolong_path_test_case!(open(~path, OFlag::O_CREAT, Mode::empty()));
+
+// open/04.t
+enoent_comp_test_case!(open(~path, OFlag::O_CREAT, Mode::from_bits_truncate(0o644)));
+
+// open/04.t
+enoent_named_file_test_case!(open(~path, OFlag::O_RDONLY, Mode::empty()));
+
+fn open_flag_wrapper_ctx(flags: OFlag) -> impl Fn(&mut TestContext, &Path) -> nix::Result<RawFd> {
+    move |_, path| open(path, flags, Mode::empty())
+}
+
+// open/14.t
+erofs_named_test_case!(
+    open,
+    open_flag_wrapper_ctx(OFlag::O_WRONLY),
+    open_flag_wrapper_ctx(OFlag::O_RDWR),
+    open_flag_wrapper_ctx(OFlag::O_RDONLY | OFlag::O_TRUNC)
+);
+
+// open/15.t
+erofs_new_file_test_case!(
+    open,
+    open_flag_wrapper_ctx(OFlag::O_RDONLY | OFlag::O_CREAT)
+);
+
+// open/12.t
+eloop_comp_test_case!(open(~path, OFlag::empty(), Mode::empty()));
+
+crate::test_case! {
+    /// open returns EISDIR if the named file is a directory
+    // open/13.t
+    eisdir
+}
+fn eisdir(ctx: &mut TestContext) {
+    let path = ctx.create(FileType::Dir).unwrap();
+
+    assert_eq!(
+        open(&path, OFlag::O_WRONLY, Mode::empty()),
+        Err(Errno::EISDIR)
+    );
+    assert_eq!(
+        open(&path, OFlag::O_RDWR, Mode::empty()),
+        Err(Errno::EISDIR)
+    );
+    assert_eq!(
+        open(&path, OFlag::O_RDONLY | OFlag::O_TRUNC, Mode::empty()),
+        Err(Errno::EISDIR)
+    );
+    assert_eq!(
+        open(&path, OFlag::O_WRONLY | OFlag::O_TRUNC, Mode::empty()),
+        Err(Errno::EISDIR)
+    );
+    assert_eq!(
+        open(&path, OFlag::O_RDWR | OFlag::O_TRUNC, Mode::empty()),
+        Err(Errno::EISDIR)
+    );
+}
+
+#[cfg(target_os = "freebsd")]
+crate::test_case! {
+    /// open returns EWOULDBLOCK when O_NONBLOCK and one of
+    /// O_SHLOCK or O_EXLOCK is specified and the file is locked
+    // open/18.t
+    locked
+}
+#[cfg(target_os = "freebsd")]
+fn locked(ctx: &mut TestContext) {
+    let file = ctx.create(FileType::Regular).unwrap();
+    let fd = open(&file, OFlag::O_RDONLY | OFlag::O_SHLOCK, Mode::empty()).unwrap();
+
+    // We open another file descriptor to test shared lock
+    assert!(open(
+        &file,
+        OFlag::O_RDONLY | OFlag::O_SHLOCK | OFlag::O_NONBLOCK,
+        Mode::empty()
+    )
+    .and_then(close)
+    .is_ok());
+
+    close(fd).unwrap();
+
+    // EWOULDBLOCK has the same value as EAGAIN on FreeBSD
+    fn assert_ewouldblock(file: &Path, lockflag_locked: OFlag, lockflag_nonblock: OFlag) {
+        let fd1 = open(file, OFlag::O_RDONLY | lockflag_locked, Mode::empty()).unwrap();
+        assert!(matches!(
+            open(
+                file,
+                OFlag::O_RDONLY | lockflag_nonblock | OFlag::O_NONBLOCK,
+                Mode::empty()
+            ),
+            Err(Errno::EWOULDBLOCK)
+        ));
+        close(fd1).unwrap();
+    }
+
+    assert_ewouldblock(&file, OFlag::O_EXLOCK, OFlag::O_EXLOCK);
+    assert_ewouldblock(&file, OFlag::O_SHLOCK, OFlag::O_EXLOCK);
+    assert_ewouldblock(&file, OFlag::O_EXLOCK, OFlag::O_SHLOCK);
+}
+
+fn open_flag_wrapper_path(flags: OFlag) -> impl Fn(&Path) -> nix::Result<RawFd> {
+    move |path| open(path, flags, Mode::empty())
+}
+
+// open/20.t — stripped: vibix has no ETXTBSY semantics.
+// etxtbsy_test_case!(
+//     open,
+//     open_flag_wrapper_path(OFlag::O_WRONLY),
+//     open_flag_wrapper_path(OFlag::O_RDWR),
+//     open_flag_wrapper_path(OFlag::O_RDONLY | OFlag::O_TRUNC)
+// );
+
+// open/22.t
+eexist_file_exists_test_case!(open(~path, OFlag::O_CREAT | OFlag::O_EXCL, Mode::empty()));
+
+// open/21.t
+efault_path_test_case!(open, |ptr| nix::libc::open(ptr, nix::libc::O_RDONLY));
+
+crate::test_case! {
+    /// open may return EINVAL when an attempt was made to open a descriptor
+    /// with an illegal combination of O_RDONLY, O_WRONLY, and O_RDWR
+    // open/23.t
+    einval_invalid_combination
+}
+fn einval_invalid_combination(ctx: &mut TestContext) {
+    fn assert_einval_open(ctx: &mut TestContext, flags: OFlag) {
+        let path = ctx.create(FileType::Regular).unwrap();
+        assert!(matches!(
+            open(&path, flags, Mode::empty()),
+            Ok(_) | Err(Errno::EINVAL)
+        ));
+    }
+
+    assert_einval_open(ctx, OFlag::O_RDONLY | OFlag::O_RDWR);
+    assert_einval_open(ctx, OFlag::O_WRONLY | OFlag::O_RDWR);
+    assert_einval_open(ctx, OFlag::O_RDONLY | OFlag::O_WRONLY | OFlag::O_RDWR);
+}

--- a/tests/pjdfstest/src/tests/rename.rs
+++ b/tests/pjdfstest/src/tests/rename.rs
@@ -1,0 +1,379 @@
+use std::fs::symlink_metadata;
+
+use nix::{
+    errno::Errno,
+    sys::stat::{lstat, stat},
+};
+
+use crate::{
+    context::{FileType, SerializedTestContext, TestContext},
+    test::FileSystemFeature,
+    tests::{assert_symlink_ctime_unchanged, AsTimeInvariant, MetadataExt},
+    utils::{link, rename},
+};
+
+use super::{
+    assert_ctime_changed,
+    errors::{
+        efault::efault_either_test_case,
+        eloop::eloop_either_test_case,
+        enametoolong::{enametoolong_either_comp_test_case, enametoolong_either_path_test_case},
+        enoent::enoent_either_named_file_test_case,
+        enotdir::enotdir_comp_either_test_case,
+        erofs::erofs_named_test_case,
+        exdev::exdev_target_test_case,
+    },
+};
+
+crate::test_case! {
+    /// rename preserve file metadata
+    // rename/00.t
+    preserve_metadata => [Regular, Fifo, Block, Char, Socket]
+}
+fn preserve_metadata(ctx: &mut TestContext, ft: FileType) {
+    let old_path = ctx.create(ft).unwrap();
+    let new_path = ctx.base_path().join("new");
+
+    let old_path_stat = lstat(&old_path).unwrap();
+
+    assert!(rename(&old_path, &new_path).is_ok());
+    assert!(!old_path.exists());
+
+    let new_path_stat = lstat(&new_path).unwrap();
+    assert_eq!(
+        old_path_stat.as_time_invariant(),
+        new_path_stat.as_time_invariant()
+    );
+
+    let link_path = ctx.base_path().join("link");
+    link(&new_path, &link_path).unwrap();
+
+    let link_stat = lstat(&link_path).unwrap();
+    let new_path_stat = lstat(&new_path).unwrap();
+    assert_eq!(
+        new_path_stat.as_time_invariant(),
+        link_stat.as_time_invariant()
+    );
+    assert_eq!(link_stat.st_nlink, 2);
+
+    let another_path = ctx.base_path().join("another");
+    assert!(rename(&new_path, &another_path).is_ok());
+    assert!(!new_path.exists());
+
+    let another_path_stat = lstat(&another_path).unwrap();
+    assert_eq!(
+        link_stat.as_time_invariant(),
+        another_path_stat.as_time_invariant()
+    );
+}
+
+crate::test_case! {
+    /// rename preserve directory metadata
+    // rename/00.t
+    preserve_metadata_dir
+}
+fn preserve_metadata_dir(ctx: &mut TestContext) {
+    let old_path = ctx.create(FileType::Dir).unwrap();
+    let new_path = ctx.base_path().join("new");
+
+    let old_path_stat = lstat(&old_path).unwrap();
+
+    assert!(rename(&old_path, &new_path).is_ok());
+    assert!(!old_path.exists());
+
+    let new_path_stat = lstat(&new_path).unwrap();
+    assert_eq!(
+        old_path_stat.as_time_invariant(),
+        new_path_stat.as_time_invariant()
+    );
+}
+
+crate::test_case! {
+    /// rename preserve symlink metadata
+    // rename/00.t
+    preserve_metadata_symlink
+}
+fn preserve_metadata_symlink(ctx: &mut TestContext) {
+    let target = ctx.create(FileType::Regular).unwrap();
+    let target_stat = lstat(&target).unwrap();
+
+    let symlink_old_path = ctx.create(FileType::Symlink(Some(target))).unwrap();
+    let symlink_stat = lstat(&symlink_old_path).unwrap();
+    let sym_target_stat = stat(&symlink_old_path).unwrap();
+
+    assert_ne!(
+        symlink_stat.as_time_invariant(),
+        sym_target_stat.as_time_invariant()
+    );
+    assert_eq!(
+        sym_target_stat.as_time_invariant(),
+        target_stat.as_time_invariant()
+    );
+
+    let sym_new_path = ctx.base_path().join("sym_new_path");
+    rename(&symlink_old_path, &sym_new_path).unwrap();
+
+    let sym_target_stat = stat(&sym_new_path).unwrap();
+    assert_eq!(target_stat, sym_target_stat);
+    assert!(!symlink_old_path.exists());
+
+    let sym_new_stat = lstat(&sym_new_path).unwrap();
+    assert_eq!(
+        symlink_stat.as_time_invariant(),
+        sym_new_stat.as_time_invariant()
+    );
+}
+
+crate::test_case! {
+    /// rename should not update ctime if it fails
+    // rename/00.t
+    unchanged_ctime_failed, serialized, root => [Regular, Dir, Fifo, Block, Char, Socket, Symlink(None)]
+}
+fn unchanged_ctime_failed(ctx: &mut SerializedTestContext, ft: FileType) {
+    let file = ctx.new_file(ft).mode(0o600).create().unwrap();
+    let other_path = ctx.gen_path();
+    let user = ctx.get_new_user();
+    ctx.as_user(user, None, || {
+        assert_symlink_ctime_unchanged(ctx, &file, || {
+            assert!(rename(&file, &other_path).is_err());
+        })
+    });
+}
+
+crate::test_case! {
+    /// write access to subdirectory is required to move it to another directory
+    // rename/21.t
+    write_access_required_subdir, serialized, root
+}
+fn write_access_required_subdir(ctx: &mut SerializedTestContext) {
+    let dir = ctx.new_file(FileType::Dir).mode(0o777).create().unwrap();
+    let subdir = ctx
+        .new_file(FileType::Dir)
+        .name(dir.join("subdir"))
+        .mode(0o700)
+        .create()
+        .unwrap();
+    let another_subdir_path = dir.join("another_subdir_path");
+
+    let new_dir = ctx.new_file(FileType::Dir).mode(0o777).create().unwrap();
+    let new_dir_subpath = new_dir.join("subpath");
+
+    let user = ctx.get_new_user();
+    ctx.as_user(user, None, || {
+        // Check that write permission on containing directory is enough
+        // to rename subdirectory. If we rename directory write access
+        // to this directory may also be required.
+        assert!(matches!(
+            rename(&subdir, &another_subdir_path),
+            Ok(_) | Err(Errno::EACCES)
+        ));
+
+        assert!(matches!(
+            rename(&another_subdir_path, &subdir),
+            Ok(_) | Err(Errno::EACCES)
+        ));
+
+        //TODO: Is it really useful?
+        // Check that write permission on containing directory is not enough
+        // to move subdirectory from that directory.
+        // Actually POSIX says that write access to `dir` and `new_dir` may be enough
+        // to move `subdir`.
+        assert!(matches!(
+            rename(&subdir, &new_dir_subpath),
+            Ok(_) | Err(Errno::EACCES)
+        ));
+    });
+
+    // Check that write permission on containing directory (${n2}) is enough
+    // to move file (${n0}) from that directory.
+    let file = ctx
+        .new_file(FileType::Regular)
+        .name(dir.join("file"))
+        .mode(0o600)
+        .create()
+        .unwrap();
+
+    ctx.as_user(user, None, || {
+        let new_path = new_dir.join("file");
+        assert!(rename(&file, &new_path).is_ok());
+    })
+}
+
+crate::test_case! {
+    /// rename should update ctime if it succeeds
+    // rename/22.t
+    changed_ctime_success, FileSystemFeature::RenameCtime => [Regular, Dir, Fifo, Block, Char, Socket, Symlink(None)]
+}
+fn changed_ctime_success(ctx: &mut TestContext, ft: FileType) {
+    let old_path = ctx.create(ft).unwrap();
+    let new_path = ctx.base_path().join("new");
+
+    let old_path_ctime = symlink_metadata(&old_path).unwrap().ctime_ts();
+
+    ctx.nap();
+
+    assert!(rename(&old_path, &new_path).is_ok());
+
+    let new_path_ctime = symlink_metadata(&new_path).unwrap().ctime_ts();
+
+    assert!(new_path_ctime > old_path_ctime);
+}
+
+crate::test_case! {
+    /// rename succeeds when to is multiply linked
+    // rename/23.t
+    to_multiply_linked => [Regular, Fifo, Block, Char, Socket]
+}
+fn to_multiply_linked(ctx: &mut TestContext, ft: FileType) {
+    let src = ctx.create(ft.clone()).unwrap();
+    let dst = ctx.create(ft).unwrap();
+
+    let dst_link = ctx.base_path().join("dst_link");
+    link(&dst, &dst_link).unwrap();
+    let dst_link_stat = lstat(&dst_link).unwrap();
+    assert_eq!(dst_link_stat.st_nlink, 2);
+
+    assert_ctime_changed(ctx, &dst_link, || {
+        assert!(rename(&src, &dst).is_ok());
+    });
+
+    let dst_link_stat = lstat(&dst_link).unwrap();
+    assert_eq!(dst_link_stat.st_nlink, 1);
+}
+
+crate::test_case! {
+    /// rename of a directory updates its .. link
+    // rename/24.t
+    updates_link_parent
+}
+fn updates_link_parent(ctx: &mut TestContext) {
+    let src_parent = ctx.create(FileType::Dir).unwrap();
+    let dst_parent = ctx.create(FileType::Dir).unwrap();
+    let dst = dst_parent.join("dst");
+    let src = ctx
+        .new_file(FileType::Dir)
+        .name(src_parent.join("src"))
+        .create()
+        .unwrap();
+
+    // Initial conditions
+    let src_parent_stat = lstat(&src_parent).unwrap();
+    let dst_parent_stat = lstat(&dst_parent).unwrap();
+
+    assert_eq!(src_parent_stat.st_nlink, 3);
+    assert_eq!(dst_parent_stat.st_nlink, 2);
+    let dotdot_stat = lstat(&src.join("..")).unwrap();
+    assert_eq!(src_parent_stat.st_ino, dotdot_stat.st_ino);
+
+    assert!(rename(&src, &dst).is_ok());
+
+    // The .. link and parents' nlinks values should be updated
+    let src_parent_stat = lstat(&src_parent).unwrap();
+    let dst_parent_stat = lstat(&dst_parent).unwrap();
+    assert_eq!(src_parent_stat.st_nlink, 2);
+    assert_eq!(dst_parent_stat.st_nlink, 3);
+    let dotdot_stat = lstat(&dst.join("..")).unwrap();
+    assert_eq!(dst_parent_stat.st_ino, dotdot_stat.st_ino);
+}
+
+// rename/12.t
+enotdir_comp_either_test_case!(rename);
+
+crate::test_case! {
+    /// rename returns ENOTDIR when the 'from' argument is a directory,
+    /// but 'to' is not a directory
+    // rename/13.t
+    enotdir_from_dir_to_not_dir => [Regular, Fifo, Block, Char, Socket]
+}
+fn enotdir_from_dir_to_not_dir(ctx: &mut TestContext, ft: FileType) {
+    let path = ctx.create(ft).unwrap();
+    let dir = ctx.create(FileType::Dir).unwrap();
+
+    assert_eq!(rename(&dir, &path).unwrap_err(), Errno::ENOTDIR);
+}
+
+// rename/01.t
+enametoolong_either_comp_test_case!(rename);
+
+// rename/02.t
+enametoolong_either_path_test_case!(rename);
+
+// rename/03.t
+enoent_either_named_file_test_case!(rename);
+
+// rename/11.t
+eloop_either_test_case!(rename);
+
+crate::test_case! {
+    /// rename returns EISDIR when the 'to' argument is a directory, but 'from' is not a directory
+    // rename/14.t
+    eisdir_to_dir_from_not_dir => [Regular, Fifo, Block, Char, Socket, Symlink(None)]
+}
+fn eisdir_to_dir_from_not_dir(ctx: &mut TestContext, ft: FileType) {
+    let dir = ctx.create(FileType::Dir).unwrap();
+    let not_dir_file = ctx.create(ft).unwrap();
+    assert_eq!(rename(&not_dir_file, &dir), Err(Errno::EISDIR));
+}
+
+// rename/16.t
+erofs_named_test_case!(rename, |ctx: &mut TestContext, file| {
+    let path = ctx.gen_path();
+    rename(file, &path)
+});
+
+// rename/17.t
+efault_either_test_case!(rename, nix::libc::rename);
+
+crate::test_case! {
+    /// rename returns EINVAL when the 'from' argument is a parent directory of 'to'
+    // rename/18.t
+    einval_parent_from_subdir_to
+}
+fn einval_parent_from_subdir_to(ctx: &mut TestContext) {
+    let subdir = ctx.create(FileType::Dir).unwrap();
+    let nested_subdir = ctx
+        .new_file(FileType::Dir)
+        .name(subdir.join("subsubdir"))
+        .create()
+        .unwrap();
+
+    assert_eq!(rename(ctx.base_path(), &subdir), Err(Errno::EINVAL));
+    assert_eq!(rename(ctx.base_path(), &nested_subdir), Err(Errno::EINVAL));
+}
+
+crate::test_case! {
+    /// rename returns EINVAL/EBUSY when an attempt is made to rename '.' or '..'
+    // rename/19.t
+    einval_ebusy_dot_dotdot
+}
+fn einval_ebusy_dot_dotdot(ctx: &mut TestContext) {
+    let subdir = ctx.create(FileType::Dir).unwrap();
+
+    assert!(matches!(
+        rename(&subdir.join("."), &ctx.gen_path()),
+        Err(Errno::EINVAL | Errno::EBUSY)
+    ));
+    assert!(matches!(
+        rename(&subdir.join(".."), &ctx.gen_path()),
+        Err(Errno::EINVAL | Errno::EBUSY)
+    ));
+}
+
+crate::test_case! {
+    /// rename returns EEXIST or ENOTEMPTY if the 'to' argument is a directory and is not empty
+    // rename/20.t
+    eexist_enotempty_to_non_empty => [Regular, Dir, Fifo, Block, Char, Socket, Symlink(None)]
+}
+fn eexist_enotempty_to_non_empty(ctx: &mut TestContext, ft: FileType) {
+    let from_dir = ctx.create(FileType::Dir).unwrap();
+    let to_dir = ctx.create(FileType::Dir).unwrap();
+    ctx.new_file(ft).name(to_dir.join("test")).create().unwrap();
+
+    assert!(matches!(
+        rename(&from_dir, &to_dir),
+        Err(Errno::EEXIST | Errno::ENOTEMPTY)
+    ));
+}
+
+// rename/15.t
+exdev_target_test_case!(rename);

--- a/tests/pjdfstest/src/tests/rmdir.rs
+++ b/tests/pjdfstest/src/tests/rmdir.rs
@@ -1,0 +1,202 @@
+use std::{
+    ffi::OsStr,
+    fs::metadata,
+    os::unix::ffi::OsStrExt,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use nix::errno::Errno;
+
+use crate::{config::Config, context::TestContext, tests::assert_mtime_changed, utils::rmdir};
+
+use super::{
+    assert_ctime_changed,
+    errors::efault::efault_path_test_case,
+    errors::{eloop::eloop_comp_test_case, erofs::erofs_named_test_case},
+    errors::{enametoolong::enametoolong_comp_test_case, enoent::enoent_named_file_test_case},
+    errors::{enametoolong::enametoolong_path_test_case, enotdir::enotdir_comp_test_case},
+};
+
+crate::test_case! {
+    /// rmdir remove directory
+    // rmdir/00.t
+    remove_dir
+}
+fn remove_dir(ctx: &mut TestContext) {
+    let dir = ctx.create(crate::context::FileType::Dir).unwrap();
+    assert!(metadata(&dir).unwrap().is_dir());
+    assert!(rmdir(&dir).is_ok());
+    assert!(!dir.exists());
+}
+
+crate::test_case! {
+    /// rmdir updates parent ctime and mtime on success
+    // rmdir/00.t
+    changed_time_parent_success
+}
+fn changed_time_parent_success(ctx: &mut TestContext) {
+    let dir = ctx.create(crate::context::FileType::Dir).unwrap();
+    assert_ctime_changed(ctx, ctx.base_path(), || {
+        assert_mtime_changed(ctx, ctx.base_path(), || {
+            assert!(rmdir(&dir).is_ok());
+        });
+    });
+}
+
+// rmdir/01.t
+enotdir_comp_test_case!(rmdir);
+
+/// Dummy mountpoint to check that rmdir returns EBUSY when using it on a mountpoint.
+struct DummyMnt {
+    path: PathBuf,
+}
+
+impl DummyMnt {
+    fn new(ctx: &mut TestContext) -> anyhow::Result<Self> {
+        // We don't really care about a specific type of file system here, the directory just have to be a mount point
+        let from = ctx.create(crate::context::FileType::Dir)?;
+        let path = ctx.create(crate::context::FileType::Dir)?;
+        let mut mount = Command::new("mount");
+
+        if cfg!(target_os = "linux") {
+            mount.arg("--bind");
+        } else {
+            mount.args(["-t", "nullfs"]);
+        }
+
+        let result = mount.arg(&from).arg(&path).output()?;
+        let stderr = OsStr::from_bytes(&result.stderr).to_string_lossy();
+        assert!(result.status.success(), "{}", stderr);
+
+        Ok(Self { path })
+    }
+}
+
+impl Drop for DummyMnt {
+    fn drop(&mut self) {
+        let umount = Command::new("umount").arg(&self.path).output();
+        if !std::thread::panicking() {
+            assert!(matches!(umount, Ok(res) if res.status.success()));
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn has_mount_cap(_: &Config, _: &Path) -> anyhow::Result<()> {
+    use caps::{has_cap, CapSet, Capability};
+
+    if !has_cap(None, CapSet::Effective, Capability::CAP_SYS_ADMIN)? {
+        anyhow::bail!("process doesn't have the CAP_SYS_ADMIN cap to mount the dummy file system")
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "freebsd")]
+fn has_mount_cap(_: &Config, _: &Path) -> anyhow::Result<()> {
+    use nix::unistd::Uid;
+    use sysctl::{Ctl, CtlValue, Sysctl};
+
+    const MOUNT_CTL: &str = "vfs.usermount";
+
+    let ctl = Ctl::new(MOUNT_CTL)?;
+
+    if !Uid::effective().is_root() && ctl.value()? == CtlValue::Int(0) {
+        anyhow::bail!("process doesn't have the rights to mount the dummy file system")
+    }
+    if !Uid::effective().is_root()
+        && !OsStr::from_bytes(&Command::new("lsvfs").output().unwrap().stdout)
+            .to_string_lossy()
+            .contains("nullfs")
+    {
+        anyhow::bail!("nullfs module is not loaded")
+    }
+
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
+fn has_mount_cap(_: &Config, _: &Path) -> anyhow::Result<()> {
+    if !Uid::effective().is_root() {
+        anyhow::bail!("process is not root, cannot mount dummy file system")
+    }
+
+    Ok(())
+}
+
+// rmdir/02.t
+enametoolong_comp_test_case!(rmdir);
+
+// rmdir/03.t
+enametoolong_path_test_case!(rmdir);
+
+// rmdir/04.t
+enoent_named_file_test_case!(rmdir);
+
+// rmdir/05.t
+eloop_comp_test_case!(rmdir);
+
+crate::test_case! {
+    /// rmdir returns EEXIST or ENOTEMPTY if the named directory
+    /// contains files other than '.' and '..' in it
+    // rmdir/06.t
+    eexist_enotempty_non_empty_dir => [Regular, Dir, Fifo, Block, Char, Socket, Symlink(None)]
+}
+fn eexist_enotempty_non_empty_dir(ctx: &mut TestContext, ft: crate::context::FileType) {
+    ctx.new_file(ft)
+        .name(ctx.base_path().join("file"))
+        .create()
+        .unwrap();
+
+    assert!(matches!(
+        rmdir(ctx.base_path()),
+        Err(Errno::EEXIST | Errno::ENOTEMPTY)
+    ));
+}
+
+crate::test_case! {
+    /// rmdir returns EINVAL if the last component of the path is '.'
+    // rmdir/12.t
+    einval_dot
+}
+fn einval_dot(ctx: &mut TestContext) {
+    assert_eq!(rmdir(&ctx.base_path().join(".")), Err(Errno::EINVAL));
+}
+
+crate::test_case! {
+    /// rmdir returns EEXIST or ENOTEMPTY if the last component of the path is '..'
+    // rmdir/12.t
+    eexist_enotempty_dotdot
+}
+#[cfg_attr(target_os = "freebsd", allow(unused_variables))]
+fn eexist_enotempty_dotdot(ctx: &mut TestContext) {
+    // TODO: Not conforming to POSIX on FreeBSD
+    // According to POSIX: EEXIST or ENOTEMPTY:
+    // The path argument names a directory that is
+    // not an empty directory,
+    // or there are hard links to the directory other than dot or a single entry in dot-dot.
+    #[cfg(not(target_os = "freebsd"))]
+    {
+        assert!(matches!(
+            rmdir(&ctx.base_path().join("..")),
+            Err(Errno::ENOTEMPTY | Errno::EEXIST)
+        ));
+    }
+}
+
+crate::test_case! {
+    /// rmdir return EBUSY if the directory to be removed is the mount point for a mounted file system
+    // rmdir/13.t
+    ebusy; has_mount_cap
+}
+fn ebusy(ctx: &mut TestContext) {
+    let dummy_mount = DummyMnt::new(ctx).unwrap();
+    assert_eq!(rmdir(&dummy_mount.path), Err(Errno::EBUSY));
+}
+
+// rmdir/14.t
+erofs_named_test_case!(rmdir);
+
+// rmdir/15.t
+efault_path_test_case!(rmdir, nix::libc::rmdir);

--- a/tests/pjdfstest/src/tests/symlink.rs
+++ b/tests/pjdfstest/src/tests/symlink.rs
@@ -1,0 +1,108 @@
+use std::{
+    fs::{metadata, remove_dir, remove_file, symlink_metadata},
+    os::unix::prelude::FileTypeExt,
+    path::Path,
+};
+
+use crate::{
+    context::{FileType, TestContext},
+    tests::{assert_times_changed, errors::enoent::enoent_comp_test_case, CTIME, MTIME},
+    utils::symlink,
+};
+
+use super::errors::{
+    eexist::eexist_file_exists_test_case,
+    efault::efault_either_test_case,
+    enametoolong::{enametoolong_comp_test_case, enametoolong_either_path_test_case},
+    enotdir::enotdir_comp_test_case,
+    erofs::erofs_new_file_test_case,
+};
+
+crate::test_case! {
+    /// symlink creates symbolic links
+    // symlink/00.t
+    create_symlink => [Regular, Dir, Block, Char, Fifo]
+}
+fn create_symlink(ctx: &mut TestContext, ft: FileType) {
+    let file = ctx.create(ft.clone()).unwrap();
+    let link = ctx.gen_path();
+    assert!(symlink(&file, &link).is_ok());
+
+    let link_stat = symlink_metadata(&link).unwrap();
+    let follow_link_stat = metadata(&link).unwrap();
+    let follow_link_type = follow_link_stat.file_type();
+    assert!(link_stat.is_symlink());
+    assert!(match ft {
+        FileType::Regular => follow_link_type.is_file(),
+        FileType::Dir => follow_link_type.is_dir(),
+        FileType::Block => follow_link_type.is_block_device(),
+        FileType::Char => follow_link_type.is_char_device(),
+        FileType::Fifo => follow_link_type.is_fifo(),
+        _ => unreachable!(),
+    });
+
+    match ft {
+        FileType::Dir => remove_dir(&file),
+        _ => remove_file(&file),
+    }
+    .unwrap();
+    assert!(!link.exists());
+}
+
+crate::test_case! {
+    /// symlink create a symbolic link to a symbolic link
+    // symlink/00.t
+    create_symlink_to_symlink
+}
+fn create_symlink_to_symlink(ctx: &mut TestContext) {
+    let target = ctx.create(FileType::Regular).unwrap();
+    let file = ctx.create(FileType::Symlink(Some(target))).unwrap();
+    let link = ctx.gen_path();
+    assert!(symlink(&file, &link).is_ok());
+
+    let link_stat = symlink_metadata(&link).unwrap();
+    let follow_link_stat = metadata(&link).unwrap();
+    let follow_link_type = follow_link_stat.file_type();
+    assert!(link_stat.is_symlink());
+    assert!(follow_link_type.is_file());
+
+    remove_file(&file).unwrap();
+    assert!(!link.exists());
+}
+
+crate::test_case! {
+    /// symlink should update parent's ctime and mtime on success
+    // symlink/00.t
+    changed_parent_time_success
+}
+fn changed_parent_time_success(ctx: &mut TestContext) {
+    assert_times_changed()
+        .path(ctx.base_path(), CTIME | MTIME)
+        .execute(ctx, true, || {
+            let link = ctx.gen_path();
+
+            assert!(symlink(Path::new("test"), &link).is_ok());
+        });
+}
+
+// symlink/01.t
+enotdir_comp_test_case!(symlink(Path::new("test"), ~path));
+
+// symlink/02.t
+// TODO: Clarify that only path2 is checked
+enametoolong_comp_test_case!(symlink(Path::new("test"), ~path));
+
+// symlink/03.t
+enametoolong_either_path_test_case!(symlink);
+
+// symlink/04.t
+enoent_comp_test_case!(symlink(Path::new("test"), ~path));
+
+// symlink/08.t
+eexist_file_exists_test_case!(symlink(Path::new("test"), ~path));
+
+// symlink/10.t
+erofs_new_file_test_case!(symlink(Path::new("test"), ~path));
+
+// symlink/12.t
+efault_either_test_case!(symlink, nix::libc::symlink);

--- a/tests/pjdfstest/src/tests/truncate.rs
+++ b/tests/pjdfstest/src/tests/truncate.rs
@@ -1,0 +1,140 @@
+use std::{fs::File, io::Write};
+
+use nix::{errno::Errno, sys::stat::lstat, unistd::truncate};
+use rand::random;
+
+use crate::{
+    context::{FileType, SerializedTestContext},
+    test::TestContext,
+    tests::{assert_ctime_changed, assert_ctime_unchanged},
+};
+
+use super::errors::{
+    efault::efault_path_test_case,
+    eloop::eloop_comp_test_case,
+    enametoolong::{enametoolong_comp_test_case, enametoolong_path_test_case},
+    enoent::{enoent_comp_test_case, enoent_named_file_test_case},
+    enotdir::enotdir_comp_test_case,
+    erofs::erofs_named_test_case,
+    // etxtbsy: stripped — vibix has no ETXTBSY semantics.
+};
+
+crate::test_case! {
+    /// truncate should extend a file, and shrink a sparse file
+    // truncate/00.t
+    extend_file_shrink_sparse
+}
+fn extend_file_shrink_sparse(ctx: &mut TestContext) {
+    let file = ctx.create(FileType::Regular).unwrap();
+    let size = 1234567;
+    assert!(truncate(&file, size).is_ok());
+
+    let actual_size = lstat(&file).unwrap().st_size;
+    assert_eq!(actual_size, size);
+
+    let size = 567;
+    assert!(truncate(&file, size).is_ok());
+
+    let actual_size = lstat(&file).unwrap().st_size;
+    assert_eq!(actual_size, size);
+}
+
+crate::test_case! {
+    /// truncate should shrink the file if the specified size is less than the actual one
+    // truncate/00.t
+    shrink_not_empty
+}
+fn shrink_not_empty(ctx: &mut TestContext) {
+    let file = ctx.create(FileType::Regular).unwrap();
+    let size = 23456;
+    let random_data: [u8; 12345] = random();
+    File::create(&file)
+        .unwrap()
+        .write_all(&random_data)
+        .unwrap();
+
+    assert!(truncate(&file, size).is_ok());
+    let actual_size = lstat(&file).unwrap().st_size;
+    assert_eq!(actual_size, size);
+
+    let size = 1;
+    assert!(truncate(&file, size).is_ok());
+    let actual_size = lstat(&file).unwrap().st_size;
+    assert_eq!(actual_size, size);
+}
+
+crate::test_case! {
+    /// truncate should update ctime if it succeeds
+    // truncate/00.t
+    update_ctime_success
+}
+fn update_ctime_success(ctx: &mut TestContext) {
+    let file = ctx.create(FileType::Regular).unwrap();
+
+    assert_ctime_changed(ctx, &file, || {
+        assert!(truncate(&file, 123).is_ok());
+    });
+}
+
+crate::test_case! {
+    /// truncate should not update ctime if it fails
+    // truncate/00.t
+    unchanged_ctime_failed, serialized, root
+}
+fn unchanged_ctime_failed(ctx: &mut SerializedTestContext) {
+    let file = ctx.create(FileType::Regular).unwrap();
+    let user = ctx.get_new_user();
+
+    assert_ctime_unchanged(ctx, &file, || {
+        ctx.as_user(user, None, || {
+            assert_eq!(truncate(&file, 123), Err(Errno::EACCES));
+        });
+    });
+}
+
+// (f)truncate/01.t
+enotdir_comp_test_case!(truncate(~path, 0));
+
+// truncate/02.t
+enametoolong_comp_test_case!(truncate(~path, 0));
+
+// truncate/03.t
+enametoolong_path_test_case!(truncate(~path, 0));
+
+// (f)truncate/04.t
+enoent_named_file_test_case!(truncate(~path, 0));
+enoent_comp_test_case!(truncate(~path, 0));
+
+// truncate/07.t
+eloop_comp_test_case!(truncate(~path, 0));
+
+crate::test_case! {
+    /// truncate returns EISDIR if the named file is a directory
+    // truncate/09.t
+    eisdir
+}
+fn eisdir(ctx: &mut TestContext) {
+    let path = ctx.create(FileType::Dir).unwrap();
+    assert_eq!(truncate(&path, 0), Err(Errno::EISDIR));
+}
+
+// (f)truncate/10.t
+erofs_named_test_case!(truncate(~path, 123));
+
+// (f)truncate/11.t — stripped: vibix has no ETXTBSY semantics.
+// etxtbsy_test_case!(truncate(~path, 123));
+
+crate::test_case! {
+    /// truncate returns EINVAL if the length argument was less than 0
+    // truncate/13.t
+    einval_negative_length
+}
+fn einval_negative_length(ctx: &mut TestContext) {
+    let path = ctx.create(FileType::Regular).unwrap();
+
+    assert_eq!(truncate(&path, -1), Err(Errno::EINVAL));
+    assert_eq!(truncate(&path, nix::libc::off_t::MIN), Err(Errno::EINVAL));
+}
+
+// (f)truncate/14.t
+efault_path_test_case!(truncate, |ptr| nix::libc::truncate(ptr, 0));

--- a/tests/pjdfstest/src/tests/unlink.rs
+++ b/tests/pjdfstest/src/tests/unlink.rs
@@ -1,0 +1,164 @@
+use std::os::fd::AsRawFd;
+
+use nix::{sys::stat::fstat, unistd::unlink};
+
+use crate::{
+    context::{FileType, SerializedTestContext, TestContext},
+    tests::{assert_ctime_changed, assert_ctime_unchanged},
+    utils::link,
+};
+
+use super::{
+    assert_mtime_changed,
+    errors::{
+        efault::efault_path_test_case,
+        eloop::eloop_comp_test_case,
+        enametoolong::{enametoolong_comp_test_case, enametoolong_path_test_case},
+        enoent::enoent_named_file_test_case,
+        enotdir::enotdir_comp_test_case,
+        erofs::erofs_named_test_case,
+    },
+};
+
+crate::test_case! {
+    /// unlink removes regular, block and char files, symbolic links, fifos and sockets
+    // unlink/00.t
+    remove_type => [Regular, Block, Char, Symlink(None), Fifo, Socket]
+}
+fn remove_type(ctx: &mut TestContext, ft: FileType) {
+    let path = ctx.create(ft).unwrap();
+
+    assert!(unlink(&path).is_ok());
+    assert!(!path.exists());
+}
+
+crate::test_case! {
+    /// successful unlink(2) updates ctime.
+    // unlink/00.t
+    update_ctime_success => [Regular, Block, Char, Fifo, Socket]
+}
+fn update_ctime_success(ctx: &mut TestContext, ft: FileType) {
+    let path = ctx.create(ft).unwrap();
+
+    let link_path = ctx.base_path().join("link");
+    link(&path, &link_path).unwrap();
+
+    assert_ctime_changed(ctx, &link_path, || {
+        assert!(unlink(&path).is_ok());
+    });
+}
+
+// TODO: why it isn't in the original test suite?
+// crate::test_case! {
+//     /// successful unlink(2) updates ctime (symlink).
+//     update_ctime_success_symlink
+// }
+// fn update_ctime_success_symlink(ctx: &mut TestContext) {
+//     let path = ctx.create(FileType::Symlink(None)).unwrap();
+//     let link_path = ctx.base_path().join("link");
+//     link(&path, &link_path).unwrap();
+//     assert_ctime_changed(ctx, &link_path, || {
+//         assert!(unlink(&path).is_ok());
+//     });
+// }
+
+crate::test_case! {
+    /// unsuccessful unlink(2) does not update ctime.
+    // unlink/00.t
+    unchanged_ctime_failed, serialized, root => [Regular, Block, Char, Fifo, Socket]
+}
+fn unchanged_ctime_failed(ctx: &mut SerializedTestContext, ft: FileType) {
+    let path = ctx.create(ft).unwrap();
+
+    let link_path = ctx.base_path().join("link");
+    link(&path, &link_path).unwrap();
+
+    let user = ctx.get_new_user();
+
+    ctx.as_user(user, None, || {
+        assert_ctime_unchanged(ctx, &link_path, || {
+            assert!(unlink(&path).is_err());
+        });
+    });
+}
+
+// TODO: why it isn't in the original test suite?
+// crate::test_case! {
+//     /// unsuccessful unlink(2) does not update ctime.
+//     unchanged_ctime_failed_symlink, serialized, root => [Regular, Fifo, Socket]
+// }
+// fn unchanged_ctime_failed_symlink(ctx: &mut SerializedTestContext, ft: FileType) {
+//     let path = ctx.create(ft).unwrap();
+
+//     let link_path = ctx.base_path().join("link");
+//     link(&path, &link_path).unwrap();
+
+//     let user = User::from_uid(Uid::from_raw(65534)).unwrap().unwrap();
+
+//     ctx.as_user(Some(user.uid), Some(user.gid), || {
+//         assert_ctime_unchanged(ctx, &link_path, || {
+//             assert!(unlink(&path).is_err());
+//         });
+//     });
+// }
+
+crate::test_case! {
+    /// successful unlink(2) on a directory entry updates ctime and mtime for the parent folder.
+    // unlink/00.t
+    update_mtime_ctime_success_folder => [Regular, Block, Char, Fifo, Socket, Symlink(None)]
+}
+fn update_mtime_ctime_success_folder(ctx: &mut TestContext, ft: FileType) {
+    let dir = ctx.new_file(FileType::Dir).create().unwrap();
+    let file = ctx.new_file(ft).name(dir.join("file")).create().unwrap();
+
+    assert_mtime_changed(ctx, &dir, || {
+        assert_ctime_changed(ctx, &dir, || {
+            assert!(unlink(&file).is_ok());
+        });
+    })
+}
+
+crate::test_case! {
+    /// An open file will not be immediately freed by unlink
+    // unlink/14.t
+    open_file_not_freed
+}
+fn open_file_not_freed(ctx: &mut TestContext) {
+    let (path, file) = ctx
+        .create_file(nix::fcntl::OFlag::O_RDWR, Some(0o644))
+        .unwrap();
+
+    assert!(unlink(&path).is_ok());
+
+    let fd_stat = fstat(file.as_raw_fd()).unwrap();
+    // A deleted file's link count should be 0
+    assert_eq!(fd_stat.st_nlink, 0);
+
+    // I/O to open but deleted files should work, too
+    const EXAMPLE_BYTES: &str = "Hello, World!";
+    nix::unistd::write(&file, EXAMPLE_BYTES.as_bytes()).unwrap();
+    let mut buf = [0; EXAMPLE_BYTES.len()];
+    nix::sys::uio::pread(&file, &mut buf, 0).unwrap();
+    assert_eq!(buf, EXAMPLE_BYTES.as_bytes());
+}
+
+// unlink/01.t
+enotdir_comp_test_case!(unlink);
+
+// unlink/02.t
+enametoolong_comp_test_case!(unlink);
+
+// unlink/03.t
+enametoolong_path_test_case!(unlink);
+
+// unlink/04.t
+enoent_named_file_test_case!(unlink);
+
+// unlink/07.t
+eloop_comp_test_case!(unlink);
+
+// unlink/12.t
+erofs_named_test_case!(unlink);
+
+// unlink/13.t
+efault_path_test_case!(unlink, nix::libc::unlink);

--- a/tests/pjdfstest/src/tests/utimensat.rs
+++ b/tests/pjdfstest/src/tests/utimensat.rs
@@ -1,0 +1,355 @@
+use std::{
+    fs::{metadata, symlink_metadata},
+    os::unix::fs::symlink,
+};
+
+#[cfg(birthtime)]
+use crate::tests::birthtime_ts;
+use crate::tests::MetadataExt;
+use crate::utils::chmod;
+use crate::{context::FileType, test::TestContext};
+use crate::{context::SerializedTestContext, test::FileSystemFeature};
+
+use nix::{
+    errno::Errno,
+    sys::{
+        stat::{utimensat, Mode, UtimensatFlags::*},
+        time::{TimeSpec, TimeValLike},
+    },
+};
+
+const UTIME_NOW: TimeSpec = TimeSpec::new(0, nix::libc::UTIME_NOW);
+const UTIME_OMIT: TimeSpec = TimeSpec::new(0, nix::libc::UTIME_OMIT);
+
+crate::test_case! {
+    /// utimensat changes timestamps on any type of file
+    // utimensat/00.t
+    changes_timestamps, FileSystemFeature::Utimensat => [Regular, Dir, Fifo, Block, Char, Socket]
+}
+fn changes_timestamps(ctx: &mut TestContext, f_type: FileType) {
+    let date1 = TimeSpec::seconds(1900000000); // Sun Mar 17 11:46:40 MDT 2030
+    let date2 = TimeSpec::seconds(1950000000); // Fri Oct 17 04:40:00 MDT 2031
+    let path = ctx.create(f_type).unwrap();
+
+    assert!(utimensat(None, &path, &date1, &date2, FollowSymlink).is_ok());
+
+    let md = metadata(&path).unwrap();
+    assert_eq!(md.atime_ts(), date1);
+    assert_eq!(md.mtime_ts(), date2);
+}
+
+crate::test_case! {
+    /// utimensat with UTIME_NOW will set the timestamps to now
+    // utimensat/01.t
+    utime_now, FileSystemFeature::Utimensat, FileSystemFeature::UtimeNow
+}
+fn utime_now(ctx: &mut TestContext) {
+    // Allow up to a 5 minute delta between timestamps
+    let margin = TimeSpec::seconds(300);
+    let null_ts = TimeSpec::seconds(0);
+    let path = ctx.create(FileType::Regular).unwrap();
+    let md = metadata(&path).unwrap();
+    let orig_atime = md.atime_ts();
+    let orig_mtime = md.mtime_ts();
+    ctx.nap();
+
+    assert!(utimensat(None, &path, &UTIME_NOW, &UTIME_NOW, FollowSymlink).is_ok());
+
+    let md = metadata(&path).unwrap();
+    let delta_atime = md.atime_ts() - orig_atime;
+    let delta_mtime = md.mtime_ts() - orig_mtime;
+    assert!(delta_atime > null_ts, "atime was not updated");
+    assert!(delta_mtime > null_ts, "mtime was not updated");
+    assert!(
+        delta_atime < margin,
+        "new atime is implausibly far in the future"
+    );
+    assert!(
+        delta_mtime < margin,
+        "new mtime is implausibly far in the future"
+    );
+}
+
+crate::test_case! {
+    /// utimensat with UTIME_OMIT will leave the timestamps unchanged
+    // utimensat/02.t
+    utime_omit, FileSystemFeature::Utimensat
+}
+fn utime_omit(ctx: &mut TestContext) {
+    let date1 = TimeSpec::seconds(1900000000); // Sun Mar 17 11:46:40 MDT 2030
+    let date2 = TimeSpec::seconds(1950000000); // Fri Oct 17 04:40:00 MDT 2031
+    let path = ctx.create(FileType::Regular).unwrap();
+    let md = metadata(&path).unwrap();
+    let orig_mtime = md.mtime_ts();
+
+    assert!(utimensat(None, &path, &date1, &UTIME_OMIT, FollowSymlink).is_ok());
+    let md = metadata(&path).unwrap();
+    assert_eq!(md.atime_ts(), date1);
+    assert_eq!(md.mtime_ts(), orig_mtime);
+
+    assert!(utimensat(None, &path, &UTIME_OMIT, &date2, FollowSymlink).is_ok());
+    let md = metadata(&path).unwrap();
+    assert_eq!(md.atime_ts(), date1);
+    assert_eq!(md.mtime_ts(), date2);
+}
+
+#[cfg(birthtime)]
+crate::test_case! {
+    /// utimensat can update birthtimes
+    // utimensat/03.t
+    birthtime, FileSystemFeature::Utimensat, FileSystemFeature::StatStBirthtime
+}
+#[cfg(birthtime)]
+fn birthtime(ctx: &mut TestContext) {
+    let date1 = TimeSpec::seconds(100000000); // Sat Mar  3 02:46:40 MST 1973
+    let date2 = TimeSpec::seconds(200000000); // Mon May  3 13:33:20 MDT 1976
+    let path = ctx.create(FileType::Regular).unwrap();
+
+    assert!(utimensat(None, &path, &date1, &date1, FollowSymlink).is_ok());
+    let md = metadata(&path).unwrap();
+    assert_eq!(date1, md.atime_ts());
+    assert_eq!(date1, md.mtime_ts());
+    assert_eq!(date1, birthtime_ts(&path));
+
+    assert!(utimensat(None, &path, &date2, &date2, FollowSymlink).is_ok());
+    let md = metadata(&path).unwrap();
+    assert_eq!(date2, md.atime_ts());
+    assert_eq!(date2, md.mtime_ts());
+    assert_eq!(date1, birthtime_ts(&path));
+}
+
+crate::test_case! {
+    /// utimensat can set mtime < atime or vice versa
+    // utimensat/04.t
+    order, FileSystemFeature::Utimensat
+}
+fn order(ctx: &mut TestContext) {
+    let date1 = TimeSpec::seconds(1900000000); // Sun Mar 17 11:46:40 MDT 2030
+    let date2 = TimeSpec::seconds(1950000000); // Fri Oct 17 04:40:00 MDT 2031
+    let path = ctx.create(FileType::Regular).unwrap();
+    assert!(utimensat(None, &path, &date1, &date2, FollowSymlink).is_ok());
+    assert!(utimensat(None, &path, &date2, &date1, FollowSymlink).is_ok());
+}
+
+crate::test_case! {
+    /// utimensat can follow symlinks
+    // utimensat/05.t
+    follow_symlink, FileSystemFeature::Utimensat
+}
+fn follow_symlink(ctx: &mut TestContext) {
+    let date1 = TimeSpec::seconds(1900000000); // Sun Mar 17 11:46:40 MDT 2030
+    let date2 = TimeSpec::seconds(1950000000); // Fri Oct 17 04:40:00 MDT 2031
+    let date3 = TimeSpec::seconds(1960000000); // Mon Feb  9 21:26:40 MST 2032
+    let date4 = TimeSpec::seconds(1970000000); // Fri Jun  4 16:13:20 MDT 2032
+    let date5 = TimeSpec::seconds(1980000000); // Tue Sep 28 10:00:00 MDT 2032
+    let date6 = TimeSpec::seconds(1990000000); // Sat Jan 22 02:46:40 MST 2033
+
+    let path = ctx.create(FileType::Regular).unwrap();
+    let lpath = path.with_extension("link");
+    symlink(&path, &lpath).unwrap();
+
+    assert!(utimensat(None, &path, &date1, &date2, FollowSymlink).is_ok());
+    assert!(utimensat(None, &lpath, &date3, &date4, NoFollowSymlink).is_ok());
+
+    let md = metadata(&path).unwrap();
+    let lmd = symlink_metadata(&lpath).unwrap();
+    assert_eq!(date1, md.atime_ts());
+    assert_eq!(date2, md.mtime_ts());
+    assert_eq!(date3, lmd.atime_ts());
+    assert_eq!(date4, lmd.mtime_ts());
+
+    assert!(utimensat(None, &lpath, &date5, &date6, FollowSymlink).is_ok());
+    let md = metadata(&path).unwrap();
+    let lmd = symlink_metadata(&lpath).unwrap();
+    assert_eq!(date5, md.atime_ts());
+    assert_eq!(date6, md.mtime_ts());
+    // If atime is disabled on the current mount, then lpath's atime should
+    // still be date3.  However, if atime is enabled, then lpath's atime will
+    // be the current system time.  For this test, it's sufficient to simply
+    // check that it didn't get set to date5.
+    assert_ne!(date5, lmd.atime_ts());
+    assert_eq!(date4, lmd.mtime_ts());
+}
+
+crate::test_case! {
+    /// A user without write permission cannot use UTIME_NOW
+    // utimensat/06.t:L26
+    utime_now_nobody, serialized, root, FileSystemFeature::Utimensat, FileSystemFeature::UtimeNow
+}
+fn utime_now_nobody(ctx: &mut SerializedTestContext) {
+    let mode = Mode::from_bits_truncate(0o644);
+    let path = ctx.create(FileType::Regular).unwrap();
+    chmod(&path, mode).unwrap();
+    let user = ctx.get_new_user();
+    ctx.as_user(user, None, || {
+        assert_eq!(
+            Err(Errno::EACCES),
+            utimensat(None, &path, &UTIME_NOW, &UTIME_NOW, FollowSymlink)
+        );
+    });
+}
+
+crate::test_case! {
+    /// The file's owner can use UTIME_NOW, even if the file is read-only
+    // utimensat/06.t:L30
+    utime_now_owner, FileSystemFeature::Utimensat, FileSystemFeature::UtimeNow
+}
+fn utime_now_owner(ctx: &mut TestContext) {
+    let path = ctx.create(FileType::Regular).unwrap();
+    let mode = Mode::from_bits_truncate(0o444);
+    chmod(&path, mode).unwrap();
+    assert!(utimensat(None, &path, &UTIME_NOW, &UTIME_NOW, FollowSymlink).is_ok());
+}
+
+crate::test_case! {
+    /// The superuser can always use UTIME_NOW
+    // utimensat/06.t:L35
+    utime_now_root, root, FileSystemFeature::Utimensat, FileSystemFeature::UtimeNow
+}
+fn utime_now_root(ctx: &mut TestContext) {
+    let path = ctx.create(FileType::Regular).unwrap();
+    let mode = Mode::from_bits_truncate(0o444);
+    chmod(&path, mode).unwrap();
+    assert!(utimensat(None, &path, &UTIME_NOW, &UTIME_NOW, FollowSymlink).is_ok());
+}
+
+crate::test_case! {
+    /// A user with write permission can use UTIME_NOW
+    // utimensat/06.t:L38
+    utime_now_write_perm, serialized, root, FileSystemFeature::Utimensat, FileSystemFeature::UtimeNow
+}
+fn utime_now_write_perm(ctx: &mut SerializedTestContext) {
+    let mode = Mode::from_bits_truncate(0o666);
+    let path = ctx.create(FileType::Regular).unwrap();
+    chmod(&path, mode).unwrap();
+    let user = ctx.get_new_user();
+    ctx.as_user(user, None, || {
+        assert!(utimensat(None, &path, &UTIME_OMIT, &UTIME_OMIT, FollowSymlink).is_ok());
+    });
+}
+
+crate::test_case! {
+    /// A user without write permission cannot set the timestamps arbitrarily
+    // utimensat/07.t:L28
+    nobody, serialized, root, FileSystemFeature::Utimensat
+}
+fn nobody(ctx: &mut SerializedTestContext) {
+    let mode = Mode::from_bits_truncate(0o644);
+    let date1 = TimeSpec::seconds(1900000000); // Sun Mar 17 11:46:40 MDT 2030
+    let date2 = TimeSpec::seconds(1950000000); // Fri Oct 17 04:40:00 MDT 2031
+    let path = ctx.create(FileType::Regular).unwrap();
+    chmod(&path, mode).unwrap();
+    let user = ctx.get_new_user();
+    ctx.as_user(user, None, || {
+        assert_eq!(
+            Err(Errno::EPERM),
+            utimensat(None, &path, &UTIME_OMIT, &date2, FollowSymlink)
+        );
+        assert_eq!(
+            Err(Errno::EPERM),
+            utimensat(None, &path, &date1, &UTIME_OMIT, FollowSymlink)
+        );
+        assert_eq!(
+            Err(Errno::EPERM),
+            utimensat(None, &path, &date1, &date2, FollowSymlink)
+        );
+    })
+}
+
+crate::test_case! {
+    /// A user with write permission cannot set the timestamps arbitrarily
+    // utimensat/07.t:L33
+    write_perm, serialized, root, FileSystemFeature::Utimensat
+}
+fn write_perm(ctx: &mut SerializedTestContext) {
+    let mode = Mode::from_bits_truncate(0o666);
+    let date1 = TimeSpec::seconds(1900000000); // Sun Mar 17 11:46:40 MDT 2030
+    let date2 = TimeSpec::seconds(1950000000); // Fri Oct 17 04:40:00 MDT 2031
+    let path = ctx.create(FileType::Regular).unwrap();
+    chmod(&path, mode).unwrap();
+    let user = ctx.get_new_user();
+    ctx.as_user(user, None, || {
+        assert_eq!(
+            Err(Errno::EPERM),
+            utimensat(None, &path, &UTIME_OMIT, &date2, FollowSymlink)
+        );
+        assert_eq!(
+            Err(Errno::EPERM),
+            utimensat(None, &path, &date1, &UTIME_OMIT, FollowSymlink)
+        );
+        assert_eq!(
+            Err(Errno::EPERM),
+            utimensat(None, &path, &date1, &date2, FollowSymlink)
+        );
+    })
+}
+
+crate::test_case! {
+    /// The owner can update the timstamps, even if the file is read-only
+    // utimensat/07.t:L40
+    owner, FileSystemFeature::Utimensat
+}
+fn owner(ctx: &mut TestContext) {
+    let date1 = TimeSpec::seconds(1900000000); // Sun Mar 17 11:46:40 MDT 2030
+    let date2 = TimeSpec::seconds(1950000000); // Fri Oct 17 04:40:00 MDT 2031
+    let path = ctx.create(FileType::Regular).unwrap();
+    let mode = Mode::from_bits_truncate(0o444);
+    chmod(&path, mode).unwrap();
+    assert!(utimensat(None, &path, &date1, &date2, FollowSymlink).is_ok());
+}
+crate::test_case! {
+    /// Root can always update the timestamps, even if the file is read-only
+    // utimensat/07.t:L44
+    root, root, FileSystemFeature::Utimensat
+}
+fn root(ctx: &mut TestContext) {
+    let date1 = TimeSpec::seconds(1900000000); // Sun Mar 17 11:46:40 MDT 2030
+    let date2 = TimeSpec::seconds(1950000000); // Fri Oct 17 04:40:00 MDT 2031
+    let path = ctx.create(FileType::Regular).unwrap();
+    let mode = Mode::from_bits_truncate(0o444);
+    chmod(&path, mode).unwrap();
+    assert!(utimensat(None, &path, &date1, &date2, FollowSymlink).is_ok());
+}
+
+crate::test_case! {
+    /// utimensat can set timestamps with subsecond precision
+    // utimensat/08.t
+    subsecond, FileSystemFeature::Utimensat
+}
+fn subsecond(ctx: &mut TestContext) {
+    // Different file systems have different timestamp resolutions.  Check that
+    // they can do 0.1 second, but don't bother checking the finest resolution.
+
+    // Sat Mar  3 02:46:40 MST 1973
+    let date1 = TimeSpec::new(100000000, 100000000);
+    // Mon May  3 13:33:20 MDT 1976
+    let date2 = TimeSpec::new(200000000, 200000000);
+
+    let path = ctx.create(FileType::Regular).unwrap();
+
+    assert!(utimensat(None, &path, &date1, &date2, FollowSymlink).is_ok());
+
+    let md = metadata(&path).unwrap();
+    assert_eq!(date1, md.atime_ts());
+    assert_eq!(date2, md.mtime_ts());
+}
+
+crate::test_case! {
+    /// utimensat is y2038 compliant
+    // utimensat/09.t
+    y2038, FileSystemFeature::Utimensat
+}
+fn y2038(ctx: &mut TestContext) {
+    // 2^31, ie Mon Jan 18 20:14:08 MST 2038
+    let date1 = TimeSpec::seconds(2147483648);
+    // 2^32, ie Sat Feb  6 23:28:16 MST 2106
+    let date2 = TimeSpec::seconds(4294967296);
+
+    let path = ctx.create(FileType::Regular).unwrap();
+
+    assert!(utimensat(None, &path, &date1, &date2, FollowSymlink).is_ok());
+
+    let md = metadata(&path).unwrap();
+    assert_eq!(date1, md.atime_ts());
+    assert_eq!(date2, md.mtime_ts());
+}

--- a/tests/pjdfstest/src/utils.rs
+++ b/tests/pjdfstest/src/utils.rs
@@ -1,0 +1,101 @@
+//! Utility functions for filesystem operations.
+//!
+//! This module provides utility functions for filesystem operations which are not available in the standard library.
+
+use std::{
+    os::fd::{FromRawFd, OwnedFd},
+    path::Path,
+};
+
+use nix::{
+    fcntl::{renameat, AtFlags, OFlag},
+    sys::stat::{fchmodat, lstat, FchmodatFlags, Mode},
+    unistd::{fchownat, linkat, symlinkat, Gid, Uid},
+};
+
+pub mod dev;
+
+/// Wrapper for `fchmodat(None, path, mode, FchmodatFlags::FollowSymlink)`.
+pub fn chmod<P: ?Sized + nix::NixPath>(path: &P, mode: nix::sys::stat::Mode) -> nix::Result<()> {
+    fchmodat(None, path, mode, FchmodatFlags::FollowSymlink)
+}
+
+/// Wrapper for `fchmodat(None, path, mode, FchmodatFlags::NoFollowSymlink)`.
+pub fn lchmod<P: ?Sized + nix::NixPath>(path: &P, mode: nix::sys::stat::Mode) -> nix::Result<()> {
+    fchmodat(None, path, mode, FchmodatFlags::NoFollowSymlink)
+}
+
+/// Wrapper for `fchownat(None, path, mode, FchownatFlags::NoFollowSymlink)`.
+pub fn lchown<P: ?Sized + nix::NixPath>(
+    path: &P,
+    owner: Option<Uid>,
+    group: Option<Gid>,
+) -> nix::Result<()> {
+    fchownat(None, path, owner, group, AtFlags::AT_SYMLINK_NOFOLLOW)
+}
+
+/// Wrapper for `rmdir`.
+pub fn rmdir<P: ?Sized + nix::NixPath>(path: &P) -> nix::Result<()> {
+    let res = path.with_nix_path(|cstr| unsafe { nix::libc::rmdir(cstr.as_ptr()) })?;
+    nix::errno::Errno::result(res).map(std::mem::drop)
+}
+
+pub const ALLPERMS: nix::sys::stat::mode_t = 0o7777;
+
+/// Wrapper for `renameat(None, old_path, None, new_path)`.
+pub fn rename<P: ?Sized + nix::NixPath>(old_path: &P, new_path: &P) -> nix::Result<()> {
+    renameat(None, old_path, None, new_path)
+}
+
+/// Wrapper for `linkat(None, old_path, None, new_path)`.
+pub fn link<P: ?Sized + nix::NixPath>(old_path: &P, new_path: &P) -> nix::Result<()> {
+    linkat(None, old_path, None, new_path, AtFlags::empty())
+}
+
+/// Wrapper for `symlinkat(path1, None, path2)`.
+pub fn symlink<P: ?Sized + nix::NixPath>(path1: &P, path2: &P) -> nix::Result<()> {
+    symlinkat(path1, None, path2)
+}
+
+/// Get mountpoint.
+pub fn get_mountpoint(base_path: &Path) -> Result<&Path, anyhow::Error> {
+    let base_dev = lstat(base_path)?.st_dev;
+
+    let mut mountpoint = base_path;
+    loop {
+        let current = match mountpoint.parent() {
+            Some(p) => p,
+            // Root
+            _ => return Ok(mountpoint),
+        };
+        let current_dev = lstat(current)?.st_dev;
+
+        if current_dev != base_dev {
+            break;
+        }
+
+        mountpoint = current;
+    }
+
+    Ok(mountpoint)
+}
+
+/// Safe wrapper for `lchflags`.
+#[cfg(lchflags)]
+pub fn lchflags<P: ?Sized + nix::NixPath>(
+    path: &P,
+    flags: nix::sys::stat::FileFlag,
+) -> nix::Result<()> {
+    use nix::errno::Errno;
+    let res =
+        path.with_nix_path(|cstr| unsafe { nix::libc::lchflags(cstr.as_ptr(), flags.bits()) })?;
+
+    Errno::result(res).map(drop)
+}
+
+/// Wrapper for open which returns [`Ownedfd`] instead of [`RawFd`].
+pub fn open<P: ?Sized + nix::NixPath>(path: &P, oflag: OFlag, mode: Mode) -> nix::Result<OwnedFd> {
+    // SAFETY: The file descriptor was initialized only by open and isn't used anywhere else,
+    // leaving the ownership to the caller.
+    nix::fcntl::open(path, oflag, mode).map(|fd| unsafe { OwnedFd::from_raw_fd(fd) })
+}

--- a/tests/pjdfstest/src/utils/dev.rs
+++ b/tests/pjdfstest/src/utils/dev.rs
@@ -1,0 +1,77 @@
+// TODO: Would be clearer with cfg_if
+
+#[cfg(target_os = "freebsd")]
+pub use freebsd::*;
+#[cfg(target_os = "illumos")]
+pub use illumos::*;
+#[cfg(target_os = "linux")]
+pub use linux::*;
+
+#[cfg(target_os = "linux")]
+mod linux {
+    pub fn makedev(major: u64, minor: u64) -> nix::libc::dev_t {
+        nix::sys::stat::makedev(major, minor)
+    }
+
+    pub fn major(dev: nix::libc::dev_t) -> u64 {
+        nix::sys::stat::major(dev)
+    }
+
+    pub fn minor(dev: nix::libc::dev_t) -> u64 {
+        nix::sys::stat::minor(dev)
+    }
+}
+
+#[cfg(target_os = "freebsd")]
+mod freebsd {
+    pub fn makedev(major: u64, minor: u64) -> nix::libc::dev_t {
+        nix::libc::makedev(major.try_into().unwrap(), minor.try_into().unwrap())
+    }
+
+    pub fn major(dev: u64) -> u64 {
+        ((dev >> 32) & 0xffffff00) | ((dev >> 8) & 0xff)
+    }
+
+    pub fn minor(dev: u64) -> u64 {
+        ((dev >> 24) & 0xff00) | (dev & 0xffff00ff)
+    }
+}
+
+#[cfg(target_os = "illumos")]
+mod illumos {
+    // sysmacros.h
+
+    type major_t = nix::libc::uint32_t;
+    type minor_t = nix::libc::uint32_t;
+
+    mod x32 {
+        const L_BITSMAJOR: usize = 14; /* # of SVR4 major device bits */
+        const L_BITSMINOR: usize = 18; /* # of SVR4 minor device bits */
+        const L_MAXMAJ: usize = 0x3fff; /* SVR4 max major value */
+        const L_MAXMIN: usize = 0x3ffff; /* MAX minor for 3b2 software drivers. */
+    }
+
+    mod x64 {
+        const L_BITSMAJOR: usize = 32; /* # of major device bits in 64-bit illumos */
+        const L_BITSMINOR: usize = 32; /* # of minor device bits in 64-bit illumos */
+        const L_MAXMAJ: usize = 0xffffffff; /* max major value */
+        const L_MAXMIN: usize = 0xffffffff; /* max minor value */
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    use x32::*;
+    #[cfg(target_pointer_width = "64")]
+    use x64::*;
+
+    pub fn makedev(major: major_t, minor: minor_t) -> nix::libc::dev_t {
+        ((major) << L_BITSMINOR) | ((minor) & L_MAXMIN)
+    }
+
+    pub fn major(dev: nix::libc::dev_t) -> major_t {
+        (dev >> L_BITSMAJOR)
+    }
+
+    pub fn minor(dev: nix::libc::dev_t) -> minor_t {
+        (dev & L_MAXMIN)
+    }
+}


### PR DESCRIPTION
Closes #580.

## Summary
- Vendor the Rust rewrite of pjdfstest (upstream commit `a53a2103ff86a1cf1643f3d075e7478725cab879`) into `tests/pjdfstest/`, preserving the upstream 2-clause BSD license verbatim at `tests/pjdfstest/LICENSE`.
- Strip test ops whose syscalls vibix doesn't implement: `chflags`, `mkfifo`, `mknod`, `nfsv4acl/`, `posix_fallocate`, `errors/etxtbsy` — 6 files / 1 directory (9 source files), each removal commented inline at the mod declaration and at every call site (`open.rs`, `truncate.rs`).
- Keep the vendored crate out of the kernel workspace (`exclude = [\"tests/pjdfstest\"]` in the root `Cargo.toml` plus an empty `[workspace]` stanza inside the crate) so its nightly/target/dep versions don't leak into the kernel build graph. Wiring into xtask is #581; CI is #582.
- Document provenance, license, and the strip list in `docs/attribution/pjdfstest.md`.

## Test plan
- [x] `cargo +nightly check --bin pjdfstest` inside `tests/pjdfstest/` compiles on the Linux host (5 dead-code warnings — all upstream).
- [x] `cargo check -p xtask` in the outer workspace still succeeds (confirms the exclude keeps the kernel build graph intact).
- [x] `cargo fmt --all -- --check` at the outer workspace and inside the vendored crate both pass.
- [ ] CI (fmt + clippy + unit + integration + ext2-image + smoke) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)