### PR TITLE
fs/ext2: trigger orphan_finalize from last-fd-close (#638)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -447,6 +447,11 @@ harness = false
 required-features = ["ext2"]
 
 [[test]]
+name = "ext2_orphan_open_close"
+harness = false
+required-features = ["ext2"]
+
+[[test]]
 name = "ext2_rename"
 harness = false
 required-features = ["ext2"]

--- a/kernel/src/fs/ext2/inode.rs
+++ b/kernel/src/fs/ext2/inode.rs
@@ -63,7 +63,7 @@
 use alloc::collections::BTreeMap;
 use alloc::sync::{Arc, Weak};
 use alloc::vec;
-use core::sync::atomic::AtomicBool;
+use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use spin::Mutex;
 
@@ -174,6 +174,20 @@ pub struct Ext2Inode {
     /// the surface exists so the unlink path and mount-time orphan
     /// replay (#564) have a well-known place to set it.
     pub unlinked: AtomicBool,
+    /// Driver-side outstanding-opens refcount. Bumped by
+    /// [`FileOps::open`] (one per successful `OpenFile::new`) and
+    /// decremented by [`FileOps::release`] (one per `OpenFile::Drop`).
+    /// When [`unlinked`](Self::unlinked) is set and this count
+    /// transitions from one to zero, the `release` hook calls
+    /// [`super::orphan_finalize::finalize`] directly to drive the
+    /// RFC 0004 §Final-close sequence — bypassing the VFS
+    /// `gc_queue`/`evict_inode` indirection that would otherwise be
+    /// blocked by the orphan-list `Arc<Inode>` pin (chicken-and-egg:
+    /// the pin is held by `orphan_list` and only released **inside**
+    /// `finalize`, so `Inode::Drop` for an orphan can never fire to
+    /// trigger eviction). See issue #638 / RFC 0004 §Wiring the
+    /// production trigger.
+    pub open_count: AtomicU32,
 }
 
 impl Ext2Inode {
@@ -184,6 +198,7 @@ impl Ext2Inode {
             meta: BlockingRwLock::new(meta),
             block_map: BlockingRwLock::new(None),
             unlinked: AtomicBool::new(false),
+            open_count: AtomicU32::new(0),
         }
     }
 }
@@ -396,6 +411,67 @@ impl FileOps for Ext2Inode {
     /// ordering rules (RFC 0004 §Write extend + §Write Ordering).
     fn write(&self, f: &OpenFile, buf: &[u8], off: u64) -> Result<usize, i64> {
         super::file::write_file_at(&f.inode, self, buf, off)
+    }
+
+    /// Bump the driver-side outstanding-opens refcount. Paired with
+    /// [`Self::release`]. Issue #638 / RFC 0004 §Wiring the production
+    /// trigger.
+    fn open(&self, _f: &OpenFile) {
+        self.open_count.fetch_add(1, Ordering::SeqCst);
+    }
+
+    /// Decrement the outstanding-opens refcount. If the count
+    /// transitions from one to zero AND the inode is unlinked
+    /// (i.e. on the per-mount [`OrphanList`]), drive the RFC 0004
+    /// §Final-close sequence synchronously via
+    /// [`super::orphan_finalize::finalize`].
+    ///
+    /// This is the in-kernel production trigger for orphan-finalize
+    /// (issue #638). The VFS `gc_queue` / `evict_inode` indirection
+    /// can't drive it because the orphan-list `Arc<Inode>` pin keeps
+    /// `Inode::Drop` from ever firing on an orphan — the pin is only
+    /// released **inside** `finalize`, which is the chicken/egg the
+    /// per-open refcount unwinds.
+    ///
+    /// On a non-orphan close: the decrement is the only side effect;
+    /// the VFS cache eventually evicts the inode through its normal
+    /// `Weak<Inode>` upgrade-failure path (no driver work needed —
+    /// ext2 has no dirty-inode writeback yet; that lives behind the
+    /// future `sync` path).
+    ///
+    /// Errors from `finalize` are absorbed with a `kwarn!`: the drop
+    /// path can't propagate, and leaving the orphan-list pin in place
+    /// means the next mount-time replay (#564) will rediscover the
+    /// inode and retry the sequence.
+    fn release(&self, _f: &OpenFile) {
+        let prev = self.open_count.fetch_sub(1, Ordering::SeqCst);
+        debug_assert!(prev > 0, "Ext2Inode::release: open_count underflow");
+        if prev != 1 {
+            return;
+        }
+        // Last close. If the inode is unlinked, run finalize. The
+        // `unlinked` atomic is set by `unlink::push_on_orphan_list`'s
+        // caller before the orphan-list pin is installed, so reading
+        // `true` here is sufficient evidence that the orphan_list
+        // entry exists (or will be observed by `finalize`'s ENOENT
+        // path otherwise — idempotent).
+        if !self.unlinked.load(Ordering::SeqCst) {
+            return;
+        }
+        let Some(super_arc) = self.super_ref.upgrade() else {
+            // Mount is mid-teardown; the orphan-list pin will be
+            // released when the per-super state drops, and any leaked
+            // on-disk state is recovered by mount-replay on the next
+            // boot.
+            return;
+        };
+        if let Err(e) = super::orphan_finalize::finalize(&super_arc, self.ino) {
+            crate::kwarn!(
+                "ext2: open_count→0 finalize ino {}: errno={}, leaving pin for replay",
+                self.ino,
+                e,
+            );
+        }
     }
 }
 

