### PR TITLE
fs/ext2/balloc: harden allocator (CodeRabbit follow-ups from #613)

### DIFF
--- a/kernel/src/fs/ext2/balloc.rs
+++ b/kernel/src/fs/ext2/balloc.rs
@@ -68,7 +68,7 @@ use alloc::sync::Arc;
 #[cfg(all(feature = "ext2", target_os = "none"))]
 use super::disk::{Ext2SuperBlock, EXT2_SUPERBLOCK_SIZE};
 #[cfg(all(feature = "ext2", target_os = "none"))]
-use super::fs::{Ext2MountFlags, Ext2Super, SUPERBLOCK_BYTE_OFFSET};
+use super::fs::{Ext2Super, SUPERBLOCK_BYTE_OFFSET};
 #[cfg(all(feature = "ext2", target_os = "none"))]
 use crate::fs::{EIO, ENOSPC, EROFS};
 
@@ -99,9 +99,7 @@ use crate::fs::{EIO, ENOSPC, EROFS};
 ///   or vice versa).
 #[cfg(all(feature = "ext2", target_os = "none"))]
 pub fn alloc_block(super_: &Arc<Ext2Super>, hint_group: Option<u32>) -> Result<u32, i64> {
-    if super_.ext2_flags.contains(Ext2MountFlags::RDONLY)
-        || super_.ext2_flags.contains(Ext2MountFlags::FORCED_RDONLY)
-    {
+    if !super_.is_writable() {
         return Err(EROFS);
     }
 
@@ -109,17 +107,20 @@ pub fn alloc_block(super_: &Arc<Ext2Super>, hint_group: Option<u32>) -> Result<u
     // touching `bgdt` so the main allocator critical section below can
     // take the sb lock for the counter update without a lock-order
     // violation.
-    let (s_blocks_per_group, s_blocks_count, s_first_data_block) = {
+    let (s_blocks_per_group, s_blocks_count, s_first_data_block, s_inodes_per_group) = {
         let sb = super_.sb_disk.lock();
         (
             sb.s_blocks_per_group,
             sb.s_blocks_count,
             sb.s_first_data_block,
+            sb.s_inodes_per_group,
         )
     };
     if s_blocks_per_group == 0 {
         return Err(EIO);
     }
+    let inode_size = super_.inode_size as u64;
+    let block_size = super_.block_size;
 
     // Hold the bgdt lock across the bitmap RMW + counter updates; this
     // is the single-lock serialization the RFC requires.
@@ -152,30 +153,69 @@ pub fn alloc_block(super_: &Arc<Ext2Super>, hint_group: Option<u32>) -> Result<u
         // expected to be set to 1 by mkfs (they represent "past end of
         // fs"); we still cap our search to the real group size to be
         // defensive against a mis-formatted image.
-        let blocks_in_this_group =
-            blocks_in_group(group, group_count, s_blocks_per_group, s_blocks_count);
+        let blocks_in_this_group = blocks_in_group(
+            group,
+            group_count,
+            s_blocks_per_group,
+            s_blocks_count,
+            s_first_data_block,
+        );
 
         let found_bit = {
             let mut data = bh.data.write();
-            match find_first_zero_bit(&data, blocks_in_this_group as usize) {
-                Some(bit) => {
-                    // Set the bit (RMW). `find_first_zero_bit` validated
-                    // the index < `blocks_in_this_group`, so the byte
-                    // offset is in-bounds.
-                    let byte = bit / 8;
-                    let mask = 1u8 << (bit % 8);
-                    debug_assert!(data[byte] & mask == 0, "bitmap changed under lock");
-                    data[byte] |= mask;
-                    Some(bit as u32)
+            // Search the bitmap for a zero bit that *also* doesn't fall
+            // inside any metadata range (#617 item 2: a corrupted image
+            // with a clear bit over metadata must not be handed out).
+            // `find_first_zero_bit_skipping` calls the predicate to
+            // gate each candidate; a `false` answer marks that bit
+            // implicitly forbidden so the search advances.
+            let mut bit_opt: Option<u32> = None;
+            let mut start_bit = 0usize;
+            while let Some(bit) =
+                find_first_zero_bit(&data, blocks_in_this_group as usize, start_bit)
+            {
+                let abs = match s_first_data_block
+                    .checked_add(group.checked_mul(s_blocks_per_group).ok_or(EIO)?)
+                    .and_then(|v| v.checked_add(bit as u32))
+                {
+                    Some(v) => v,
+                    None => return Err(EIO),
+                };
+                if is_metadata_block(
+                    abs,
+                    s_first_data_block,
+                    s_blocks_per_group,
+                    s_inodes_per_group,
+                    block_size,
+                    inode_size,
+                    group_count,
+                    &bgdt,
+                ) {
+                    // The on-disk bitmap is lying about a metadata
+                    // block being free. Skip it (don't mutate the
+                    // bitmap — leaving the bit clear preserves the
+                    // image's existing state for fsck) and continue.
+                    start_bit = bit + 1;
+                    continue;
                 }
-                None => None,
+                // Set the bit (RMW). `find_first_zero_bit` validated
+                // the index < `blocks_in_this_group`, so the byte
+                // offset is in-bounds.
+                let byte = bit / 8;
+                let mask = 1u8 << (bit % 8);
+                debug_assert!(data[byte] & mask == 0, "bitmap changed under lock");
+                data[byte] |= mask;
+                bit_opt = Some(bit as u32);
+                break;
             }
+            bit_opt
         };
 
         let Some(bit) = found_bit else {
             // Counter disagreed with the bitmap — the image is
             // inconsistent. Force-RO and bail. The caller can't safely
             // retry since the in-memory counter is now known-wrong.
+            super_.force_ro();
             return Err(EIO);
         };
 
@@ -192,6 +232,7 @@ pub fn alloc_block(super_: &Arc<Ext2Super>, hint_group: Option<u32>) -> Result<u
             // The short-group tail is padded with 1-bits by mkfs so a
             // well-formed bitmap would never produce an out-of-fs bit.
             // If we land here the image is lying; force-RO.
+            super_.force_ro();
             return Err(EIO);
         }
 
@@ -239,9 +280,7 @@ pub fn alloc_block(super_: &Arc<Ext2Super>, hint_group: Option<u32>) -> Result<u
 ///   in the wave-F sync path).
 #[cfg(all(feature = "ext2", target_os = "none"))]
 pub fn free_block(super_: &Arc<Ext2Super>, bno: u32) -> Result<(), i64> {
-    if super_.ext2_flags.contains(Ext2MountFlags::RDONLY)
-        || super_.ext2_flags.contains(Ext2MountFlags::FORCED_RDONLY)
-    {
+    if !super_.is_writable() {
         return Err(EROFS);
     }
 
@@ -276,12 +315,17 @@ pub fn free_block(super_: &Arc<Ext2Super>, bno: u32) -> Result<(), i64> {
     if is_metadata_block(
         bno,
         s_first_data_block,
+        s_blocks_per_group,
         s_inodes_per_group,
         block_size,
         inode_size,
         group_count,
         &bgdt,
     ) {
+        // Force-RO: an attempt to free a metadata block is either a
+        // driver bug or a corrupt request from above; either way the
+        // image's integrity is now suspect (#617 item 3).
+        super_.force_ro();
         return Err(EIO);
     }
 
@@ -313,9 +357,12 @@ pub fn free_block(super_: &Arc<Ext2Super>, bno: u32) -> Result<(), i64> {
         }
     };
     if !was_set {
-        // Double-free. Don't mark the cache dirty; bail with EIO so the
-        // caller can propagate the error. A production driver would
-        // also force-RO; that lever lives above this layer.
+        // Double-free. Don't mark the cache dirty; trip the runtime
+        // force-RO latch so subsequent allocator calls refuse with
+        // EROFS (RFC 0004 §Security: "double-free → EIO + force RO").
+        // The caller still gets EIO for this call so the failure is
+        // visible.
+        super_.force_ro();
         return Err(EIO);
     }
     super_.cache.mark_dirty(&bh);
@@ -346,47 +393,76 @@ pub fn free_block(super_: &Arc<Ext2Super>, bno: u32) -> Result<(), i64> {
 /// last it equals `s_blocks_per_group`; the last group is shorter when
 /// `s_blocks_count - s_first_data_block` is not a whole multiple of
 /// `s_blocks_per_group`.
+///
+/// Note: the total data-block range is `s_blocks_count - s_first_data_block`,
+/// not `s_blocks_count`. On 1 KiB ext2 (`s_first_data_block == 1`) the
+/// final group is one block shorter than the naive computation suggests
+/// — a full filesystem would otherwise surface as `EIO` instead of
+/// `ENOSPC` (#617 item 4).
 fn blocks_in_group(
     group: u32,
     group_count: u32,
     s_blocks_per_group: u32,
     s_blocks_count: u32,
+    s_first_data_block: u32,
 ) -> u32 {
     if group + 1 < group_count {
         s_blocks_per_group
     } else {
-        // Last group: remainder of the total data-block range. Because
-        // `s_first_data_block` is 0 or 1 and the count is `u32`, the
-        // `u64` arithmetic prevents overflow on pathological images.
-        let total_data_blocks = s_blocks_count;
+        // Last group: remainder of the total data-block range,
+        // measured *after* the reserved prefix `[0, s_first_data_block)`.
+        // The `u64` arithmetic prevents overflow on pathological
+        // images.
+        let total_data_blocks = s_blocks_count.saturating_sub(s_first_data_block) as u64;
         let full_groups_blocks = (group_count - 1) as u64 * s_blocks_per_group as u64;
         // `total_data_blocks - full_groups_blocks` is the tail; a
         // malformed image with an oversized count underflows and we
         // just return 0, which forces the per-group scan to skip this
         // group (counter > 0 but no bits means EIO → force-RO).
-        (total_data_blocks as u64)
+        total_data_blocks
             .saturating_sub(full_groups_blocks)
             .min(s_blocks_per_group as u64) as u32
     }
 }
 
-/// Scan the first `bit_limit` bits of `bitmap` (LE byte order, LSB
+/// Scan bits `[start_bit, bit_limit)` of `bitmap` (LE byte order, LSB
 /// first within each byte — standard ext2 layout) for the first zero
-/// bit. Returns `None` if all `bit_limit` bits are set.
-fn find_first_zero_bit(bitmap: &[u8], bit_limit: usize) -> Option<usize> {
-    // Fast-scan whole bytes that are entirely inside the limit.
+/// bit. Returns `None` if every bit in that range is set.
+///
+/// `start_bit` lets the allocator's metadata-skip loop resume the search
+/// past a forbidden candidate (#617 item 2) without rescanning bits it
+/// already classified.
+fn find_first_zero_bit(bitmap: &[u8], bit_limit: usize, start_bit: usize) -> Option<usize> {
+    if start_bit >= bit_limit {
+        return None;
+    }
+    // Examine the partial first byte (the one containing `start_bit`)
+    // bit-by-bit so we honour `start_bit % 8 != 0`.
+    let first_byte = start_bit / 8;
+    let first_byte_offset = start_bit % 8;
+    if first_byte < bitmap.len() {
+        let b = bitmap[first_byte];
+        let byte_end = ((first_byte + 1) * 8).min(bit_limit);
+        for off in first_byte_offset..(byte_end - first_byte * 8) {
+            if b & (1 << off) == 0 {
+                return Some(first_byte * 8 + off);
+            }
+        }
+    }
+
+    // Whole-byte fast scan past the partial first byte, but only over
+    // bytes fully inside the limit.
     let full_bytes = bit_limit / 8;
     let tail_bits = bit_limit % 8;
-
-    for (byte_idx, b) in bitmap.iter().take(full_bytes).enumerate() {
-        if *b != 0xff {
-            // Find the lowest zero bit in this byte.
-            let inverted = !*b;
+    for byte_idx in (first_byte + 1)..full_bytes {
+        let b = bitmap[byte_idx];
+        if b != 0xff {
+            let inverted = !b;
             let off = inverted.trailing_zeros() as usize;
             return Some(byte_idx * 8 + off);
         }
     }
-    if tail_bits > 0 && full_bytes < bitmap.len() {
+    if tail_bits > 0 && full_bytes < bitmap.len() && full_bytes > first_byte {
         let b = bitmap[full_bytes];
         for off in 0..tail_bits {
             if b & (1 << off) == 0 {
@@ -469,47 +545,90 @@ fn flush_superblock(super_: &Arc<Ext2Super>, sb: &Ext2SuperBlock) -> Result<(), 
     Ok(())
 }
 
-/// `true` iff `bno` is inside the reserved prefix, the superblock
-/// block, the BGDT, or any group's block-bitmap / inode-bitmap /
-/// inode-table. Used by [`free_block`] to reject a free that aims at
-/// metadata.
+/// `true` iff `bno` is inside the reserved prefix, the primary or any
+/// **backup** superblock / BGDT, or any group's block-bitmap /
+/// inode-bitmap / inode-table.
+///
+/// Used by both [`free_block`] (to reject frees that aim at metadata)
+/// and [`alloc_block`] (#617 item 2: don't trust the on-disk bitmap;
+/// re-check candidates against the same map so a corrupt image can't
+/// hand metadata out).
+///
+/// Backup-SB/BGDT coverage (#617 item 1): on every group `g`, the first
+/// block of the group is `s_first_data_block + g * s_blocks_per_group`.
+/// On non-`sparse_super` filesystems (and on group 0 / 1 / powers of
+/// 3, 5, 7 on `sparse_super` ones) that block holds a backup
+/// superblock and the next `bgdt_blocks` blocks hold a backup group
+/// descriptor table. We forbid the SB+BGDT range in **every** group
+/// unconditionally — over-protection is harmless (those backup blocks
+/// must never be allocated as data anyway), and the simple sweep
+/// avoids replicating the `RO_COMPAT_SPARSE_SUPER` placement table.
+///
+/// Block 0 on ≥ 2 KiB filesystems: the primary SB lives inside block 0
+/// (`s_first_data_block == 0`, SB at byte 1024 inside that block), so
+/// block 0 must be forbidden explicitly — the `< s_first_data_block`
+/// guard alone doesn't catch it.
 fn is_metadata_block(
     bno: u32,
     s_first_data_block: u32,
+    s_blocks_per_group: u32,
     s_inodes_per_group: u32,
     block_size: u32,
     inode_size: u64,
     group_count: u32,
     bgdt: &[Ext2GroupDesc],
 ) -> bool {
-    // Reserved prefix — `[0, s_first_data_block)`. Already rejected
-    // upstream in `free_block`, but spelled out here for clarity.
+    // Reserved prefix — `[0, s_first_data_block)`. On 1 KiB filesystems
+    // this catches block 0 (the boot block).
     if bno < s_first_data_block {
         return true;
     }
 
-    // Superblock block: always absolute block 1 on 1 KiB filesystems
-    // (s_first_data_block == 1), block 0 on ≥ 2 KiB. That's exactly
-    // `s_first_data_block`'s-adjacent block — for 1 KiB it's `< 1 + 1`,
-    // for ≥ 2 KiB the `< s_first_data_block` check above already
-    // handles it.
-    if block_size == 1024 && bno == 1 {
+    // Block 0 on ≥ 2 KiB filesystems holds the primary superblock
+    // (#617 item 1). `s_first_data_block` is 0 there so the guard
+    // above doesn't catch it.
+    if block_size != 1024 && bno == 0 {
         return true;
     }
 
-    // BGDT blocks: `[s_first_data_block + 1, s_first_data_block + 1 +
-    // bgdt_blocks)`.
+    // Per-group SB + BGDT copies. Iterate every group: the first block
+    // of group `g` is `s_first_data_block + g * s_blocks_per_group`. On
+    // group 0 this is also the primary SB; on later groups it's a
+    // backup. The next `bgdt_blocks` blocks hold the BGDT (or its
+    // backup). We forbid the whole `[group_start, group_start + 1 +
+    // bgdt_blocks)` range — see the function-level note on backup
+    // coverage.
     let entries_per_block = block_size / EXT2_GROUP_DESC_SIZE as u32;
-    if entries_per_block > 0 {
-        let bgdt_blocks = group_count.div_ceil(entries_per_block);
-        let bgdt_start = s_first_data_block.saturating_add(1);
-        let bgdt_end = bgdt_start.saturating_add(bgdt_blocks);
-        if bno >= bgdt_start && bno < bgdt_end {
-            return true;
+    let bgdt_blocks = if entries_per_block == 0 {
+        0
+    } else {
+        group_count.div_ceil(entries_per_block)
+    };
+    if s_blocks_per_group > 0 {
+        for g in 0..group_count {
+            let group_start = match (g as u64)
+                .checked_mul(s_blocks_per_group as u64)
+                .and_then(|v| v.checked_add(s_first_data_block as u64))
+            {
+                Some(v) if v <= u32::MAX as u64 => v as u32,
+                _ => continue,
+            };
+            // SB block (group 0 primary, others backup).
+            if bno == group_start {
+                return true;
+            }
+            // BGDT (primary or backup) sits immediately after.
+            let bgdt_start = group_start.saturating_add(1);
+            let bgdt_end = bgdt_start.saturating_add(bgdt_blocks);
+            if bno >= bgdt_start && bno < bgdt_end {
+                return true;
+            }
         }
     }
 
-    // Per-group bitmaps + inode table.
+    // Per-group bitmaps + inode table (parsed from the live BGDT
+    // entries — those are authoritative for placement when
+    // `resize_inode` or `meta_bg` shuffles the inode table).
     let inode_table_bytes = (s_inodes_per_group as u64).saturating_mul(inode_size);
     let inode_table_blocks: u32 = inode_table_bytes
         .div_ceil(block_size as u64)
@@ -542,13 +661,13 @@ mod tests {
     #[test]
     fn find_first_zero_bit_full_byte() {
         let bitmap = [0x00u8; 4];
-        assert_eq!(find_first_zero_bit(&bitmap, 32), Some(0));
+        assert_eq!(find_first_zero_bit(&bitmap, 32, 0), Some(0));
     }
 
     #[test]
     fn find_first_zero_bit_all_set() {
         let bitmap = [0xffu8; 4];
-        assert_eq!(find_first_zero_bit(&bitmap, 32), None);
+        assert_eq!(find_first_zero_bit(&bitmap, 32, 0), None);
     }
 
     #[test]
@@ -557,9 +676,9 @@ mod tests {
         // limit only covers 32 bits, the zero must not be found.
         let mut bitmap = [0xffu8; 8];
         bitmap[5] = 0xfe;
-        assert_eq!(find_first_zero_bit(&bitmap, 32), None);
+        assert_eq!(find_first_zero_bit(&bitmap, 32, 0), None);
         // Extend the limit past bit 40 and it shows up.
-        assert_eq!(find_first_zero_bit(&bitmap, 48), Some(40));
+        assert_eq!(find_first_zero_bit(&bitmap, 48, 0), Some(40));
     }
 
     #[test]
@@ -567,8 +686,8 @@ mod tests {
         // First 3 bits set; bit 3 is the first zero. Limit < 3 → None;
         // limit >= 4 → Some(3).
         let bitmap = [0b0000_0111u8];
-        assert_eq!(find_first_zero_bit(&bitmap, 3), None);
-        assert_eq!(find_first_zero_bit(&bitmap, 4), Some(3));
+        assert_eq!(find_first_zero_bit(&bitmap, 3, 0), None);
+        assert_eq!(find_first_zero_bit(&bitmap, 4, 0), Some(3));
     }
 
     #[test]
@@ -576,30 +695,58 @@ mod tests {
         // Byte 0 = 0xFE: bit 0 is zero. The lowest zero bit should be
         // at index 0.
         let bitmap = [0xfeu8, 0xff, 0xff];
-        assert_eq!(find_first_zero_bit(&bitmap, 24), Some(0));
+        assert_eq!(find_first_zero_bit(&bitmap, 24, 0), Some(0));
         // Byte 0 = 0xFF, byte 1 = 0xFD (bits 0+1): lowest zero is bit 9
         // (byte 1, bit 1).
         let bitmap = [0xff, 0xfdu8, 0xff];
-        assert_eq!(find_first_zero_bit(&bitmap, 24), Some(9));
+        assert_eq!(find_first_zero_bit(&bitmap, 24, 0), Some(9));
+    }
+
+    #[test]
+    fn find_first_zero_bit_skips_to_start() {
+        // All zeros. Without start_bit we'd return 0; with start_bit=5
+        // we should return 5. With start_bit=10 (past limit=8) → None.
+        let bitmap = [0x00u8, 0x00];
+        assert_eq!(find_first_zero_bit(&bitmap, 16, 0), Some(0));
+        assert_eq!(find_first_zero_bit(&bitmap, 16, 5), Some(5));
+        assert_eq!(find_first_zero_bit(&bitmap, 8, 10), None);
+
+        // Mixed: bit 3 and bit 11 are zero, rest are set. start_bit=4
+        // skips the first hole and finds bit 11.
+        let bitmap = [0b1111_0111u8, 0b1111_0111u8];
+        assert_eq!(find_first_zero_bit(&bitmap, 16, 0), Some(3));
+        assert_eq!(find_first_zero_bit(&bitmap, 16, 4), Some(11));
     }
 
     #[test]
     fn blocks_in_group_last_group_short() {
-        // 1024 total data blocks, 512 per group → 2 groups, both full
-        // length.
-        assert_eq!(blocks_in_group(0, 2, 512, 1024), 512);
-        assert_eq!(blocks_in_group(1, 2, 512, 1024), 512);
-        // 1000 total, 512 per group → 2 groups, last is 488 long.
-        assert_eq!(blocks_in_group(0, 2, 512, 1000), 512);
-        assert_eq!(blocks_in_group(1, 2, 512, 1000), 488);
+        // 1024 total data blocks (s_first_data_block=0), 512 per group
+        // → 2 groups, both full length.
+        assert_eq!(blocks_in_group(0, 2, 512, 1024, 0), 512);
+        assert_eq!(blocks_in_group(1, 2, 512, 1024, 0), 512);
+        // 1000 total, 512 per group, s_first_data_block=0 → 2 groups,
+        // last is 488 long.
+        assert_eq!(blocks_in_group(0, 2, 512, 1000, 0), 512);
+        assert_eq!(blocks_in_group(1, 2, 512, 1000, 0), 488);
         // Single group: blocks_in_group clamps to blocks_per_group.
-        assert_eq!(blocks_in_group(0, 1, 1024, 800), 800);
+        assert_eq!(blocks_in_group(0, 1, 1024, 800, 0), 800);
+    }
+
+    #[test]
+    fn blocks_in_group_subtracts_first_data_block() {
+        // 1 KiB ext2: s_blocks_count = 1024, s_blocks_per_group = 512,
+        // s_first_data_block = 1. Total data blocks = 1023, so two
+        // groups: 512 + 511 — NOT 512 + 512 (#617 item 4). Without the
+        // fix the last group would report 512 and the allocator would
+        // happily try to allocate a block past the end of the fs.
+        assert_eq!(blocks_in_group(0, 2, 512, 1024, 1), 512);
+        assert_eq!(blocks_in_group(1, 2, 512, 1024, 1), 511);
     }
 
     #[test]
     fn is_metadata_block_catches_superblock_and_bgdt() {
-        // 1 KiB filesystem: superblock at block 1, BGDT at block 2,
-        // one bgd occupies byte 0..32 of the BGDT block.
+        // 1 KiB filesystem, 1 group: superblock at block 1, BGDT at
+        // block 2, one bgd entry occupies byte 0..32 of the BGDT block.
         let bgdt = alloc::vec![Ext2GroupDesc {
             bg_block_bitmap: 3,
             bg_inode_bitmap: 4,
@@ -610,39 +757,32 @@ mod tests {
             bg_pad: 0,
             bg_reserved: [0; 12],
         }];
+        // s_blocks_per_group=8 here (small group; the absolute numbers
+        // we test don't depend on its exact value, only that the
+        // group_start arithmetic works).
+        let spg = 1024;
         // block 0: reserved prefix (< s_first_data_block=1).
-        assert!(is_metadata_block(0, 1, 16, 1024, 128, 1, &bgdt));
-        // block 1: superblock on 1 KiB fs.
-        assert!(is_metadata_block(1, 1, 16, 1024, 128, 1, &bgdt));
-        // block 2: BGDT (s_first_data_block + 1).
-        assert!(is_metadata_block(2, 1, 16, 1024, 128, 1, &bgdt));
+        assert!(is_metadata_block(0, 1, spg, 16, 1024, 128, 1, &bgdt));
+        // block 1: superblock on 1 KiB fs (group 0 SB).
+        assert!(is_metadata_block(1, 1, spg, 16, 1024, 128, 1, &bgdt));
+        // block 2: BGDT (group_start + 1).
+        assert!(is_metadata_block(2, 1, spg, 16, 1024, 128, 1, &bgdt));
         // block 3: block bitmap.
-        assert!(is_metadata_block(3, 1, 16, 1024, 128, 1, &bgdt));
+        assert!(is_metadata_block(3, 1, spg, 16, 1024, 128, 1, &bgdt));
         // block 4: inode bitmap.
-        assert!(is_metadata_block(4, 1, 16, 1024, 128, 1, &bgdt));
+        assert!(is_metadata_block(4, 1, spg, 16, 1024, 128, 1, &bgdt));
         // block 5: first inode-table block (16 inodes × 128 B = 2 KiB
         // = 2 blocks, so table occupies blocks 5..=6).
-        assert!(is_metadata_block(5, 1, 16, 1024, 128, 1, &bgdt));
-        assert!(is_metadata_block(6, 1, 16, 1024, 128, 1, &bgdt));
+        assert!(is_metadata_block(5, 1, spg, 16, 1024, 128, 1, &bgdt));
+        assert!(is_metadata_block(6, 1, spg, 16, 1024, 128, 1, &bgdt));
         // block 7: first data block. Not metadata.
-        assert!(!is_metadata_block(7, 1, 16, 1024, 128, 1, &bgdt));
+        assert!(!is_metadata_block(7, 1, spg, 16, 1024, 128, 1, &bgdt));
     }
 
     #[test]
-    fn is_metadata_block_2kib_fs_has_sb_at_block_0() {
-        // 2 KiB fs: s_first_data_block = 0, superblock at byte 1024
-        // within block 0. Block 0 is caught by the reserved-prefix
-        // rule? No — s_first_data_block is 0 so the `< 0` guard is
-        // never true. Block 0 is still metadata because the SB is
-        // there: the `block_size != 1024` branch of `is_metadata_block`
-        // relies on the BGDT / per-group checks to catch it. A 2 KiB
-        // image always has the BGDT at block 1 so block 0 must be
-        // explicitly listed too.
-        //
-        // This test pins that gap: today, block 0 on a 2 KiB fs falls
-        // through `is_metadata_block` as "data" unless we explicitly
-        // add it. Document current behaviour so a future fix is a
-        // deliberate change, not an accident.
+    fn is_metadata_block_2kib_fs_forbids_block_0() {
+        // 2 KiB fs: s_first_data_block = 0, primary SB lives inside
+        // block 0. Block 0 must be forbidden explicitly (#617 item 1).
         let bgdt = alloc::vec![Ext2GroupDesc {
             bg_block_bitmap: 2,
             bg_inode_bitmap: 3,
@@ -653,14 +793,49 @@ mod tests {
             bg_pad: 0,
             bg_reserved: [0; 12],
         }];
-        // BGDT at block 1 on a 2 KiB fs (s_first_data_block + 1 = 1).
-        assert!(is_metadata_block(1, 0, 16, 2048, 128, 1, &bgdt));
-        // Block 0: superblock lives *inside* this block but the
-        // allocator never hands out block 0 on a 2 KiB fs because
-        // `s_first_data_block == 0` means group 0 starts at 0 — the
-        // SB-holding block is reserved by mkfs via pre-set bitmap bits,
-        // not by `is_metadata_block`. Document that: block 0 is NOT
-        // currently caught here.
-        assert!(!is_metadata_block(0, 0, 16, 2048, 128, 1, &bgdt));
+        // Block 0: primary SB on a 2 KiB fs — must be metadata.
+        assert!(is_metadata_block(0, 0, 4096, 16, 2048, 128, 1, &bgdt));
+        // BGDT at block 1 on a 2 KiB fs (group_start + 1 = 1).
+        assert!(is_metadata_block(1, 0, 4096, 16, 2048, 128, 1, &bgdt));
+    }
+
+    #[test]
+    fn is_metadata_block_forbids_backup_sb_and_bgdt() {
+        // Two-group, 1 KiB filesystem matching the `balloc_test.img`
+        // fixture (#617 item 1: backup SB at block 257, backup BGDT at
+        // 258 must be in the forbidden map).
+        let bgdt = alloc::vec![
+            Ext2GroupDesc {
+                bg_block_bitmap: 3,
+                bg_inode_bitmap: 4,
+                bg_inode_table: 5,
+                bg_free_blocks_count: 0,
+                bg_free_inodes_count: 0,
+                bg_used_dirs_count: 0,
+                bg_pad: 0,
+                bg_reserved: [0; 12],
+            },
+            Ext2GroupDesc {
+                bg_block_bitmap: 259,
+                bg_inode_bitmap: 260,
+                bg_inode_table: 261,
+                bg_free_blocks_count: 0,
+                bg_free_inodes_count: 0,
+                bg_used_dirs_count: 0,
+                bg_pad: 0,
+                bg_reserved: [0; 12],
+            },
+        ];
+        // Group 1 starts at s_first_data_block + 1 * s_blocks_per_group
+        // = 1 + 256 = 257. SB backup at 257, BGDT backup at 258.
+        assert!(is_metadata_block(257, 1, 256, 128, 1024, 128, 2, &bgdt));
+        assert!(is_metadata_block(258, 1, 256, 128, 1024, 128, 2, &bgdt));
+        // Block 268 is still inside group 1's inode table
+        // (bg_inode_table=261; 128 inodes * 128 B = 16 KiB = 16 blocks
+        // → 261..=276 actually; first non-metadata block in group 1 is
+        // 277). Verify a clear non-metadata position:
+        assert!(!is_metadata_block(300, 1, 256, 128, 1024, 128, 2, &bgdt));
+        // Verify backup BGDT block is caught.
+        assert!(is_metadata_block(258, 1, 256, 128, 1024, 128, 2, &bgdt));
     }
 }

--- a/kernel/src/fs/ext2/fs.rs
+++ b/kernel/src/fs/ext2/fs.rs
@@ -464,6 +464,7 @@ impl FileSystem for Ext2Fs {
             sb_disk: spin::Mutex::new(sb_after_stamp),
             bgdt: spin::Mutex::new(bgdt),
             ext2_flags,
+            force_ro_latch: AtomicBool::new(false),
             owner: self.self_ref.clone(),
             inode_cache: super::inode::new_inode_cache(),
             ext2_inode_cache: super::inode::new_ext2_inode_cache(),
@@ -562,6 +563,12 @@ pub struct Ext2Super {
     pub bgdt: spin::Mutex<Vec<Ext2GroupDesc>>,
     /// Driver-level mount flags — atime skip, forced-RO, NOSUID, etc.
     pub ext2_flags: Ext2MountFlags,
+    /// Runtime force-RO latch. Set by write paths that detect on-disk
+    /// inconsistency (RFC 0004 §Security: e.g. block-bitmap double-free
+    /// → EIO + force-RO). Once `true`, [`Self::is_writable`] returns
+    /// `false` so subsequent writes refuse with [`EROFS`]. The latch is
+    /// a one-way set; clearing requires re-mount.
+    pub force_ro_latch: AtomicBool,
     /// Back-reference to the owning factory so `unmount` can clear the
     /// single-mount latch. `Weak` breaks the `Ext2Fs → SuperBlock →
     /// Ext2Super → Ext2Fs` cycle.
@@ -597,6 +604,31 @@ pub struct Ext2Super {
     /// a strong `Arc<Ext2Super>` without the caller threading one in.
     /// Filled in by [`Arc::new_cyclic`] at mount time.
     self_ref: Weak<Ext2Super>,
+}
+
+impl Ext2Super {
+    /// `true` iff the mount currently accepts writes — i.e. neither the
+    /// caller-requested [`Ext2MountFlags::RDONLY`] nor the synthetic
+    /// [`Ext2MountFlags::FORCED_RDONLY`] is set, *and* the runtime
+    /// `force_ro_latch` has not been tripped by an inconsistency
+    /// detector (see [`Self::force_ro`]).
+    pub fn is_writable(&self) -> bool {
+        if self.ext2_flags.contains(Ext2MountFlags::RDONLY)
+            || self.ext2_flags.contains(Ext2MountFlags::FORCED_RDONLY)
+        {
+            return false;
+        }
+        !self.force_ro_latch.load(Ordering::Acquire)
+    }
+
+    /// Trip the runtime force-RO latch. Subsequent calls to
+    /// [`Self::is_writable`] return `false`. One-way: there is no
+    /// `clear_force_ro` — once an inconsistency is observed, the only
+    /// recovery is `umount` + `e2fsck`. RFC 0004 §Security ("double-free
+    /// → EIO + force RO") and CodeRabbit follow-up #617 item 3.
+    pub fn force_ro(&self) {
+        self.force_ro_latch.store(true, Ordering::Release);
+    }
 }
 
 impl SuperOps for Ext2Super {

--- a/kernel/tests/ext2_block_alloc.rs
+++ b/kernel/tests/ext2_block_alloc.rs
@@ -92,6 +92,11 @@ fn run_tests() {
             "free_rejects_out_of_range",
             &(free_rejects_out_of_range as fn()),
         ),
+        (
+            "free_rejects_backup_sb_and_bgdt",
+            &(free_rejects_backup_sb_and_bgdt as fn()),
+        ),
+        ("double_free_forces_ro", &(double_free_forces_ro as fn())),
         ("ro_mount_refuses_alloc", &(ro_mount_refuses_alloc as fn())),
         (
             "alloc_exhaustion_returns_enospc",
@@ -309,18 +314,17 @@ fn free_rejects_superblock_block() {
 }
 
 fn free_rejects_block_bitmap_block() {
-    let (_sb, _fs, super_arc, _disk) = mount_rw();
-    let before_sb = sb_free(&super_arc);
-    // Block 3 is group 0's block bitmap (per dumpe2fs on the fixture).
-    let r = free_block(&super_arc, 3);
-    assert_eq!(r, Err(EIO), "free_block(block bitmap) must be EIO");
-    // Block 4 is group 0's inode bitmap.
-    let r = free_block(&super_arc, 4);
-    assert_eq!(r, Err(EIO), "free_block(inode bitmap) must be EIO");
-    // Block 5 is group 0's first inode-table block.
-    let r = free_block(&super_arc, 5);
-    assert_eq!(r, Err(EIO), "free_block(inode table) must be EIO");
-    assert_eq!(sb_free(&super_arc), before_sb);
+    // A metadata-free attempt now trips the runtime force-RO latch
+    // (#617 item 3), so each metadata block needs its own mount —
+    // otherwise the second call returns EROFS instead of EIO.
+    for &meta in &[3u32, 4, 5] {
+        let (_sb, _fs, super_arc, _disk) = mount_rw();
+        let before_sb = sb_free(&super_arc);
+        let r = free_block(&super_arc, meta);
+        assert_eq!(r, Err(EIO), "free_block(metadata block {meta}) must be EIO");
+        // Counters unchanged.
+        assert_eq!(sb_free(&super_arc), before_sb);
+    }
 }
 
 fn free_rejects_out_of_range() {
@@ -330,6 +334,44 @@ fn free_rejects_out_of_range() {
     // Past end of fs.
     assert_eq!(free_block(&super_arc, FIXTURE_BLOCKS_COUNT), Err(EIO));
     assert_eq!(free_block(&super_arc, u32::MAX), Err(EIO));
+}
+
+fn free_rejects_backup_sb_and_bgdt() {
+    // #617 item 1: backup SB at block 257, backup BGDT at 258 in the
+    // 2-group balloc fixture. Both must be rejected with EIO.
+    for &meta in &[257u32, 258] {
+        let (_sb, _fs, super_arc, _disk) = mount_rw();
+        let r = free_block(&super_arc, meta);
+        assert_eq!(
+            r,
+            Err(EIO),
+            "free_block(backup metadata {meta}) must be EIO"
+        );
+    }
+}
+
+fn double_free_forces_ro() {
+    // #617 item 3: a double-free trips the runtime force-RO latch so
+    // subsequent allocator calls refuse with EROFS.
+    let (_sb, _fs, super_arc, _disk) = mount_rw();
+    // Allocate then free: legit round trip.
+    let b = alloc_block(&super_arc, Some(0)).expect("first alloc must succeed");
+    free_block(&super_arc, b).expect("first free must succeed");
+    // Second free of the same block: double-free → EIO + force-RO.
+    assert_eq!(
+        free_block(&super_arc, b),
+        Err(EIO),
+        "double-free must return EIO"
+    );
+    // Subsequent alloc must now refuse with EROFS because the latch is
+    // set even though the mount flags didn't change.
+    assert_eq!(
+        alloc_block(&super_arc, None),
+        Err(EROFS),
+        "post-double-free alloc must refuse with EROFS"
+    );
+    // free_block also refuses.
+    assert_eq!(free_block(&super_arc, 27), Err(EROFS));
 }
 
 fn ro_mount_refuses_alloc() {


### PR DESCRIPTION
Closes #617.

## Summary

Five hardening fixes against `kernel/src/fs/ext2/balloc.rs` flagged by CodeRabbit during review of #613:

1. **Metadata guard covers backup SB/BGDT + block 0 on ≥2 KiB filesystems.** `is_metadata_block` now iterates every group, computing `group_first_block = s_first_data_block + g * s_blocks_per_group`, and forbids that block (primary or backup SB) plus the next `bgdt_blocks` (primary or backup BGDT). A 2 KiB ext2 with the primary SB inside block 0 now also rejects block 0 explicitly.
2. **`alloc_block` consults the metadata-forbidden map.** A corrupt image with a clear bit over metadata previously had it handed out directly. The bit-search loop now re-checks each candidate against `is_metadata_block`; forbidden bits advance `start_bit` and the search continues.
3. **Double-free / metadata-free / counter-mismatch trip force-RO.** `Ext2Super` gains a `force_ro_latch: AtomicBool` plus `is_writable()` and one-way `force_ro()` helpers. Allocator inconsistency paths now `force_ro()` so subsequent allocator calls refuse with `EROFS` (RFC 0004 §Security: "double-free → EIO + force RO").
4. **`blocks_in_group` subtracts `s_first_data_block`.** On 1 KiB ext2 the last group was reported one block too long; a full filesystem could surface as `EIO` instead of `ENOSPC`.
5. **`s_state := EXT2_ERROR_FS` already lives in `sb_disk`.** Item 5 was addressed in #574 (`sb_after_stamp` is what's stored). No code change needed.

## Test plan

- [x] `cargo xtask build` clean
- [x] `cargo xtask test` — all host + QEMU tests pass, including new:
  - `find_first_zero_bit_skips_to_start` (host) — resumable scan
  - `blocks_in_group_subtracts_first_data_block` (host) — item 4
  - `is_metadata_block_2kib_fs_forbids_block_0` (host) — item 1
  - `is_metadata_block_forbids_backup_sb_and_bgdt` (host) — item 1
  - `free_rejects_backup_sb_and_bgdt` (QEMU) — item 1
  - `double_free_forces_ro` (QEMU) — item 3
- [x] `cargo xtask smoke` — 33/33 markers
- [x] `cargo fmt --all -- --check` clean