### PR TITLE
sys: wire faccessat/faccessat2 with real-vs-effective UID distinction

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -333,6 +333,10 @@ name = "syscall_utimensat"
 harness = false
 
 [[test]]
+name = "syscall_faccessat"
+harness = false
+
+[[test]]
 name = "ntty_sigint_flush"
 harness = false
 

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -944,6 +944,20 @@ pub unsafe extern "C" fn syscall_dispatch(
         #[cfg(feature = "vfs_creds")]
         UTIMENSAT => super::syscalls::vfs::sys_utimensat_impl(a0 as i32, a1, a2, a3 as u32),
 
+        // access / faccessat / faccessat2 (issue #545, RFC 0004
+        // Workstream A wave 1). Same A↔B gate as the other VFS arms —
+        // these syscalls make DAC decisions against the caller's
+        // credentials, so until Workstream B flips `vfs_creds` on they
+        // must remain unreachable from ring-3 (the dispatcher's
+        // default returns `-ENOSYS`). Integration tests call
+        // `sys_*_impl` directly regardless of feature state.
+        #[cfg(feature = "vfs_creds")]
+        ACCESS => super::syscalls::vfs::sys_access_impl(a0, a1),
+        #[cfg(feature = "vfs_creds")]
+        FACCESSAT => super::syscalls::vfs::sys_faccessat_impl(a0 as i32, a1, a2, a3 as u32),
+        #[cfg(feature = "vfs_creds")]
+        FACCESSAT2 => super::syscalls::vfs::sys_faccessat2_impl(a0 as i32, a1, a2, a3 as u32),
+
         // mount(source, target, fstype, flags, data) — RFC 0004 §Mount API.
         // Superuser-only; rejects unknown flag bits; resolves fstype by name
         // against the fstype registry populated by `vfs::init`. See issue #575.
@@ -1651,6 +1665,9 @@ pub mod syscall_nr {
     pub const FCHOWNAT: u64 = 260;
     pub const FCHMODAT: u64 = 268;
     pub const UTIMENSAT: u64 = 280;
+    pub const ACCESS: u64 = 21;
+    pub const FACCESSAT: u64 = 269;
+    pub const FACCESSAT2: u64 = 439;
     pub const MOUNT: u64 = 165;
     pub const UMOUNT2: u64 = 166;
     pub const POLL: u64 = 7;
@@ -1785,6 +1802,11 @@ mod tests {
 
         // utimensat (issue #544)
         assert_eq!(syscall_nr::UTIMENSAT, 280, "SYS_utimensat must be 280");
+
+        // access / faccessat / faccessat2 (issue #545)
+        assert_eq!(syscall_nr::ACCESS, 21, "SYS_access must be 21");
+        assert_eq!(syscall_nr::FACCESSAT, 269, "SYS_faccessat must be 269");
+        assert_eq!(syscall_nr::FACCESSAT2, 439, "SYS_faccessat2 must be 439");
 
         // Mount plumbing (issue #575, RFC 0004 Workstream F)
         assert_eq!(syscall_nr::MOUNT, 165, "SYS_mount must be 165");

--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -1511,11 +1511,9 @@ fn access_mode_to_access(mode: u32) -> Access {
 }
 
 /// Shared body for `access`, `faccessat`, and `faccessat2`. Returns 0
-/// on permitted, negative errno otherwise.
-///
-/// `accept_unknown_flag_bits` is `false` for both `faccessat` and
-/// `faccessat2` here (see module-level comment). The parameter is kept
-/// to make the policy explicit at the call site.
+/// on permitted, negative errno otherwise. Both `faccessat` and
+/// `faccessat2` reject unknown flag bits (see module-level comment),
+/// so a single body suffices.
 fn faccessat_impl(dfd: i32, path_uva: u64, mode: u32, flags: u32) -> i64 {
     // Mode validation: only the low three bits are valid, plus F_OK==0.
     if mode & !(R_OK | W_OK | X_OK) != 0 {

--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -60,6 +60,27 @@ pub const AT_REMOVEDIR: u32 = 0x200;
 /// value (RFC 0002 §flags).
 pub const AT_SYMLINK_FOLLOW: u32 = 0x400;
 
+/// `AT_EACCESS` — flag to `faccessat(2)` that asks the kernel to use
+/// the *effective* uid/gid for the permission check instead of the
+/// POSIX-default *real* uid/gid. Linux value 0x200; shares its bit
+/// pattern with `AT_REMOVEDIR` (the `unlinkat(2)` flag) — the two
+/// belong to disjoint syscall flag namespaces and the value collision
+/// is harmless in practice.
+pub const AT_EACCESS: u32 = 0x200;
+
+/// `F_OK` — `access(2)` mode meaning "test for existence only" (no
+/// permission bit checked). When `mode == F_OK` (i.e. `0`), a
+/// successful path resolve is itself the answer; no `permission()`
+/// callback is invoked.
+pub const F_OK: u32 = 0;
+/// `R_OK` — `access(2)` mode bit asking "is read permission granted?"
+pub const R_OK: u32 = 4;
+/// `W_OK` — `access(2)` mode bit asking "is write permission granted?"
+pub const W_OK: u32 = 2;
+/// `X_OK` — `access(2)` mode bit asking "is execute (or search, on a
+/// directory) permission granted?"
+pub const X_OK: u32 = 1;
+
 /// `S_ISVTX` — the POSIX "sticky bit" in `InodeMeta.mode`. When set on
 /// a directory, `unlink`/`rename` require the caller to own either the
 /// target file or the directory (or be root). Linux value 0o1000.
@@ -1418,6 +1439,185 @@ pub unsafe fn sys_lchown_impl(path_uva: u64, uid: u64, gid: u64) -> i64 {
 /// `fchownat(dfd, path, uid, gid, flags)` — `*at` form of chown.
 pub unsafe fn sys_fchownat_impl(dfd: i32, path_uva: u64, uid: u64, gid: u64, flags: u32) -> i64 {
     chownat_impl(dfd, path_uva, uid as u32, gid as u32, flags)
+}
+
+// ---------------------------------------------------------------------------
+// access / faccessat / faccessat2 (issue #545, RFC 0004 Workstream A wave 1)
+//
+// `access(2)` lets a caller probe whether they would be permitted to
+// open/read/write/execute `path` without actually doing so. The
+// distinguishing feature vs. the normal permission path is the use of
+// the **real** uid/gid (not effective) — historically intended for
+// setuid binaries asking "what could the real user have done?".
+//
+// `faccessat(dirfd, path, mode, flags)` is the *at form. `AT_EACCESS`
+// flips the check back to the effective uid/gid; `AT_SYMLINK_NOFOLLOW`
+// stops on a trailing symlink (in which case the resolution naturally
+// fails on most callers' use cases — kept for POSIX completeness).
+//
+// `faccessat2(dirfd, path, mode, flags)` is the Linux extension that
+// validates flag bits strictly (rejecting unknown bits with `EINVAL`
+// rather than silently masking them). Both implementations here reject
+// unknown bits — the codebase's other `*at` syscalls (`fchmodat`,
+// `fchownat`, `unlinkat`) follow the same explicit-whitelist
+// convention, and matching it keeps a future flag addition from
+// silently being a no-op.
+// ---------------------------------------------------------------------------
+
+/// Build the credential snapshot the access-check should consult.
+///
+/// POSIX `access(2)` (and `faccessat(.., 0)`) checks against the
+/// caller's **real** uid/gid, not effective. We model that by cloning
+/// the per-task credential and overriding the effective IDs — including
+/// `euid` and `egid`, which is what `default_permission` actually
+/// reads — to mirror the real IDs. The `AT_EACCESS` flag short-circuits
+/// this and returns the snapshot unchanged so the effective IDs apply.
+///
+/// `suid`/`sgid` are intentionally left at their original values: they
+/// don't participate in `default_permission` and POSIX never asks the
+/// access check to consult them.
+fn access_check_credential(cur: &Credential, use_effective: bool) -> Credential {
+    if use_effective {
+        cur.clone()
+    } else {
+        Credential::from_task_ids(
+            cur.uid,
+            cur.uid,
+            cur.suid,
+            cur.gid,
+            cur.gid,
+            cur.sgid,
+            cur.groups.clone(),
+        )
+    }
+}
+
+/// Translate an `access(2)` mode bitmask into [`Access`] flags.
+///
+/// Returns `Access::NONE` for `F_OK` (0) — the caller treats that as
+/// "skip the permission callback, the path resolve was sufficient".
+fn access_mode_to_access(mode: u32) -> Access {
+    let mut a = Access::NONE;
+    if mode & R_OK != 0 {
+        a = a | Access::READ;
+    }
+    if mode & W_OK != 0 {
+        a = a | Access::WRITE;
+    }
+    if mode & X_OK != 0 {
+        a = a | Access::EXECUTE;
+    }
+    a
+}
+
+/// Shared body for `access`, `faccessat`, and `faccessat2`. Returns 0
+/// on permitted, negative errno otherwise.
+///
+/// `accept_unknown_flag_bits` is `false` for both `faccessat` and
+/// `faccessat2` here (see module-level comment). The parameter is kept
+/// to make the policy explicit at the call site.
+fn faccessat_impl(dfd: i32, path_uva: u64, mode: u32, flags: u32) -> i64 {
+    // Mode validation: only the low three bits are valid, plus F_OK==0.
+    if mode & !(R_OK | W_OK | X_OK) != 0 {
+        return EINVAL;
+    }
+    // Flag validation: only AT_EACCESS, AT_SYMLINK_NOFOLLOW, and
+    // AT_EMPTY_PATH are recognised. Any other bit is rejected so a
+    // future addition is whitelisted explicitly.
+    let allowed = AT_EACCESS | AT_SYMLINK_NOFOLLOW | AT_EMPTY_PATH;
+    if flags & !allowed != 0 {
+        return EINVAL;
+    }
+
+    let buf = match copy_user_path(path_uva) {
+        Ok(b) => b,
+        Err(e) => return e,
+    };
+    let path = buf.as_slice();
+
+    let is_absolute = path.first() == Some(&b'/');
+    if dfd != AT_FDCWD && !is_absolute {
+        // Per-fd dfd resolution is tracked under #239; until then, only
+        // AT_FDCWD or absolute paths reach the inode.
+        return EINVAL;
+    }
+
+    let cur = crate::task::current_credentials();
+    let use_effective = flags & AT_EACCESS != 0;
+    let check_cred = access_check_credential(&cur, use_effective);
+
+    // The path walk must run under the same credential that will later
+    // gate the permission check, so an unsearchable ancestor returns
+    // `EACCES` (real ID's view) rather than silently resolving as the
+    // effective ID and then failing the leaf check with the wrong
+    // errno. `AT_SYMLINK_NOFOLLOW` selects the lstat-style walk — on a
+    // terminal symlink the resolved inode *is* the symlink, and
+    // `default_permission` against link bits (typically 0o777) makes
+    // the answer almost always "yes"; that mirrors Linux.
+    let follow = flags & AT_SYMLINK_NOFOLLOW == 0;
+    let (inode, _nd) = match resolve_inode_as(path, follow, check_cred.clone()) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
+    // F_OK: existence is the answer. Skip the permission callback.
+    let access = access_mode_to_access(mode);
+    if access == Access::NONE {
+        return 0;
+    }
+
+    // EROFS short-circuit for W_OK on a read-only mount. Linux does
+    // this even when the file's mode bits would grant write — the
+    // syscall reports the answer the *next* write would actually get,
+    // which is EROFS, not EACCES. Matches `do_faccessat` in the Linux
+    // kernel.
+    if access.contains(Access::WRITE) {
+        if let Some(sb) = inode.sb.upgrade() {
+            if sb.flags.contains(crate::fs::vfs::SbFlags::RDONLY) {
+                // Per Linux: only block writes to regular files /
+                // directories — character devices on a RO mount are
+                // still writeable through the device backend, so
+                // `access(W_OK)` should not lie about that. RamFs
+                // doesn't yet model writable devices on a RO SB so
+                // this branch is conservative; revisit if a driver
+                // ever needs the carve-out.
+                match inode.kind {
+                    InodeKind::Reg | InodeKind::Dir | InodeKind::Link => return EROFS,
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    match inode.ops.permission(&inode, &check_cred, access) {
+        Ok(()) => 0,
+        Err(e) => e,
+    }
+}
+
+/// `access(path, mode)` — POSIX.1-2017 §access. Equivalent to
+/// `faccessat(AT_FDCWD, path, mode, 0)`. The check uses the caller's
+/// **real** uid/gid (not effective).
+pub unsafe fn sys_access_impl(path_uva: u64, mode: u64) -> i64 {
+    faccessat_impl(AT_FDCWD, path_uva, mode as u32, 0)
+}
+
+/// `faccessat(dirfd, path, mode, flags)` — POSIX.1-2017 §faccessat.
+///
+/// `flags` honors `AT_EACCESS` (use effective IDs),
+/// `AT_SYMLINK_NOFOLLOW`, and `AT_EMPTY_PATH`. Unknown bits are
+/// rejected with `EINVAL`.
+pub unsafe fn sys_faccessat_impl(dfd: i32, path_uva: u64, mode: u64, flags: u32) -> i64 {
+    faccessat_impl(dfd, path_uva, mode as u32, flags)
+}
+
+/// `faccessat2(dirfd, path, mode, flags)` — Linux extension that adds
+/// strict flag-bit validation on top of `faccessat`. Our `faccessat`
+/// already rejects unknown flag bits (see module-level comment), so
+/// the bodies are identical — the separate entry point exists to give
+/// `glibc`'s `faccessat2` shim a stable syscall number.
+pub unsafe fn sys_faccessat2_impl(dfd: i32, path_uva: u64, mode: u64, flags: u32) -> i64 {
+    faccessat_impl(dfd, path_uva, mode as u32, flags)
 }
 
 // ---------------------------------------------------------------------------

--- a/kernel/tests/syscall_faccessat.rs
+++ b/kernel/tests/syscall_faccessat.rs
@@ -1,0 +1,527 @@
+//! Integration test for issue #545: `access(2)` / `faccessat(2)` /
+//! `faccessat2(2)` wired through `InodeOps::permission` with the POSIX
+//! real-vs-effective UID distinction.
+//!
+//! Each impl is compiled unconditionally; the syscall dispatch arms
+//! are gated behind `#[cfg(feature = "vfs_creds")]` per RFC 0004's
+//! A-before-B ordering. Tests call `sys_*_impl` directly so the VFS
+//! wiring is exercised regardless of feature state, mirroring the
+//! mkdir/unlink/chmod convention.
+//!
+//! Coverage per the issue contract:
+//! - `F_OK` on an existing file succeeds; on a missing path → `ENOENT`.
+//! - `R_OK` / `W_OK` / `X_OK` round-trip against `default_permission`.
+//! - A task with `ruid != euid` (the setuid-binary scenario) gets
+//!   different answers from `access` (real ID) and `faccessat(...,
+//!   AT_EACCESS)` (effective ID) — the central distinguishing feature.
+//! - Unknown flag bits → `EINVAL`.
+//! - Mode bits outside `R_OK | W_OK | X_OK` → `EINVAL`.
+//! - Relative path with `dfd != AT_FDCWD` → `EINVAL` (per-fd dirfd
+//!   resolution is tracked under #239).
+//! - `faccessat2` returns the same answer as `faccessat` for
+//!   well-formed inputs.
+//! - Dispatch arms return `-ENOSYS` until `vfs_creds` flips on.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use core::ptr;
+
+use vibix::arch::x86_64::syscall::{syscall_dispatch, syscall_nr};
+use vibix::arch::x86_64::syscalls::vfs::{
+    sys_access_impl, sys_chmod_impl, sys_chown_impl, sys_faccessat2_impl, sys_faccessat_impl,
+    AT_EACCESS, AT_FDCWD, AT_SYMLINK_NOFOLLOW, F_OK, R_OK, W_OK, X_OK,
+};
+use vibix::fs::vfs::Credential;
+use vibix::fs::{EACCES, EINVAL, ENOENT};
+use vibix::mem::vmatree::{Share, Vma};
+use vibix::mem::vmobject::AnonObject;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+use x86_64::structures::paging::PageTableFlags;
+
+const SYS_OPEN: u64 = 2;
+const SYS_CLOSE: u64 = 3;
+
+const O_WRONLY: u64 = 0o1;
+const O_CREAT: u64 = 0o100;
+
+const ENOSYS: i64 = -38;
+
+const USER_PAGE_VA: usize = 0x0000_2008_0000_0000;
+const USER_PAGE_LEN: usize = 4 * 4096;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    vibix::task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("access_f_ok_existing", &(access_f_ok_existing as fn())),
+        (
+            "access_f_ok_missing_enoent",
+            &(access_f_ok_missing_enoent as fn()),
+        ),
+        ("access_r_ok_owner", &(access_r_ok_owner as fn())),
+        (
+            "access_w_ok_other_eaccess",
+            &(access_w_ok_other_eaccess as fn()),
+        ),
+        (
+            "access_x_ok_no_x_bit_eaccess",
+            &(access_x_ok_no_x_bit_eaccess as fn()),
+        ),
+        (
+            "access_uses_real_uid_not_effective",
+            &(access_uses_real_uid_not_effective as fn()),
+        ),
+        (
+            "faccessat_eaccess_uses_effective_uid",
+            &(faccessat_eaccess_uses_effective_uid as fn()),
+        ),
+        (
+            "faccessat_unknown_flag_einval",
+            &(faccessat_unknown_flag_einval as fn()),
+        ),
+        (
+            "faccessat_invalid_mode_einval",
+            &(faccessat_invalid_mode_einval as fn()),
+        ),
+        (
+            "faccessat_relative_with_dfd_einval",
+            &(faccessat_relative_with_dfd_einval as fn()),
+        ),
+        (
+            "faccessat2_matches_faccessat",
+            &(faccessat2_matches_faccessat as fn()),
+        ),
+        (
+            "access_dispatch_gate_enosys",
+            &(access_dispatch_gate_enosys as fn()),
+        ),
+        (
+            "faccessat_symlink_nofollow_accepted",
+            &(faccessat_symlink_nofollow_accepted as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+fn install_user_staging_vma() {
+    static INSTALLED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+    if INSTALLED.swap(true, core::sync::atomic::Ordering::SeqCst) {
+        return;
+    }
+    let prot_pte =
+        (PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE).bits();
+    vibix::task::install_vma_on_current(Vma::new(
+        USER_PAGE_VA,
+        USER_PAGE_VA + USER_PAGE_LEN,
+        0x3,
+        prot_pte,
+        Share::Private,
+        AnonObject::new(Some(USER_PAGE_LEN / 4096)),
+        0,
+    ));
+    unsafe {
+        let dst = USER_PAGE_VA as *mut u8;
+        let mut i = 0;
+        while i < USER_PAGE_LEN {
+            ptr::write_volatile(dst.add(i), 0);
+            i += 4096;
+        }
+    }
+}
+
+fn stage(bytes: &[u8]) -> u64 {
+    install_user_staging_vma();
+    assert!(bytes.len() < 4096);
+    unsafe {
+        let dst = USER_PAGE_VA as *mut u8;
+        for (i, b) in bytes.iter().enumerate() {
+            ptr::write_volatile(dst.add(i), *b);
+        }
+        ptr::write_volatile(dst.add(bytes.len()), 0);
+    }
+    USER_PAGE_VA as u64
+}
+
+fn open(path: &[u8], flags: u64, mode: u64) -> i64 {
+    let uva = stage(path);
+    unsafe { syscall_dispatch(core::ptr::null_mut(), SYS_OPEN, uva, flags, mode, 0, 0, 0) }
+}
+
+fn close(fd: i64) -> i64 {
+    unsafe { syscall_dispatch(core::ptr::null_mut(), SYS_CLOSE, fd as u64, 0, 0, 0, 0, 0) }
+}
+
+fn chmod(path: &[u8], mode: u32) -> i64 {
+    let uva = stage(path);
+    unsafe { sys_chmod_impl(uva, mode as u64) }
+}
+
+fn chown(path: &[u8], uid: u32, gid: u32) -> i64 {
+    let uva = stage(path);
+    unsafe { sys_chown_impl(uva, uid as u64, gid as u64) }
+}
+
+fn access(path: &[u8], mode: u32) -> i64 {
+    let uva = stage(path);
+    unsafe { sys_access_impl(uva, mode as u64) }
+}
+
+fn faccessat(dfd: i32, path: &[u8], mode: u32, flags: u32) -> i64 {
+    let uva = stage(path);
+    unsafe { sys_faccessat_impl(dfd, uva, mode as u64, flags) }
+}
+
+fn faccessat2(dfd: i32, path: &[u8], mode: u32, flags: u32) -> i64 {
+    let uva = stage(path);
+    unsafe { sys_faccessat2_impl(dfd, uva, mode as u64, flags) }
+}
+
+fn create_regular(path: &[u8]) -> i64 {
+    let fd = open(path, O_WRONLY | O_CREAT, 0o644);
+    assert!(fd >= 3, "create({:?}) expected fd, got {}", path, fd);
+    fd
+}
+
+fn set_root_creds() {
+    vibix::task::set_current_credentials(Credential::kernel());
+}
+
+/// Set ruid/euid/suid (and gid trio) directly so we can exercise the
+/// real-vs-effective distinction. Supplementary groups left empty.
+fn set_split_creds(ruid: u32, euid: u32, rgid: u32, egid: u32) {
+    vibix::task::set_current_credentials(Credential::from_task_ids(
+        ruid,
+        euid,
+        euid,
+        rgid,
+        egid,
+        egid,
+        alloc::vec::Vec::new(),
+    ));
+}
+
+fn set_creds(uid: u32, gid: u32) {
+    vibix::task::set_current_credentials(Credential::from_task_ids(
+        uid,
+        uid,
+        uid,
+        gid,
+        gid,
+        gid,
+        alloc::vec::Vec::new(),
+    ));
+}
+
+// --- Tests --------------------------------------------------------------
+
+fn access_f_ok_existing() {
+    set_root_creds();
+    let fd = create_regular(b"/tmp/access-fok");
+    close(fd);
+    let r = access(b"/tmp/access-fok", F_OK);
+    assert_eq!(r, 0, "F_OK on existing file must succeed, got {}", r);
+}
+
+fn access_f_ok_missing_enoent() {
+    set_root_creds();
+    let r = access(b"/tmp/no-such-file-for-access", F_OK);
+    assert_eq!(r, ENOENT, "F_OK on missing path must be ENOENT, got {}", r);
+}
+
+fn access_r_ok_owner() {
+    set_root_creds();
+    let fd = create_regular(b"/tmp/access-rok-owner");
+    close(fd);
+    // Hand ownership to uid 1000 with mode 0o600 (owner rw, no one else).
+    assert_eq!(chown(b"/tmp/access-rok-owner", 1000, 1000), 0);
+    assert_eq!(chmod(b"/tmp/access-rok-owner", 0o600), 0);
+    set_creds(1000, 1000);
+
+    let r = access(b"/tmp/access-rok-owner", R_OK);
+    assert_eq!(r, 0, "R_OK by owner must succeed, got {}", r);
+    let r = access(b"/tmp/access-rok-owner", W_OK);
+    assert_eq!(r, 0, "W_OK by owner must succeed, got {}", r);
+    set_root_creds();
+}
+
+fn access_w_ok_other_eaccess() {
+    set_root_creds();
+    let fd = create_regular(b"/tmp/access-wok-other");
+    close(fd);
+    assert_eq!(chown(b"/tmp/access-wok-other", 1000, 1000), 0);
+    // 0o644: owner rw, group r, other r — no W_OK for other.
+    assert_eq!(chmod(b"/tmp/access-wok-other", 0o644), 0);
+    set_creds(2000, 2000);
+
+    let r = access(b"/tmp/access-wok-other", W_OK);
+    assert_eq!(
+        r, EACCES,
+        "W_OK by non-owner non-group must be EACCES, got {}",
+        r
+    );
+    // R_OK is granted by the `other` class.
+    let r = access(b"/tmp/access-wok-other", R_OK);
+    assert_eq!(r, 0, "R_OK by other class must succeed, got {}", r);
+    set_root_creds();
+}
+
+fn access_x_ok_no_x_bit_eaccess() {
+    set_root_creds();
+    let fd = create_regular(b"/tmp/access-xok-noexec");
+    close(fd);
+    assert_eq!(chown(b"/tmp/access-xok-noexec", 1000, 1000), 0);
+    assert_eq!(chmod(b"/tmp/access-xok-noexec", 0o644), 0);
+    set_creds(1000, 1000);
+
+    let r = access(b"/tmp/access-xok-noexec", X_OK);
+    assert_eq!(
+        r, EACCES,
+        "X_OK on a non-executable file must be EACCES even for owner, got {}",
+        r
+    );
+    set_root_creds();
+}
+
+/// The central real-vs-effective distinction. Set up a task whose
+/// ruid != euid (the setuid-binary scenario) and confirm `access(2)`
+/// (real ID) returns a *different* answer than `faccessat(...,
+/// AT_EACCESS)` (effective ID).
+fn access_uses_real_uid_not_effective() {
+    set_root_creds();
+    let fd = create_regular(b"/tmp/access-real-vs-eff");
+    close(fd);
+    // File owned by uid 1000, mode 0o600 (only owner can read/write).
+    assert_eq!(chown(b"/tmp/access-real-vs-eff", 1000, 1000), 0);
+    assert_eq!(chmod(b"/tmp/access-real-vs-eff", 0o600), 0);
+
+    // Task: ruid=2000 (the "real user"), euid=1000 (the file owner —
+    // as if they had just exec'd a setuid-1000 binary).
+    set_split_creds(2000, 1000, 2000, 1000);
+
+    // Default access(2) consults the *real* uid 2000, which is the
+    // `other` class on this 0o600 file → EACCES.
+    let r = access(b"/tmp/access-real-vs-eff", R_OK);
+    assert_eq!(
+        r, EACCES,
+        "access(R_OK) under ruid=2000 must be EACCES (real ID is not the owner), got {}",
+        r
+    );
+
+    // faccessat with AT_EACCESS consults the *effective* uid 1000,
+    // which is the file owner → success.
+    let r = faccessat(AT_FDCWD, b"/tmp/access-real-vs-eff", R_OK, AT_EACCESS);
+    assert_eq!(
+        r, 0,
+        "faccessat(R_OK, AT_EACCESS) under euid=1000 must succeed (effective ID is the owner), got {}",
+        r
+    );
+
+    set_root_creds();
+}
+
+fn faccessat_eaccess_uses_effective_uid() {
+    set_root_creds();
+    let fd = create_regular(b"/tmp/faccessat-eacc");
+    close(fd);
+    assert_eq!(chown(b"/tmp/faccessat-eacc", 1000, 1000), 0);
+    assert_eq!(chmod(b"/tmp/faccessat-eacc", 0o600), 0);
+
+    // ruid=1000 (file owner), euid=2000 (some other user). Mirror of
+    // the setuid-on-binary-owned-by-others case.
+    set_split_creds(1000, 2000, 1000, 2000);
+
+    // Default: real uid 1000 → owner → success.
+    let r = faccessat(AT_FDCWD, b"/tmp/faccessat-eacc", W_OK, 0);
+    assert_eq!(
+        r, 0,
+        "faccessat(W_OK, 0) under ruid=1000 must succeed, got {}",
+        r
+    );
+
+    // AT_EACCESS: effective uid 2000 → other class → EACCES.
+    let r = faccessat(AT_FDCWD, b"/tmp/faccessat-eacc", W_OK, AT_EACCESS);
+    assert_eq!(
+        r, EACCES,
+        "faccessat(W_OK, AT_EACCESS) under euid=2000 must be EACCES, got {}",
+        r
+    );
+
+    set_root_creds();
+}
+
+fn faccessat_unknown_flag_einval() {
+    set_root_creds();
+    let fd = create_regular(b"/tmp/faccessat-bad-flag");
+    close(fd);
+    // 0x800 is not in {AT_EACCESS, AT_SYMLINK_NOFOLLOW, AT_EMPTY_PATH}.
+    let r = faccessat(AT_FDCWD, b"/tmp/faccessat-bad-flag", F_OK, 0x800);
+    assert_eq!(r, EINVAL, "unknown flag bit must be EINVAL, got {}", r);
+}
+
+fn faccessat_invalid_mode_einval() {
+    set_root_creds();
+    let fd = create_regular(b"/tmp/faccessat-bad-mode");
+    close(fd);
+    // Bits above the low three are reserved.
+    let r = faccessat(AT_FDCWD, b"/tmp/faccessat-bad-mode", 0o10, 0);
+    assert_eq!(
+        r, EINVAL,
+        "mode with reserved bit must be EINVAL, got {}",
+        r
+    );
+}
+
+fn faccessat_relative_with_dfd_einval() {
+    set_root_creds();
+    // Per-fd dirfd resolution is #239; relative path + non-AT_FDCWD
+    // is rejected up front rather than silently resolving against
+    // the namespace root.
+    let r = faccessat(7, b"relative/path", F_OK, 0);
+    assert_eq!(
+        r, EINVAL,
+        "relative path with dfd != AT_FDCWD must be EINVAL, got {}",
+        r
+    );
+}
+
+fn faccessat2_matches_faccessat() {
+    set_root_creds();
+    let fd = create_regular(b"/tmp/faccessat2-eq");
+    close(fd);
+    let a = faccessat(AT_FDCWD, b"/tmp/faccessat2-eq", R_OK, 0);
+    let b = faccessat2(AT_FDCWD, b"/tmp/faccessat2-eq", R_OK, 0);
+    assert_eq!(a, b, "faccessat2 must mirror faccessat for valid inputs");
+    // And the strict-bit-check path also rejects unknown bits.
+    let r = faccessat2(AT_FDCWD, b"/tmp/faccessat2-eq", F_OK, 0x4000);
+    assert_eq!(
+        r, EINVAL,
+        "faccessat2 must reject unknown flag bits, got {}",
+        r
+    );
+}
+
+fn faccessat_symlink_nofollow_accepted() {
+    set_root_creds();
+    // AT_SYMLINK_NOFOLLOW is a recognised flag — must not be EINVAL
+    // even on a regular (non-symlink) file. The result is just F_OK
+    // success since the file exists.
+    let fd = create_regular(b"/tmp/faccessat-nofollow");
+    close(fd);
+    let r = faccessat(
+        AT_FDCWD,
+        b"/tmp/faccessat-nofollow",
+        F_OK,
+        AT_SYMLINK_NOFOLLOW,
+    );
+    assert_eq!(
+        r, 0,
+        "AT_SYMLINK_NOFOLLOW on a regular file must succeed, got {}",
+        r
+    );
+}
+
+#[cfg(not(feature = "vfs_creds"))]
+fn access_dispatch_gate_enosys() {
+    set_root_creds();
+    let uva = stage(b"/tmp/anything-access");
+    let r = unsafe {
+        syscall_dispatch(
+            core::ptr::null_mut(),
+            syscall_nr::ACCESS,
+            uva,
+            F_OK as u64,
+            0,
+            0,
+            0,
+            0,
+        )
+    };
+    assert_eq!(
+        r, ENOSYS,
+        "SYS_access must dispatch to ENOSYS until vfs_creds flips on, got {}",
+        r
+    );
+    let r = unsafe {
+        syscall_dispatch(
+            core::ptr::null_mut(),
+            syscall_nr::FACCESSAT,
+            AT_FDCWD as u64,
+            uva,
+            F_OK as u64,
+            0,
+            0,
+            0,
+        )
+    };
+    assert_eq!(
+        r, ENOSYS,
+        "SYS_faccessat must dispatch to ENOSYS until vfs_creds flips on, got {}",
+        r
+    );
+    let r = unsafe {
+        syscall_dispatch(
+            core::ptr::null_mut(),
+            syscall_nr::FACCESSAT2,
+            AT_FDCWD as u64,
+            uva,
+            F_OK as u64,
+            0,
+            0,
+            0,
+        )
+    };
+    assert_eq!(
+        r, ENOSYS,
+        "SYS_faccessat2 must dispatch to ENOSYS until vfs_creds flips on, got {}",
+        r
+    );
+}
+
+#[cfg(feature = "vfs_creds")]
+fn access_dispatch_gate_enosys() {
+    set_root_creds();
+    let fd = create_regular(b"/tmp/anything-access-on");
+    close(fd);
+    let uva = stage(b"/tmp/anything-access-on");
+    let r = unsafe {
+        syscall_dispatch(
+            core::ptr::null_mut(),
+            syscall_nr::ACCESS,
+            uva,
+            F_OK as u64,
+            0,
+            0,
+            0,
+            0,
+        )
+    };
+    assert_eq!(
+        r, 0,
+        "SYS_access dispatcher must reach the impl with vfs_creds on, got {}",
+        r
+    );
+}


### PR DESCRIPTION
Closes #545

## Summary

Wires `access(2)`, `faccessat(2)`, and `faccessat2(2)` to `InodeOps::permission` with the POSIX real-vs-effective UID distinction. Implements RFC 0004 Workstream A wave 1.

- Default check uses **real** uid/gid (POSIX `access(2)`); `AT_EACCESS` switches to effective uid/gid (the central distinguishing feature).
- `F_OK` is a pure existence test; `R_OK | W_OK | X_OK` map onto `Access::{READ, WRITE, EXECUTE}`. Reserved mode bits → `EINVAL`.
- Recognised flags: `AT_EACCESS`, `AT_SYMLINK_NOFOLLOW`, `AT_EMPTY_PATH`. Unknown bits → `EINVAL` for both `faccessat` and `faccessat2` (matching the codebase's other `*at` whitelists).
- `W_OK` on a read-only superblock short-circuits to `EROFS` before consulting `permission`, matching Linux's `do_faccessat`.
- Dispatch arms are gated behind `#[cfg(feature = "vfs_creds")]` per the A↔B handshake; impls compile unconditionally so tests reach them directly.
- Syscall numbers anchored in `syscall_numbers_match_linux_x86_64_abi`: ACCESS=21, FACCESSAT=269, FACCESSAT2=439.

## Test plan

- [x] `cargo xtask build` clean.
- [x] `cargo xtask test` passes (the single `wait4_condvar_race` 90s timeout in the harness output is an unrelated flake on this host; my test runs alphabetically before that and `cargo xtask test --test syscall_faccessat` exits 0).
- [x] `cargo xtask smoke` — all 33 markers present.
- [x] `cargo fmt --all -- --check` clean.
- [x] New integration test `syscall_faccessat` covers F_OK existence, R/W/X access, ruid != euid distinction, AT_EACCESS, unknown flag → EINVAL, invalid mode → EINVAL, dfd != AT_FDCWD with relative path → EINVAL, faccessat2 parity, AT_SYMLINK_NOFOLLOW accepted, and the `vfs_creds`-off dispatch-gate ENOSYS check.