### PR TITLE
test-util: extract shared RamDisk helper for ext2 integration tests (#627)

### DIFF
--- a/kernel/tests/common/ext2_ramdisk.rs
+++ b/kernel/tests/common/ext2_ramdisk.rs
@@ -1,0 +1,137 @@
+//! Shared `RamDisk` helper for ext2 integration tests.
+//!
+//! Every ext2 integration test needs a `BlockDevice`-shaped backing
+//! store over the 64 KiB golden image. Before this helper, each test
+//! file (`ext2_ialloc.rs`, `ext2_dir_ops.rs`, `ext2_unlink.rs`, ...)
+//! carried a near-identical ~70-line copy of the same struct. CodeRabbit
+//! flagged the duplication on #626 (issue #627).
+//!
+//! ## Include pattern
+//!
+//! Integration tests under `kernel/tests/` are each their own
+//! `#![no_std] #![no_main]` crate, so a normal `mod common; use common::...;`
+//! reference would fail to resolve and would also try to compile the
+//! file as its own test binary. Instead, every consumer pulls this in
+//! with the per-file `#[path = "..."]` include pattern:
+//!
+//! ```ignore
+//! #[path = "common/ext2_ramdisk.rs"]
+//! mod ext2_ramdisk;
+//! use ext2_ramdisk::RamDisk;
+//! ```
+//!
+//! That makes the file an inline module of the consumer crate, which
+//! keeps it under the `no_std` / `no_main` harness without ever being
+//! built as a standalone test binary.
+//!
+//! ## Surface
+//!
+//! Intentionally minimal — just the constructor, the read-only latch,
+//! the write-count probe, and the `BlockDevice` impl:
+//!
+//! - [`RamDisk::from_image`] — wrap an in-memory image, asserting the
+//!   length is a multiple of `block_size`.
+//! - [`RamDisk::set_read_only`] — flip the harness-level RO latch so a
+//!   forgotten dirty-writeback path surfaces as `BlockError::ReadOnly`
+//!   instead of silently mutating the image.
+//! - [`RamDisk::writes`] — observe the cumulative write count for
+//!   "RO mount must not issue any writes" assertions.
+//! - `BlockDevice` impl — block-aligned `read_at` / `write_at` over a
+//!   `Mutex<Vec<u8>>`.
+
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+use spin::Mutex;
+
+use vibix::block::{BlockDevice, BlockError};
+
+pub struct RamDisk {
+    block_size: u32,
+    storage: Mutex<Vec<u8>>,
+    writes: AtomicU32,
+    read_only: AtomicBool,
+}
+
+impl RamDisk {
+    /// Wrap `bytes` as an in-memory block device with the given
+    /// `block_size`. The image length must be a multiple of the block
+    /// size — otherwise `read_at` / `write_at` would have unreachable
+    /// trailing bytes.
+    pub fn from_image(bytes: &[u8], block_size: u32) -> Arc<Self> {
+        assert!(bytes.len() % block_size as usize == 0);
+        Arc::new(Self {
+            block_size,
+            storage: Mutex::new(bytes.to_vec()),
+            writes: AtomicU32::new(0),
+            read_only: AtomicBool::new(false),
+        })
+    }
+
+    /// Flip the harness-level RO latch. While set, every `write_at`
+    /// returns `BlockError::ReadOnly` so a buggy writeback path surfaces
+    /// loudly instead of silently mutating the in-memory image.
+    pub fn set_read_only(&self, ro: bool) {
+        self.read_only.store(ro, Ordering::Relaxed);
+    }
+
+    /// Cumulative count of `write_at` calls that reached storage.
+    /// Lets RO tests assert `writes() == 0`.
+    pub fn writes(&self) -> u32 {
+        self.writes.load(Ordering::Relaxed)
+    }
+}
+
+impl BlockDevice for RamDisk {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
+        let bs = self.block_size as u64;
+        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
+            return Err(BlockError::BadAlign);
+        }
+        let storage = self.storage.lock();
+        let end = offset
+            .checked_add(buf.len() as u64)
+            .ok_or(BlockError::OutOfRange)?;
+        if end > storage.len() as u64 {
+            return Err(BlockError::OutOfRange);
+        }
+        let off = offset as usize;
+        buf.copy_from_slice(&storage[off..off + buf.len()]);
+        Ok(())
+    }
+
+    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
+        // Honor the harness-level RO latch first: a read-only mount
+        // must never reach storage with a write. Returning ReadOnly
+        // (instead of silently mutating) lets the RO tests assert
+        // writes() == 0 and catches regressions where a future
+        // dirty-writeback path forgets to gate on MS_RDONLY.
+        if self.read_only.load(Ordering::Relaxed) {
+            return Err(BlockError::ReadOnly);
+        }
+        let bs = self.block_size as u64;
+        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
+            return Err(BlockError::BadAlign);
+        }
+        let mut storage = self.storage.lock();
+        let end = offset
+            .checked_add(buf.len() as u64)
+            .ok_or(BlockError::Enospc)?;
+        if end > storage.len() as u64 {
+            return Err(BlockError::Enospc);
+        }
+        let off = offset as usize;
+        storage[off..off + buf.len()].copy_from_slice(buf);
+        self.writes.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+
+    fn block_size(&self) -> u32 {
+        self.block_size
+    }
+
+    fn capacity(&self) -> u64 {
+        self.storage.lock().len() as u64
+    }
+}

