### PR TITLE
fs/ext2: wire slow-symlink read through indirect walker (#603)

### DIFF
--- a/kernel/src/fs/ext2/symlink.rs
+++ b/kernel/src/fs/ext2/symlink.rs
@@ -1,4 +1,4 @@
-//! ext2 symlink read path — fast (inline) and slow (first data block).
+//! ext2 symlink read path — fast (inline) and slow (indirect walker).
 //!
 //! RFC 0004 (`docs/RFC/0004-ext2-filesystem-driver.md`), Workstream D
 //! wave 2, issue #563. ext2 stores the target of a symbolic link in one
@@ -17,30 +17,42 @@
 //! confusion". Missing any leg lets a crafted image leak up to 60 bytes
 //! of inode-table memory to userspace through `readlink`. The copy is
 //! always clamped to `min(i_size, 60, user_buflen)` on the fast path
-//! and `min(i_size, block_size, user_buflen)` on the slow path.
+//! and `min(i_size, user_buflen)` on the slow path (with `i_size`
+//! itself bounded by `EXT2_SYMLINK_READ_MAX`).
 //!
 //! `readlink(2)` is **not** NUL-terminated — POSIX mandates that
 //! callers use the return value as the byte count. This module returns
 //! the byte count; callers (`InodeOps::readlink`) must never append a
 //! trailing zero.
 //!
-//! # Slow-symlink scope in this wave
+//! # Slow-symlink read path
 //!
-//! Targets > 60 bytes live in the inode's data blocks. The full read
-//! path requires the indirect-block walker (issue #560, not yet
-//! merged). Until #560 lands, this module only handles slow symlinks
-//! whose entire target fits in the first direct block
-//! (`i_block[0]`) — i.e. `i_size <= block_size`. In practice every
-//! POSIX symlink target fits in a single 1 KiB / 4 KiB block (the
-//! hard cap is `PATH_MAX == 4096`), so the "walker required" case is
-//! only hit on ≤ 1 KiB-block filesystems with targets > 1 KiB, which
-//! are exceptionally rare. A target that would need indirect lookup
-//! returns `EIO` for now; the follow-up issue (linked at #563's close)
-//! wires the slow path through the walker in a later change.
+//! Targets > 60 bytes live in the inode's data blocks. The reader
+//! walks the block chain through [`super::indirect::resolve_block`] —
+//! the same routine that backs regular-file reads (see
+//! [`super::file::read_file_at`]) — and concatenates each block into
+//! the caller buffer. `PATH_MAX` (4096 including the implicit NUL,
+//! i.e. `EXT2_SYMLINK_TARGET_MAX == 4095` bytes) bounds the walk, so a
+//! legal symlink never chases past single-indirect even on a 1 KiB-
+//! block filesystem (4 × 1 KiB direct + 1 KiB indirect would already
+//! exceed the cap). An `i_size` above the cap surfaces as
+//! `ENAMETOOLONG` — image corruption rather than an honest POSIX
+//! symlink. Sparse holes inside a symlink body are structurally
+//! impossible; if [`resolve_block`] surfaces `Ok(None)` the image is
+//! treated as corrupt and the read returns `EIO`.
 
 #![allow(dead_code)]
 
 use super::disk::{Ext2Inode, EXT2_N_BLOCKS};
+
+/// Upper bound on a legal symlink target's `i_size`. POSIX caps a path
+/// at 4096 bytes including the trailing NUL; the on-disk symlink stores
+/// the target **without** a NUL, so the largest honest `i_size` is
+/// 4095. An `i_size` above this is image corruption — either a hostile
+/// image trying to spill the reader past a single allocated block, or
+/// a filesystem writer that didn't clamp. Matches
+/// [`super::link::EXT2_SYMLINK_TARGET_MAX`] on the write side.
+pub const EXT2_SYMLINK_READ_MAX: u32 = 4095;
 
 /// ext2 `i_mode` file-type mask. Matches the POSIX `S_IFMT` bitmask
 /// (top 4 bits of the 16-bit mode word).
@@ -113,25 +125,34 @@ pub fn read_fast_symlink(inode: &Ext2Inode, buf: &mut [u8]) -> Result<usize, i64
     Ok(n)
 }
 
-/// Copy the slow-symlink target out of the inode's **first direct
-/// block** into `buf`.
+/// Copy a slow-symlink target into `buf` via the indirect-block
+/// walker, returning the number of bytes written.
 ///
