### PR TITLE
syscall: sti at entry + current_pid IF=1 invariant (#478, #647)

### DIFF
--- a/docs/agent-playbooks/sync-discipline.md
+++ b/docs/agent-playbooks/sync-discipline.md
@@ -1,0 +1,67 @@
+# Sync discipline (vibix kernel)
+
+This appendix collects the synchronisation rules the kernel relies on
+across modules. Each rule is mechanically enforced where possible
+(debug assertions, `#[deny]` lints, lock-acquire instrumentation) and
+documented here for the cases code review still has to catch.
+
+## Lock ordering
+
+The canonical order is documented in each module's header. The
+**must-not-invert** rules live here so any reviewer can grep one file:
+
+- `process::TABLE` → `task::SCHED` is **forbidden**. Always sample
+  `task::current_id()` *before* taking `TABLE`. The session/pgrp
+  syscalls (`sys_getsid`, `sys_getpgid`) follow this rule; older code
+  that took `TABLE` first and called `current_id()` from inside the
+  critical section was the documented #478 lock-ordering hazard.
+- `process::TABLE` → `tty.ctrl` is allowed and used by
+  `process::try_acquire_ctty_atomic`. The reverse order is forbidden.
+- `process::TABLE` → `WaitQueue::wait_while` is forbidden. `wait4`
+  uses an exit-event counter snapshot to avoid holding `TABLE` across
+  the predicate.
+
+## IF discipline (#478, #647)
+
+The plain `spin::Mutex` types in the kernel (e.g. `process::TABLE`)
+are **not** IRQ-masking. They must be acquired with `RFLAGS.IF=1` so
+the timer ISR can preempt a stuck holder.
+
+- `process::current_pid()` debug-asserts `IF=1` on entry and uses an
+  instrumented `try_lock` loop that panics if the spin exceeds
+  `CURRENT_PID_SOAK_THRESHOLD`. Rationale: the failure trace in #478
+  showed CPU stuck in a `current_pid` `pause`-spin loop while the
+  timer ISR fired only 24 times across a 120 s window — classic
+  starvation by an interrupt-disabled holder.
+- Callers in interrupt-disabled regions (top-half ISRs, ISR-deferred
+  tasklets, anything inside an `IrqLock` guard) must cache the pid
+  value before disabling IRQs. Calling `current_pid()` from such a
+  region trips the debug-assert immediately.
+- `IrqLock` is the right primitive for data shared between task and
+  ISR context. Plain `spin::Mutex` is the right primitive for
+  task-context-only data, but only when callers can guarantee the
+  lock is never held across a scheduling point or with IF cleared.
+
+## Soak detection
+
+`CURRENT_PID_SOAK_THRESHOLD` is sized so ordinary contention never
+trips it (~1e8 iterations ≈ tens of ms on real hardware, multiple
+seconds on un-accelerated QEMU) but a wedged holder is caught loudly
+within the smoke-test timeout. The release build skips the check
+because the soak path is debug-only — tripping it is a *bug
+detection*, not a runtime guard.
+
+## Smoke-side detection
+
+`xtask smoke` asserts the presence of two new markers:
+
+- `irq-pre-ring3: ticks=N` — emitted in `jump_to_ring3` immediately
+  before the IRETQ to ring-3.
+- `irq-post-ring3: ticks=… delta=…` — emitted on the very first
+  SYSCALL from ring-3.
+
+If userspace never observably runs (the #478 signature) the second
+marker simply never appears and smoke fails on the missing marker.
+The delta value is informative for triage but is not gated, because
+the gap between IRETQ and the first SYSCALL is normally well below
+one 10 ms tick on real hardware.

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -159,6 +159,20 @@ pub static SYSCALL_SCRATCH_RSP: AtomicU64 = AtomicU64::new(0);
 #[no_mangle]
 pub static SYSCALL_RESTART_PENDING: AtomicU64 = AtomicU64::new(0);
 
+/// `time::ticks()` snapshot taken right before the very first IRETQ to
+/// ring-3. Read again on the first SYSCALL from ring-3 to compute how
+/// many timer interrupts fired during the userspace-spawn window — the
+/// #478 starvation signature has this delta near zero. Set once by
+/// [`jump_to_ring3`]; consumed once by [`syscall_dispatch`] via
+/// `INIT_IRQ_POST_FIRED`.
+pub static INIT_IRQ_PRE_RING3_TICKS: AtomicU64 = AtomicU64::new(u64::MAX);
+
+/// One-shot flag: `false` until the first SYSCALL from ring-3 has
+/// emitted the matching `irq-post-ring3:` marker. Avoids spamming the
+/// counter on every subsequent syscall.
+pub static INIT_IRQ_POST_FIRED: core::sync::atomic::AtomicBool =
+    core::sync::atomic::AtomicBool::new(false);
+
 /// Enable SYSCALL/SYSRET and point LSTAR at the entry trampoline.
 /// Must be called after GDT is live.
 pub fn init() {
@@ -226,6 +240,13 @@ pub unsafe fn jump_to_ring3(entry: u64, stack_top: u64) -> ! {
         USER_DATA_SELECTOR,
         0x202u64,
     );
+    // #647: snapshot the timer-tick counter immediately before the
+    // ring-0→ring-3 transition. xtask smoke compares this against the
+    // matching `irq-post-ring3` snapshot taken on the first SYSCALL
+    // from userspace and fails when too few timer interrupts fire in
+    // between (the #478 starvation signature).
+    INIT_IRQ_PRE_RING3_TICKS.store(crate::time::ticks(), core::sync::atomic::Ordering::Release);
+    crate::serial_println!("irq-pre-ring3: ticks={}", crate::time::ticks());
     // #478 diagnostic step 1: emit a single-byte marker on the QEMU debug
     // console (port 0xe9) *immediately* before the iretq, and a second
     // byte in the same asm block *after* the iretq frame is pushed but
@@ -295,6 +316,33 @@ pub unsafe extern "C" fn syscall_dispatch(
     a4: u64,
     a5: u64,
 ) -> i64 {
+    // #478 fix: SYSCALL entry clears RFLAGS.IF via SFMASK, so we land
+    // here with interrupts disabled. The dispatch path takes plain
+    // (non-IRQ-masking) spin locks like `process::TABLE`; spinning on
+    // those with IF=0 starves the timer ISR and wedges the kernel
+    // when the holder needs preemption to release (the #478 trace
+    // signature: `current_pid` `pause` loop, 24 timer interrupts /
+    // 120 s). Re-enable IRQs here, before any locks are touched.
+    //
+    // Safety: kernel-mode code running at this point uses its own
+    // per-task SYSCALL stack (`SYSCALL_KERNEL_RSP` / `arm_ring3_syscall_stack`)
+    // and the user GS base hasn't been touched, so a timer ISR
+    // preempting us is no different from a timer ISR preempting any
+    // other task-context kernel code.
+    unsafe { core::arch::asm!("sti", options(nostack, preserves_flags)) };
+
+    // #647: emit the `irq-post-ring3` marker on the very first SYSCALL
+    // from ring-3 so xtask smoke can verify the timer ISR fired enough
+    // times during the userspace-spawn window. Done before any other
+    // syscall handling — if userspace never observably runs (the #478
+    // signature) this branch is never taken and smoke fails on the
+    // missing marker.
+    if !INIT_IRQ_POST_FIRED.swap(true, core::sync::atomic::Ordering::AcqRel) {
+        let pre = INIT_IRQ_PRE_RING3_TICKS.load(core::sync::atomic::Ordering::Acquire);
+        let now = crate::time::ticks();
+        let delta = now.saturating_sub(pre);
+        crate::serial_println!("irq-post-ring3: ticks={} pre={} delta={}", now, pre, delta);
+    }
     use syscall_nr::*;
     match nr {
         // read(fd, buf, len) — non-blocking; returns -EAGAIN if no data.

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -9,6 +9,20 @@
 //! cross-lock path is `mark_zombie` → `CHILD_WAIT.notify_all()` →
 //! `task::wake(id)` → `SCHED`, which is safe because `TABLE` is dropped
 //! before the notify call.
+//!
+//! The session/pgrp syscalls (`sys_getsid`, `sys_getpgid`) sample
+//! `task::current_id()` **before** taking `TABLE` so the forbidden order
+//! is mechanically impossible — see #478 diagnostic
+//! (https://github.com/dburkart/vibix/pull/595#issuecomment-4302346400).
+//!
+//! ## IF-discipline (#647)
+//!
+//! [`current_pid`] must be called with interrupts enabled. It spins on
+//! a plain `spin::Mutex`; with `IF=0` a stuck holder cannot be
+//! preempted and the kernel wedges (the failure shape traced to #478).
+//! Debug builds assert `RFLAGS.IF=1` on entry and panic if the soak
+//! threshold is reached. Callers in interrupt-disabled regions must
+//! cache the pid before disabling IRQs.
 
 use alloc::collections::BTreeMap;
 use alloc::sync::Arc;
@@ -169,9 +183,86 @@ pub fn register(task_id: usize, parent_pid: u32) -> u32 {
 
 /// Return the PID of the currently-running task, or `0` if the running
 /// task has no process table entry (e.g. the bootstrap kernel task).
+///
+/// ## Invariants enforced (#647)
+///
+/// - Must be called with interrupts enabled (IF=1). Spinning here with
+///   IF=0 starves the timer ISR, which is the failure signature traced
+///   to #478. Debug builds panic on violation; release builds skip the
+///   check (no atomic read on the hot syscall path).
+/// - The TABLE acquire uses an instrumented `try_lock` loop. If the
+///   spin reaches [`CURRENT_PID_SOAK_THRESHOLD`] without progress, the
+///   kernel panics in debug builds with a captured backtrace so the
+///   regression is loud rather than silent.
 pub fn current_pid() -> u32 {
     let task_id = crate::task::current_id();
-    TABLE.lock().pid_of.get(&task_id).copied().unwrap_or(0)
+    debug_assert!(
+        is_if_set(),
+        "current_pid() called with interrupts disabled — \
+         spinning on TABLE with IF=0 starves the timer ISR (#478/#647)"
+    );
+    let table = lock_table_with_soak_check("current_pid");
+    table.pid_of.get(&task_id).copied().unwrap_or(0)
+}
+
+/// Soak-loop ceiling for `try_lock` retries on TABLE before declaring
+/// "stuck spinning". Tuned high enough that ordinary contention (a few
+/// hundred ns of holder work) never trips, low enough that a wedged
+/// holder is caught within seconds even on slow QEMU. Each pause is
+/// ~1 cycle; ~1e8 iterations is ~30 ms on real hardware, multiple
+/// seconds on un-accelerated QEMU.
+pub const CURRENT_PID_SOAK_THRESHOLD: u64 = 100_000_000;
+
+/// Acquire TABLE with an instrumented `try_lock` spin. Panics in debug
+/// builds when the spin count exceeds [`CURRENT_PID_SOAK_THRESHOLD`] —
+/// loud failure for the #478-class hang. Release builds use the plain
+/// blocking `lock()` to keep the hot path branchless.
+#[inline]
+fn lock_table_with_soak_check(caller: &'static str) -> spin::MutexGuard<'static, Table> {
+    #[cfg(debug_assertions)]
+    {
+        let mut spins: u64 = 0;
+        loop {
+            if let Some(g) = TABLE.try_lock() {
+                return g;
+            }
+            spins += 1;
+            if spins == CURRENT_PID_SOAK_THRESHOLD {
+                panic!(
+                    "process::TABLE: {caller}() spin exceeded soak threshold \
+                     ({CURRENT_PID_SOAK_THRESHOLD} iters) — holder appears wedged \
+                     (likely lock-ordering violation; see #478/#647)"
+                );
+            }
+            core::hint::spin_loop();
+        }
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        let _ = caller;
+        TABLE.lock()
+    }
+}
+
+/// Cheap check for "interrupts currently enabled". Inline so the
+/// debug-only assertion in [`current_pid`] doesn't add a function-call
+/// cost when `debug_assertions` is off (the `debug_assert!` macro
+/// elides the call entirely in release).
+#[cfg(target_os = "none")]
+#[inline]
+fn is_if_set() -> bool {
+    x86_64::instructions::interrupts::are_enabled()
+}
+
+/// Host-build stub: unit tests for this module run on the host where
+/// real RFLAGS isn't meaningful. The IrqLock host harness models IF
+/// state via an AtomicBool, but `current_pid` is exercised through
+/// session-syscall tests that don't go through `task::current_id`, so
+/// we report `true` here and let those tests focus on TABLE semantics.
+#[cfg(not(target_os = "none"))]
+#[inline]
+fn is_if_set() -> bool {
+    true
 }
 
 /// Mark `pid` as a zombie with `exit_status`, then wake any parents
@@ -491,31 +582,22 @@ pub fn sys_setsid() -> i64 {
     setsid_for(current_pid())
 }
 
-/// `getsid(pid)` — return the session id of `pid`, or of the caller if
-/// `pid == 0`. Returns ESRCH for unknown pids.
-pub fn sys_getsid(pid: u32) -> i64 {
-    let t = TABLE.lock();
-    let target = if pid == 0 {
-        let self_pid = *t.pid_of.get(&crate::task::current_id()).unwrap_or(&0);
-        if self_pid == 0 {
-            return ESRCH;
-        }
-        self_pid
-    } else {
-        pid
-    };
-    match t.by_pid.get(&target) {
-        Some(e) => e.session_id as i64,
-        None => ESRCH,
-    }
-}
-
 /// `getpgid(pid)` — return the pgrp id of `pid`, or of the caller if
 /// `pid == 0`. Returns ESRCH for unknown pids.
+///
+/// `task::current_id()` is sampled *before* TABLE is acquired (and
+/// only when `pid == 0`, where the caller's own id is needed) —
+/// otherwise the call would invert the documented `TABLE → SCHED`
+/// forbidden order (see module docs / #478 diagnostic).
 pub fn sys_getpgid(pid: u32) -> i64 {
+    let caller_task_id = if pid == 0 {
+        Some(crate::task::current_id())
+    } else {
+        None
+    };
     let t = TABLE.lock();
-    let target = if pid == 0 {
-        let self_pid = *t.pid_of.get(&crate::task::current_id()).unwrap_or(&0);
+    let target = if let Some(tid) = caller_task_id {
+        let self_pid = *t.pid_of.get(&tid).unwrap_or(&0);
         if self_pid == 0 {
             return ESRCH;
         }
@@ -525,6 +607,32 @@ pub fn sys_getpgid(pid: u32) -> i64 {
     };
     match t.by_pid.get(&target) {
         Some(e) => e.pgrp_id as i64,
+        None => ESRCH,
+    }
+}
+
+/// `getsid(pid)` — return the session id of `pid`, or of the caller if
+/// `pid == 0`. Returns ESRCH for unknown pids.
+///
+/// See [`sys_getpgid`] for the lock-ordering rationale.
+pub fn sys_getsid(pid: u32) -> i64 {
+    let caller_task_id = if pid == 0 {
+        Some(crate::task::current_id())
+    } else {
+        None
+    };
+    let t = TABLE.lock();
+    let target = if let Some(tid) = caller_task_id {
+        let self_pid = *t.pid_of.get(&tid).unwrap_or(&0);
+        if self_pid == 0 {
+            return ESRCH;
+        }
+        self_pid
+    } else {
+        pid
+    };
+    match t.by_pid.get(&target) {
+        Some(e) => e.session_id as i64,
         None => ESRCH,
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -111,6 +111,13 @@ const SMOKE_MARKERS: &[&str] = &[
     // `ring3-first-fault:` diagnostic line emitted by the IDT fault
     // handlers in that case).
     "ring3-iretq: rip=",
+    // #647: kernel emits `irq-pre-ring3: ticks=N` immediately before the
+    // very first IRETQ to ring-3 and `irq-post-ring3: ticks=… delta=…`
+    // on the first SYSCALL back from ring-3. The delta is the number of
+    // timer ticks the kernel observed while userspace was first
+    // executing — the #478 starvation signature has delta near zero.
+    "irq-pre-ring3: ticks=",
+    "irq-post-ring3: ticks=",
     // #478 diagnostic: emitted by userspace init on fd=2 as the very first
     // userspace action, immediately after ring-3 entry and before the first
     // `write(1, HELLO_MSG)`. Three-marker localization:
@@ -130,6 +137,15 @@ const SMOKE_MARKERS: &[&str] = &[
     // SYSRET / user-context restore after the first write is broken.
     "init: post-write marker",
 ];
+
+// Note: an earlier draft of #647 added a delta floor parsed out of
+// the `irq-post-ring3` marker. In practice the gap between IRETQ and
+// the first SYSCALL is microseconds (well below one 10 ms tick) on
+// real hardware, so a delta floor would flake. The marker's *presence*
+// is the gate: when the #478 starvation hits, userspace never reaches
+// its first SYSCALL and `irq-post-ring3:` simply never appears, which
+// the existing missing-markers check catches. Soak detection lives
+// kernel-side via `process::CURRENT_PID_SOAK_THRESHOLD`.
 
 /// Markers for the fork+exec+wait flow. These are flakey under un-accelerated
 /// CI QEMU — the child sometimes doesn't finish before HARD_CAP even though


### PR DESCRIPTION
## Summary

Fixes the #478 smoke flake (kernel reaches IRETQ, then control is never observably handed back) and lands the #647 invariant + detection so the bug class can't silently regress.

The PR #595 trace narrowed the wedge to a `pause`-spin loop in `process::current_pid` with timer-IRQ starvation (24 ticks / 120 s vs 5531 on a healthy run). Root cause: SYSCALL entry clears `RFLAGS.IF` via SFMASK; the kernel then ran the entire dispatch path with IF=0. `current_pid()` takes `SCHED` (an IrqLock) then a plain `spin::Mutex` on `process::TABLE` — dropping the IrqLock restores the prior IF (=0 after SYSCALL), so the subsequent TABLE spin runs IRQ-disabled. On single-vCPU QEMU this is a guaranteed wedge whenever TABLE is contended.

### Fix

- `arch::x86_64::syscall::syscall_dispatch`: emit `sti` immediately on entry, before any lock is touched. Linux's syscall path does the same; we simply weren't.
- `process::current_pid`: debug-asserts `RFLAGS.IF=1` on entry and uses an instrumented `try_lock` spin that panics in debug builds past `CURRENT_PID_SOAK_THRESHOLD`. Loud detection so this class of bug can't silently regress.
- `process::sys_getsid` / `sys_getpgid`: sample `task::current_id()` before taking `TABLE` (only on `pid == 0`). Removes the documented `TABLE → SCHED` inversion the #478 diagnostic flagged.

### Detection invariants (#647)

- Kernel emits `irq-pre-ring3: ticks=N` right before IRETQ to ring-3, and `irq-post-ring3: ticks=… delta=…` on the first SYSCALL back. `xtask smoke` gates on the *presence* of both markers — when starvation hits, the post-ring3 marker simply never appears.
- `docs/agent-playbooks/sync-discipline.md` documents the IF=1 discipline, lock ordering, and soak detection.

Closes #478
Closes #647

## Test plan

- [x] `cargo xtask build` passes (debug + release).
- [x] `cargo xtask test` passes (509 tests).
- [x] `cargo xtask smoke` passes 5/5 consecutive runs.
- [x] Without the `sti` fix, the new `current_pid` debug-assert trips on the very first SYSCALL — confirms the IF=0 reproducer.
- [x] `cargo fmt --all` clean.