--- a/kernel/tests/ext2_dir_ops.rs
+++ b/kernel/tests/ext2_dir_ops.rs
@@ -29,11 +29,9 @@ use alloc::sync::{Arc, Weak};
 use alloc::vec;
 use alloc::vec::Vec;
 use core::panic::PanicInfo;
-use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use core::sync::atomic::AtomicBool;
 
-use spin::Mutex;
-
-use vibix::block::{BlockDevice, BlockError};
+use vibix::block::BlockDevice;
 use vibix::fs::ext2::dir;
 use vibix::fs::ext2::{iget, Ext2Fs, Ext2Inode, Ext2InodeMeta, Ext2Super};
 use vibix::fs::vfs::ops::{FileSystem as _, MountSource};
@@ -91,85 +89,12 @@ fn run_tests() {
 }
 
 // ---------------------------------------------------------------------------
-// RamDisk copy — matches ext2_mount.rs / ext2_inode_iget.rs.
+// Shared `RamDisk` — see kernel/tests/common/ext2_ramdisk.rs (issue #627).
 // ---------------------------------------------------------------------------
 
-struct RamDisk {
-    block_size: u32,
-    storage: Mutex<Vec<u8>>,
-    writes: AtomicU32,
-    read_only: AtomicBool,
-}
-
-impl RamDisk {
-    fn from_image(bytes: &[u8], block_size: u32) -> Arc<Self> {
-        assert!(bytes.len() % block_size as usize == 0);
-        Arc::new(Self {
-            block_size,
-            storage: Mutex::new(bytes.to_vec()),
-            writes: AtomicU32::new(0),
-            read_only: AtomicBool::new(false),
-        })
-    }
-
-    fn set_read_only(&self, ro: bool) {
-        self.read_only.store(ro, Ordering::Relaxed);
-    }
-
-    fn writes(&self) -> u32 {
-        self.writes.load(Ordering::Relaxed)
-    }
-}
-
-impl BlockDevice for RamDisk {
-    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::OutOfRange)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::OutOfRange);
-        }
-        let off = offset as usize;
-        buf.copy_from_slice(&storage[off..off + buf.len()]);
-        Ok(())
-    }
-    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
-        // Honor the harness-level RO flag: a read-only mount must never
-        // reach the backend with a write. Returning ReadOnly (instead of
-        // silently mutating) lets the RO test assert writes() == 0 and
-        // catches regressions where a future dirty-writeback path
-        // forgets to gate on MS_RDONLY.
-        if self.read_only.load(Ordering::Relaxed) {
-            return Err(BlockError::ReadOnly);
-        }
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let mut storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::Enospc)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::Enospc);
-        }
-        let off = offset as usize;
-        storage[off..off + buf.len()].copy_from_slice(buf);
-        self.writes.fetch_add(1, Ordering::Relaxed);
-        Ok(())
-    }
-    fn block_size(&self) -> u32 {
-        self.block_size
-    }
-    fn capacity(&self) -> u64 {
-        self.storage.lock().len() as u64
-    }
-}
+#[path = "common/ext2_ramdisk.rs"]
+mod ext2_ramdisk;
+use ext2_ramdisk::RamDisk;
 
 fn mount_golden_ro() -> (
     Arc<vibix::fs::vfs::super_block::SuperBlock>,

--- a/kernel/tests/ext2_ialloc.rs
+++ b/kernel/tests/ext2_ialloc.rs
@@ -24,13 +24,9 @@
 extern crate alloc;
 
 use alloc::sync::Arc;
-use alloc::vec::Vec;
 use core::panic::PanicInfo;
-use core::sync::atomic::{AtomicU32, Ordering};
 
-use spin::Mutex;
-
-use vibix::block::{BlockDevice, BlockError};
+use vibix::block::BlockDevice;
 use vibix::fs::ext2::{alloc_inode, free_inode, Ext2Fs};
 use vibix::fs::vfs::ops::{FileSystem as _, MountSource};
 use vibix::fs::vfs::MountFlags;
@@ -91,67 +87,12 @@ fn run_tests() {
 }
 
 // ---------------------------------------------------------------------------
-// RamDisk — mirrors the copy in ext2_inode_iget.rs.
+// Shared `RamDisk` — see kernel/tests/common/ext2_ramdisk.rs (issue #627).
 // ---------------------------------------------------------------------------
 
-struct RamDisk {
-    block_size: u32,
-    storage: Mutex<Vec<u8>>,
-    writes: AtomicU32,
-}
-
-impl RamDisk {
-    fn from_image(bytes: &[u8], block_size: u32) -> Arc<Self> {
-        assert!(bytes.len() % block_size as usize == 0);
-        Arc::new(Self {
-            block_size,
-            storage: Mutex::new(bytes.to_vec()),
-            writes: AtomicU32::new(0),
-        })
-    }
-}
-
-impl BlockDevice for RamDisk {
-    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::OutOfRange)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::OutOfRange);
-        }
-        let off = offset as usize;
-        buf.copy_from_slice(&storage[off..off + buf.len()]);
-        Ok(())
-    }
-    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let mut storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::Enospc)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::Enospc);
-        }
-        let off = offset as usize;
-        storage[off..off + buf.len()].copy_from_slice(buf);
-        self.writes.fetch_add(1, Ordering::Relaxed);
-        Ok(())
-    }
-    fn block_size(&self) -> u32 {
-        self.block_size
-    }
-    fn capacity(&self) -> u64 {
-        self.storage.lock().len() as u64
-    }
-}
+#[path = "common/ext2_ramdisk.rs"]
+mod ext2_ramdisk;
+use ext2_ramdisk::RamDisk;
 
 fn mount_golden_rw() -> (
     Arc<vibix::fs::vfs::super_block::SuperBlock>,

--- a/kernel/tests/ext2_unlink.rs
+++ b/kernel/tests/ext2_unlink.rs
@@ -31,13 +31,9 @@
 extern crate alloc;
 
 use alloc::sync::Arc;
-use alloc::vec::Vec;
 use core::panic::PanicInfo;
-use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
-use spin::Mutex;
-
-use vibix::block::{BlockDevice, BlockError};
+use vibix::block::BlockDevice;
 use vibix::fs::ext2::{iget, Ext2Fs, Ext2Super};
 use vibix::fs::vfs::ops::{FileSystem as _, MountSource};
 use vibix::fs::vfs::super_block::SuperBlock;
@@ -98,76 +94,12 @@ fn run_tests() {
 }
 
 // ---------------------------------------------------------------------------
-// RamDisk — matches ext2_ialloc.rs / ext2_dir_ops.rs.
+// Shared `RamDisk` — see kernel/tests/common/ext2_ramdisk.rs (issue #627).
 // ---------------------------------------------------------------------------
 
-struct RamDisk {
-    block_size: u32,
-    storage: Mutex<Vec<u8>>,
-    writes: AtomicU32,
-    read_only: AtomicBool,
-}
-
-impl RamDisk {
-    fn from_image(bytes: &[u8], block_size: u32) -> Arc<Self> {
-        assert!(bytes.len() % block_size as usize == 0);
-        Arc::new(Self {
-            block_size,
-            storage: Mutex::new(bytes.to_vec()),
-            writes: AtomicU32::new(0),
-            read_only: AtomicBool::new(false),
-        })
-    }
-
-    fn set_read_only(&self, ro: bool) {
-        self.read_only.store(ro, Ordering::Relaxed);
-    }
-}
-
-impl BlockDevice for RamDisk {
-    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::OutOfRange)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::OutOfRange);
-        }
-        let off = offset as usize;
-        buf.copy_from_slice(&storage[off..off + buf.len()]);
-        Ok(())
-    }
-    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
-        if self.read_only.load(Ordering::Relaxed) {
-            return Err(BlockError::ReadOnly);
-        }
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let mut storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::Enospc)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::Enospc);
-        }
-        let off = offset as usize;
-        storage[off..off + buf.len()].copy_from_slice(buf);
-        self.writes.fetch_add(1, Ordering::Relaxed);
-        Ok(())
-    }
-    fn block_size(&self) -> u32 {
-        self.block_size
-    }
-    fn capacity(&self) -> u64 {
-        self.storage.lock().len() as u64
-    }
-}
+#[path = "common/ext2_ramdisk.rs"]
+mod ext2_ramdisk;
+use ext2_ramdisk::RamDisk;
 
 fn mount_rw() -> (Arc<SuperBlock>, Arc<Ext2Fs>, Arc<Ext2Super>, Arc<RamDisk>) {
     let disk = RamDisk::from_image(GOLDEN_IMG.as_slice(), 512);


### PR DESCRIPTION
## Summary

Closes #627.

Every ext2 integration test crate carries a near-identical ~70-line copy of the same `RamDisk` struct (a `Mutex<Vec<u8>>`-backed `BlockDevice` impl with a write-count atomic and a read-only latch). CodeRabbit flagged the duplication on #626. This change extracts the helper to `kernel/tests/common/ext2_ramdisk.rs` and switches the three call sites named in the issue (`ext2_ialloc.rs`, `ext2_dir_ops.rs`, `ext2_unlink.rs`) to use it.

The helper is included via the per-file

```rust
#[path = "common/ext2_ramdisk.rs"]
mod ext2_ramdisk;
use ext2_ramdisk::RamDisk;
```

pattern. Each integration test under `kernel/tests/` is its own `#![no_std] #![no_main]` crate, so a normal `mod common` reference would not resolve, and the file lives in `tests/common/` (a subdirectory) so cargo's autotest discovery skips it. No `[[test]]` entry is needed.

Surface is intentionally minimal: `from_image`, `set_read_only`, `writes`, plus the `BlockDevice` impl. `writes()` is kept because `ext2_dir_ops.rs` consumes it for the "RO mount must not issue any writes" assertions.

Pure dedup — no behavioural change. Net diff: -202 LoC across the three test files. The unified `write_at` gates on the `read_only` latch unconditionally; that gate already existed in two of the three copies, and for `ext2_ialloc.rs` the latch defaults to `false`, so the path stays a no-op there.

Other ext2 test files (`ext2_create.rs`, `ext2_link.rs`, `ext2_mount.rs`, `ext2_orphan_*.rs`, `ext2_rename.rs`, `ext2_setattr.rs`, `ext2_file_*.rs`, `ext2_block_alloc.rs`, `ext2_inode_iget.rs`) and the block-cache tests also carry their own copies but are explicitly out of scope for #627. A follow-up issue will track migrating them.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo xtask build` succeeds
- [x] `cargo xtask test-integration` runs the three migrated test crates green (verified `ext2_dir_ops` 5/5 in the integration log; `ext2_file_write` flake on the same run was unrelated and passed on rerun)
- [ ] CI: full `cargo xtask test` + `cargo xtask smoke` (auto-gated)