### PR TITLE
sched: add HwClock/HwIrq adapters and env() accessor (#666)

### DIFF
--- a/kernel/src/arch/mod.rs
+++ b/kernel/src/arch/mod.rs
@@ -5,3 +5,14 @@ pub mod x86_64;
 pub use x86_64::backtrace;
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::{init, init_apic};
+
+/// Acknowledge the timer IRQ that drove the current scheduler tick.
+///
+/// Arch-level shim so that scheduler/seam adapters (`task::env::HwIrq`)
+/// don't reach into x86-specific modules. Today: forwards to the LAPIC
+/// EOI write; on a future legacy-PIC fallback or non-x86 port the
+/// PIC/IOAPIC policy stays centralized here.
+#[cfg(target_arch = "x86_64")]
+pub fn ack_timer_irq() {
+    x86_64::apic::lapic_eoi();
+}

--- a/kernel/src/task/env.rs
+++ b/kernel/src/task/env.rs
@@ -139,3 +139,70 @@ pub trait IrqSource: Sync {
     /// PIC EOI. Called from the timer ISR — must be IRQ-safe.
     fn ack_timer(&self);
 }
+
+// ---------------------------------------------------------------------------
+// Production adapters (Phase 1 wave 2, issue #666).
+//
+// Zero-sized wrappers over the existing `crate::time::*` and
+// `crate::arch::*` globals. Each method is a pure forwarding call so
+// the equivalence audit is mechanical: `HwClock::now()` is exactly
+// `crate::time::ticks()` boxed into a `Tick`, etc. No added
+// synchronization (no `Once`, `Mutex`, or atomic load) sits between a
+// caller and the underlying global — the `static` adapter values are
+// `'static` ZSTs and `env()` is a const-shaped function returning two
+// references.
+//
+// `HwIrq` and `env()` depend on `crate::arch::*` and so are gated to
+// `target_os = "none"` builds; the trait definitions above stay
+// host-buildable for the future `MockClock` / `MockIrqSource`
+// (issue #668).
+// ---------------------------------------------------------------------------
+
+/// Production `Clock` over the PIT tick counter and the
+/// `crate::time::WAKEUPS` deadline map.
+pub struct HwClock;
+
+impl Clock for HwClock {
+    fn now(&self) -> Tick {
+        Tick(crate::time::ticks())
+    }
+
+    fn drain_expired(&self, now: Tick) -> Vec<TaskId> {
+        crate::time::drain_expired(now.0)
+    }
+
+    fn enqueue_wakeup(&self, deadline: Tick, id: TaskId) {
+        crate::time::enqueue_wakeup(deadline.0, id);
+    }
+}
+
+/// Production `IrqSource` over the LAPIC end-of-interrupt path.
+#[cfg(target_os = "none")]
+pub struct HwIrq;
+
+#[cfg(target_os = "none")]
+impl IrqSource for HwIrq {
+    fn ack_timer(&self) {
+        crate::arch::x86_64::apic::lapic_eoi();
+    }
+}
+
+/// Singleton `HwClock` handed out by [`env`].
+pub static HW_CLOCK: HwClock = HwClock;
+
+/// Singleton `HwIrq` handed out by [`env`].
+#[cfg(target_os = "none")]
+pub static HW_IRQ: HwIrq = HwIrq;
+
+/// Production wire-up of the scheduler / IRQ seam.
+///
+/// Returns the singleton `Clock` + `IrqSource` pair that the scheduler
+/// and the timer ISR will route through once issue #667 migrates the
+/// callers. Body is intentionally a single tuple of two `&'static`
+/// references — no `Once`, no `Mutex`, no atomic load — so that the
+/// production path adds zero synchronization vs. the pre-seam direct
+/// calls (RFC 0005 Equivalence condition 2).
+#[cfg(target_os = "none")]
+pub fn env() -> (&'static dyn Clock, &'static dyn IrqSource) {
+    (&HW_CLOCK, &HW_IRQ)
+}

--- a/kernel/src/task/env.rs
+++ b/kernel/src/task/env.rs
@@ -183,7 +183,7 @@ pub struct HwIrq;
 #[cfg(target_os = "none")]
 impl IrqSource for HwIrq {
     fn ack_timer(&self) {
-        crate::arch::x86_64::apic::lapic_eoi();
+        crate::arch::ack_timer_irq();
     }
 }
 

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -86,6 +86,25 @@ static REAPER_WQ: WaitQueue = WaitQueue::new();
 /// Install the bootstrap task wrapping the currently-running thread.
 /// Must be called exactly once, before any [`spawn`].
 pub fn init() {
+    // Confirm the production seam wire-up is reachable before any
+    // scheduler dispatch (RFC 0005 §Security A1). `env()` must hand
+    // back the `HwClock` / `HwIrq` singletons — the same `&'static`
+    // addresses as `&env::HW_CLOCK` / `&env::HW_IRQ`. Pointer-equality
+    // on the trait-object data pointers catches any accidental rewire
+    // to a different impl. Cheap enough to keep in non-debug too, but
+    // `debug_assert!` matches the rest of `task::init`'s invariant
+    // checks.
+    debug_assert!({
+        let (clock, irq) = env::env();
+        core::ptr::eq(
+            clock as *const _ as *const (),
+            &env::HW_CLOCK as *const _ as *const (),
+        ) && core::ptr::eq(
+            irq as *const _ as *const (),
+            &env::HW_IRQ as *const _ as *const (),
+        )
+    });
+
     let mut sched = SCHED.lock();
     assert!(sched.current.is_none(), "task::init called twice");
     sched.current = Some(Box::new(Task::bootstrap()));

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -88,21 +88,17 @@ static REAPER_WQ: WaitQueue = WaitQueue::new();
 pub fn init() {
     // Confirm the production seam wire-up is reachable before any
     // scheduler dispatch (RFC 0005 §Security A1). `env()` must hand
-    // back the `HwClock` / `HwIrq` singletons — the same `&'static`
-    // addresses as `&env::HW_CLOCK` / `&env::HW_IRQ`. Pointer-equality
-    // on the trait-object data pointers catches any accidental rewire
-    // to a different impl. Cheap enough to keep in non-debug too, but
-    // `debug_assert!` matches the rest of `task::init`'s invariant
-    // checks.
+    // back the `HwClock` / `HwIrq` singletons. We compare the trait
+    // object references directly — `core::ptr::eq` on `&dyn Trait`
+    // compares both the data pointer and the vtable pointer, so two
+    // ZST adapters that happened to share a data address but had
+    // different impls would still fail. Casting through `*const ()`
+    // would silently lose the vtable half of the identity check.
     debug_assert!({
         let (clock, irq) = env::env();
-        core::ptr::eq(
-            clock as *const _ as *const (),
-            &env::HW_CLOCK as *const _ as *const (),
-        ) && core::ptr::eq(
-            irq as *const _ as *const (),
-            &env::HW_IRQ as *const _ as *const (),
-        )
+        let hw_clock: &dyn env::Clock = &env::HW_CLOCK;
+        let hw_irq: &dyn env::IrqSource = &env::HW_IRQ;
+        core::ptr::eq(clock, hw_clock) && core::ptr::eq(irq, hw_irq)
     });
 
     let mut sched = SCHED.lock();


### PR DESCRIPTION
## Summary

Closes #666. Phase 1 wave 2 of [RFC 0005](docs/RFC/0005-scheduler-irq-seam.md), building on the trait definitions merged in #672 (#665).

- Adds zero-sized `HwClock` adapter forwarding `Clock` methods to `crate::time::{ticks, drain_expired, enqueue_wakeup}` (one statement each — Equivalence condition 1, pure forwarding).
- Adds zero-sized `HwIrq` adapter (target_os = "none") forwarding `ack_timer` to `crate::arch::x86_64::apic::lapic_eoi`.
- Adds `static HW_CLOCK` / `static HW_IRQ` singletons and `pub fn env() -> (&'static dyn Clock, &'static dyn IrqSource)` returning them as a literal tuple — no `Once`, `Mutex`, or atomic load (Equivalence condition 2, no added synchronization).
- Adds a `debug_assert!` in `task::init()` checking `env()` hands back the production singletons before first scheduler dispatch (Security A1).

No callers migrate here — `env()` is reachable but the scheduler still calls `crate::time::*` and the timer ISR still calls `notify_eoi` directly. #667 plumbs the seam through callers; #668 adds the mocks.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo xtask build` (target `x86_64-unknown-none`) — clean
- [x] `cargo build -p vibix --lib` (host) — clean
- [x] `cargo xtask test` — 518 passed; 0 failed
- [x] Behavioral no-op: env() defined but unused, so QEMU serial-log diff vs. pre-seam main expected to be byte-identical (CI gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)