--- a/kernel/src/fs/ext2/orphan_finalize.rs
+++ b/kernel/src/fs/ext2/orphan_finalize.rs
@@ -64,30 +64,30 @@
 //! - Step 4 is in-memory only; a crash here costs nothing beyond the
 //!   pin until the next mount.
 //!
-//! # Out of scope
+//! # Production triggers
 //!
-//! - The production trigger (wiring the last-fd-close event to this
-//!   finalize call). In the current ext2 driver, the orphan list holds
-//!   `Arc<Inode>` strong refs — the last `OpenFile` drop doesn't cause
-//!   the `Inode` to hit zero while an orphan-list entry exists.
-//!   [`Ext2Super::evict_inode`](super::fs::Ext2Super) is the hook site
-//!   the VFS `gc_queue` drives, but it only fires when the VFS drops
-//!   the last `Arc<Inode>` it holds, which only happens after the
-//!   orphan-list pin is explicitly released. Until the production
-//!   trigger is wired (follow-up issue; see "Wiring the production
-//!   trigger" below), callers invoke [`finalize`] directly — this is
-//!   sufficient for the mount-time replay path (#564) and for the
-//!   integration tests that exercise the sequence end-to-end.
+//! Three call sites drive [`finalize`] in the live driver:
 //!
-//! # Wiring the production trigger
-//!
-//! The RFC 0004 design envisions a per-`OpenFile` drop that, after
-//! decrementing a driver-side refcount, calls this module's [`finalize`]
-//! when the count hits zero for an unlinked inode. That refcount hook
-//! doesn't exist yet on `OpenFile`; adding it is a separate VFS surface
-//! change and will be handled in a follow-up. Until then, mount-time
-//! replay (#564) and explicit calls (from tests, or a future background
-//! orphan-sweep) are the two callers.
+//! 1. **Last-fd-close** (issue #638): the per-`Ext2Inode`
+//!    `open_count` atomic is bumped by [`FileOps::open`](crate::fs::vfs::ops::FileOps::open)
+//!    and decremented by [`FileOps::release`](crate::fs::vfs::ops::FileOps::release)
+//!    on every successful `OpenFile` construction / drop. When the
+//!    count transitions one→zero on an inode whose `unlinked` flag is
+//!    set, the `release` hook calls [`finalize`] directly — bypassing
+//!    the VFS `gc_queue` / `evict_inode` indirection that would
+//!    otherwise be blocked by the orphan-list `Arc<Inode>` pin
+//!    (chicken-and-egg: the pin is held by `orphan_list` and only
+//!    released **inside** `finalize`, so `Inode::Drop` for an orphan
+//!    can never fire to enqueue eviction).
+//! 2. **Mount-time orphan-chain replay** (#564): inodes left on
+//!    `s_last_orphan` from a previous mount are walked and finalized
+//!    before the SB becomes visible to userspace.
+//! 3. **VFS eviction passthrough** (#573): if a non-fd path manages to
+//!    drop the last `Arc<Inode>` for an orphan (e.g. a future
+//!    background orphan-sweep), [`Ext2Super::evict_inode`](super::fs::Ext2Super)
+//!    routes through here as a defence-in-depth fallback. In normal
+//!    operation the per-open trigger above runs first and the eviction
+//!    path becomes a no-op (orphan_list entry already gone).
 
 use alloc::sync::Arc;
 

