### PR TITLE
block: invariant assertion — no spin lock across block-I/O wait (#556)

### DIFF
--- a/kernel/src/block/cache.rs
+++ b/kernel/src/block/cache.rs
@@ -68,9 +68,10 @@ use alloc::sync::Arc;
 use alloc::vec;
 use core::sync::atomic::{AtomicBool, AtomicU32, AtomicU8, Ordering};
 
-use spin::{Mutex, Once, RwLock};
+use spin::{Once, RwLock};
 
 use super::{BlockDevice, BlockError};
+use crate::debug_lockdep::{assert_no_spinlocks_held, SpinLock};
 
 /// Valid bit — the in-memory slab reflects the on-disk block as of its
 /// most recent read-back.
@@ -216,7 +217,7 @@ pub struct BlockCache {
     /// Cache body + CLOCK-Pro metadata. Guarded together so the
     /// eviction sweep sees a consistent view of residency + classes +
     /// hand.
-    inner: Mutex<CacheInner>,
+    inner: SpinLock<CacheInner>,
     /// Dirty-set mirror used by the writeback daemon (populated by
     /// `mark_dirty`, cleared by `sync_dirty_buffer`). Stored as keys,
     /// not `Weak` handles — the daemon re-looks-up the `Arc` out of
@@ -224,7 +225,7 @@ pub struct BlockCache {
     /// still flushes correctly. A separate mutex so the writeback
     /// daemon (future) can snapshot the dirty set without contending
     /// on the CLOCK-Pro critical section.
-    dirty: Mutex<BTreeSet<(DeviceId, u64)>>,
+    dirty: SpinLock<BTreeSet<(DeviceId, u64)>>,
     /// Cap beyond which eviction must start reclaiming. Observed by
     /// `bread` when deciding whether to run a CLOCK-Pro sweep.
     max_buffers: usize,
@@ -260,13 +261,13 @@ impl BlockCache {
             device,
             next_device_id: AtomicU32::new(0),
             block_size,
-            inner: Mutex::new(CacheInner {
+            inner: SpinLock::new(CacheInner {
                 entries: BTreeMap::new(),
                 classes: BTreeMap::new(),
                 non_resident: VecDeque::new(),
                 clock_hand: None,
             }),
-            dirty: Mutex::new(BTreeSet::new()),
+            dirty: SpinLock::new(BTreeSet::new()),
             max_buffers,
         })
     }
@@ -470,6 +471,13 @@ impl BlockCache {
             let offset = blk
                 .checked_mul(self.block_size as u64)
                 .ok_or(BlockError::OutOfRange)?;
+            // RFC 0004 §Buffer cache normative invariant: no spin
+            // lock may be held across a block-I/O wait. The cache
+            // dropped its `inner` SpinLock above (the eviction
+            // sweep block ended at L459); this assertion is the
+            // tripwire that fires loudly if a future caller layer
+            // re-enters `bread` while still holding one.
+            assert_no_spinlocks_held("BlockCache::bread \u{2192} device.read_at");
             self.device.read_at(offset, &mut data[..])?;
         }
         fresh.state.store(STATE_VALID, Ordering::Release);
@@ -648,6 +656,14 @@ impl BlockCache {
                     return Err(BlockError::OutOfRange);
                 }
             };
+            // RFC 0004 §Buffer cache normative invariant: the
+            // `BufferHead.data` RwLock was released above (snapshot
+            // was taken inside its own scope at L631-L636) and the
+            // cache `inner` / `dirty` SpinLocks were released after
+            // the residency lookup at L619-L625. Trip loudly if a
+            // future caller layer re-enters `sync_dirty_buffer`
+            // while still holding any spinlock.
+            assert_no_spinlocks_held("BlockCache::sync_dirty_buffer \u{2192} device.write_at");
             self.device.write_at(offset, &snapshot)
         } else {
             // Not resident and we don't know the block number. This
@@ -963,6 +979,7 @@ mod tests {
     use crate::block::{BlockError, SECTOR_SIZE};
     use alloc::vec::Vec;
     use core::sync::atomic::{AtomicU32, AtomicUsize};
+    use spin::Mutex;
 
     /// In-memory stand-in for a real `BlockDevice`. Only the bits the
     /// cache skeleton's trivial tests consult (`block_size`, `capacity`)

--- a/kernel/src/debug_lockdep.rs
+++ b/kernel/src/debug_lockdep.rs
@@ -248,19 +248,35 @@ pub use spinlock::{SpinLock, SpinLockGuard};
 mod tests {
     use super::*;
 
-    /// Ensure the counter starts at zero for each test. Tests run
-    /// serially in their own threads under `cargo test`; sharing the
-    /// global counter would cause cross-test interference. Reset
-    /// explicitly at the top of each test.
+    /// Serialise tests that touch the shared `HELD_SPINLOCKS` static.
+    /// libtest runs `#[test]`s in parallel by default (one per worker
+    /// thread); without this lock two tests would interleave their
+    /// `lock` / `drop` / `assert_no_spinlocks_held` calls on the
+    /// shared counter and one would observe the other's intermediate
+    /// state. Same pattern as `kernel/src/fs/vfs/gc_queue.rs`. Use
+    /// `std::sync::Mutex` so a panicking test poisons the lock
+    /// rather than deadlocking the suite — `into_inner` recovers.
     #[cfg(debug_assertions)]
-    fn reset_counter() {
+    static TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Take the test lock and reset the counter. Returned guard
+    /// holds the `TEST_LOCK` for the lifetime of the test scope —
+    /// keep it alive (e.g. `let _guard = test_guard();`) so other
+    /// tests block until this one finishes.
+    #[cfg(debug_assertions)]
+    fn test_guard() -> std::sync::MutexGuard<'static, ()> {
+        let g = TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // Reset under the lock so a previous test that paniced
+        // mid-acquire (leaving the counter > 0) doesn't poison
+        // the next test's invariant.
         HELD_SPINLOCKS.store(0, Ordering::Relaxed);
+        g
     }
 
     #[cfg(debug_assertions)]
     #[test]
     fn counter_increments_on_lock_decrements_on_drop() {
-        reset_counter();
+        let _t = test_guard();
         let m = SpinLock::new(0u32);
         assert_eq!(held_spinlocks(), 0);
         {
@@ -273,7 +289,7 @@ mod tests {
     #[cfg(debug_assertions)]
     #[test]
     fn counter_tracks_nested_locks() {
-        reset_counter();
+        let _t = test_guard();
         let a = SpinLock::new(1u8);
         let b = SpinLock::new(2u8);
         let _ga = a.lock();
@@ -284,7 +300,7 @@ mod tests {
     #[cfg(debug_assertions)]
     #[test]
     fn try_lock_increments_only_on_success() {
-        reset_counter();
+        let _t = test_guard();
         let m = SpinLock::new(7u8);
         let _g = m.lock();
         assert_eq!(held_spinlocks(), 1);
@@ -297,7 +313,7 @@ mod tests {
     #[cfg(debug_assertions)]
     #[test]
     fn assert_passes_with_no_locks_held() {
-        reset_counter();
+        let _t = test_guard();
         // Should not panic.
         assert_no_spinlocks_held("test:no-lock-site");
     }
@@ -306,7 +322,11 @@ mod tests {
     #[test]
     #[should_panic(expected = "debug_lockdep: invariant violated at test:violation-site")]
     fn assert_panics_when_lock_held() {
-        reset_counter();
+        // `should_panic` test still needs the lock to keep the
+        // counter free of interference from a sibling test until
+        // the panic fires. The `Mutex` poisoning recovers in
+        // `test_guard`'s `unwrap_or_else`.
+        let _t = test_guard();
         let m = SpinLock::new(0u8);
         let _g = m.lock();
         // Holding `_g` across this call MUST panic.
@@ -316,7 +336,7 @@ mod tests {
     #[cfg(debug_assertions)]
     #[test]
     fn guard_deref_and_mutate() {
-        reset_counter();
+        let _t = test_guard();
         let m = SpinLock::new(0u32);
         {
             let mut g = m.lock();

--- a/kernel/src/debug_lockdep.rs
+++ b/kernel/src/debug_lockdep.rs
@@ -1,0 +1,341 @@
+//! Minimal debug-build lockdep tripwire — tracks the count of
+//! kernel spinlocks currently held by the caller and asserts the
+//! count is zero at every block-I/O wait point.
+//!
+//! Implements RFC 0004 — Workstream C normative invariant:
+//! **"no spin lock is held across a block-I/O wait."** Holding a
+//! spinlock across a device wait can deadlock: the wait may schedule
+//! away (or, even on a polled driver, take milliseconds), during
+//! which any task that needs the same lock spins burning CPU and any
+//! IRQ handler that touches the lock dead-spins on a CPU that has
+//! it disabled.
+//!
+//! # Mechanism
+//!
+//! - [`SpinLock::lock`] / [`SpinLockGuard::drop`] increment /
+//!   decrement [`HELD_SPINLOCKS`] under `cfg(debug_assertions)`. In
+//!   release builds both calls are no-ops and the wrapper compiles
+//!   to the same code as the underlying `spin::Mutex`.
+//! - The kernel's [`crate::sync::IrqLock`] participates in the same
+//!   counter so a held IRQ-masking spinlock is visible to the
+//!   tripwire too.
+//! - [`assert_no_spinlocks_held`] panics with a message that names
+//!   the I/O site (caller) and the held-lock count if the invariant
+//!   is violated. Callers pass a short label like
+//!   `"BlockCache::bread → device.read_at"` so the panic carries
+//!   triage context out of the box.
+//!
+//! # Per-CPU
+//!
+//! vibix is single-CPU today; the counter is a single
+//! [`AtomicU32`] standing in for the future per-CPU slot. When SMP
+//! lands, this becomes a `[AtomicU32; NCPU]` indexed by `cpu::id()`;
+//! every public entrypoint here is the natural seam to widen.
+//!
+//! # Cost in release builds
+//!
+//! Every counter mutation is `#[cfg(debug_assertions)]`-gated; the
+//! `#[inline]` no-op stubs let the optimiser delete the call entirely.
+//! [`SpinLock<T>`] is `#[repr(transparent)]` over `spin::Mutex<T>` so
+//! the wrapper has no runtime cost beyond what the optimiser already
+//! folds away.
+
+#[cfg(debug_assertions)]
+use core::sync::atomic::{AtomicU32, Ordering};
+
+/// Per-CPU count of spinlocks currently held by this CPU. Single-CPU
+/// today; widen to `[AtomicU32; NCPU]` indexed by `cpu::id()` when SMP
+/// arrives.
+///
+/// Only present in debug builds — release builds compile out the
+/// counter entirely.
+#[cfg(debug_assertions)]
+static HELD_SPINLOCKS: AtomicU32 = AtomicU32::new(0);
+
+/// Bump the held-spinlock counter. Called by [`SpinLock::lock`] and
+/// the kernel's `IrqLock::lock` immediately after the underlying
+/// spin acquire returns.
+///
+/// In release builds this is a no-op the optimiser deletes.
+#[cfg(debug_assertions)]
+#[inline]
+pub fn inc_held_spinlocks() {
+    HELD_SPINLOCKS.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Release-build no-op. See the debug-build sibling above.
+#[cfg(not(debug_assertions))]
+#[inline]
+pub fn inc_held_spinlocks() {}
+
+/// Decrement the held-spinlock counter. Called by the spinlock
+/// guard's `Drop` impl just before releasing the underlying spin
+/// lock.
+#[cfg(debug_assertions)]
+#[inline]
+pub fn dec_held_spinlocks() {
+    // `saturating_sub` semantics via fetch_sub then clamp would
+    // burn an extra atomic op; instead, debug-assert the underflow
+    // would never happen (an unbalanced dec means a guard was
+    // dropped without a paired inc, which is a wrapper bug).
+    let prev = HELD_SPINLOCKS.fetch_sub(1, Ordering::Relaxed);
+    debug_assert!(
+        prev > 0,
+        "debug_lockdep: dec_held_spinlocks underflow — guard dropped without paired inc"
+    );
+}
+
+/// Release-build no-op. See the debug-build sibling above.
+#[cfg(not(debug_assertions))]
+#[inline]
+pub fn dec_held_spinlocks() {}
+
+/// Read the current held-spinlock count. Exposed for tests; production
+/// callers should prefer [`assert_no_spinlocks_held`].
+#[cfg(debug_assertions)]
+#[inline]
+pub fn held_spinlocks() -> u32 {
+    HELD_SPINLOCKS.load(Ordering::Relaxed)
+}
+
+/// Release-build stub: always reports zero (no tracking).
+#[cfg(not(debug_assertions))]
+#[inline]
+pub fn held_spinlocks() -> u32 {
+    0
+}
+
+/// Panic if any spinlock is currently held. Called immediately
+/// before every block-I/O wait point in `kernel/src/block/`.
+///
+/// `io_site` should name the caller, e.g.
+/// `"BlockCache::bread → device.read_at"`. The panic message
+/// includes both the site and the held-count so a triage reader
+/// sees what site tripped and how many locks were stuck.
+///
+/// In release builds this compiles to a no-op and the `io_site`
+/// string is dead code (the optimiser deletes the call).
+#[cfg(debug_assertions)]
+#[inline]
+#[track_caller]
+pub fn assert_no_spinlocks_held(io_site: &str) {
+    let n = held_spinlocks();
+    assert!(
+        n == 0,
+        "debug_lockdep: invariant violated at {} — {} spinlock(s) held across block-I/O wait. \
+         RFC 0004 §Buffer cache: no spin lock may be held across a block-I/O wait. \
+         Drop the held SpinLock / IrqLock guard before issuing the I/O.",
+        io_site,
+        n,
+    );
+}
+
+/// Release-build no-op. The argument is `_` so the call site
+/// optimises out cleanly.
+#[cfg(not(debug_assertions))]
+#[inline]
+pub fn assert_no_spinlocks_held(_io_site: &str) {}
+
+// ------------------------------------------------------------------
+// SpinLock<T> — instrumented wrapper around spin::Mutex<T>.
+// ------------------------------------------------------------------
+
+#[cfg(any(test, target_os = "none"))]
+mod spinlock {
+    use super::{dec_held_spinlocks, inc_held_spinlocks};
+    use core::ops::{Deref, DerefMut};
+
+    /// Tracking wrapper around `spin::Mutex<T>` — bumps the
+    /// per-CPU held-spinlock counter on `lock`, decrements on
+    /// guard drop. Use anywhere a plain `spin::Mutex` would do
+    /// when the lock is reachable from a path that may eventually
+    /// hit a block-I/O wait — the wrapper makes a violation
+    /// trip [`super::assert_no_spinlocks_held`] at the wait
+    /// point.
+    ///
+    /// `#[repr(transparent)]` so a `SpinLock<T>` and a
+    /// `spin::Mutex<T>` have identical memory layouts; the
+    /// wrapper's only runtime cost is the debug-build counter
+    /// op (compiled out of release).
+    #[repr(transparent)]
+    pub struct SpinLock<T: ?Sized> {
+        inner: spin::Mutex<T>,
+    }
+
+    impl<T> SpinLock<T> {
+        /// Construct a new `SpinLock` wrapping `value`. `const`
+        /// so the wrapper can live in a `static`.
+        pub const fn new(value: T) -> Self {
+            Self {
+                inner: spin::Mutex::new(value),
+            }
+        }
+
+        /// Consume the lock and return the inner value. Bypasses
+        /// the counter — no acquire happens.
+        pub fn into_inner(self) -> T {
+            self.inner.into_inner()
+        }
+    }
+
+    impl<T: ?Sized> SpinLock<T> {
+        /// Acquire the lock. Spins on contention; bumps the
+        /// held-spinlock counter on success.
+        pub fn lock(&self) -> SpinLockGuard<'_, T> {
+            let guard = self.inner.lock();
+            inc_held_spinlocks();
+            SpinLockGuard { guard: Some(guard) }
+        }
+
+        /// Try to acquire without spinning. On `Some`, bumps the
+        /// counter; on `None` the counter is untouched.
+        pub fn try_lock(&self) -> Option<SpinLockGuard<'_, T>> {
+            let guard = self.inner.try_lock()?;
+            inc_held_spinlocks();
+            Some(SpinLockGuard { guard: Some(guard) })
+        }
+
+        /// Whether the lock is currently held. Advisory only —
+        /// the state may change immediately after the check.
+        pub fn is_locked(&self) -> bool {
+            self.inner.is_locked()
+        }
+    }
+
+    /// RAII guard for a [`SpinLock`]. Decrements the held-spinlock
+    /// counter and releases the underlying `spin::Mutex` on drop.
+    pub struct SpinLockGuard<'a, T: ?Sized + 'a> {
+        // `Option` so `Drop` can take the inner guard and drop it
+        // *after* decrementing the counter — the counter must
+        // observe the unlock before any subsequent
+        // `assert_no_spinlocks_held` runs on this CPU.
+        guard: Option<spin::MutexGuard<'a, T>>,
+    }
+
+    impl<T: ?Sized> Deref for SpinLockGuard<'_, T> {
+        type Target = T;
+        fn deref(&self) -> &T {
+            self.guard.as_ref().expect("guard present until drop")
+        }
+    }
+
+    impl<T: ?Sized> DerefMut for SpinLockGuard<'_, T> {
+        fn deref_mut(&mut self) -> &mut T {
+            self.guard.as_mut().expect("guard present until drop")
+        }
+    }
+
+    impl<T: ?Sized> Drop for SpinLockGuard<'_, T> {
+        fn drop(&mut self) {
+            // Decrement first so the counter is in sync with the
+            // "no longer holding any lock" state by the time the
+            // underlying spin lock is released. Order doesn't
+            // strictly matter on a single CPU (no preemption
+            // window between the two ops on the same core), but
+            // dec-before-release matches the conventional
+            // release-acquire pattern of "publish state, then
+            // open the gate".
+            dec_held_spinlocks();
+            self.guard = None;
+        }
+    }
+}
+
+#[cfg(any(test, target_os = "none"))]
+pub use spinlock::{SpinLock, SpinLockGuard};
+
+#[cfg(all(test, not(target_os = "none")))]
+mod tests {
+    use super::*;
+
+    /// Ensure the counter starts at zero for each test. Tests run
+    /// serially in their own threads under `cargo test`; sharing the
+    /// global counter would cause cross-test interference. Reset
+    /// explicitly at the top of each test.
+    #[cfg(debug_assertions)]
+    fn reset_counter() {
+        HELD_SPINLOCKS.store(0, Ordering::Relaxed);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn counter_increments_on_lock_decrements_on_drop() {
+        reset_counter();
+        let m = SpinLock::new(0u32);
+        assert_eq!(held_spinlocks(), 0);
+        {
+            let _g = m.lock();
+            assert_eq!(held_spinlocks(), 1);
+        }
+        assert_eq!(held_spinlocks(), 0);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn counter_tracks_nested_locks() {
+        reset_counter();
+        let a = SpinLock::new(1u8);
+        let b = SpinLock::new(2u8);
+        let _ga = a.lock();
+        let _gb = b.lock();
+        assert_eq!(held_spinlocks(), 2);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn try_lock_increments_only_on_success() {
+        reset_counter();
+        let m = SpinLock::new(7u8);
+        let _g = m.lock();
+        assert_eq!(held_spinlocks(), 1);
+        // Contended try_lock must NOT bump the counter — it didn't
+        // acquire the lock.
+        assert!(m.try_lock().is_none());
+        assert_eq!(held_spinlocks(), 1);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn assert_passes_with_no_locks_held() {
+        reset_counter();
+        // Should not panic.
+        assert_no_spinlocks_held("test:no-lock-site");
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "debug_lockdep: invariant violated at test:violation-site")]
+    fn assert_panics_when_lock_held() {
+        reset_counter();
+        let m = SpinLock::new(0u8);
+        let _g = m.lock();
+        // Holding `_g` across this call MUST panic.
+        assert_no_spinlocks_held("test:violation-site");
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn guard_deref_and_mutate() {
+        reset_counter();
+        let m = SpinLock::new(0u32);
+        {
+            let mut g = m.lock();
+            *g = 42;
+        }
+        assert_eq!(*m.lock(), 42);
+    }
+
+    /// Release-build sanity: with `debug_assertions` off the
+    /// counter is gone and the assertion is a no-op. We can only
+    /// observe this indirectly — the inc/dec/held APIs all return
+    /// or do nothing, so a held lock should NOT trip the assert.
+    #[cfg(not(debug_assertions))]
+    #[test]
+    fn release_build_assert_is_noop_even_with_held_lock() {
+        let m = SpinLock::new(0u8);
+        let _g = m.lock();
+        // No panic — release builds skip tracking entirely.
+        assert_no_spinlocks_held("test:release-noop");
+        assert_eq!(held_spinlocks(), 0);
+    }
+}

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -17,6 +17,7 @@ pub mod abi;
 pub mod block;
 pub mod build_info;
 pub mod cpu;
+pub mod debug_lockdep;
 #[cfg(any(test, target_os = "none"))]
 pub mod fork_abi;
 #[cfg(any(test, target_os = "none"))]

--- a/kernel/src/sync/irqlock.rs
+++ b/kernel/src/sync/irqlock.rs
@@ -67,6 +67,12 @@ impl<T: ?Sized> IrqLock<T> {
     pub fn lock(&self) -> IrqLockGuard<'_, T> {
         let prev_if = arch_if::save_and_disable();
         let guard = self.inner.lock();
+        // Count the IRQ-masking spinlock toward the held-spinlock
+        // invariant (RFC 0004 §Buffer cache, no-spin-across-I/O).
+        // A held `IrqLock` is the *worst* lock to hold across a
+        // block-I/O wait — it disables IRQs, so the wait can't
+        // even progress on tick.
+        crate::debug_lockdep::inc_held_spinlocks();
         IrqLockGuard {
             guard: Some(guard),
             prev_if,
@@ -79,10 +85,13 @@ impl<T: ?Sized> IrqLock<T> {
     pub fn try_lock(&self) -> Option<IrqLockGuard<'_, T>> {
         let prev_if = arch_if::save_and_disable();
         match self.inner.try_lock() {
-            Some(guard) => Some(IrqLockGuard {
-                guard: Some(guard),
-                prev_if,
-            }),
+            Some(guard) => {
+                crate::debug_lockdep::inc_held_spinlocks();
+                Some(IrqLockGuard {
+                    guard: Some(guard),
+                    prev_if,
+                })
+            }
             None => {
                 arch_if::restore(prev_if);
                 None
@@ -116,6 +125,11 @@ impl<T: ?Sized> Drop for IrqLockGuard<'_, T> {
         // let a pending IRQ observe the data under the (still held)
         // lock semantics and deadlock-via-reentry.
         self.guard = None;
+        // Decrement after the underlying spin release so the
+        // counter reflects "no longer holding the lock" by the
+        // time IF is restored and any IRQ that fires can run an
+        // `assert_no_spinlocks_held`.
+        crate::debug_lockdep::dec_held_spinlocks();
         arch_if::restore(self.prev_if);
     }
 }


### PR DESCRIPTION
Closes #556

## Summary

Adds a debug-build tripwire for RFC 0004 §Buffer cache normative invariant: **"no spin lock is held across a block-I/O wait."** Holding a spinlock across a device wait can deadlock — the wait may take arbitrarily long, while contending tasks burn CPU and IRQs that touch the lock dead-spin on a CPU that has interrupts disabled.

### Mechanism (`kernel/src/debug_lockdep.rs`)

- A per-CPU `HELD_SPINLOCKS: u32` counter (single-CPU today; a natural seam to widen when SMP arrives).
- `inc_held_spinlocks` / `dec_held_spinlocks` / `assert_no_spinlocks_held(io_site)` are all `#[cfg(debug_assertions)]` with `#[inline]` no-op stubs in release builds — the optimiser deletes the calls entirely, so the wait paths pay nothing.
- A `SpinLock<T>` newtype, `#[repr(transparent)]` over `spin::Mutex<T>`, that bumps / decrements the counter on acquire / drop. `IrqLock` participates too (a held IRQ-masking spinlock is the worst possible thing to hold across an I/O wait).

### Wired call sites (`kernel/src/block/cache.rs`)

- `BlockCache.inner` and `BlockCache.dirty` migrated from `spin::Mutex` to the tracking `SpinLock`. These are the cache's hot spinlocks; the existing code already drops them before issuing device I/O (RFC 0004 §Buffer cache, OS-engineer B5 hazard) — the assertion is the loud tripwire.
- `assert_no_spinlocks_held("BlockCache::bread → device.read_at")` immediately before the populate-on-miss `read_at`.
- `assert_no_spinlocks_held("BlockCache::sync_dirty_buffer → device.write_at")` immediately before the writeback `write_at`.
- The writeback daemon flushes via `sync_fs` → `sync_dirty_buffer`, so the assertion above covers it transitively.

The panic message names both the I/O site and the held-lock count so triage is "look at the named caller" rather than "decode a generic deadlock."

## Test plan

- [x] Six new host unit tests (counter inc/dec, nested locks, `try_lock` semantics, panic-on-violation, guard deref).
- [x] `cargo xtask build` — clean.
- [x] `cargo xtask test` — 515/515 host tests pass; QEMU integration tests pass.
- [x] `cargo xtask smoke` — all 33 markers present.
- [x] `cargo fmt --all -- --check` — clean.