-/// This is the interim slow path while the indirect walker (#560) is
-/// in flight: it reads `inode.i_block[0]` through the buffer cache,
-/// clamps to `min(i_size, block_size, buf.len())`, and returns. A
-/// target that spills past the first direct block (requires `i_size >
-/// block_size`, i.e. `> 4 KiB` on a 4 KiB filesystem) returns `EIO` —
-/// callers that hit this case are blocked on the walker follow-up.
+/// Walks logical blocks `0..ceil(i_size / block_size)` through
+/// [`super::indirect::resolve_block`] — the same routine that backs
+/// regular-file reads — concatenating each block's contents into
+/// `buf`. The copy is clamped to `min(i_size, buf.len())`; on an
+/// attacker-forged image with `i_size > EXT2_SYMLINK_READ_MAX` the
+/// read surfaces `ENAMETOOLONG` before any `bread`, so a crafted
+/// inode cannot coax the reader into stitching together arbitrary
+/// amounts of disk content.
+///
+/// A zero pointer anywhere along the walk — including a sparse hole
+/// that [`resolve_block`] would normally report as `Ok(None)` — maps
+/// to `EIO`. A symlink is either wholly allocated or doesn't exist;
+/// a partially-allocated body is image corruption.
 ///
 /// Callers must have checked `is_symlink(inode) == true` and
-/// `is_fast_symlink(inode) == false` before entering.
+/// `is_fast_symlink(inode) == false` before entering. The dispatcher
+/// [`read_symlink`] already enforces this.
 #[cfg(all(feature = "ext2", target_os = "none"))]