--- a/kernel/src/fs/ext2/rename.rs
+++ b/kernel/src/fs/ext2/rename.rs
@@ -535,8 +535,12 @@ pub fn rename(
     //     blocks. The victim's dirent is already gone by step 5.
     if let Some(ino) = victim_hit_zero {
         if let Some((v_arc, v_ext2)) = victim_arcs.as_ref() {
-            v_ext2.unlinked.store(true, Ordering::SeqCst);
+            // Push-then-mark ordering: see the matching note in
+            // `unlink::unlink_common` step 8 — the open-fd-close
+            // finalize trigger (#638) reads `unlinked` then expects
+            // the orphan_list pin to already be there.
             push_on_orphan_list(&super_, ino, v_arc)?;
+            v_ext2.unlinked.store(true, Ordering::SeqCst);
         }
     }
 

--- a/kernel/src/fs/ext2/unlink.rs
+++ b/kernel/src/fs/ext2/unlink.rs
@@ -599,10 +599,17 @@ fn unlink_common(
         decrement_used_dirs(&super_, loc.child_ino)?;
     }
 
-    // 8. On hit-zero: mark unlinked, push on orphan list.
+    // 8. On hit-zero: push on orphan list, then mark unlinked. The
+    //    push-then-mark ordering matters for the open-fd-close finalize
+    //    trigger (#638): a concurrent `OpenFile::Drop` reads
+    //    `unlinked == true` and immediately calls `finalize_orphan`,
+    //    which expects the orphan_list pin to already be installed.
+    //    Setting `unlinked` last guarantees the releaser observes
+    //    "unlinked && pin present" rather than racing into a finalize
+    //    that returns `ENOENT` and silently leaks the orphan inode.
     if new_links == 0 {
-        child_ext2.unlinked.store(true, Ordering::SeqCst);
         push_on_orphan_list(&super_, loc.child_ino, &child_arc)?;
+        child_ext2.unlinked.store(true, Ordering::SeqCst);
     }
 
     Ok(())

--- a/kernel/src/fs/vfs/open_file.rs
+++ b/kernel/src/fs/vfs/open_file.rs
@@ -89,14 +89,20 @@ impl OpenFile {
             // list.
             finalize_pending_detach(&sb);
         }
-        Arc::new(Self {
+        let of = Arc::new(Self {
             dentry,
             inode,
             offset: BlockingMutex::new(0),
             flags: AtomicU32::new(flags),
             ops,
             sb,
-        })
+        });
+        // Fire the driver `open` hook now that the `OpenFile` is fully
+        // constructed and the SB pin has been migrated to
+        // `dentry_pin_count`. Drivers (ext2) use this to bump a
+        // per-open refcount that pairs with the `release` hook below.
+        of.ops.open(&of);
+        of
     }
 }
 
