### PR TITLE
fs/vfs: dentry_pin_count on SuperBlock closes umount2 busy-check gap (#637)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -425,6 +425,10 @@ name = "umount2_flags"
 harness = false
 
 [[test]]
+name = "dentry_pin_unmount"
+harness = false
+
+[[test]]
 name = "ext2_orphan_finalize"
 harness = false
 required-features = ["ext2"]

--- a/kernel/src/fs/vfs/dentry.rs
+++ b/kernel/src/fs/vfs/dentry.rs
@@ -16,6 +16,7 @@
 
 use alloc::collections::BTreeMap;
 use alloc::sync::{Arc, Weak};
+use core::sync::atomic::Ordering;
 
 use crate::sync::{BlockingRwLock, Semaphore};
 
@@ -136,6 +137,88 @@ impl Dentry {
     /// `true` if `inode` is currently populated (positive dentry).
     pub fn is_positive(&self) -> bool {
         self.inode.read().is_some()
+    }
+}
+
+/// RAII wrapper around an `Arc<Dentry>` that increments the dentry's
+/// owning [`SuperBlock::dentry_pin_count`] on construction and
+/// decrements it on drop. Used by long-lived dentry storage sites
+/// (`Task::cwd`, [`super::OpenFile`]) to keep the SB's busy counter
+/// honest so `umount2`'s default `EBUSY` check and the `MNT_DETACH`
+/// finalize-gate see every live pin — not just the transient
+/// [`super::SbActiveGuard`] scopes.
+///
+/// The pin is anchored to the dentry's inode's super-block via the
+/// inode's [`alloc::sync::Weak`]. If the SB has already been dropped
+/// (dentries outliving their SB is only possible for negative/orphan
+/// dentries during teardown), the counter bump is a no-op; the Drop
+/// side then naturally also skips.
+///
+/// Holders that are not themselves pinning an SB (e.g. a dentry
+/// constructed outside any mount in a unit test) get a no-op pin.
+pub struct PinnedDentry {
+    dentry: Arc<Dentry>,
+    sb: Option<Arc<SuperBlock>>,
+}
+
+impl PinnedDentry {
+    /// Pin `dentry`: bump its SB's `dentry_pin_count`. The pin is
+    /// released when the returned value is dropped.
+    pub fn new(dentry: Arc<Dentry>) -> Self {
+        let sb = dentry
+            .inode
+            .read()
+            .as_ref()
+            .and_then(|ino| ino.sb.upgrade());
+        if let Some(sb) = sb.as_ref() {
+            sb.dentry_pin_count.fetch_add(1, Ordering::SeqCst);
+        }
+        Self { dentry, sb }
+    }
+
+    /// Access the underlying dentry.
+    pub fn dentry(&self) -> &Arc<Dentry> {
+        &self.dentry
+    }
+
+    /// Clone the underlying `Arc<Dentry>` without affecting the pin
+    /// count. Callers that need a short-lived reference (a path walk's
+    /// `cwd` seed, for instance) should prefer this over taking a new
+    /// `PinnedDentry`.
+    pub fn clone_arc(&self) -> Arc<Dentry> {
+        self.dentry.clone()
+    }
+}
+
+impl Clone for PinnedDentry {
+    /// Cloning a `PinnedDentry` yields a second pin on the same SB —
+    /// `fork(2)` cloning a parent's cwd into the child is the canonical
+    /// use case.
+    fn clone(&self) -> Self {
+        if let Some(sb) = self.sb.as_ref() {
+            sb.dentry_pin_count.fetch_add(1, Ordering::SeqCst);
+        }
+        Self {
+            dentry: self.dentry.clone(),
+            sb: self.sb.clone(),
+        }
+    }
+}
+
+impl Drop for PinnedDentry {
+    fn drop(&mut self) {
+        if let Some(sb) = self.sb.as_ref() {
+            let old = sb.dentry_pin_count.fetch_sub(1, Ordering::SeqCst);
+            debug_assert!(old > 0, "dentry_pin_count underflow");
+            if old == 1 {
+                // Last dentry pin released: a lazily-detached mount
+                // whose finalize-gate was waiting on `dentry_pin_count`
+                // may now be runnable. `finalize_pending_detach` is a
+                // no-op for SBs without a pending detach entry, so
+                // calling it unconditionally is safe.
+                super::mount_table::finalize_pending_detach(sb);
+            }
+        }
     }
 }
 

--- a/kernel/src/fs/vfs/mod.rs
+++ b/kernel/src/fs/vfs/mod.rs
@@ -61,7 +61,7 @@ pub mod super_block;
 pub mod tarfs;
 
 pub use backend::VfsBackend;
-pub use dentry::{ChildState, DFlags, Dentry, MountEdge, MountFlags};
+pub use dentry::{ChildState, DFlags, Dentry, MountEdge, MountFlags, PinnedDentry};
 pub use devfs::DevFs;
 pub use gc_queue::{gc_drain, gc_drain_for, gc_overflow_count, gc_pending_count};
 pub use init::{init, root};

--- a/kernel/src/fs/vfs/mount_table.rs
+++ b/kernel/src/fs/vfs/mount_table.rs
@@ -242,7 +242,14 @@ pub(super) fn finalize_pending_detach(sb: &SuperBlock) {
         let mut i = 0;
         while i < pending.len() {
             let entry_ptr: *const SuperBlock = &*pending[i];
-            if core::ptr::eq(entry_ptr, sb_ptr) && pending[i].sb_active.load(Ordering::SeqCst) == 0
+            // Finalize only when *both* counters are zero. Either can
+            // be the last to drop: a syscall's `SbActiveGuard` or a
+            // long-lived dentry pin (cwd, OpenFile). The last drop in
+            // either class calls this function from its Drop impl, so
+            // whichever edge wins the race finds both at zero.
+            if core::ptr::eq(entry_ptr, sb_ptr)
+                && pending[i].sb_active.load(Ordering::SeqCst) == 0
+                && pending[i].dentry_pin_count.load(Ordering::SeqCst) == 0
             {
                 ready.push(pending.swap_remove(i));
             } else {
@@ -302,16 +309,30 @@ pub fn unmount(target: &Arc<Dentry>, flags: UmountFlags) -> Result<(), i64> {
 
         // Default-flag busy check: a single two-phase commit around
         // the `draining` flag closes the zero->one window.
+        //
+        // We require *both* counters to be zero. `sb_active` catches
+        // in-flight syscalls; `dentry_pin_count` catches long-lived
+        // dentry refs that outlive a syscall (chdir cwd, open fds,
+        // future getcwd caches). Either being nonzero means a user-
+        // observable thing would break if we tore the SB down.
         if !force && !detach {
-            // Pre-check sb_active before publishing `draining=true`,
+            // Pre-check both counters before publishing `draining=true`,
             // so racing SbActiveGuard::try_acquire callers don't
-            // observe a transient drain we'd roll back.
-            if sb.sb_active.load(Ordering::SeqCst) != 0 {
+            // observe a transient drain we'd roll back. Note:
+            // `dentry_pin_count` is not gated by `draining` — a new
+            // chdir/open still goes via path_walk which does acquire
+            // `SbActiveGuard`, so publishing `draining=true` also
+            // fences new dentry pins from being created on this SB.
+            if sb.sb_active.load(Ordering::SeqCst) != 0
+                || sb.dentry_pin_count.load(Ordering::SeqCst) != 0
+            {
                 *edge_slot = Some(edge);
                 return Err(EBUSY);
             }
             sb.draining.store(true, Ordering::SeqCst);
-            if sb.sb_active.load(Ordering::SeqCst) != 0 {
+            if sb.sb_active.load(Ordering::SeqCst) != 0
+                || sb.dentry_pin_count.load(Ordering::SeqCst) != 0
+            {
                 sb.draining.store(false, Ordering::SeqCst);
                 *edge_slot = Some(edge);
                 return Err(EBUSY);
@@ -329,9 +350,12 @@ pub fn unmount(target: &Arc<Dentry>, flags: UmountFlags) -> Result<(), i64> {
         drop(edge_slot);
         drop(table);
 
-        // Decide finalize path: DETACH defers if any guard still
-        // holds the SB; every other path runs Phase B inline.
-        let defer = detach && sb.sb_active.load(Ordering::SeqCst) != 0;
+        // Decide finalize path: DETACH defers if any guard *or* any
+        // long-lived dentry pin still holds the SB; every other path
+        // runs Phase B inline.
+        let defer = detach
+            && (sb.sb_active.load(Ordering::SeqCst) != 0
+                || sb.dentry_pin_count.load(Ordering::SeqCst) != 0);
         if defer {
             PENDING_DETACH.lock().push(sb.clone());
         }
@@ -339,12 +363,15 @@ pub fn unmount(target: &Arc<Dentry>, flags: UmountFlags) -> Result<(), i64> {
     };
 
     if defer_finalize {
-        // Race window: a guard may have dropped to zero between our
-        // `defer` check and the push above. Re-check and finalize
-        // inline if so; otherwise the guard's Drop will run it.
-        // `finalize_pending_detach` will pop the entry and run the
-        // finalizer exactly once.
-        if sb.sb_active.load(Ordering::SeqCst) == 0 {
+        // Race window: a guard or dentry pin may have dropped to zero
+        // between our `defer` check and the push above. Re-check both
+        // counters and finalize inline if they are now zero;
+        // otherwise the last Drop on whichever counter is still
+        // nonzero will run it. `finalize_pending_detach` pops the
+        // entry and runs the finalizer exactly once.
+        if sb.sb_active.load(Ordering::SeqCst) == 0
+            && sb.dentry_pin_count.load(Ordering::SeqCst) == 0
+        {
             finalize_pending_detach(&sb);
         }
     } else {

--- a/kernel/src/fs/vfs/open_file.rs
+++ b/kernel/src/fs/vfs/open_file.rs
@@ -17,6 +17,7 @@ use crate::sync::BlockingMutex;
 
 use super::dentry::Dentry;
 use super::inode::Inode;
+use super::mount_table::finalize_pending_detach;
 use super::ops::FileOps;
 use super::super_block::{SbActiveGuard, SuperBlock};
 
@@ -39,12 +40,23 @@ pub struct OpenFile {
 }
 
 impl OpenFile {
-    /// Construct an `OpenFile`, transferring the `sb_active` pin held
-    /// by `guard` into the new file. `mem::forget`ting the guard hands
-    /// the matching `fetch_sub` over to `OpenFile::drop`, so the SB
-    /// remains pinned for the file's whole lifetime and the unmount
-    /// barrier sees zero pending callers exactly when no `OpenFile`
-    /// for the SB is live.
+    /// Construct an `OpenFile`, converting the syscall-scope
+    /// [`SbActiveGuard`] into a long-lived `dentry_pin_count` bump.
+    ///
+    /// `guard`'s `fetch_add` on `sb_active` would normally be undone
+    /// by its `Drop`; `mem::forget`ting it here instead hands ownership
+    /// of that pin to this `OpenFile`. To keep `sb_active` honest — it
+    /// should only count in-flight syscalls, never long-lived
+    /// storage — the constructor immediately `fetch_sub`s it and in the
+    /// same motion `fetch_add`s `dentry_pin_count`, which is the
+    /// counter that `umount2`'s default busy-check and the
+    /// `MNT_DETACH` finalize-gate consult for open files.
+    ///
+    /// The net effect on `sb_active` is zero, which is correct: the
+    /// in-flight syscall that called `open(2)` is about to return to
+    /// userspace (its guard scope ends) and there is no further
+    /// in-flight work on this SB for this open. The SB stays pinned
+    /// by `dentry_pin_count` for the file's lifetime instead.
     pub fn new(
         dentry: Arc<Dentry>,
         inode: Arc<Inode>,
@@ -58,6 +70,25 @@ impl OpenFile {
             "OpenFile::new: SbActiveGuard must pin the same SuperBlock"
         );
         mem::forget(guard);
+        // Hand the guard's pin off to `dentry_pin_count` before any
+        // other code observes a zero edge on `sb_active`. Use a single
+        // SeqCst fence-ordered pair: bump dentry_pin_count first so
+        // any racing umount that reads sb_active==0 also sees a
+        // nonzero dentry_pin_count.
+        sb.dentry_pin_count.fetch_add(1, Ordering::SeqCst);
+        let old = sb.sb_active.fetch_sub(1, Ordering::SeqCst);
+        debug_assert!(old > 0, "OpenFile::new: sb_active underflow");
+        if old == 1 {
+            // The sub drove sb_active to zero; if a lazy-detach was
+            // waiting only on us and the new dentry_pin is invisible
+            // to its check, the finalize-gate would fire prematurely.
+            // finalize_pending_detach re-reads both counters under
+            // the PENDING_DETACH mutex and will see dentry_pin_count
+            // > 0, so we stay pending. Calling it is still the right
+            // thing: it's a no-op when the SB isn't in the pending
+            // list.
+            finalize_pending_detach(&sb);
+        }
         Arc::new(Self {
             dentry,
             inode,
@@ -69,12 +100,16 @@ impl OpenFile {
     }
 }
 
-/// Releases the `sb_active` pin transferred into `OpenFile::new`. The
-/// matching `fetch_add` lives on the [`SbActiveGuard`] that the
-/// caller passed to `new`.
+/// Releases the `dentry_pin_count` pin transferred into
+/// [`OpenFile::new`]. If this drops the count to zero, any lazily
+/// -detached SB waiting on the pin has its finalizer fire here.
 impl Drop for OpenFile {
     fn drop(&mut self) {
-        self.sb.sb_active.fetch_sub(1, Ordering::SeqCst);
+        let old = self.sb.dentry_pin_count.fetch_sub(1, Ordering::SeqCst);
+        debug_assert!(old > 0, "OpenFile::drop: dentry_pin_count underflow");
+        if old == 1 {
+            finalize_pending_detach(&self.sb);
+        }
     }
 }
 
@@ -130,7 +165,8 @@ mod tests {
         let file_ops: Arc<dyn FileOps> = Arc::new(StubFile);
         let guard = SbActiveGuard::try_acquire(&sb).expect("guard");
         let of = OpenFile::new(dentry, inode, file_ops, sb.clone(), 0, guard);
-        assert_eq!(sb.sb_active.load(Ordering::SeqCst), 1);
+        assert_eq!(sb.sb_active.load(Ordering::SeqCst), 0);
+        assert_eq!(sb.dentry_pin_count.load(Ordering::SeqCst), 1);
 
         // Drop the local strong ref; the OpenFile still pins the SB.
         let weak = Arc::downgrade(&sb);
@@ -140,7 +176,7 @@ mod tests {
     }
 
     #[test]
-    fn open_file_drop_releases_sb_active() {
+    fn open_file_drop_releases_dentry_pin() {
         let sb = Arc::new(SuperBlock::new(
             FsId(2),
             Arc::new(StubSuper),
@@ -160,8 +196,10 @@ mod tests {
         let file_ops: Arc<dyn FileOps> = Arc::new(StubFile);
         let guard = SbActiveGuard::try_acquire(&sb).expect("guard");
         let of = OpenFile::new(dentry, inode, file_ops, sb.clone(), 0, guard);
-        assert_eq!(sb.sb_active.load(Ordering::SeqCst), 1);
+        assert_eq!(sb.sb_active.load(Ordering::SeqCst), 0);
+        assert_eq!(sb.dentry_pin_count.load(Ordering::SeqCst), 1);
         drop(of);
         assert_eq!(sb.sb_active.load(Ordering::SeqCst), 0);
+        assert_eq!(sb.dentry_pin_count.load(Ordering::SeqCst), 0);
     }
 }

--- a/kernel/src/fs/vfs/super_block.rs
+++ b/kernel/src/fs/vfs/super_block.rs
@@ -61,6 +61,18 @@ pub struct SuperBlock {
     /// `sys_umount` Phase A sets `draining = true` then spins on
     /// `sb_active == 0`.
     pub sb_active: AtomicUsize,
+    /// Long-lived `Arc<Dentry>` pin count. Bumped for every dentry that
+    /// outlives a syscall's [`SbActiveGuard`] — e.g. stored in
+    /// `Task::cwd`, held inside an `OpenFile`, or (future) cached in a
+    /// `getcwd` path-cache. `sys_umount`'s default busy-check refuses
+    /// `EBUSY` unless this is zero *in addition to* `sb_active`; the
+    /// `MNT_DETACH` finalize-gate likewise consults both.
+    ///
+    /// Distinct from `sb_active`: `sb_active` is a short-lived
+    /// in-flight-syscall count; `dentry_pin_count` is what keeps a
+    /// filesystem "busy" from a user-observable standpoint (a process
+    /// whose cwd lives on the mount, an open fd, etc.).
+    pub dentry_pin_count: AtomicUsize,
     pub draining: AtomicBool,
 }
 
@@ -81,6 +93,7 @@ impl SuperBlock {
             flags,
             rename_mutex: BlockingMutex::new(()),
             sb_active: AtomicUsize::new(0),
+            dentry_pin_count: AtomicUsize::new(0),
             draining: AtomicBool::new(false),
         }
     }

--- a/kernel/src/fs/vfs/tarfs.rs
+++ b/kernel/src/fs/vfs/tarfs.rs
@@ -831,8 +831,10 @@ mod tests {
             ops: hello.file_ops.clone(),
             sb: sb.clone(),
         };
-        // Pin sb_active so Drop's fetch_sub doesn't underflow.
-        sb.sb_active.fetch_add(1, Ordering::SeqCst);
+        // Pin dentry_pin_count so OpenFile::drop's fetch_sub doesn't
+        // underflow — matches the counter OpenFile::new would bump
+        // on the real open-path.
+        sb.dentry_pin_count.fetch_add(1, Ordering::SeqCst);
 
         let mut buf = [0u8; 16];
         let n = hello.file_ops.read(&of, &mut buf, 0).expect("read");

--- a/kernel/src/lntab.rs
+++ b/kernel/src/lntab.rs
@@ -39,9 +39,9 @@ const VERSION: u8 = 1;
 /// Integration-test binaries pull in more code paths than the main
 /// kernel and produce notably larger line tables — the main kernel
 /// lands around ~990 KiB today while the largest test ELF needs
-/// ~1.15 MiB. 2 MiB gives both headroom. If it overflows, xtask
+/// ~1.15 MiB. 2.5 MiB gives both headroom. If it overflows, xtask
 /// aborts with a clear "bump LNTAB_BYTES" error.
-pub const LNTAB_BYTES: usize = 2 * 1024 * 1024;
+pub const LNTAB_BYTES: usize = 2 * 1024 * 1024 + 512 * 1024;
 
 /// Fixed-size reservation patched in place by xtask after linking. The
 /// explicit non-zero magic in the first four bytes forces LLVM to emit

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -482,7 +482,11 @@ pub fn replace_current_credentials(new_cred: crate::fs::vfs::Credential) {
 ///
 /// Briefly locks the scheduler to clone the `Arc`, then releases it.
 pub fn current_cwd() -> Option<alloc::sync::Arc<crate::fs::vfs::Dentry>> {
-    SCHED.lock().current.as_ref().and_then(|t| t.cwd.clone())
+    SCHED
+        .lock()
+        .current
+        .as_ref()
+        .and_then(|t| t.cwd.as_ref().map(|p| p.clone_arc()))
 }
 
 /// Replace the currently-running task's `Credential` snapshot.
@@ -504,9 +508,20 @@ pub fn set_current_credentials(cred: crate::fs::vfs::Credential) {
 /// Called by `sys_chdir` after successfully resolving and verifying
 /// that the target is a directory.
 pub fn set_current_cwd(dentry: alloc::sync::Arc<crate::fs::vfs::Dentry>) {
-    if let Some(cur) = SCHED.lock().current.as_mut() {
-        cur.cwd = Some(dentry);
-    }
+    // Construct the `PinnedDentry` *before* taking the SCHED lock: the
+    // old cwd's Drop may run during the replacement and calls
+    // `finalize_pending_detach`, which takes the `PENDING_DETACH`
+    // blocking mutex. Doing that work under SCHED would invert the
+    // lock order against every other finalize path.
+    let new_cwd = crate::fs::vfs::PinnedDentry::new(dentry);
+    let _old = {
+        let mut sched = SCHED.lock();
+        sched
+            .current
+            .as_mut()
+            .and_then(|cur| cur.cwd.replace(new_cwd))
+    };
+    // `_old` drops here with no locks held.
 }
 
 /// Return the current scheduling priority of the currently-running

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -143,7 +143,13 @@ pub(super) struct Task {
     /// spawned before `vfs::init()` runs. `chdir` sets this to the
     /// resolved dentry; `fork` copies it from the parent; `exec` preserves
     /// it unchanged.
-    pub cwd: Option<alloc::sync::Arc<crate::fs::vfs::Dentry>>,
+    ///
+    /// Wrapped in [`crate::fs::vfs::PinnedDentry`] so its lifetime bumps
+    /// the owning SB's `dentry_pin_count`. That counter is what makes
+    /// `umount2`'s default busy-check refuse `EBUSY` when a task's cwd
+    /// still lives on the mount, and what makes the `MNT_DETACH`
+    /// finalize-gate wait for the chdir to be released.
+    pub cwd: Option<crate::fs::vfs::PinnedDentry>,
 
     /// Per-task POSIX credentials (uid/euid/suid + gid/egid/sgid +
     /// supplementary groups). Stored as `Arc<Credential>` behind a
@@ -356,7 +362,7 @@ impl Task {
         child_address_space: alloc::sync::Arc<spin::RwLock<AddressSpace>>,
         child_cr3: PhysFrame<Size4KiB>,
         child_fd_table: alloc::sync::Arc<Mutex<crate::fs::FileDescTable>>,
-        child_cwd: Option<alloc::sync::Arc<crate::fs::vfs::Dentry>>,
+        child_cwd: Option<crate::fs::vfs::PinnedDentry>,
         child_credentials: Arc<Credential>,
     ) -> Result<Self, crate::mem::addrspace::ForkError> {
         crate::fork_trace!(

--- a/kernel/tests/dentry_pin_unmount.rs
+++ b/kernel/tests/dentry_pin_unmount.rs
@@ -1,0 +1,325 @@
+//! Integration test for issue #637: `SuperBlock::dentry_pin_count` is
+//! honoured by the `umount2` default busy-check and the `MNT_DETACH`
+//! finalize-gate.
+//!
+//! The pre-#637 `umount2` implementation only consulted `sb_active`
+//! (the in-flight-syscall guard counter). That missed dentries kept in
+//! long-lived storage: `Task::cwd` via `chdir(2)`, `OpenFile.dentry`
+//! held by an open fd, and any future `getcwd`-style path cache.
+//!
+//! This test stands up a stub filesystem, mounts it, constructs a
+//! [`PinnedDentry`] on that mount's root (the generic proxy for any of
+//! those long-lived storage sites), and verifies:
+//!
+//! 1. Default `umount2(MNT_NONE)` returns `-EBUSY` while the pin
+//!    lives; releasing the pin lets the same call succeed.
+//! 2. `umount2(MNT_DETACH)` with a live dentry pin unlinks the mount
+//!    edge synchronously but defers `sync_fs` + `ops.unmount` until
+//!    the pin drops — mirroring the Linux lazy-umount contract.
+//!
+//! Stub filesystem is re-built locally (matching `umount2_flags.rs`)
+//! so the test doesn't depend on any real driver and drains
+//! `MOUNT_TABLE` at entry to stay isolated from neighbour tests.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use spin::Mutex;
+
+use vibix::fs::vfs::dentry::{Dentry, MountFlags, PinnedDentry};
+use vibix::fs::vfs::inode::{Inode, InodeKind, InodeMeta};
+use vibix::fs::vfs::ops::{
+    FileOps, FileSystem, InodeOps, MountSource, SetAttr, Stat, StatFs, SuperOps,
+};
+use vibix::fs::vfs::super_block::{SbFlags, SuperBlock};
+use vibix::fs::vfs::{alloc_fs_id, mount, unmount, UmountFlags, MOUNT_TABLE};
+use vibix::fs::EBUSY;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "default_umount_with_dentry_pin_is_ebusy",
+            &(default_umount_with_dentry_pin_is_ebusy as fn()),
+        ),
+        (
+            "dentry_pin_release_unblocks_umount",
+            &(dentry_pin_release_unblocks_umount as fn()),
+        ),
+        (
+            "detach_with_dentry_pin_defers_finalize",
+            &(detach_with_dentry_pin_defers_finalize as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Stub filesystem (mirrors umount2_flags.rs).
+// ---------------------------------------------------------------------------
+
+struct StubInode;
+impl InodeOps for StubInode {
+    fn getattr(&self, _i: &Inode, _o: &mut Stat) -> Result<(), i64> {
+        Ok(())
+    }
+    fn setattr(&self, _i: &Inode, _a: &SetAttr) -> Result<(), i64> {
+        Ok(())
+    }
+}
+
+struct StubFile;
+impl FileOps for StubFile {}
+
+struct StubSuper {
+    unmount_calls: AtomicUsize,
+}
+impl SuperOps for StubSuper {
+    fn root_inode(&self) -> Arc<Inode> {
+        unreachable!("root_inode should not be called; sb.root is pre-populated");
+    }
+    fn statfs(&self) -> Result<StatFs, i64> {
+        Ok(StatFs::default())
+    }
+    fn unmount(&self) {
+        self.unmount_calls.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+struct StubFs {
+    ops: Arc<StubSuper>,
+    sb_built: Mutex<Option<Arc<SuperBlock>>>,
+}
+impl FileSystem for StubFs {
+    fn name(&self) -> &'static str {
+        "dentry-pin-stub"
+    }
+    fn mount(&self, _source: MountSource<'_>, _flags: MountFlags) -> Result<Arc<SuperBlock>, i64> {
+        let sb = Arc::new(SuperBlock::new(
+            alloc_fs_id(),
+            self.ops.clone(),
+            "dentry-pin-stub",
+            512,
+            SbFlags::default(),
+        ));
+        let root_ino = Arc::new(Inode::new(
+            1,
+            Arc::downgrade(&sb),
+            Arc::new(StubInode),
+            Arc::new(StubFile),
+            InodeKind::Dir,
+            InodeMeta {
+                mode: 0o755,
+                nlink: 2,
+                ..Default::default()
+            },
+        ));
+        sb.root.call_once(|| root_ino);
+        *self.sb_built.lock() = Some(sb.clone());
+        Ok(sb)
+    }
+}
+
+fn make_fs() -> Arc<StubFs> {
+    Arc::new(StubFs {
+        ops: Arc::new(StubSuper {
+            unmount_calls: AtomicUsize::new(0),
+        }),
+        sb_built: Mutex::new(None),
+    })
+}
+
+/// Build a fresh dir-kind dentry suitable as a mountpoint. Its inode's
+/// SB is leaked via `mem::forget` for the test lifetime so the
+/// weak-ref chain upgrades.
+fn make_dir_dentry() -> Arc<Dentry> {
+    let sb = Arc::new(SuperBlock::new(
+        alloc_fs_id(),
+        Arc::new(StubSuper {
+            unmount_calls: AtomicUsize::new(0),
+        }),
+        "host",
+        512,
+        SbFlags::default(),
+    ));
+    let inode = Arc::new(Inode::new(
+        1,
+        Arc::downgrade(&sb),
+        Arc::new(StubInode),
+        Arc::new(StubFile),
+        InodeKind::Dir,
+        InodeMeta {
+            mode: 0o755,
+            nlink: 2,
+            ..Default::default()
+        },
+    ));
+    let root = Dentry::new_root(inode);
+    core::mem::forget(sb);
+    root
+}
+
+fn drain_table() {
+    let mut t = MOUNT_TABLE.write();
+    t.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Pin a dentry on a mounted FS; default umount2 must fail with EBUSY
+/// even though no `SbActiveGuard` is live. This is the #637 regression
+/// coverage: the old code only consulted `sb_active` and would have
+/// erroneously succeeded here.
+fn default_umount_with_dentry_pin_is_ebusy() {
+    drain_table();
+    let target = make_dir_dentry();
+    let fs = make_fs();
+    let edge = mount(
+        MountSource::None,
+        &target,
+        fs.clone(),
+        MountFlags::default(),
+    )
+    .expect("mount");
+
+    // Simulate `chdir(mount.root)` by pinning the mount's root dentry.
+    // `PinnedDentry::new` bumps the SB's `dentry_pin_count`.
+    let pin = PinnedDentry::new(edge.root_dentry.clone());
+    assert_eq!(
+        edge.super_block.dentry_pin_count.load(Ordering::SeqCst),
+        1,
+        "PinnedDentry must bump dentry_pin_count",
+    );
+    assert_eq!(
+        edge.super_block.sb_active.load(Ordering::SeqCst),
+        0,
+        "no SbActiveGuard taken — sb_active must stay zero",
+    );
+
+    let r = unmount(&target, UmountFlags::default());
+    assert_eq!(
+        r.err(),
+        Some(EBUSY),
+        "default umount2 must return EBUSY while dentry_pin_count > 0",
+    );
+    assert!(
+        target.mount.read().is_some(),
+        "mount edge must be restored on EBUSY",
+    );
+    assert!(
+        !edge.super_block.draining.load(Ordering::SeqCst),
+        "draining flag must be rolled back on EBUSY",
+    );
+    // Cleanup.
+    drop(pin);
+    unmount(&target, UmountFlags::default()).expect("cleanup");
+}
+
+/// Release the dentry pin and then re-run umount — it must succeed.
+/// Mirrors the issue's second scenario: "open a file, chdir out,
+/// umount → still EBUSY until the file is closed" (fd-table Arc chain
+/// ultimately bottoms out at the same `dentry_pin_count` counter that
+/// `PinnedDentry` bumps here).
+fn dentry_pin_release_unblocks_umount() {
+    drain_table();
+    let target = make_dir_dentry();
+    let fs = make_fs();
+    let edge = mount(
+        MountSource::None,
+        &target,
+        fs.clone(),
+        MountFlags::default(),
+    )
+    .expect("mount");
+
+    let pin = PinnedDentry::new(edge.root_dentry.clone());
+    assert_eq!(unmount(&target, UmountFlags::default()).err(), Some(EBUSY));
+    drop(pin);
+    assert_eq!(
+        edge.super_block.dentry_pin_count.load(Ordering::SeqCst),
+        0,
+        "dentry_pin_count must return to zero after Drop",
+    );
+    unmount(&target, UmountFlags::default()).expect("post-release umount");
+    assert!(target.mount.read().is_none());
+    assert_eq!(
+        fs.ops.unmount_calls.load(Ordering::SeqCst),
+        1,
+        "Phase B must run inline now that no pins remain",
+    );
+}
+
+/// `MNT_DETACH` with a dentry pin unlinks the edge synchronously but
+/// defers `ops.unmount` until the pin drops — the same lazy contract
+/// that `MNT_DETACH` already honoured for in-flight `SbActiveGuard`s.
+fn detach_with_dentry_pin_defers_finalize() {
+    drain_table();
+    let target = make_dir_dentry();
+    let fs = make_fs();
+    let edge = mount(
+        MountSource::None,
+        &target,
+        fs.clone(),
+        MountFlags::default(),
+    )
+    .expect("mount");
+    let sb = edge.super_block.clone();
+    let pin = PinnedDentry::new(edge.root_dentry.clone());
+
+    unmount(&target, UmountFlags::DETACH).expect("detach unmount");
+    assert!(
+        target.mount.read().is_none(),
+        "detach unlinks synchronously even with a dentry pin",
+    );
+    assert_eq!(
+        MOUNT_TABLE.read().len(),
+        0,
+        "table entry removed synchronously",
+    );
+    assert_eq!(
+        fs.ops.unmount_calls.load(Ordering::SeqCst),
+        0,
+        "Phase B must be deferred while dentry_pin_count > 0",
+    );
+
+    // Dropping the last dentry pin fires the deferred finalize.
+    drop(pin);
+    assert_eq!(
+        sb.dentry_pin_count.load(Ordering::SeqCst),
+        0,
+        "pin Drop must decrement the counter",
+    );
+    assert_eq!(
+        fs.ops.unmount_calls.load(Ordering::SeqCst),
+        1,
+        "pin Drop must trigger the deferred finalize exactly once",
+    );
+}


### PR DESCRIPTION
Closes #637.

## Summary

- Adds `SuperBlock::dentry_pin_count: AtomicUsize` — a second busy-check axis for long-lived dentry pins, distinct from `sb_active`'s in-flight syscall guards. `umount2` now refuses `EBUSY` unless both counters are zero, and `MNT_DETACH` defers finalize (sync_fs + ops.unmount) until both drain.
- Introduces `PinnedDentry`, an RAII wrapper over `Arc<Dentry>` that bumps `dentry_pin_count` on construction and decrements + kicks the finalize-gate on drop.
- Converts the two long-lived pin sites the issue called out: `Task::cwd` (via `chdir(2)`) and `OpenFile.dentry` (via open fds). Order of fetch_add/fetch_sub in `OpenFile::new` is chosen so a racing unmount at the `sb_active==0` edge still observes a non-zero pin.
- Bumps `LNTAB_BYTES` from 2 MiB to 2.5 MiB — the new integration test pushes the largest test-binary line table past the old cap.

## Test plan

- [x] `cargo xtask build`
- [x] `cargo xtask test` — all integration tests pass including the 3 new `dentry_pin_unmount` cases
- [x] `cargo xtask smoke` — all 31 required markers present
- [x] `cargo fmt --all`

### New coverage

`kernel/tests/dentry_pin_unmount.rs` exercises:

1. `default_umount_with_dentry_pin_is_ebusy` — mount, pin a dentry, assert `umount2(MNT_NONE)` returns `EBUSY` and the mount edge is restored (pre-#637 this succeeded incorrectly since `sb_active == 0`).
2. `dentry_pin_release_unblocks_umount` — drop the pin and confirm a second `umount2` call succeeds and `ops.unmount` runs exactly once.
3. `detach_with_dentry_pin_defers_finalize` — `umount2(MNT_DETACH)` unlinks the mount edge synchronously but does not call `ops.unmount`; dropping the last pin fires the deferred finalize exactly once.