-pub fn read_slow_symlink_direct_only(
+pub fn read_slow_symlink(
     inode: &Ext2Inode,
-    super_: &super::fs::Ext2Super,
+    super_: &alloc::sync::Arc<super::fs::Ext2Super>,
     buf: &mut [u8],
 ) -> Result<usize, i64> {
-    use crate::fs::{EINVAL, EIO};
+    use super::indirect::{resolve_block, Geometry, WalkError};
+    use crate::fs::{EINVAL, EIO, ENAMETOOLONG};
 
     if !is_symlink(inode) {
         return Err(EINVAL);
@@ -140,44 +161,69 @@ pub fn read_slow_symlink_direct_only(
         // Caller confusion: this entry point is the slow path only.
         return Err(EINVAL);
     }
+    // PATH_MAX guard. A legal POSIX symlink target is ≤ 4095 bytes
+    // (4096 including the implicit trailing NUL that userspace appends,
+    // which we do not store on disk). `i_size` above this is either
+    // corruption or a hostile image trying to spill the reader past
+    // the allocated extent; refuse loudly. Note the write path
+    // (`link::symlink`) clamps to the same cap before allocation, so
+    // no honest vibix-written symlink ever trips this.
+    if inode.i_size > EXT2_SYMLINK_READ_MAX {
+        return Err(ENAMETOOLONG);
+    }
+
     let block_size = super_.block_size as u64;
-    // Interim restriction: only the first direct block. Indirect walk
-    // lands with #560.
-    if (inode.i_size as u64) > block_size {
-        return Err(EIO);
-    }
-    let blk = inode.i_block[0];
-    if blk == 0 {
-        // Sparse / hole in a symlink is nonsense — symlinks are never
-        // partially allocated. Treat as EIO (image corruption).
-        return Err(EIO);
-    }
-    // Bounds-check against the filesystem extent. The full walker
-    // (#560) also rejects block pointers that fall inside the
-    // metadata-forbidden bitmap; here we only need the minimum
-    // sanity check — a hostile image could otherwise read any
-    // device sector.
+    debug_assert!(block_size > 0, "mount validated block_size != 0");
+
     let (s_first_data_block, s_blocks_count) = {
         let sb = super_.sb_disk.lock();
         (sb.s_first_data_block, sb.s_blocks_count)
     };
-    if (blk as u64) >= s_blocks_count as u64 {
-        return Err(EIO);
-    }
-    if (blk as u64) < s_first_data_block as u64 {
-        return Err(EIO);
+    let geom = Geometry::new(super_.block_size, s_first_data_block, s_blocks_count).ok_or(EIO)?;
+    let md = super::file::build_metadata_map(super_);
+
+    let total = core::cmp::min(inode.i_size as usize, buf.len());
+    if total == 0 {
+        return Ok(0);
     }
 
-    let bh = super_
-        .cache
-        .bread(super_.device_id, blk as u64)
-        .map_err(|_| EIO)?;
-    let data = bh.data.read();
-    let n = core::cmp::min(inode.i_size as usize, block_size as usize);
-    let n = core::cmp::min(n, buf.len());
-    let n = core::cmp::min(n, data.len());
-    buf[..n].copy_from_slice(&data[..n]);
-    Ok(n)
+    let mut copied = 0usize;
+    while copied < total {
+        let logical = (copied as u64 / block_size) as u32;
+        let in_block = copied % block_size as usize;
+        let remaining_in_block = block_size as usize - in_block;
+        let chunk = core::cmp::min(remaining_in_block, total - copied);
+
+        match resolve_block(
+            &super_.cache,
+            super_.device_id,
+            &geom,
+            &md,
+            &inode.i_block,
+            logical,
+            None,
+        ) {
+            Ok(Some(abs)) => {
+                let bh = super_
+                    .cache
+                    .bread(super_.device_id, abs as u64)
+                    .map_err(|_| EIO)?;
+                let data = bh.data.read();
+                debug_assert!(in_block + chunk <= data.len());
+                buf[copied..copied + chunk].copy_from_slice(&data[in_block..in_block + chunk]);
+            }
+            // A symlink body with a hole is corruption — see module
+            // docs. `write_slow_symlink_target` allocates every
+            // logical block before publishing the inode, so a hole
+            // means the image is lying to us.
+            Ok(None) => return Err(EIO),
+            Err(WalkError::Io) => return Err(EIO),
+            Err(WalkError::Corrupt) => return Err(EIO),
+        }
+        copied += chunk;
+    }
+
+    Ok(copied)
 }
 
 /// Dispatch entry point: copy a symlink's target into `buf`, returning
@@ -185,15 +231,15 @@ pub fn read_slow_symlink_direct_only(
 /// wires to for ext2 inodes (#559 wires the `InodeOps` impl itself).
 ///
 /// * Fast symlinks (target ≤ 60 bytes, stored inline) always succeed.
-/// * Slow symlinks fall back to the direct-block-only path while #560
-///   is in flight; targets > `block_size` return `EIO` until the
-///   indirect walker lands.
+/// * Slow symlinks walk the inode's data-block chain through the
+///   indirect walker ([`read_slow_symlink`]); `i_size >
+///   EXT2_SYMLINK_READ_MAX` surfaces as `ENAMETOOLONG`.
 /// * Non-symlink inodes return `EINVAL` — the POSIX errno for
 ///   `readlink` on a non-link.
 #[cfg(all(feature = "ext2", target_os = "none"))]
 pub fn read_symlink(
     inode: &Ext2Inode,
-    super_: &super::fs::Ext2Super,
+    super_: &alloc::sync::Arc<super::fs::Ext2Super>,
     buf: &mut [u8],
 ) -> Result<usize, i64> {
     if !is_symlink(inode) {
@@ -202,7 +248,7 @@ pub fn read_symlink(
     if is_fast_symlink(inode) {
         read_fast_symlink(inode, buf)
     } else {
-        read_slow_symlink_direct_only(inode, super_, buf)
+        read_slow_symlink(inode, super_, buf)
     }
 }
 

--- a/kernel/tests/ext2_link.rs
+++ b/kernel/tests/ext2_link.rs
@@ -82,6 +82,10 @@ fn run_tests() {
             &(symlink_slow_200_bytes_walker as fn()),
         ),
         (
+            "symlink_slow_multi_block_via_walker",
+            &(symlink_slow_multi_block_via_walker as fn()),
+        ),
+        (
             "symlink_read_rejects_oversize_i_size",
             &(symlink_read_rejects_oversize_i_size as fn()),
         ),
@@ -521,6 +525,141 @@ fn symlink_slow_200_bytes_walker() {
     let n = read_symlink(&d, &super_arc, &mut short).expect("readback short");
     assert_eq!(n, 50);
     assert_eq!(&short[..], &target[..50]);
+
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+/// Issue #603: the walker-backed slow reader must resolve logical
+/// block 1 — not just block 0 — when `i_size > block_size`. The
+/// symlink write path still caps slow symlinks at one data block (see
+/// `write_slow_symlink_target`), so we can't build this on top of
+/// `ext2_symlink` alone. Instead we allocate two data blocks by hand,
+/// write the target halves into them via the buffer cache, and feed
+/// the reader a synthetic `disk::Ext2Inode` whose `i_block[0..2]`
+/// points at those blocks. This is exactly what a hostile (or more
+/// capable) writer would produce on disk, and it forces the walker
+/// to step off the first direct slot.
+fn symlink_slow_multi_block_via_walker() {
+    use vibix::fs::ext2::alloc_block;
+    use vibix::fs::ext2::disk::Ext2Inode as DiskInode;
+    use vibix::fs::ext2::symlink::{read_symlink as read_symlink_fn, EXT2_S_IFLNK};
+
+    let (sb, _fs, super_arc, _disk) = mount_golden_rw();
+    // The golden image is 1 KiB blocks; we need a target length > one
+    // block so logical block 1 is reached, but still <= PATH_MAX - 1.
+    let block_size = super_arc.block_size as usize;
+    assert_eq!(
+        block_size, 1024,
+        "this test assumes the 1 KiB-block golden image"
+    );
+    let target_len: usize = block_size + 200; // 1224 bytes, spans 2 blocks
+
+    // Allocate two fresh data blocks on the image. `alloc_block`
+    // consults the block bitmap so the pointers it returns are legal
+    // data-block numbers, not metadata.
+    let blk0 = alloc_block(&super_arc, None).expect("alloc_block 0");
+    let blk1 = alloc_block(&super_arc, None).expect("alloc_block 1");
+    assert_ne!(blk0, blk1, "allocator must hand back distinct blocks");
+
+    // Deterministic per-byte pattern, easy to spot a mis-alignment.
+    let target: alloc::vec::Vec<u8> = (0..target_len)
+        .map(|i| ((i as u32 * 37 + 11) & 0xff) as u8)
+        .collect();
+
+    // Stamp the first block_size bytes into blk0 …
+    {
+        let bh = super_arc
+            .cache
+            .bread(super_arc.device_id, blk0 as u64)
+            .expect("bread blk0");
+        {
+            let mut data = bh.data.write();
+            for b in data.iter_mut() {
+                *b = 0;
+            }
+            data[..block_size].copy_from_slice(&target[..block_size]);
+        }
+        super_arc.cache.mark_dirty(&bh);
+        super_arc.cache.sync_dirty_buffer(&bh).expect("sync blk0");
+    }
+    // … and the remaining 200 bytes into blk1.
+    let tail_len = target_len - block_size;
+    {
+        let bh = super_arc
+            .cache
+            .bread(super_arc.device_id, blk1 as u64)
+            .expect("bread blk1");
+        {
+            let mut data = bh.data.write();
+            for b in data.iter_mut() {
+                *b = 0;
+            }
+            data[..tail_len].copy_from_slice(&target[block_size..]);
+        }
+        super_arc.cache.mark_dirty(&bh);
+        super_arc.cache.sync_dirty_buffer(&bh).expect("sync blk1");
+    }
+
+    // Synthetic disk inode: S_IFLNK, two direct pointers, i_size
+    // spanning the two blocks. This struct is never written back —
+    // the reader operates on whatever `&Ext2Inode` it's handed.
+    let mut i_block = [0u32; 15];
+    i_block[0] = blk0;
+    i_block[1] = blk1;
+    let d = DiskInode {
+        i_mode: EXT2_S_IFLNK | 0o777,
+        i_uid: 0,
+        i_size: target_len as u32,
+        i_atime: 0,
+        i_ctime: 0,
+        i_mtime: 0,
+        i_dtime: 0,
+        i_gid: 0,
+        i_links_count: 1,
+        // `i_blocks` is in 512-byte units.
+        i_blocks: (2 * block_size as u32) / 512,
+        i_flags: 0,
+        i_block,
+        i_dir_acl_or_size_high: 0,
+        l_i_uid_high: 0,
+        l_i_gid_high: 0,
+    };
+    assert!(is_symlink(&d));
+    assert!(
+        !is_fast_symlink(&d),
+        "multi-block synthetic must not match the fast-symlink gate"
+    );
+
+    // Full readback: the walker must stitch blocks 0 and 1 together.
+    // Sentinel-fill past the expected end so we can prove the reader
+    // stops at `i_size`.
+    let mut buf = alloc::vec![0xc3u8; target_len + 32];
+    let n = read_symlink_fn(&d, &super_arc, &mut buf).expect("readback multi-block");
+    assert_eq!(n, target_len);
+    assert_eq!(&buf[..n], target.as_slice());
+    for &b in &buf[n..] {
+        assert_eq!(b, 0xc3, "reader wrote past i_size");
+    }
+
+    // Mid-block short buffer exercises the logical-block-0 tail copy
+    // while still proving the walker index math.
+    let mut short = [0u8; 42];
+    let n = read_symlink_fn(&d, &super_arc, &mut short).expect("readback short");
+    assert_eq!(n, 42);
+    assert_eq!(&short[..], &target[..42]);
+
+    // Cross-boundary short buffer (block_size - 3 .. block_size + 5
+    // worth of read) catches an off-by-one at the direct -> direct
+    // seam on logical block 1.
+    let mut cross = alloc::vec![0u8; block_size + 5];
+    let n = read_symlink_fn(&d, &super_arc, &mut cross).expect("readback cross");
+    assert_eq!(n, block_size + 5);
+    assert_eq!(&cross[..block_size], &target[..block_size]);
+    assert_eq!(
+        &cross[block_size..block_size + 5],
+        &target[block_size..block_size + 5]
+    );
 
     sb.ops.unmount();
     drop(super_arc);

--- a/kernel/tests/ext2_link.rs
+++ b/kernel/tests/ext2_link.rs
@@ -78,6 +78,14 @@ fn run_tests() {
         ),
         ("symlink_slow_61_bytes", &(symlink_slow_61_bytes as fn())),
         (
+            "symlink_slow_200_bytes_walker",
+            &(symlink_slow_200_bytes_walker as fn()),
+        ),
+        (
+            "symlink_read_rejects_oversize_i_size",
+            &(symlink_read_rejects_oversize_i_size as fn()),
+        ),
+        (
             "symlink_boundary_60_vs_61",
             &(symlink_boundary_60_vs_61 as fn()),
         ),
@@ -461,6 +469,100 @@ fn symlink_slow_61_bytes() {
     let n = read_symlink(&d, &super_arc, &mut buf).expect("read back slow symlink");
     assert_eq!(n, target.len());
     assert_eq!(&buf[..n], &target);
+
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+/// Issue #603: wire the slow-symlink read through the indirect walker
+/// rather than the interim direct-only path. A 200-byte target stored
+/// in a single 1 KiB data block exercises the walker's direct-slot
+/// branch on the slow-symlink read code path. We can't construct a
+/// multi-block slow symlink yet because the write side
+/// (`write_slow_symlink_target`) still refuses targets larger than one
+/// block — that's tracked as its own follow-up — but the walker plumbs
+/// the same code path as regular-file reads, so exercising it here
+/// catches any regression in the slow-symlink pipeline.
+fn symlink_slow_200_bytes_walker() {
+    let (sb, _fs, super_arc, _disk) = mount_golden_rw();
+    let parent_vfs = iget(&super_arc, &sb, 2).expect("iget root");
+    let parent = make_ext2_inode_from_disk(&super_arc, &sb, 2);
+
+    // 200-byte target: well past the 60-byte fast boundary, still
+    // inside a single 1 KiB block so the write side is happy. The
+    // pattern is non-repeating enough that a mis-aligned or truncated
+    // read surfaces immediately.
+    let target: [u8; 200] = core::array::from_fn(|i| ((i as u32 * 131 + 17) & 0xff) as u8);
+    let sl = ext2_symlink(&super_arc, &parent, &parent_vfs, &sb, b"long200", &target)
+        .expect("symlink slow 200");
+    let sl_ino = sl.ino as u32;
+
+    let d = read_disk_inode(&super_arc, sl_ino);
+    assert!(is_symlink(&d));
+    assert!(
+        !is_fast_symlink(&d),
+        "200-byte target is past the inline boundary"
+    );
+    assert_eq!(d.i_size as usize, target.len());
+    assert_ne!(d.i_blocks, 0, "slow symlink allocates a data block");
+
+    // Full readback through the walker-backed slow path. Sentinel-fill
+    // the buffer so we catch a reader that over-writes past `i_size`.
+    let mut buf = [0xa5u8; 256];
+    let n = read_symlink(&d, &super_arc, &mut buf).expect("readback 200");
+    assert_eq!(n, target.len());
+    assert_eq!(&buf[..n], &target);
+    // Byte past the end must be untouched (no zero-terminate, no
+    // stray block copy).
+    assert_eq!(buf[n], 0xa5, "reader must not write past i_size");
+
+    // Short buffer: reader clamps to `buf.len()` without error.
+    let mut short = [0u8; 50];
+    let n = read_symlink(&d, &super_arc, &mut short).expect("readback short");
+    assert_eq!(n, 50);
+    assert_eq!(&short[..], &target[..50]);
+
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+/// Issue #603: an `i_size` above `PATH_MAX - 1` (4095) is either
+/// image corruption or a hostile image trying to spill the reader
+/// past the allocated extent. The walker-backed slow-symlink reader
+/// must surface `ENAMETOOLONG` before issuing any `bread`. We
+/// construct the bogus state by creating a legal 64-byte slow
+/// symlink, then synthesising a disk inode with `i_size` poked up
+/// past the cap and running the reader against that struct directly.
+fn symlink_read_rejects_oversize_i_size() {
+    use vibix::fs::ext2::symlink::read_symlink as read_symlink_fn;
+
+    let (sb, _fs, super_arc, _disk) = mount_golden_rw();
+    let parent_vfs = iget(&super_arc, &sb, 2).expect("iget root");
+    let parent = make_ext2_inode_from_disk(&super_arc, &sb, 2);
+
+    // Create a real 64-byte slow symlink so we have a well-formed
+    // inode to mutate.
+    let target: [u8; 64] = core::array::from_fn(|i| b'z' - (i % 26) as u8);
+    let sl = ext2_symlink(
+        &super_arc,
+        &parent,
+        &parent_vfs,
+        &sb,
+        b"oversizebase",
+        &target,
+    )
+    .expect("symlink base");
+    let sl_ino = sl.ino as u32;
+
+    let mut d = read_disk_inode(&super_arc, sl_ino);
+    // 4096 == one past the legal cap. Don't write this back to disk —
+    // the test exercises the reader's in-memory guard only.
+    d.i_size = 4096;
+    let mut buf = [0u8; 256];
+    let err = read_symlink_fn(&d, &super_arc, &mut buf)
+        .err()
+        .expect("oversize i_size must fail");
+    assert_eq!(err, ENAMETOOLONG);
 
     sb.ops.unmount();
     drop(super_arc);


### PR DESCRIPTION
Closes #603

## Summary

- Replaces the interim `read_slow_symlink_direct_only` (which returned `EIO` for any symlink target larger than one block) with a walker-backed loop that mirrors `read_file_at`, so the slow-symlink read path is no longer gated on block size.
- Adds an up-front `EXT2_SYMLINK_READ_MAX = 4095` (POSIX `PATH_MAX - 1`) guard that surfaces `ENAMETOOLONG` before any `bread`, closing the confused-deputy hazard where an attacker-forged inode could point `i_size` past the allocated extent to stitch arbitrary device sectors into the returned buffer.
- Renames the entry point to `read_slow_symlink` now that the direct-only caveat is gone.
- Treats a sparse hole anywhere along the walk as `EIO`: a symlink body is wholly allocated or the image is corrupt.

## Test plan

- [x] `cargo xtask build` — green.
- [x] `cargo test --test ext2_link --features ext2 …` — all 12 tests pass, including the two new ones:
  - `symlink_slow_200_bytes_walker` — 200-byte target written via the #570 symlink write path and read back through the walker-backed slow reader. Sentinel-checks the reader never writes past `i_size`; also exercises the short-buffer clamp.
  - `symlink_read_rejects_oversize_i_size` — synthetic disk inode with `i_size = 4096` must fail `ENAMETOOLONG` before any `bread` (in-memory guard; no on-disk mutation).
- [x] Module-level host unit tests for the fast-symlink path still pass — the `read_symlink` dispatcher signature now takes `&Arc<Ext2Super>`, matching the existing call sites in `kernel/tests/ext2_link.rs`.

## Not in scope

Exercising the indirect-slot branch of the slow-symlink walker end-to-end requires a multi-block slow symlink, which `write_slow_symlink_target` still refuses (it clamps slow symlinks to one data block). Extending the write path is tracked separately. The walker itself is shared code with `read_file_at`, and `kernel/tests/ext2_file_read.rs` already covers single / double / triple-indirect reads, so the indirect branches are regression-covered today via the file-read path.