@@ -105,6 +111,13 @@ impl OpenFile {
 /// -detached SB waiting on the pin has its finalizer fire here.
 impl Drop for OpenFile {
     fn drop(&mut self) {
+        // Driver `release` hook runs BEFORE the SB pin release. ext2's
+        // orphan-finalize trigger needs the inode + super still
+        // structurally pinned so it can call `finalize_orphan` (which
+        // touches the buffer cache, sb_disk, BGDT) without racing the
+        // mount teardown. The hook is infallible by trait contract.
+        self.ops.release(self);
+
         let old = self.sb.dentry_pin_count.fetch_sub(1, Ordering::SeqCst);
         debug_assert!(old > 0, "OpenFile::drop: dentry_pin_count underflow");
         if old == 1 {

--- a/kernel/src/fs/vfs/ops.rs
+++ b/kernel/src/fs/vfs/ops.rs
@@ -312,6 +312,32 @@ pub trait FileOps: Send + Sync {
     fn fsync(&self, _f: &OpenFile, _data_only: bool) -> Result<(), i64> {
         Ok(())
     }
+
+    /// Driver hook fired exactly once per [`OpenFile`] right after the
+    /// `OpenFile` is fully constructed (after `OpenFile::new` has handed
+    /// the `SbActiveGuard` pin off to `dentry_pin_count`). The `OpenFile`
+    /// reference is stable for the duration of the call.
+    ///
+    /// Default: no-op. Drivers that need a per-open refcount (ext2's
+    /// orphan-finalize trigger, RFC 0004 §Final-close sequence) bump it
+    /// here. Failure surfacing isn't supported — the open has already
+    /// pinned the SB and the syscall layer has no rollback path; if a
+    /// driver hook needs to fail, it must do so earlier (e.g. inside
+    /// `InodeOps::lookup` / `InodeOps::create`).
+    fn open(&self, _f: &OpenFile) {}
+
+    /// Driver hook fired exactly once per [`OpenFile`] from
+    /// [`OpenFile::Drop`], **before** the SB pin is released. The
+    /// `OpenFile` reference is stable for the duration of the call.
+    ///
+    /// Default: no-op. Drivers that need a per-open refcount (ext2's
+    /// orphan-finalize trigger) decrement it here and may run terminal
+    /// finalize work synchronously (e.g. truncate-to-zero + free_inode
+    /// for an unlinked-but-open inode whose count just hit zero). The
+    /// hook is infallible — drop paths can't propagate errors to the
+    /// caller; drivers should `kwarn!` and absorb any I/O failure (the
+    /// next mount-time replay path will retry).
+    fn release(&self, _f: &OpenFile) {}
 }
 
 /// Default POSIX permission check: owner / group / other bits in

--- a/kernel/tests/ext2_create.rs
+++ b/kernel/tests/ext2_create.rs
@@ -259,6 +259,7 @@ fn make_ext2_inode_from_disk(
         meta: BlockingRwLock::new(meta),
         block_map: BlockingRwLock::new(None),
         unlinked: AtomicBool::new(false),
+        open_count: AtomicU32::new(0),
     }
 }
 

--- a/kernel/tests/ext2_dir_ops.rs
+++ b/kernel/tests/ext2_dir_ops.rs
@@ -259,6 +259,7 @@ fn make_ext2_inode_from_stat(
         meta: BlockingRwLock::new(meta),
         block_map: BlockingRwLock::new(None),
         unlinked: AtomicBool::new(false),
+        open_count: AtomicU32::new(0),
     }
 }
 

--- a/kernel/tests/ext2_link.rs
+++ b/kernel/tests/ext2_link.rs
@@ -268,6 +268,7 @@ fn make_ext2_inode_from_disk(
         meta: BlockingRwLock::new(meta),
         block_map: BlockingRwLock::new(None),
         unlinked: AtomicBool::new(false),
+        open_count: AtomicU32::new(0),
     }
 }
 

--- a/kernel/tests/ext2_orphan_open_close.rs
+++ b/kernel/tests/ext2_orphan_open_close.rs
@@ -1,0 +1,338 @@
+//! Integration test for issue #638: ext2 orphan-finalize **production
+//! trigger** (last `OpenFile::Drop` on an unlinked inode runs the
+//! RFC 0004 §Final-close sequence in-line, without unmount/remount).
+//!
+//! This test exercises the chain:
+//!
+//!   `iget` -> `OpenFile::new` (open_count = 1) -> `rmdir` (unlinked = true,
+//!   orphan_list pin installed) -> `drop(OpenFile)` (release hook -> finalize)
+//!
+//! and checks the postconditions:
+//!
+//! 1. With the OpenFile alive, the orphan_list pin survives across rmdir
+//!    (the inode is `unlinked` but blocks/inode are still reserved).
+//! 2. Dropping the OpenFile causes `release` to observe the
+//!    open_count → 0 transition with `unlinked == true` and call
+//!    `finalize_orphan` directly. After the drop:
+//!    - orphan_list is empty,
+//!    - `s_last_orphan` reverts to 0 (single-entry chain),
+//!    - the on-disk inode slot is fully tombstoned (`i_links_count == 0`,
+//!      `i_dtime != 0`),
+//!    - the `s_free_inodes_count` and `s_free_blocks_count` counters
+//!      both moved.
+//! 3. With **no** open files at unlink time, `rmdir` (which runs an
+//!    internal `iget` that releases its strong ref on return) leaves the
+//!    orphan pinned by the `orphan_list` itself — the open_count from
+//!    the internal iget never went above zero (no `OpenFile` was built),
+//!    so there's no automatic finalize. The mount-time replay path
+//!    (#564) and `evict_inode` remain the safety nets, both unchanged.
+//!
+//! Together these prove the production trigger fires when (and only
+//! when) a real `OpenFile` was outstanding.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+use spin::Mutex;
+
+use vibix::block::{BlockDevice, BlockError};
+use vibix::fs::ext2::{iget, Ext2Fs, Ext2Super};
+use vibix::fs::vfs::dentry::Dentry;
+use vibix::fs::vfs::open_file::OpenFile;
+use vibix::fs::vfs::ops::{FileSystem as _, MountSource};
+use vibix::fs::vfs::super_block::{SbActiveGuard, SuperBlock};
+use vibix::fs::vfs::MountFlags;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+const GOLDEN_IMG: &[u8; 65_536] = include_bytes!("../src/fs/ext2/fixtures/golden.img");
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "open_unlink_close_finalizes_orphan",
+            &(open_unlink_close_finalizes_orphan as fn()),
+        ),
+        (
+            "rmdir_with_no_openers_keeps_orphan_pinned",
+            &(rmdir_with_no_openers_keeps_orphan_pinned as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RamDisk — same shape as the other ext2 integration tests.
+// ---------------------------------------------------------------------------
+
+struct RamDisk {
+    block_size: u32,
+    storage: Mutex<Vec<u8>>,
+    writes: AtomicU32,
+    read_only: AtomicBool,
+}
+
+impl RamDisk {
+    fn from_image(bytes: &[u8], block_size: u32) -> Arc<Self> {
+        assert!(bytes.len() % block_size as usize == 0);
+        Arc::new(Self {
+            block_size,
+            storage: Mutex::new(bytes.to_vec()),
+            writes: AtomicU32::new(0),
+            read_only: AtomicBool::new(false),
+        })
+    }
+}
+
+impl BlockDevice for RamDisk {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
+        let bs = self.block_size as u64;
+        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
+            return Err(BlockError::BadAlign);
+        }
+        let storage = self.storage.lock();
+        let end = offset
+            .checked_add(buf.len() as u64)
+            .ok_or(BlockError::OutOfRange)?;
+        if end > storage.len() as u64 {
+            return Err(BlockError::OutOfRange);
+        }
+        let off = offset as usize;
+        buf.copy_from_slice(&storage[off..off + buf.len()]);
+        Ok(())
+    }
+    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
+        if self.read_only.load(Ordering::Relaxed) {
+            return Err(BlockError::ReadOnly);
+        }
+        let bs = self.block_size as u64;
+        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
+            return Err(BlockError::BadAlign);
+        }
+        let mut storage = self.storage.lock();
+        let end = offset
+            .checked_add(buf.len() as u64)
+            .ok_or(BlockError::Enospc)?;
+        if end > storage.len() as u64 {
+            return Err(BlockError::Enospc);
+        }
+        let off = offset as usize;
+        storage[off..off + buf.len()].copy_from_slice(buf);
+        self.writes.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+    fn block_size(&self) -> u32 {
+        self.block_size
+    }
+    fn capacity(&self) -> u64 {
+        self.storage.lock().len() as u64
+    }
+}
+
+fn mount_rw() -> (Arc<SuperBlock>, Arc<Ext2Fs>, Arc<Ext2Super>, Arc<RamDisk>) {
+    let disk = RamDisk::from_image(GOLDEN_IMG.as_slice(), 512);
+    let fs = Ext2Fs::new_with_device(disk.clone() as Arc<dyn BlockDevice>);
+    let sb = fs
+        .mount(MountSource::None, MountFlags(0))
+        .expect("RW mount");
+    let super_arc = fs.current_super().expect("current_super");
+    (sb, fs, super_arc, disk)
+}
+
+// On-disk offsets for tombstone-state assertions. Duplicated from
+// ext2_orphan_finalize.rs so the test stays self-contained against the
+// golden image's mkfs.ext2 layout.
+const BGDT_BYTE_OFFSET_1K: usize = 2048;
+const BGD_OFF_INODE_TABLE: usize = 8;
+const INODE_SIZE: usize = 128;
+const INODE_OFF_DTIME: usize = 20;
+const INODE_OFF_LINKS_COUNT: usize = 26;
+const BLOCK_SIZE_BYTES: usize = 1024;
+
+fn u32_le(image: &[u8], off: usize) -> u32 {
+    u32::from_le_bytes(image[off..off + 4].try_into().unwrap())
+}
+fn u16_le(image: &[u8], off: usize) -> u16 {
+    u16::from_le_bytes(image[off..off + 2].try_into().unwrap())
+}
+fn inode_slot_offset(image: &[u8], ino: u32) -> usize {
+    let itab_block = u32_le(image, BGDT_BYTE_OFFSET_1K + BGD_OFF_INODE_TABLE) as usize;
+    let slot_in_table = (ino as usize) - 1;
+    itab_block * BLOCK_SIZE_BYTES + slot_in_table * INODE_SIZE
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Exercise the full open → unlink → close → in-line-finalize chain.
+fn open_unlink_close_finalizes_orphan() {
+    let (sb, _fs, super_arc, disk) = mount_rw();
+
+    let (free_inodes_before, free_blocks_before) = {
+        let d = super_arc.sb_disk.lock();
+        (d.s_free_inodes_count, d.s_free_blocks_count)
+    };
+
+    // Resolve the orphan-target inode (lost+found, ino 11) and build a
+    // real `OpenFile` against it. `OpenFile::new` invokes the FileOps
+    // `open` hook, which bumps `Ext2Inode::open_count` to 1.
+    let root = iget(&super_arc, &sb, 2).expect("iget root");
+    let lf_inode = iget(&super_arc, &sb, 11).expect("iget lost+found");
+    let dentry = Dentry::new_root(lf_inode.clone());
+    let guard = SbActiveGuard::try_acquire(&sb).expect("SbActiveGuard");
+    let of = OpenFile::new(
+        dentry,
+        lf_inode.clone(),
+        lf_inode.file_ops.clone(),
+        sb.clone(),
+        0,
+        guard,
+    );
+
+    // Now rmdir lost+found through the InodeOps surface. The unlink
+    // path sets `unlinked = true` (after `push_on_orphan_list`) — the
+    // ordering matters for the release-trigger race; see the matching
+    // note in `unlink::unlink_common`.
+    root.ops
+        .rmdir(&root, b"lost+found")
+        .expect("rmdir(lost+found)");
+
+    // With the OpenFile still live the orphan_list pin is preserved
+    // and finalize has not yet fired.
+    assert!(
+        super_arc.orphan_list.lock().contains_key(&11),
+        "open holds the orphan pin until OpenFile::Drop"
+    );
+    assert_eq!(
+        super_arc.sb_disk.lock().s_last_orphan,
+        11,
+        "rmdir leaves chain head at ino 11"
+    );
+
+    // The user-facing inode Arc held by the test is also still live —
+    // drop it so the `OpenFile`'s `Arc<Inode>` is the only non-orphan
+    // pin remaining. (Even with this drop, `orphan_list` keeps
+    // `lf_inode`'s allocation alive via its own Arc — the drop here
+    // just confirms the trigger doesn't depend on a user-side strong
+    // ref hanging around.)
+    drop(lf_inode);
+
+    // Drop the OpenFile. `OpenFile::Drop` runs the FileOps `release`
+    // hook **before** releasing the SB pin; for ext2 that decrements
+    // open_count from 1 → 0 and, observing `unlinked == true`, calls
+    // `orphan_finalize::finalize` synchronously.
+    drop(of);
+
+    // Finalize postconditions.
+    assert!(
+        super_arc.orphan_list.lock().is_empty(),
+        "release-hook finalize must drop the in-memory pin"
+    );
+    assert_eq!(
+        super_arc.sb_disk.lock().s_last_orphan,
+        0,
+        "release-hook finalize must clear the on-disk chain head"
+    );
+
+    let free_inodes_after = super_arc.sb_disk.lock().s_free_inodes_count;
+    assert_eq!(
+        free_inodes_after,
+        free_inodes_before + 1,
+        "release-hook finalize must bump s_free_inodes_count"
+    );
+    let free_blocks_after = super_arc.sb_disk.lock().s_free_blocks_count;
+    assert!(
+        free_blocks_after > free_blocks_before,
+        "release-hook finalize must free lost+found's data block (before={free_blocks_before}, after={free_blocks_after})"
+    );
+
+    // Tombstone state on the raw RamDisk image (bypasses any cache).
+    {
+        let storage = disk.storage.lock();
+        let slot_off = inode_slot_offset(&storage, 11);
+        let links = u16_le(&storage, slot_off + INODE_OFF_LINKS_COUNT);
+        let dtime = u32_le(&storage, slot_off + INODE_OFF_DTIME);
+        assert_eq!(
+            links, 0,
+            "release-hook finalize must preserve i_links_count == 0"
+        );
+        assert_ne!(
+            dtime, 0,
+            "release-hook finalize must stamp a nonzero i_dtime tombstone"
+        );
+    }
+
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+/// When no `OpenFile` was ever built for the to-be-orphaned inode, the
+/// release-hook trigger naturally never fires (open_count never reached
+/// >0 from a real open), so the orphan pin sticks around — the
+/// existing `evict_inode` and mount-replay paths remain the recovery
+/// sites. This pins the boundary so a future change can't accidentally
+/// finalize on an `iget` round-trip with no opener.
+fn rmdir_with_no_openers_keeps_orphan_pinned() {
+    let (sb, _fs, super_arc, _disk) = mount_rw();
+
+    let root = iget(&super_arc, &sb, 2).expect("iget root");
+    // Pre-load ino 11 into the cache so it has an Arc<Ext2Inode>
+    // visible to the orphan-list bookkeeping; do NOT build an
+    // OpenFile.
+    let _lf = iget(&super_arc, &sb, 11).expect("iget lost+found");
+
+    root.ops
+        .rmdir(&root, b"lost+found")
+        .expect("rmdir(lost+found)");
+
+    // No OpenFile was ever constructed → open_count stayed at zero
+    // → no release-hook finalize fired. The orphan_list still pins
+    // ino 11 and the on-disk chain head is still 11.
+    assert!(
+        super_arc.orphan_list.lock().contains_key(&11),
+        "without any opener, orphan_list pin must persist past rmdir"
+    );
+    assert_eq!(
+        super_arc.sb_disk.lock().s_last_orphan,
+        11,
+        "without any opener, on-disk chain head must remain at ino 11"
+    );
+
+    // Drop the lf Arc to simulate cache eviction; orphan_list still
+    // holds its own strong ref so the inode allocation stays live.
+    drop(_lf);
+    assert!(
+        super_arc.orphan_list.lock().contains_key(&11),
+        "orphan_list strong ref keeps the inode resident across user-Arc drop"
+    );
+
+    sb.ops.unmount();
+    drop(super_arc);
+}

--- a/kernel/tests/ext2_rename.rs
+++ b/kernel/tests/ext2_rename.rs
@@ -268,6 +268,7 @@ fn ext2_from_disk(
         meta: BlockingRwLock::new(meta),
         block_map: BlockingRwLock::new(None),
         unlinked: AtomicBool::new(false),
+        open_count: AtomicU32::new(0),
     }
 }
 


### PR DESCRIPTION
Closes #638.

## Summary

- Adds `FileOps::open` / `FileOps::release` lifecycle hooks to the
  VFS `FileOps` trait (default no-op). `OpenFile::new` calls `open`
  after the SB pin is migrated into `dentry_pin_count`;
  `OpenFile::Drop` calls `release` *before* dropping the SB pin so
  release-time finalize logic still sees a pinned super.
- Wires ext2's outstanding-opens refcount on `Ext2Inode`
  (`open_count: AtomicU32`). On the 1->0 release transition where
  `unlinked == true`, ext2 calls `orphan_finalize::finalize` directly.
  Resolves the chicken-and-egg in RFC 0004's orphan-list residency
  invariant: the orphan_list `Arc<Inode>` pin kept the inode alive
  forever, so VFS gc never reached `evict_inode` for orphans, so the
  pin was never released, and so on.
- Race fix in `unlink.rs` and `rename.rs`: `push_on_orphan_list` now
  happens *before* `unlinked.store(true)`. Previously a concurrent
  releaser could observe `unlinked == true` between the store and
  the push, finalize-with-ENOENT, and silently leak the orphan when
  the push completed.
- Updates `orphan_finalize` module doc to list the three production
  triggers (release hook #638, mount-time replay #564, evict_inode
  passthrough #573).

## Test plan

- [x] New `ext2_orphan_open_close` integration test:
  - `open_unlink_close_finalizes_orphan` -- holds an OpenFile across
    rmdir, asserts orphan pin survives, drops OpenFile, asserts
    orphan_list empty + `s_last_orphan == 0` + free counters bumped
    + on-disk tombstone (`i_links_count == 0`, `i_dtime != 0`).
  - `rmdir_with_no_openers_keeps_orphan_pinned` -- control case;
    confirms the trigger is open-count driven, not synchronous on
    rmdir.
- [x] `cargo xtask build` clean (only pre-existing dead-code warning).
- [x] `cargo xtask test` green (one pre-existing wait4_condvar_race
      flake on retry, unrelated; passes on second run).
- [x] `cargo xtask smoke` -- all 35 markers present.
- [x] `cargo fmt --all -- --check` clean.