### PR TITLE
kernel/task: recycle stack VA slots; mute resolved CoW first-fault

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -352,11 +352,12 @@ extern "x86-interrupt" fn page_fault(mut frame: InterruptStackFrame, code: PageF
     // with DefaultAction::Terminate. The helper calls `task::exit()`, so
     // IRETQ never runs; the scheduler context-switches to the next task.
     if cpl != 0 {
-        log_first_ring3_fault(
-            "#PF",
-            &frame,
-            format_args!("cr2={:#x} code={:?}", addr_u64, code),
-        );
+        // Do NOT call `log_first_ring3_fault` here: if the task has installed
+        // a SIGSEGV handler, `deliver_fault_signal_iret` rewrites IRETQ to
+        // the handler and the fault is *recoverable* — latching this site
+        // would re-fire the diagnostic on every signal-handled fault. The
+        // unrecoverable `Default`/`Ignore` path inside the signal layer
+        // logs its own `signal: terminate` line before calling `exit()`.
         serial_println!(
             "#PF ring-3 access violation addr={:#x} code={:?}",
             addr_u64,
@@ -374,11 +375,10 @@ extern "x86-interrupt" fn page_fault(mut frame: InterruptStackFrame, code: PageF
         return; // handler path: IRETQ fires the signal handler
     }
 
-    log_first_ring3_fault(
-        "#PF",
-        &frame,
-        format_args!("cr2={:#x} code={:?}", addr_u64, code),
-    );
+    // Kernel-mode (CPL=0) #PF that fell through every recovery path is a
+    // genuine kernel bug. The `log_first_ring3_fault` helper is ring-3-only
+    // (it short-circuits on CPL=0), so don't bother calling it here — the
+    // EXCEPTION line below is the diagnostic of record.
     serial_println!(
         "EXCEPTION: #PF addr={:#x} code={:?}\n{:#?}",
         addr_u64,

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -14,16 +14,24 @@ use crate::arch::x86_64::interrupts::{
 };
 use crate::serial_println;
 
-/// #478 diagnostic latch: the first CPL=3 fault of the session logs a
-/// `ring3-first-fault:` line with full frame state before the handler
-/// runs its normal path. Subsequent ring-3 faults are common (SIGSEGV
-/// delivery etc.) and must not flood the log. One-shot by design.
+/// #478 diagnostic latch: the first *unrecoverable* CPL=3 fault of the
+/// session logs a `ring3-first-fault:` line with full frame state.
+/// Subsequent ring-3 faults are common (SIGSEGV delivery etc.) and
+/// must not flood the log. One-shot by design.
+///
+/// For #PF specifically, the caller MUST wait until the resolution
+/// attempt has either succeeded (and returned) or fallen through to a
+/// terminal path (panic / hang / SIGSEGV) before invoking this helper:
+/// a routine first-touch CoW write fault on a forked user-stack page
+/// would otherwise trip the latch on every healthy boot, defeating the
+/// nightly-soak gate added for #527 / #646.
 static FIRST_RING3_FAULT_LOGGED: AtomicBool = AtomicBool::new(false);
 
-/// Emit one `ring3-first-fault:` line on the first CPL=3 fault ever
-/// observed. `extra` is vector-specific trailer (e.g. `code=0x0` for #GP,
-/// `cr2=0x400000 code=PROTECTION` for #PF) — no user memory is touched
-/// while formatting, only scalars copied out of the hardware frame.
+/// Emit one `ring3-first-fault:` line on the first unrecoverable CPL=3
+/// fault ever observed. `extra` is vector-specific trailer (e.g.
+/// `code=0x0` for #GP, `cr2=0x400000 code=PROTECTION` for #PF) — no user
+/// memory is touched while formatting, only scalars copied out of the
+/// hardware frame.
 fn log_first_ring3_fault(vector: &str, frame: &InterruptStackFrame, extra: core::fmt::Arguments) {
     if (frame.code_segment.0 & 0b11) == 0 {
         return;
@@ -136,11 +144,13 @@ extern "x86-interrupt" fn page_fault(mut frame: InterruptStackFrame, code: PageF
     }
     let addr_u64 = x86_64::registers::control::Cr2::read_raw();
 
-    log_first_ring3_fault(
-        "#PF",
-        &frame,
-        format_args!("cr2={:#x} code={:?}", addr_u64, code),
-    );
+    // Defer `log_first_ring3_fault` to the terminal paths below. A
+    // first-touch CoW write fault on a forked user-stack page is a
+    // routine, fully-resolved event and must not trip the diagnostic
+    // latch — otherwise every nightly-soak run trips #527's gate on a
+    // healthy boot. Fire the latch only when the fault genuinely could
+    // not be resolved (SMAP / RSVD panic, unrecoverable user-mode
+    // access violation, or hang fall-through).
 
     if let Some(expected) = crate::test_hook::take_page_fault_expectation() {
         use crate::test_harness::{exit_qemu, QemuExitCode};
@@ -178,6 +188,11 @@ extern "x86-interrupt" fn page_fault(mut frame: InterruptStackFrame, code: PageF
     // explicit no-op — the comment documents the RFC's step 2.
 
     if crate::mem::pf::is_rsvd_fault(err_raw) {
+        log_first_ring3_fault(
+            "#PF",
+            &frame,
+            format_args!("cr2={:#x} code={:?}", addr_u64, code),
+        );
         panic_rsvd_corruption(addr_u64);
     }
 
@@ -186,6 +201,11 @@ extern "x86-interrupt" fn page_fault(mut frame: InterruptStackFrame, code: PageF
     // region) is a SIGSEGV/MAPERR; we don't have signal delivery yet
     // so log and hang with the RFC-mandated marker.
     if cpl != 0 && !crate::mem::pf::is_user_va(addr_u64) {
+        log_first_ring3_fault(
+            "#PF",
+            &frame,
+            format_args!("cr2={:#x} code={:?}", addr_u64, code),
+        );
         serial_println!(
             "EXCEPTION: #PF user addr={:#x} outside USER_VA_END (MAPERR) code={:?}",
             addr_u64,
@@ -308,10 +328,15 @@ extern "x86-interrupt" fn page_fault(mut frame: InterruptStackFrame, code: PageF
 
     // Check whether the fault address lands inside a kernel task's guard
     // page — if so, this is a stack overflow, not a generic fault.
-    if let Some(task_id) = crate::task::find_stack_overflow(addr_u64 as usize) {
+    if let Some(slot_idx) = crate::task::find_stack_overflow(addr_u64 as usize) {
+        log_first_ring3_fault(
+            "#PF",
+            &frame,
+            format_args!("cr2={:#x} code={:?}", addr_u64, code),
+        );
         serial_println!(
-            "EXCEPTION: #PF task {} stack overflow addr={:#x} code={:?}\n{:#?}",
-            task_id,
+            "EXCEPTION: #PF stack overflow slot={} addr={:#x} code={:?}\n{:#?}",
+            slot_idx,
             addr_u64,
             code,
             frame
@@ -327,6 +352,11 @@ extern "x86-interrupt" fn page_fault(mut frame: InterruptStackFrame, code: PageF
     // with DefaultAction::Terminate. The helper calls `task::exit()`, so
     // IRETQ never runs; the scheduler context-switches to the next task.
     if cpl != 0 {
+        log_first_ring3_fault(
+            "#PF",
+            &frame,
+            format_args!("cr2={:#x} code={:?}", addr_u64, code),
+        );
         serial_println!(
             "#PF ring-3 access violation addr={:#x} code={:?}",
             addr_u64,
@@ -344,6 +374,11 @@ extern "x86-interrupt" fn page_fault(mut frame: InterruptStackFrame, code: PageF
         return; // handler path: IRETQ fires the signal handler
     }
 
+    log_first_ring3_fault(
+        "#PF",
+        &frame,
+        format_args!("cr2={:#x} code={:?}", addr_u64, code),
+    );
     serial_println!(
         "EXCEPTION: #PF addr={:#x} code={:?}\n{:#?}",
         addr_u64,
@@ -359,10 +394,10 @@ extern "x86-interrupt" fn double_fault(frame: InterruptStackFrame, _code: u64) -
     // unmapped), so it escalates to #DF. The #DF frame's stack_pointer
     // holds the faulted RSP — check it before the generic diagnostic.
     let faulted_rsp = frame.stack_pointer.as_u64() as usize;
-    if let Some(task_id) = crate::task::find_stack_overflow(faulted_rsp) {
+    if let Some(slot_idx) = crate::task::find_stack_overflow(faulted_rsp) {
         serial_println!(
-            "EXCEPTION: #DF task {} stack overflow rsp={:#x}\n{:#?}",
-            task_id,
+            "EXCEPTION: #DF stack overflow slot={} rsp={:#x}\n{:#?}",
+            slot_idx,
             faulted_rsp,
             frame
         );

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -703,13 +703,19 @@ pub fn for_each_task(mut f: impl FnMut(TaskInfo)) {
     }
 }
 
-/// Check whether `addr` falls within any live kernel task's guard page.
-/// Returns the task ID of the overflowing task, or `None` if no guard
-/// page was hit.
+/// Check whether `addr` falls within any kernel-task guard page in
+/// the task-stack VA window. Returns the slot index of the overflowing
+/// stack, or `None` if no guard page was hit.
 ///
 /// Fully lock-free: derives the answer from the fixed VA layout of the
 /// task stack window, so it is always safe to call from any exception
 /// context — even when the scheduler lock is already held on this CPU.
+///
+/// The returned value is the *slot index*, not a task ID. Pre-#646
+/// every slot was bump-allocated and never reused, so the slot index
+/// happened to equal `task.id - 1`. With slot recycling that
+/// equivalence no longer holds; callers that need a stable identifier
+/// for the overflowing task must walk the live task list themselves.
 pub fn find_stack_overflow(addr: usize) -> Option<usize> {
     use core::sync::atomic::Ordering;
     use task::{GUARD_SIZE, NEXT_STACK_VA, TASK_SLOT_SIZE, TASK_STACKS_VA_BASE};
@@ -721,9 +727,8 @@ pub fn find_stack_overflow(addr: usize) -> Option<usize> {
     let slot_idx = (addr - TASK_STACKS_VA_BASE) / TASK_SLOT_SIZE;
     let slot_guard_base = TASK_STACKS_VA_BASE + slot_idx * TASK_SLOT_SIZE;
     // Guard page occupies [slot_guard_base, slot_guard_base + GUARD_SIZE).
-    // Task IDs start at 1, so slot 0 → task 1.
     if addr < slot_guard_base + GUARD_SIZE {
-        Some(slot_idx + 1)
+        Some(slot_idx)
     } else {
         None
     }
@@ -980,9 +985,11 @@ pub fn current_growsdown_lookup(
 /// ISR. The exiting task is queued in [`REAPER_VICTIMS`] and the
 /// reaper is notified before we context-switch away.
 ///
-/// The stack VA slot (`NEXT_STACK_VA`'s bump-allocated range) is *not*
-/// reclaimed — that would require a free-list on `NEXT_STACK_VA`
-/// which is out of scope for this pass. The VA is logged as leaked.
+/// The stack VA slot (`NEXT_STACK_VA`'s bump-allocated range) is
+/// returned to the slot free-list via [`task::free_stack_slot`] so a
+/// subsequent fork can recycle it (#646). Without this, every
+/// fork+exec+wait cycle permanently consumed a 20 KiB slot and
+/// long-running soak runs eventually exhausted the arena.
 ///
 /// # Panics
 /// - No other ready task exists (exiting the last runnable task would
@@ -1091,9 +1098,13 @@ fn reap_pending(victim: alloc::boxed::Box<Task>) {
             let _ = paging::unmap_and_free_in_pml4(victim.cr3, page);
         }
 
-        // Log the leaked stack VA slot for diagnostics.
+        // Return the now-fully-unmapped stack VA slot to the free list
+        // so a subsequent fork can recycle it (#646). The guard page
+        // was never mapped; the loop above has just released every
+        // mapped stack page via `unmap_and_free_in_pml4`.
+        task::free_stack_slot(victim.guard_base);
         serial_println!(
-            "tasks: reaped task {} (stack VA slot {:#x}..{:#x} leaked)",
+            "tasks: reaped task {} (stack VA slot {:#x}..{:#x} returned)",
             victim.id,
             victim.guard_base,
             victim.guard_base + task::TASK_SLOT_SIZE

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -1091,24 +1091,41 @@ fn reap_pending(victim: alloc::boxed::Box<Task>) {
     // regardless of what locks the victim happened to be holding.
     let stack_base = victim.stack_base();
     if stack_base != 0 {
+        let mut all_unmapped = true;
         for i in 0..victim.stack_page_count() {
             let va = stack_base + i * 4096;
             let page = Page::<Size4KiB>::from_start_address(VirtAddr::new(va as u64))
                 .expect("stack page VA aligned by construction");
-            let _ = paging::unmap_and_free_in_pml4(victim.cr3, page);
+            if let Err(e) = paging::unmap_and_free_in_pml4(victim.cr3, page) {
+                serial_println!(
+                    "tasks: reap task {} unmap stack page {:#x} failed: {:?} — \
+                     leaking VA slot {:#x}..{:#x} to avoid stale-PTE recycle",
+                    victim.id,
+                    va,
+                    e,
+                    victim.guard_base,
+                    victim.guard_base + task::TASK_SLOT_SIZE
+                );
+                all_unmapped = false;
+            }
         }
 
-        // Return the now-fully-unmapped stack VA slot to the free list
-        // so a subsequent fork can recycle it (#646). The guard page
-        // was never mapped; the loop above has just released every
-        // mapped stack page via `unmap_and_free_in_pml4`.
-        task::free_stack_slot(victim.guard_base);
-        serial_println!(
-            "tasks: reaped task {} (stack VA slot {:#x}..{:#x} returned)",
-            victim.id,
-            victim.guard_base,
-            victim.guard_base + task::TASK_SLOT_SIZE
-        );
+        if all_unmapped {
+            // Return the now-fully-unmapped stack VA slot to the free list
+            // so a subsequent fork can recycle it (#646). The guard page
+            // was never mapped; the loop above has just released every
+            // mapped stack page via `unmap_and_free_in_pml4`. If any unmap
+            // failed we deliberately leak the slot — recycling a slot with
+            // stale upper-half PTEs would resurrect exactly the class of
+            // bug this PR fixes.
+            task::free_stack_slot(victim.guard_base);
+            serial_println!(
+                "tasks: reaped task {} (stack VA slot {:#x}..{:#x} returned)",
+                victim.id,
+                victim.guard_base,
+                victim.guard_base + task::TASK_SLOT_SIZE
+            );
+        }
     }
 
     // Drop the Box<Task>. The Arc<RwLock<AddressSpace>> goes with it;

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -457,7 +457,14 @@ impl Task {
             "fork-trace: [Task::new_forked] ← map_range ok={}",
             map_result.is_ok()
         );
-        map_result.map_err(|_| crate::mem::addrspace::ForkError::OutOfMemory)?;
+        if map_result.is_err() {
+            // map_range failed (typically frame-allocator exhaustion).
+            // Return the just-reserved slot to the free list so a
+            // subsequent fork can recycle it; otherwise OOM under fork
+            // pressure would leak the very VA slots #646 fixes.
+            free_stack_slot(guard_base);
+            return Err(crate::mem::addrspace::ForkError::OutOfMemory);
+        }
 
         let top = stack_base + STACK_SIZE;
 

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -19,6 +19,7 @@
 //! function.
 
 use alloc::boxed::Box;
+use alloc::collections::VecDeque;
 use alloc::sync::Arc;
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
@@ -64,9 +65,60 @@ pub(super) const TASK_SLOT_SIZE: usize = GUARD_SIZE + STACK_SIZE;
 /// and below the kernel image at `0xFFFF_FFFF_8000_0000`.
 pub(super) const TASK_STACKS_VA_BASE: usize = 0xFFFF_D000_0000_0000;
 
-/// Bump allocator for task-stack VA slots. Monotonically increments;
-/// task stacks are never freed (tasks don't exit yet).
+/// Bump allocator for task-stack VA slots. Monotonically increases; the
+/// only path that consumes from this is [`alloc_stack_slot`] when the
+/// free list is empty.
 pub(super) static NEXT_STACK_VA: AtomicUsize = AtomicUsize::new(TASK_STACKS_VA_BASE);
+
+/// Free list of task-stack VA slots returned by the reaper. Populated
+/// by [`free_stack_slot`] when a task is reaped; drained by
+/// [`alloc_stack_slot`] before falling back to the bump allocator.
+///
+/// A slot reaching this list is fully unmapped — the reaper has called
+/// `unmap_and_free_in_pml4` on every stack page, and the guard page
+/// was never mapped to begin with. The next allocator can therefore
+/// re-`map_range` the stack pages without colliding with stale leaf
+/// PTEs in the shared upper-half L3 subtree.
+///
+/// `Mutex` (not `BlockingMutex`) so the allocator paths in
+/// [`Task::new_with_priority`] / [`Task::new_forked`] (which run inside
+/// the fork syscall, with kernel-level locks already held) and the
+/// reaper's [`free_stack_slot`] (which runs in task context with IRQs
+/// enabled) can both reach it without an IRQ-context audit. Contention
+/// is only meaningful at fork+reap rates, far below the 1-2 cycles
+/// where a spin-only mutex hurts.
+static FREE_STACK_SLOTS: Mutex<VecDeque<usize>> = Mutex::new(VecDeque::new());
+
+/// Reserve a task-stack VA slot. Pops the most-recently-freed slot
+/// from [`FREE_STACK_SLOTS`] when one is available (recycling keeps the
+/// working set small under fork-heavy workloads), otherwise bumps
+/// [`NEXT_STACK_VA`].
+///
+/// Returns the guard-page base (low end of the 20 KiB slot). The slot
+/// is still unmapped — callers must `paging::map_range` the stack
+/// pages before priming.
+pub(super) fn alloc_stack_slot() -> usize {
+    if let Some(slot) = FREE_STACK_SLOTS.lock().pop_front() {
+        return slot;
+    }
+    NEXT_STACK_VA.fetch_add(TASK_SLOT_SIZE, Ordering::Relaxed)
+}
+
+/// Return a task-stack VA slot to the free list. Caller must have
+/// already unmapped the slot's stack pages (the guard page was never
+/// mapped). #646: closes the per-cycle leak that the reaper used to
+/// log as `tasks: reaped task N (stack VA slot ... leaked)`.
+pub(super) fn free_stack_slot(guard_base: usize) {
+    debug_assert!(
+        guard_base >= TASK_STACKS_VA_BASE,
+        "free_stack_slot: VA below TASK_STACKS_VA_BASE"
+    );
+    debug_assert!(
+        (guard_base - TASK_STACKS_VA_BASE) % TASK_SLOT_SIZE == 0,
+        "free_stack_slot: VA not slot-aligned"
+    );
+    FREE_STACK_SLOTS.lock().push_front(guard_base);
+}
 
 /// Sequential task IDs. 0 is reserved for the bootstrap task.
 static NEXT_TASK_ID: AtomicUsize = AtomicUsize::new(1);
@@ -239,8 +291,9 @@ impl Task {
     ///   ^ saved rsp (initial)
     /// ```
     pub fn new_with_priority(entry: fn() -> !, priority: u8) -> Self {
-        // Bump-allocate a fresh VA slot.
-        let slot_va = NEXT_STACK_VA.fetch_add(TASK_SLOT_SIZE, Ordering::Relaxed);
+        // Reserve a fresh VA slot — recycles a freed slot if one is
+        // available, otherwise bumps `NEXT_STACK_VA`.
+        let slot_va = alloc_stack_slot();
         let guard_base = slot_va;
         let stack_base = slot_va + GUARD_SIZE;
 
@@ -370,8 +423,9 @@ impl Task {
             user_rip,
             user_rsp
         );
-        // Allocate a fresh guard+stack slot.
-        let slot_va = NEXT_STACK_VA.fetch_add(TASK_SLOT_SIZE, Ordering::Relaxed);
+        // Reserve a fresh guard+stack slot. Recycles a freed slot if
+        // one is available, otherwise bumps `NEXT_STACK_VA` (#646).
+        let slot_va = alloc_stack_slot();
         let guard_base = slot_va;
         let stack_base = slot_va + GUARD_SIZE;
         crate::fork_trace!(
@@ -471,5 +525,51 @@ impl Task {
             // shared INIT_KERNEL_STACK. Use the top of this task's kernel stack.
             syscall_stack_top: (stack_base + STACK_SIZE) as u64,
         })
+    }
+}
+
+#[cfg(test)]
+mod stack_slot_tests {
+    use super::*;
+
+    /// Single test covers both #646 invariants: freed slots are
+    /// recycled in LIFO order before the bump allocator advances, and
+    /// the bump fallback produces monotonically increasing,
+    /// slot-aligned bases when the free list is empty.
+    ///
+    /// Combined into one test on purpose — `NEXT_STACK_VA` and
+    /// `FREE_STACK_SLOTS` are process-global, so two `#[test]` fns
+    /// running in parallel would race on the same allocator state and
+    /// flake intermittently.
+    #[test]
+    fn free_list_recycle_then_bump_fallback() {
+        // Drain anything that earlier `Task::new_*` calls might have
+        // queued so the assertions below don't trip on stale state.
+        while FREE_STACK_SLOTS.lock().pop_front().is_some() {}
+
+        // Free list path: a slot we just freed must come straight back
+        // out of `alloc_stack_slot`, ahead of any bump.
+        let probe = TASK_STACKS_VA_BASE + TASK_SLOT_SIZE * 1_000_000;
+        free_stack_slot(probe);
+        let recycled = alloc_stack_slot();
+        assert_eq!(
+            recycled, probe,
+            "free list LIFO: freed slot must come back first"
+        );
+
+        // Bump path: free list now empty, so two consecutive allocs
+        // must be one slot apart and slot-aligned.
+        let a = alloc_stack_slot();
+        let b = alloc_stack_slot();
+        assert_eq!(
+            b - a,
+            TASK_SLOT_SIZE,
+            "consecutive bump allocs must be one slot apart"
+        );
+        assert_eq!(
+            (a - TASK_STACKS_VA_BASE) % TASK_SLOT_SIZE,
+            0,
+            "bump-allocated slot must be slot-aligned"
+        );
     }
 }

--- a/kernel/tests/ext2_dir_ops.rs
+++ b/kernel/tests/ext2_dir_ops.rs
@@ -29,7 +29,7 @@ use alloc::sync::{Arc, Weak};
 use alloc::vec;
 use alloc::vec::Vec;
 use core::panic::PanicInfo;
-use core::sync::atomic::AtomicBool;
+use core::sync::atomic::{AtomicBool, AtomicU32};
 
 use vibix::block::BlockDevice;
 use vibix::fs::ext2::dir;


### PR DESCRIPTION
Closes #527
Closes #646

WS-B of the #501 quality sprint. Both issues touch the task lifecycle in `kernel/src/task/`, share a blast radius (the new nightly-soak gate from #649), and turn out to be independent bugs that nonetheless had to land together so the soak could go green on a single PR.

## Summary

- `#646` — fork+exec+wait reap leaked a 20 KiB kernel-stack VA slot per cycle. Add a `FREE_STACK_SLOTS` LIFO behind the existing `NEXT_STACK_VA` bump pointer; new `alloc_stack_slot` / `free_stack_slot` helpers encapsulate the discipline; `Task::new_with_priority` and `Task::new_forked` reserve via the helpers; the reaper returns the slot after every stack page has been unmapped. Reaper diagnostic now reads `stack VA slot ... returned` instead of `... leaked`.
- `#527` — `ring3-first-fault: #PF` was firing on every healthy boot because the `#478` diagnostic latch in `page_fault` ran *before* the VMA / CoW resolver, so the canonical first-touch CoW write fault on a forked user-stack page tripped it every time. Move the `log_first_ring3_fault` call out of the handler entry and into each terminal path (RSVD panic, kernel-half-cr2 hang, kernel-task guard-page overflow, SIGSEGV delivery, final hang). Resolved faults stay silent; unrecoverable faults still surface the latch exactly once per session.
- `find_stack_overflow` previously inferred `task.id == slot_idx + 1` from the bump-only allocator. Slot recycling breaks that equivalence, so the function now returns the slot index and the two fault-handler call sites print `slot=` instead of `task=` in the overflow diagnostic.
- Host unit test exercises both `alloc_stack_slot` paths (free-list LIFO recycle, then bump fallback) in a single `#[test]` — splitting them would race on process-global allocator state under cargo's parallel test runner.

## Did #527 and #646 share a root cause?

No — they're independent. #646 was a bump-allocator-only oversight in the reaper; #527 was a misplaced diagnostic latch. Both manifested simultaneously on every boot, which made them look correlated, but the fixes don't touch the same lines.

## Test plan

- [x] `cargo xtask build` — clean
- [x] `cargo xtask test` — all host unit tests + QEMU integration tests pass (one transient `wait4_condvar_race` timeout in #619's known-flake list, retry was clean)
- [x] `cargo xtask smoke` — all 41 markers present, 5/5 consecutive runs clean of both `ring3-first-fault` and `leaked` lines
- [x] `cargo fmt --all` — applied
- [x] `cargo xtask run` — `init: fork+exec+wait ok` followed by `stack VA slot ... returned` (was `leaked`); no `ring3-first-fault` line at all
