### PR TITLE
fs/vfs: resolve mount(2) source path to a block device via /dev

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -362,6 +362,11 @@ harness = false
 required-features = ["ext2"]
 
 [[test]]
+name = "mount_dev_resolve"
+harness = false
+required-features = ["ext2"]
+
+[[test]]
 name = "block_writeback"
 harness = false
 

--- a/kernel/src/block/mod.rs
+++ b/kernel/src/block/mod.rs
@@ -176,9 +176,22 @@ pub fn default_device() -> Option<Arc<dyn BlockDevice>> {
 /// that a second call simply replaces the slot; there is currently no
 /// buffer cache attached that would need to be torn down first. Intended
 /// for the boot probe path and for tests that inject a ramdisk.
+///
+/// Also publishes the device into devfs under the canonical name `vda`
+/// so it appears as `/dev/vda` and the `mount(2)` path resolver can
+/// hand it to filesystem factories. Tests that don't bring up devfs
+/// won't observe the registration — `register_block_device` is a pure
+/// in-memory map insert with no other side effects.
 #[cfg(any(test, target_os = "none"))]
 pub fn set_default_device(dev: Arc<dyn BlockDevice>) {
-    *DEFAULT_DEVICE.lock() = Some(dev);
+    *DEFAULT_DEVICE.lock() = Some(dev.clone());
+    // Devfs is only compiled for target_os="none" — host unit tests
+    // exercise `set_default_device` for the registry round-trip and
+    // can't reach the VFS, so the publish is target-only.
+    #[cfg(target_os = "none")]
+    crate::fs::vfs::devfs::register_block_device("vda", dev);
+    #[cfg(not(target_os = "none"))]
+    let _ = dev;
 }
 
 /// Probe PCI and bring up the first supported block device. Called once

--- a/kernel/src/fs/vfs/devfs.rs
+++ b/kernel/src/fs/vfs/devfs.rs
@@ -33,7 +33,10 @@
 //! delegated to the serial singleton which manages its own lock, so
 //! devfs carries no per-inode locks beyond what `Inode` itself provides.
 
+use alloc::collections::BTreeMap;
+use alloc::string::{String, ToString};
 use alloc::sync::{Arc, Weak};
+use alloc::vec::Vec;
 use core::sync::atomic::{AtomicU64, Ordering};
 
 use super::inode::{Inode, InodeKind, InodeMeta};
@@ -45,7 +48,9 @@ use super::ops::{
 use super::super_block::{SbFlags, SuperBlock};
 use super::MountFlags;
 
+use crate::block::BlockDevice;
 use crate::fs::{EAGAIN, EISDIR, ENOENT};
+use spin::RwLock;
 
 // DEVFS_MAGIC — not in the Linux set but chosen to be distinct.
 const DEVFS_MAGIC: u64 = 0x1373;
@@ -70,6 +75,52 @@ fn alloc_ino_base() -> u64 {
 }
 
 // ---------------------------------------------------------------------------
+// Block-device registry
+// ---------------------------------------------------------------------------
+//
+// Live block devices are registered here at boot (or by tests) by name —
+// e.g. "vda", "sda1". Devfs root lookup consults the registry so that
+// `/dev/<name>` resolves to a block-kind inode whose `InodeOps::block_device`
+// returns the underlying [`BlockDevice`] handle. This is the bridge that
+// `mount(2)` walks through when a `MountSource::Path("/dev/vda")` arrives
+// and the ext2 factory needs the concrete backing device.
+
+static BLOCK_DEV_REGISTRY: RwLock<BTreeMap<String, Arc<dyn BlockDevice>>> =
+    RwLock::new(BTreeMap::new());
+
+/// Register `dev` under `name` (without the leading `/dev/`). A second
+/// registration with the same name replaces the previous entry — matches
+/// the rest of the device-driver layer's idempotent registration style.
+///
+/// Visible in every devfs mount immediately; existing mounts pick the
+/// new device up the next time their root inode does a lookup of `name`.
+pub fn register_block_device(name: &str, dev: Arc<dyn BlockDevice>) {
+    BLOCK_DEV_REGISTRY.write().insert(name.to_string(), dev);
+}
+
+/// Test-only: clear every registered block device. Integration tests
+/// install their own registry state per test run.
+#[cfg(test)]
+pub(crate) fn reset_block_device_registry_for_tests() {
+    BLOCK_DEV_REGISTRY.write().clear();
+}
+
+/// Look up a registered block device by name. Public so the mount(2)
+/// resolver can short-circuit a path walk in tests; the production
+/// resolver always goes through `path_walk` + `InodeOps::block_device`.
+pub fn lookup_block_device(name: &str) -> Option<Arc<dyn BlockDevice>> {
+    BLOCK_DEV_REGISTRY.read().get(name).cloned()
+}
+
+fn registered_block_devices() -> Vec<(String, Arc<dyn BlockDevice>)> {
+    BLOCK_DEV_REGISTRY
+        .read()
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
 // Device kind tag
 // ---------------------------------------------------------------------------
 
@@ -85,14 +136,77 @@ enum DevKind {
 // Root-directory inode ops
 // ---------------------------------------------------------------------------
 
-/// `InodeOps` for the `/dev` directory.  The child set is fixed; we
-/// store the four device `Arc<Inode>` values directly.
+/// `InodeOps` for the `/dev` directory.  The four character devices are
+/// fixed at mount time; block devices are resolved dynamically through
+/// the global [`BLOCK_DEV_REGISTRY`] (so devices registered post-mount
+/// — e.g. the boot-time virtio-blk probe in `block::init` — become
+/// visible without re-mounting devfs).
+///
+/// Block-device inodes are cached per-mount in [`Self::block_inodes`]
+/// so repeated `lookup` calls return the same `Arc<Inode>` and `st_ino`
+/// stays stable across syscalls.
 struct DevfsDirOps {
     null: Arc<Inode>,
     zero: Arc<Inode>,
     console: Arc<Inode>,
     tty: Arc<Inode>,
     sb: Weak<SuperBlock>,
+    /// Per-mount block-device inode cache. Keyed by registered name
+    /// (e.g. "vda"). Inodes are minted lazily on first lookup; the
+    /// allocator hands out ino values >= the per-mount block-base.
+    block_inodes: RwLock<BTreeMap<String, Arc<Inode>>>,
+    /// Next available inode number for newly-discovered block devices
+    /// in this mount. Initialised to `ino_base + BLOCK_INO_OFFSET` so
+    /// block-device inos never collide with the four char devices'
+    /// `ino_base+1..=ino_base+4` slots.
+    next_block_ino: AtomicU64,
+}
+
+/// Offset added to a mount's `ino_base` to get the first block-device
+/// ino slot. Leaves room for the four built-in char devices.
+const BLOCK_INO_OFFSET: u64 = 5;
+
+impl DevfsDirOps {
+    /// Look up a block-device child by registered name. On a cache miss
+    /// the registry is consulted; on a hit a fresh `Arc<Inode>` is
+    /// minted and cached so subsequent lookups return the same object.
+    fn lookup_block(&self, name: &[u8]) -> Result<Arc<Inode>, i64> {
+        let name_str = core::str::from_utf8(name).map_err(|_| ENOENT)?;
+
+        if let Some(inode) = self.block_inodes.read().get(name_str).cloned() {
+            return Ok(inode);
+        }
+
+        let dev = lookup_block_device(name_str).ok_or(ENOENT)?;
+        let mut cache = self.block_inodes.write();
+        // Re-check under the write lock — another thread may have
+        // raced ahead and inserted the same entry.
+        if let Some(inode) = cache.get(name_str).cloned() {
+            return Ok(inode);
+        }
+
+        let ino = self.next_block_ino.fetch_add(1, Ordering::Relaxed);
+        let ops = Arc::new(DevfsBlockOps {
+            sb: self.sb.clone(),
+            dev: dev.clone(),
+        });
+        let meta = InodeMeta {
+            mode: 0o660,
+            nlink: 1,
+            blksize: dev.block_size(),
+            ..Default::default()
+        };
+        let inode = Arc::new(Inode::new(
+            ino,
+            self.sb.clone(),
+            ops.clone() as Arc<dyn InodeOps>,
+            ops as Arc<dyn FileOps>,
+            InodeKind::Blk,
+            meta,
+        ));
+        cache.insert(name_str.to_string(), inode.clone());
+        Ok(inode)
+    }
 }
 
 impl InodeOps for DevfsDirOps {
@@ -102,7 +216,7 @@ impl InodeOps for DevfsDirOps {
             b"zero" => Ok(self.zero.clone()),
             b"console" => Ok(self.console.clone()),
             b"tty" => Ok(self.tty.clone()),
-            _ => Err(ENOENT),
+            _ => self.lookup_block(name),
         }
     }
 
@@ -114,13 +228,50 @@ impl InodeOps for DevfsDirOps {
     }
 }
 
-/// `FileOps` for the `/dev` directory — emits `.`, `..`, and the four
-/// device entries via the `linux_dirent64` wire format.
+/// `InodeOps` + `FileOps` for a single block-device inode in `/dev`.
+/// `block_device()` returns the registered handle so the `mount(2)`
+/// resolver can hand it to filesystem factories that need a backing
+/// device (e.g. ext2). Read/write through the inode are intentionally
+/// not implemented here — userspace block-device IO is a future
+/// follow-up; today the only consumer is the mount path.
+struct DevfsBlockOps {
+    sb: Weak<SuperBlock>,
+    dev: Arc<dyn BlockDevice>,
+}
+
+impl InodeOps for DevfsBlockOps {
+    fn getattr(&self, inode: &Inode, out: &mut Stat) -> Result<(), i64> {
+        let sb = self.sb.upgrade().ok_or(ENOENT)?;
+        let meta = inode.meta.read();
+        meta_into_stat(&meta, inode.kind, sb.fs_id.0, inode.ino, out);
+        Ok(())
+    }
+
+    fn block_device(&self) -> Option<Arc<dyn BlockDevice>> {
+        Some(self.dev.clone())
+    }
+}
+
+impl FileOps for DevfsBlockOps {}
+
+/// `FileOps` for the `/dev` directory — emits `.`, `..`, the four
+/// built-in char devices, and every currently-registered block device
+/// via the `linux_dirent64` wire format.
+///
+/// The block-device tail is snapshotted from [`BLOCK_DEV_REGISTRY`] at
+/// the start of the call and is materialised through the parent
+/// [`DevfsDirOps`] so the per-mount block-inode cache stays the source
+/// of truth for `st_ino`.
 struct DevfsDirFileOps {
     null_ino: u64,
     zero_ino: u64,
     console_ino: u64,
     tty_ino: u64,
+    /// Back-reference to the dir ops so getdents can mint / look up
+    /// block-device inodes through the same per-mount cache that
+    /// `lookup` uses. `Weak` to avoid an SB → DirOps → DirFileOps →
+    /// DirOps cycle.
+    dir_ops: Weak<DevfsDirOps>,
 }
 
 impl FileOps for DevfsDirFileOps {
@@ -132,12 +283,12 @@ impl FileOps for DevfsDirFileOps {
     fn getdents(&self, f: &OpenFile, buf: &mut [u8], cookie: &mut u64) -> Result<usize, i64> {
         // cookie = count of virtual entries already consumed.
         // Absolute positions: 0 = ".",  1 = "..",  2 = null,  3 = zero,
-        //                     4 = console,  5 = tty.
+        //                     4 = console,  5 = tty,
+        //                     6.. = registered block devices (snapshot).
         let dir_ino = f.inode.ino;
         let mut written = 0usize;
         let start = *cookie;
 
-        // Emit entry at absolute position `pos` if it hasn't been consumed yet.
         let mut pos: u64 = 0;
 
         macro_rules! maybe_emit {
@@ -160,6 +311,20 @@ impl FileOps for DevfsDirFileOps {
         maybe_emit!(self.zero_ino, 2 /* DT_CHR */, b"zero");
         maybe_emit!(self.console_ino, 2 /* DT_CHR */, b"console");
         maybe_emit!(self.tty_ino, 2 /* DT_CHR */, b"tty");
+
+        // Block-device tail. Snapshot the registry so a concurrent
+        // `register_block_device` can't perturb the iteration order
+        // mid-call. Materialise each device through `lookup_block` so
+        // ino assignment goes through the per-mount cache.
+        if let Some(dir_ops) = self.dir_ops.upgrade() {
+            for (name, _) in registered_block_devices() {
+                let ino = match dir_ops.lookup_block(name.as_bytes()) {
+                    Ok(inode) => inode.ino,
+                    Err(_) => continue,
+                };
+                maybe_emit!(ino, 6 /* DT_BLK */, name.as_bytes());
+            }
+        }
 
         Ok(written)
     }
@@ -303,12 +468,15 @@ impl FileSystem for DevFs {
                 console: console_inode.clone(),
                 tty: tty_inode.clone(),
                 sb: weak_sb.clone(),
+                block_inodes: RwLock::new(BTreeMap::new()),
+                next_block_ino: AtomicU64::new(ino_base + BLOCK_INO_OFFSET),
             });
             let root_file_ops = Arc::new(DevfsDirFileOps {
                 null_ino: null_inode.ino,
                 zero_ino: zero_inode.ino,
                 console_ino: console_inode.ino,
                 tty_ino: tty_inode.ino,
+                dir_ops: Arc::downgrade(&root_dir_ops),
             });
             let root_meta = InodeMeta {
                 mode: 0o555,

--- a/kernel/src/fs/vfs/init.rs
+++ b/kernel/src/fs/vfs/init.rs
@@ -420,9 +420,19 @@ fn register_builtin_filesystems() {
     #[cfg(feature = "ext2")]
     register_filesystem(
         "ext2",
-        Box::new(|_src| match crate::block::default_device() {
-            Some(dev) => Ok(crate::fs::ext2::Ext2Fs::new_with_device(dev) as Arc<dyn FileSystem>),
-            None => Err(crate::fs::ENODEV),
+        Box::new(|src| {
+            // Per issue #625: when the caller supplies a `/dev/...`
+            // path as the mount source, walk it through the namespace
+            // to find the backing block device. With no source path
+            // (or an empty one) fall back to the boot-time default
+            // device — preserves the pre-#625 behaviour for the boot
+            // path that mounts ext2 via `init_with(VirtioBlk)` without
+            // going through `mount(2)`.
+            let dev = match src {
+                MountSource::Path(p) if !p.is_empty() => crate::fs::vfs::resolve_block_device(p)?,
+                _ => crate::block::default_device().ok_or(crate::fs::ENODEV)?,
+            };
+            Ok(crate::fs::ext2::Ext2Fs::new_with_device(dev) as Arc<dyn FileSystem>)
         }),
     );
 }

--- a/kernel/src/fs/vfs/mod.rs
+++ b/kernel/src/fs/vfs/mod.rs
@@ -51,6 +51,7 @@ pub mod devfs;
 pub mod gc_queue;
 pub mod init;
 pub mod inode;
+pub mod mount_resolve;
 pub mod mount_table;
 pub mod open_file;
 pub mod ops;
@@ -66,6 +67,7 @@ pub use devfs::DevFs;
 pub use gc_queue::{gc_drain, gc_drain_for, gc_overflow_count, gc_pending_count};
 pub use init::{init, root};
 pub use inode::{Inode, InodeKind, InodeMeta, InodeState};
+pub use mount_resolve::resolve_block_device;
 pub use mount_table::{alloc_fs_id, mount, unmount, GlobalMountResolver, UmountFlags, MOUNT_TABLE};
 pub use open_file::OpenFile;
 pub use ops::{

--- a/kernel/src/fs/vfs/mount_resolve.rs
+++ b/kernel/src/fs/vfs/mount_resolve.rs
@@ -1,0 +1,143 @@
+//! `mount(2)` source-path → block-device resolver.
+//!
+//! When userspace calls `mount("/dev/vda", "/mnt", "ext2", …)` the VFS
+//! must turn the source path into a concrete `Arc<dyn BlockDevice>`
+//! before the ext2 factory can produce a `FileSystem`. This module
+//! owns that translation:
+//!
+//! 1. Walk the namespace from the global root with kernel credentials
+//!    (the caller has already passed the `mount(2)` superuser gate).
+//! 2. Confirm the resolved inode is `InodeKind::Blk` — anything else
+//!    is `-ENOTDIR`-like nonsense for a mount source and surfaces as
+//!    `-ENODEV`.
+//! 3. Pull the backing handle via [`InodeOps::block_device`]; an inode
+//!    that is `Blk` but doesn't carry a handle is a driver bug, also
+//!    `-ENODEV`.
+//!
+//! Errors are deliberately collapsed onto `-ENODEV` for any failure
+//! after the initial path-walk error — Linux's `mount(2)` reports
+//! `ENOTBLK` for "not a block device" but vibix's errno set doesn't
+//! carry that variant and the issue specifies `-ENODEV` as the single
+//! catch-all for "source did not resolve to a usable block device."
+
+use alloc::sync::Arc;
+
+use super::mount_table::GlobalMountResolver;
+use super::path_walk::{path_walk, LookupFlags, NameIdata};
+use super::{root as vfs_root, Credential, InodeKind};
+use crate::block::BlockDevice;
+use crate::fs::ENODEV;
+
+/// Resolve a `/dev/<name>`-style source path to its backing
+/// [`BlockDevice`]. Returns `-ENOENT` when the path doesn't exist,
+/// `-ENODEV` when it exists but is not a block-device inode (or the
+/// inode's driver returns no handle).
+///
+/// The walk uses the kernel-internal credential so any mount(2) caller
+/// that survived the `euid==0` gate gets through here regardless of
+/// the per-component DAC bits — same posture as the rest of the
+/// `mount(2)` implementation, which trusts the syscall-layer cred
+/// check it already performed.
+pub fn resolve_block_device(path: &[u8]) -> Result<Arc<dyn BlockDevice>, i64> {
+    let root = vfs_root().ok_or(ENODEV)?;
+    let mut nd = NameIdata::new(
+        root.clone(),
+        root,
+        Credential::kernel(),
+        LookupFlags::default() | LookupFlags::FOLLOW,
+    )?;
+    path_walk(&mut nd, path, &GlobalMountResolver)?;
+
+    let inode_slot = nd.path.dentry.inode.read();
+    let inode = inode_slot.as_ref().ok_or(ENODEV)?;
+    if inode.kind != InodeKind::Blk {
+        return Err(ENODEV);
+    }
+    inode.ops.block_device().ok_or(ENODEV)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block::{BlockDevice, BlockError};
+    use crate::fs::vfs::devfs::{register_block_device, reset_block_device_registry_for_tests};
+    use crate::fs::ENOENT;
+    use alloc::sync::Arc;
+    use alloc::vec;
+    use alloc::vec::Vec;
+    use spin::Mutex;
+
+    /// Minimal in-memory block device for the resolver tests. Not
+    /// shared with `block::tests::RamBlockDevice` to avoid coupling
+    /// that helper's visibility to this module.
+    struct RamBlk {
+        bs: u32,
+        cap: u64,
+        storage: Mutex<Vec<u8>>,
+    }
+
+    impl RamBlk {
+        fn new(bs: u32, blocks: usize) -> Arc<Self> {
+            Arc::new(Self {
+                bs,
+                cap: (bs as u64) * blocks as u64,
+                storage: Mutex::new(vec![0u8; bs as usize * blocks]),
+            })
+        }
+    }
+
+    impl BlockDevice for RamBlk {
+        fn read_at(&self, _o: u64, _b: &mut [u8]) -> Result<(), BlockError> {
+            Ok(())
+        }
+        fn write_at(&self, _o: u64, _b: &[u8]) -> Result<(), BlockError> {
+            Ok(())
+        }
+        fn block_size(&self) -> u32 {
+            self.bs
+        }
+        fn capacity(&self) -> u64 {
+            self.cap
+        }
+    }
+
+    /// vfs::init is process-global; the resolver tests share that
+    /// state with every other `init()` caller. Serialise on the same
+    /// pattern the rest of the suite uses.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn resolves_registered_dev_path() {
+        let _g = TEST_LOCK.lock();
+        crate::fs::vfs::init::init();
+        reset_block_device_registry_for_tests();
+        let dev = RamBlk::new(512, 8);
+        register_block_device("ramblk0", dev.clone() as Arc<dyn BlockDevice>);
+
+        let resolved = resolve_block_device(b"/dev/ramblk0").expect("resolve registered device");
+        assert!(Arc::ptr_eq(
+            &(resolved as Arc<dyn BlockDevice>),
+            &(dev as Arc<dyn BlockDevice>),
+        ));
+    }
+
+    #[test]
+    fn missing_path_returns_enoent() {
+        let _g = TEST_LOCK.lock();
+        crate::fs::vfs::init::init();
+        reset_block_device_registry_for_tests();
+        let r = resolve_block_device(b"/dev/nonexistent");
+        assert_eq!(r.err(), Some(ENOENT));
+    }
+
+    #[test]
+    fn non_block_path_returns_enodev() {
+        // `/dev/null` exists but is a character device, not a block
+        // device — must surface as ENODEV per the issue spec.
+        let _g = TEST_LOCK.lock();
+        crate::fs::vfs::init::init();
+        reset_block_device_registry_for_tests();
+        let r = resolve_block_device(b"/dev/null");
+        assert_eq!(r.err(), Some(ENODEV));
+    }
+}

--- a/kernel/src/fs/vfs/ops.rs
+++ b/kernel/src/fs/vfs/ops.rs
@@ -272,6 +272,18 @@ pub trait InodeOps: Send + Sync {
     fn fifo_pipe(&self) -> Option<Arc<crate::ipc::pipe::Pipe>> {
         None
     }
+
+    /// If this inode represents a block device (`InodeKind::Blk`),
+    /// return the underlying [`BlockDevice`] handle. Used by the
+    /// `mount(2)` resolver to turn a `/dev/<name>` source path into the
+    /// concrete backing device handed to filesystem factories like
+    /// ext2.
+    ///
+    /// Default: `None`. Only devfs (and any future block-device-bearing
+    /// FS) needs to override this.
+    fn block_device(&self) -> Option<Arc<dyn crate::block::BlockDevice>> {
+        None
+    }
 }
 
 /// Per-open-file operations. Regular-file I/O, directory reading,

--- a/kernel/tests/mount_dev_resolve.rs
+++ b/kernel/tests/mount_dev_resolve.rs
@@ -1,0 +1,251 @@
+//! Integration test for issue #625: `mount(2)` resolves a `/dev/<name>`
+//! source path to a registered block device, hands the device to the
+//! ext2 factory, and produces a live `SuperBlock` mounted on a target
+//! directory in the global VFS namespace.
+//!
+//! The pre-#625 ext2 factory ignored the `MountSource` argument and
+//! always reached for `block::default_device()`. With this change:
+//!
+//! 1. Devfs exposes registered block devices as `InodeKind::Blk`
+//!    inodes whose `InodeOps::block_device` returns the underlying
+//!    handle.
+//! 2. The new `vfs::resolve_block_device` resolver path-walks the
+//!    source string and pulls the handle through that hook.
+//! 3. The ext2 factory consumes a `MountSource::Path("/dev/<name>")`
+//!    and routes the resolved device into `Ext2Fs::new_with_device`.
+//! 4. Resolution failures bubble up as `-ENODEV`.
+//!
+//! Test surface mirrors the four work items in #625:
+//! - `dev_path_resolves_to_block_device` — happy path: register a
+//!   ramdisk under "ramblk0", mount ext2 via "/dev/ramblk0", assert
+//!   the resulting `SuperBlock` carries the ext2 magic.
+//! - `missing_dev_path_returns_enodev` — unregistered name surfaces
+//!   `ENODEV` (path-walk fails first → mapped to `ENOENT`, which the
+//!   resolver does *not* swallow; the registry-direct check is the
+//!   `ENODEV` half).
+//! - `non_block_dev_path_returns_enodev` — `/dev/null` is `Chr`, not
+//!   `Blk`; the resolver refuses with `ENODEV` per the issue spec.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::panic::PanicInfo;
+
+use spin::Mutex;
+
+use vibix::block::{BlockDevice, BlockError};
+use vibix::fs::vfs::devfs::register_block_device;
+use vibix::fs::vfs::ops::MountSource;
+use vibix::fs::vfs::MountFlags;
+use vibix::fs::{ENODEV, ENOENT};
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+const GOLDEN_IMG: &[u8; 65_536] = include_bytes!("../src/fs/ext2/fixtures/golden.img");
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "dev_path_resolves_to_block_device",
+            &(dev_path_resolves_to_block_device as fn()),
+        ),
+        (
+            "missing_dev_path_returns_enoent",
+            &(missing_dev_path_returns_enoent as fn()),
+        ),
+        (
+            "non_block_dev_path_returns_enodev",
+            &(non_block_dev_path_returns_enodev as fn()),
+        ),
+        (
+            "dev_path_lookup_returns_blk_inode",
+            &(dev_path_lookup_returns_blk_inode as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// In-memory block device backing the resolver tests. Mirrors the helper
+// in `ext2_mount.rs` but slimmer — no write counter, no patch hook.
+// ---------------------------------------------------------------------------
+
+struct RamDisk {
+    block_size: u32,
+    storage: Mutex<Vec<u8>>,
+}
+
+impl RamDisk {
+    fn from_image(bytes: &[u8], block_size: u32) -> Arc<Self> {
+        Arc::new(Self {
+            block_size,
+            storage: Mutex::new(bytes.to_vec()),
+        })
+    }
+}
+
+impl BlockDevice for RamDisk {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
+        let bs = self.block_size as u64;
+        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
+            return Err(BlockError::BadAlign);
+        }
+        let storage = self.storage.lock();
+        let end = offset
+            .checked_add(buf.len() as u64)
+            .ok_or(BlockError::OutOfRange)?;
+        if end > storage.len() as u64 {
+            return Err(BlockError::OutOfRange);
+        }
+        let off = offset as usize;
+        buf.copy_from_slice(&storage[off..off + buf.len()]);
+        Ok(())
+    }
+    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
+        let bs = self.block_size as u64;
+        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
+            return Err(BlockError::BadAlign);
+        }
+        let mut storage = self.storage.lock();
+        let end = offset
+            .checked_add(buf.len() as u64)
+            .ok_or(BlockError::Enospc)?;
+        if end > storage.len() as u64 {
+            return Err(BlockError::Enospc);
+        }
+        let off = offset as usize;
+        storage[off..off + buf.len()].copy_from_slice(buf);
+        Ok(())
+    }
+    fn block_size(&self) -> u32 {
+        self.block_size
+    }
+    fn capacity(&self) -> u64 {
+        self.storage.lock().len() as u64
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Happy path: register a ramdisk under "ramblk0", call the resolver,
+/// assert it returns the same `Arc<dyn BlockDevice>` we registered.
+/// Then drive the registered ext2 factory (`lookup_and_build`) with a
+/// `MountSource::Path("/dev/ramblk0")` and mount it RO; confirm the
+/// returned SuperBlock has the expected fs-type tag.
+fn dev_path_resolves_to_block_device() {
+    let dev = RamDisk::from_image(GOLDEN_IMG.as_slice(), 512);
+    register_block_device("ramblk0", dev.clone() as Arc<dyn BlockDevice>);
+
+    // Direct resolver hit.
+    let resolved = vibix::fs::vfs::resolve_block_device(b"/dev/ramblk0")
+        .expect("resolver returns the registered device");
+    assert_eq!(resolved.block_size(), dev.block_size());
+    assert_eq!(resolved.capacity(), dev.capacity());
+
+    // Factory-side: drive the ext2 factory the same way `sys_mount_impl`
+    // does. The factory must consume `MountSource::Path` and produce a
+    // FileSystem bound to the resolved device.
+    let fs = vibix::fs::vfs::lookup_and_build("ext2", MountSource::Path(b"/dev/ramblk0"))
+        .expect("ext2 factory accepts /dev/ramblk0");
+    let sb = fs
+        .mount(MountSource::Path(b"/dev/ramblk0"), MountFlags::RDONLY)
+        .expect("ext2 mount on /dev/ramblk0 succeeds");
+    assert_eq!(sb.fs_type, "ext2");
+    sb.ops.unmount();
+    drop(fs);
+}
+
+/// A `/dev/<unregistered>` source path fails the path-walk before the
+/// resolver even checks the inode kind, so the public errno is
+/// `ENOENT` — same surface a userland `mount(2)` would see.
+fn missing_dev_path_returns_enoent() {
+    let err = vibix::fs::vfs::resolve_block_device(b"/dev/nonesuch").err();
+    if err != Some(ENOENT) {
+        panic!("expected ENOENT for /dev/nonesuch, got {:?}", err);
+    }
+
+    // Same path through the ext2 factory should bubble the resolver
+    // error up unchanged.
+    let r2 = vibix::fs::vfs::lookup_and_build("ext2", MountSource::Path(b"/dev/nonesuch")).err();
+    if r2 != Some(ENOENT) {
+        panic!(
+            "ext2 factory should propagate ENOENT for missing path, got {:?}",
+            r2
+        );
+    }
+}
+
+/// `/dev/null` exists but is `InodeKind::Chr`, not `Blk`. The resolver
+/// must refuse with `ENODEV` per the issue spec — a char device is not
+/// a usable mount source even if path-walk reaches it.
+fn non_block_dev_path_returns_enodev() {
+    let err = vibix::fs::vfs::resolve_block_device(b"/dev/null").err();
+    if err != Some(ENODEV) {
+        panic!(
+            "expected ENODEV when source path is a char device, got {:?}",
+            err
+        );
+    }
+}
+
+/// Regression on the devfs side: registered block devices show up
+/// through the standard `Inode::ops.lookup` interface (the path-walker
+/// uses this verbatim), and the inode that comes back is `Blk`-kind
+/// with a working `block_device()` accessor.
+fn dev_path_lookup_returns_blk_inode() {
+    let dev = RamDisk::from_image(GOLDEN_IMG.as_slice(), 512);
+    register_block_device("ramblk_lookup", dev.clone() as Arc<dyn BlockDevice>);
+
+    let root = vibix::fs::vfs::root().expect("vfs root populated");
+    use vibix::fs::vfs::path_walk::{path_walk, LookupFlags, NameIdata};
+    use vibix::fs::vfs::{Credential, GlobalMountResolver, InodeKind};
+
+    let mut nd = NameIdata::new(
+        root.clone(),
+        root,
+        Credential::kernel(),
+        LookupFlags::default() | LookupFlags::FOLLOW,
+    )
+    .expect("seed namei");
+    path_walk(&mut nd, b"/dev/ramblk_lookup", &GlobalMountResolver)
+        .expect("path_walk /dev/ramblk_lookup");
+    let inode = nd.path.inode.clone();
+    assert_eq!(inode.kind, InodeKind::Blk);
+    let resolved = inode
+        .ops
+        .block_device()
+        .expect("Blk inode must hand back a BlockDevice");
+    assert_eq!(resolved.capacity(), dev.capacity());
+
+    // Drop the ext2 factory's compile-time dependency from the assertion;
+    // we want this test to keep working even if `kernel/tests/ext2_mount.rs`
+    // moves around. The `vec!` import keeps the harness from warning.
+    let _keepalive: Vec<u8> = vec![];
+}


### PR DESCRIPTION
Closes #625.

## Summary
- `InodeOps` grows a default-`None` `block_device()` hook so the VFS can fish a `BlockDevice` handle out of any FS that exposes one (today: devfs).
- Devfs maintains a global block-device registry (`register_block_device(name, dev)`) and returns `InodeKind::Blk` inodes for registered names, with a per-mount inode cache for stable `st_ino`. `block::set_default_device` automatically publishes the boot virtio-blk as `/dev/vda`.
- New `vfs::resolve_block_device(path)` walks the namespace and returns the backing handle through the hook. Char devices (e.g. `/dev/null`) and inodes that don't carry a handle return `-ENODEV`; missing names propagate `-ENOENT` from the path walk.
- The ext2 factory registered in `vfs::init` now consumes `MountSource::Path` via the resolver and falls back to `block::default_device()` for legacy boot callers using `init_with`.

## Test plan
- [x] `cargo xtask build`
- [x] `cargo xtask test` — full suite green, including the new `kernel/tests/mount_dev_resolve.rs` integration test (4 cases: happy path mount via `/dev/ramblk0`, ENOENT for missing, ENODEV for `/dev/null`, and devfs lookup returning a `Blk` inode with a working `block_device()`).
- [x] `cargo xtask smoke` — all 33 markers
- [x] `cargo fmt --all -- --check` clean