### PR TITLE
test: userspace shell-pipeline integration test (echo | cat | wc -c)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,6 +275,46 @@ jobs:
           path: target/debugcon.log
           if-no-files-found: ignore
 
+  # Issue #462: end-to-end shell-pipeline integration test. Boots the
+  # `userspace_shell_pipeline` binary as PID 1 and asserts the
+  # `SHELL_PIPELINE_OK: 4` marker on serial. Exercises pipe2 + fork +
+  # dup2 + close + read/write + wait4 against RFC 0003.
+  shell-pipeline:
+    name: shell-pipeline integration test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y --no-install-recommends \
+            qemu-system-x86 xorriso build-essential
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: nightly
+          components: rust-src, llvm-tools, rustfmt, clippy
+          targets: x86_64-unknown-none
+
+      - name: Cache cargo + limine
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+            build/limine
+          key: ${{ runner.os }}-cargo-shell-pipeline-${{ hashFiles('**/Cargo.lock', 'xtask/src/main.rs') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-shell-pipeline-
+            ${{ runner.os }}-cargo-
+
+      - name: cargo xtask shell-pipeline
+        run: cargo xtask shell-pipeline
+
   # RFC 0004 Workstream G P2 (#582): run the vendored pjdfstest harness
   # (#580 + #581) and fail if the emitted
   # `target/pjdfstest-results.json` diverges from the committed baseline

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "userspace/init",
     "userspace/pjdfstest_runner",
     "userspace/repro_fork",
+    "userspace/shell_pipeline",
 ]
 # tests/pjdfstest is a vendored copy of saidsay-so/pjdfstest (2-clause BSD). It
 # is intentionally kept outside the workspace until #581 wires it into xtask —

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -638,10 +638,26 @@ pub unsafe extern "C" fn syscall_dispatch(
             // own SyscallReturnContext on the kernel stack. Per-task by
             // construction: no cross-task races vs. the old FORK_USER_*
             // globals (issue #504).
-            let user_rip = (*ctx).user_rip;
-            let user_rflags = (*ctx).user_rflags;
-            let user_rsp = (*ctx).user_rsp;
-
+            //
+            // The full GPR set (including SysV callee-saved rbx/rbp/r12-r15)
+            // is published into the child via ForkUserRegs — see #690.
+            let regs = crate::fork_abi::ForkUserRegs {
+                user_rip: (*ctx).user_rip,
+                user_rflags: (*ctx).user_rflags,
+                user_rsp: (*ctx).user_rsp,
+                user_rdi: (*ctx).user_rdi,
+                user_rsi: (*ctx).user_rsi,
+                user_rdx: (*ctx).user_rdx,
+                user_r10: (*ctx).user_r10,
+                user_r8: (*ctx).user_r8,
+                user_r9: (*ctx).user_r9,
+                user_rbx: (*ctx).user_rbx,
+                user_rbp: (*ctx).user_rbp,
+                user_r12: (*ctx).user_r12,
+                user_r13: (*ctx).user_r13,
+                user_r14: (*ctx).user_r14,
+                user_r15: (*ctx).user_r15,
+            };
             // #502 probe: dump the current RFLAGS at fork-dispatch entry.
             // Expected: IF (bit 9) = 0, masked by MSR_FMASK's IF bit on
             // SYSCALL entry. If IF is ever observed = 1 here, FMASK
@@ -654,9 +670,9 @@ pub unsafe extern "C" fn syscall_dispatch(
                     "fork-trace: [syscall:FORK enter] parent_task={} user_rip={:#x} \
                      user_rflags={:#x} user_rsp={:#x} kernel_rflags={:#x} IF={}",
                     crate::task::current_id(),
-                    user_rip,
-                    user_rflags,
-                    user_rsp,
+                    regs.user_rip,
+                    regs.user_rflags,
+                    regs.user_rsp,
                     rflags_now,
                     (rflags_now >> 9) & 1,
                 );
@@ -673,22 +689,21 @@ pub unsafe extern "C" fn syscall_dispatch(
             }
 
             crate::fork_trace!("fork-trace: [syscall:FORK] → fork_current_task()");
-            let child_task_id =
-                match crate::task::fork_current_task(user_rip, user_rflags, user_rsp) {
-                    Ok(id) => {
-                        crate::fork_trace!(
-                            "fork-trace: [syscall:FORK] ← fork_current_task() child_task_id={}",
-                            id
-                        );
+            let child_task_id = match crate::task::fork_current_task(&regs) {
+                Ok(id) => {
+                    crate::fork_trace!(
+                        "fork-trace: [syscall:FORK] ← fork_current_task() child_task_id={}",
                         id
-                    }
-                    Err(_) => {
-                        crate::fork_trace!(
-                            "fork-trace: [syscall:FORK] ← fork_current_task() ERR=ENOMEM"
-                        );
-                        return -12; // ENOMEM
-                    }
-                };
+                    );
+                    id
+                }
+                Err(_) => {
+                    crate::fork_trace!(
+                        "fork-trace: [syscall:FORK] ← fork_current_task() ERR=ENOMEM"
+                    );
+                    return -12; // ENOMEM
+                }
+            };
             crate::fork_trace!(
                 "fork-trace: [syscall:FORK] → process::register(task_id={}, parent_pid={})",
                 child_task_id,
@@ -1552,6 +1567,24 @@ syscall_entry:
     // 3. Save return-to-user context on the kernel stack (high→low
     //    address so the struct at rsp is laid out as in
     //    `SyscallReturnContext`).
+    //
+    //    Callee-saved set first (highest addresses of the struct): #690
+    //    requires we publish the parent's full SysV callee-saved GPRs
+    //    through to the fork child. Saving them here (rather than only
+    //    in the FORK arm) keeps SyscallReturnContext a uniform snapshot
+    //    of "what user registers were live at SYSCALL entry" — useful
+    //    for any future syscall that needs to mint a thread/coroutine
+    //    starting from the caller's full register file (e.g. clone()).
+    //    Cost is 6 extra pushes per syscall on the hottest path; SysV
+    //    treats these as caller-preserved at function-call boundaries
+    //    so dispatch's C code already neither reads nor depends on
+    //    their preserved values across the call into syscall_dispatch.
+    push r15
+    push r14
+    push r13
+    push r12
+    push rbp
+    push rbx
     push [rip + {syscall_scratch_rsp}]  // user RSP (stashed above)
     push r11                             // user RFLAGS (SYSRETQ restores from r11)
     push rcx                             // user RIP    (SYSRETQ jumps to rcx)
@@ -1563,6 +1596,8 @@ syscall_entry:
     //       [rsp+0]=rax [+8]=rdi [+16]=rsi [+24]=rdx
     //       [+32]=r10 [+40]=r8 [+48]=r9
     //       [+56]=user_rip [+64]=user_rflags [+72]=user_rsp
+    //       [+80]=user_rbx [+88]=user_rbp
+    //       [+96]=user_r12 [+104]=user_r13 [+112]=user_r14 [+120]=user_r15
     //     These slots are adjacent to the rip/rflags/rsp frame above so a
     //     single pointer (rsp) addresses the whole `SyscallReturnContext`.
     //     The FORK and SIGRETURN handlers read/write their own saved
@@ -1594,8 +1629,8 @@ syscall_entry:
     //      a5:  r9        → [rsp+8] (arg7)   — spilled before clobber
     //
     //    SysV requires rsp to be 16-byte aligned immediately before the
-    //    CALL instruction. The 3+7 preceding pushes leave rsp at
-    //    (top-80) — already 0 mod 16. Reserving two 8-byte slots for
+    //    CALL instruction. The 6+3+7 preceding pushes leave rsp at
+    //    (top-128) — already 0 mod 16. Reserving two 8-byte slots for
     //    arg6 and arg7 keeps rsp 0 mod 16 when the CALL executes.
     //
     //    ctx-pointer capture: the SyscallReturnContext is at the *current*
@@ -1626,8 +1661,8 @@ syscall_entry:
     //     rewritten) return value in rax, which becomes the value
     //     SYSRETQ delivers.
     //
-    //     Stack is at top-80 (3+7 = 10 pushes), already 0 mod 16 — no
-    //     extra alignment is needed for this CALL.
+    //     Stack is at top-128 (6+3+7 = 16 pushes), already 0 mod 16 —
+    //     no extra alignment is needed for this CALL.
     mov rdi, rsp        // ctx → arg0
     mov rsi, rax        // rv → arg1
     call check_and_deliver_signals
@@ -1658,6 +1693,16 @@ syscall_entry:
 3:
     pop rcx           // user RIP  → rcx  (for SYSRETQ)
     pop r11           // user RFLAGS → r11 (for SYSRETQ)
+    // rsp now points at the user_rsp slot. The 6 callee-saved slots
+    // (rbx, rbp, r12-r15) sit immediately above it. Load them via mov
+    // rather than pop so we can defer abandoning the kernel stack
+    // until the very last instruction before SYSRETQ.
+    mov rbx, [rsp + 8]   // user rbx
+    mov rbp, [rsp + 16]  // user rbp
+    mov r12, [rsp + 24]  // user r12
+    mov r13, [rsp + 32]  // user r13
+    mov r14, [rsp + 40]  // user r14
+    mov r15, [rsp + 48]  // user r15
     pop rsp           // user RSP  → rsp  (return to user stack)
 
     // 7. Return to ring-3.

--- a/kernel/src/fork_abi.rs
+++ b/kernel/src/fork_abi.rs
@@ -1,34 +1,88 @@
 //! Fork ABI helpers — pure layout logic, host-testable.
 //!
 //! The fork child's first context switch must resume into the SYSRET
-//! trampoline with the parent's captured user-mode register context in
-//! the callee-saved GPRs that the trampoline consumes. The stack-frame
-//! layout is fiddly enough that we want host unit-test coverage of the
-//! slot math; this module factors it out of `task::Task::new_forked` so
-//! the test doesn't need a live kernel stack.
+//! trampoline with the parent's full captured user-mode register set
+//! restored — see #690 for why "full" matters: SysV treats `rbx`, `rbp`,
+//! `r12`–`r15` as callee-saved across function calls, so any userspace
+//! local the compiler holds in one of these across `sys_fork()` must
+//! survive the syscall in the child too. The kernel cannot rely on
+//! "callee-saved means we leave them alone": the child's first dispatch
+//! into ring-3 happens via `fork_child_sysret`, not a paired ret with
+//! the parent, so we have to publish the parent's values explicitly.
 //!
-//! The layout written by [`prime_fork_child_stack`] matches the pop
-//! sequence at the tail of `context_switch`. The subsequent `ret`
-//! jumps into `fork_child_sysret`, which reads the same callee-saved
-//! registers — just loaded from these stack slots — via `mov` (not
-//! `pop`) and builds the SYSRETQ state from them:
+//! The stack-frame layout is fiddly enough that we want host unit-test
+//! coverage of the slot math; this module factors it out of
+//! `task::Task::new_forked` so the test doesn't need a live kernel
+//! stack.
+//!
+//! The layout written by [`prime_fork_child_stack`] matches:
+//!   1. The pop sequence at the tail of `context_switch` (which loads
+//!      rbx/rbp/r12-r15 directly with their final user values).
+//!   2. The `mov`/`pop` sequence at the head of `fork_child_sysret`,
+//!      which loads rcx/r11 (RIP/RFLAGS for SYSRETQ), the syscall-arg
+//!      registers (rdi/rsi/rdx/r10/r8/r9 — though by SysV they aren't
+//!      callee-saved, restoring them lets a userspace fork wrapper
+//!      observe a deterministic register state in both parent and
+//!      child paths), and finally rsp.
+//!
+//! Stack layout (low addr → high; `rsp` after context_switch's `ret`
+//! pops the trampoline address points at user_rip slot):
 //!
 //! ```text
-//!   rsp+0x00  r15 = 0                 ← context_switch: pop r15
-//!   rsp+0x08  r14 = 0                 ← context_switch: pop r14
-//!   rsp+0x10  r13 = 0                 ← context_switch: pop r13
-//!   rsp+0x18  r12 = user_rip          ← context_switch: pop r12
-//!                                       fork_child_sysret: mov rcx, r12
-//!   rsp+0x20  rbp = user_rsp          ← context_switch: pop rbp
-//!                                       fork_child_sysret: mov rsp, rbp
-//!   rsp+0x28  rbx = user_rflags       ← context_switch: pop rbx
-//!                                       fork_child_sysret: mov r11, rbx
+//!   rsp+0x00  r15 = user_r15          ← context_switch: pop r15
+//!   rsp+0x08  r14 = user_r14          ← context_switch: pop r14
+//!   rsp+0x10  r13 = user_r13          ← context_switch: pop r13
+//!   rsp+0x18  r12 = user_r12          ← context_switch: pop r12
+//!   rsp+0x20  rbp = user_rbp          ← context_switch: pop rbp
+//!   rsp+0x28  rbx = user_rbx          ← context_switch: pop rbx
 //!   rsp+0x30  ret = fork_child_sysret ← context_switch: ret
+//!   rsp+0x38  user_rip                \   fork_child_sysret reads
+//!   rsp+0x40  user_rflags             |   these to build the SYSRETQ
+//!   rsp+0x48  user_rsp                |   state plus the user
+//!   rsp+0x50  user_rdi                |   syscall-arg registers, then
+//!   rsp+0x58  user_rsi                |   issues SYSRETQ.
+//!   rsp+0x60  user_rdx                |
+//!   rsp+0x68  user_r10                |
+//!   rsp+0x70  user_r8                 |
+//!   rsp+0x78  user_r9                 /
 //! ```
 //!
 //! See issue #504 — replacing `FORK_USER_*` globals with per-task
-//! state means we stash the user context in these callee-saved slots
-//! at fork time rather than publishing it via cross-CPU atomics.
+//! state means we stash the user context in these slots at fork time
+//! rather than publishing it via cross-CPU atomics. Issue #690
+//! extended the slot set from the original 3 (rip, rsp, rflags) +
+//! placeholders to the full 13-GPR set (callee-saved + arg regs).
+
+/// Snapshot of every user GPR the FORK syscall path needs to publish
+/// to the child. Bundled as a single struct so the priming function
+/// signature stays readable at the call site (and so adding more
+/// registers later — e.g. for clone3-style thread spawn — is a single
+/// edit).
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ForkUserRegs {
+    pub user_rip: u64,
+    pub user_rflags: u64,
+    pub user_rsp: u64,
+    pub user_rdi: u64,
+    pub user_rsi: u64,
+    pub user_rdx: u64,
+    pub user_r10: u64,
+    pub user_r8: u64,
+    pub user_r9: u64,
+    pub user_rbx: u64,
+    pub user_rbp: u64,
+    pub user_r12: u64,
+    pub user_r13: u64,
+    pub user_r14: u64,
+    pub user_r15: u64,
+}
+
+/// Total bytes of stack consumed by [`prime_fork_child_stack`].
+///
+/// 7 qwords for the `context_switch` callee-saved frame + return slot,
+/// plus 9 qwords for the user GPRs `fork_child_sysret` consumes
+/// (3 SYSRETQ regs + 6 arg regs).
+pub const FORK_PRIME_BYTES: usize = (7 + 9) * 8;
 
 /// Populate the top of a freshly-mapped kernel stack for a forked
 /// child so the first `context_switch` into it returns through
@@ -40,27 +94,36 @@
 ///
 /// # Safety
 /// - `top` must point one byte past the end of a writable region of
-///   at least 56 bytes (7 × 8 bytes) that is owned exclusively by
-///   the new task.
+///   at least [`FORK_PRIME_BYTES`] that is owned exclusively by the
+///   new task.
 /// - `fork_child_sysret_addr` must be the address of a trampoline
-///   matching the pop sequence documented above.
+///   matching the documented layout above.
 #[inline]
 pub unsafe fn prime_fork_child_stack(
     top: usize,
-    user_rip: u64,
-    user_rflags: u64,
-    user_rsp: u64,
+    regs: &ForkUserRegs,
     fork_child_sysret_addr: usize,
 ) -> usize {
-    let rsp = top - 7 * 8;
+    let rsp = top - FORK_PRIME_BYTES;
     let slots = rsp as *mut usize;
-    slots.add(0).write(0); // r15
-    slots.add(1).write(0); // r14
-    slots.add(2).write(0); // r13
-    slots.add(3).write(user_rip as usize); // r12 → rcx
-    slots.add(4).write(user_rsp as usize); // rbp → rsp
-    slots.add(5).write(user_rflags as usize); // rbx → r11
-    slots.add(6).write(fork_child_sysret_addr); // ret
+    // context_switch pops these in low→high order
+    slots.add(0).write(regs.user_r15 as usize); // pop r15
+    slots.add(1).write(regs.user_r14 as usize); // pop r14
+    slots.add(2).write(regs.user_r13 as usize); // pop r13
+    slots.add(3).write(regs.user_r12 as usize); // pop r12
+    slots.add(4).write(regs.user_rbp as usize); // pop rbp
+    slots.add(5).write(regs.user_rbx as usize); // pop rbx
+    slots.add(6).write(fork_child_sysret_addr); // ret → fork_child_sysret
+                                                // fork_child_sysret consumes these via pop / [rsp+N] mov (see asm)
+    slots.add(7).write(regs.user_rip as usize); // → rcx (SYSRETQ RIP)
+    slots.add(8).write(regs.user_rflags as usize); // → r11 (SYSRETQ RFLAGS)
+    slots.add(9).write(regs.user_rsp as usize); // → rsp (SYSRETQ user RSP)
+    slots.add(10).write(regs.user_rdi as usize); // → rdi
+    slots.add(11).write(regs.user_rsi as usize); // → rsi
+    slots.add(12).write(regs.user_rdx as usize); // → rdx
+    slots.add(13).write(regs.user_r10 as usize); // → r10
+    slots.add(14).write(regs.user_r8 as usize); // → r8
+    slots.add(15).write(regs.user_r9 as usize); // → r9
     rsp
 }
 
@@ -68,51 +131,68 @@ pub unsafe fn prime_fork_child_stack(
 mod tests {
     use super::*;
 
+    fn sample_regs() -> ForkUserRegs {
+        ForkUserRegs {
+            user_rip: 0xDEAD_BEEF_1234_5678,
+            user_rflags: 0x0000_0000_0000_0202,
+            user_rsp: 0x0000_7FFF_C0DE_0000,
+            user_rdi: 0x1111_1111_1111_1111,
+            user_rsi: 0x2222_2222_2222_2222,
+            user_rdx: 0x3333_3333_3333_3333,
+            user_r10: 0xAAAA_AAAA_AAAA_AAAA,
+            user_r8: 0x8888_8888_8888_8888,
+            user_r9: 0x9999_9999_9999_9999,
+            user_rbx: 0xBBBB_BBBB_BBBB_BBBB,
+            user_rbp: 0xBDBD_BDBD_BDBD_BDBD,
+            user_r12: 0xC0C0_C0C0_C0C0_C0C0,
+            user_r13: 0xD0D0_D0D0_D0D0_D0D0,
+            user_r14: 0xE0E0_E0E0_E0E0_E0E0,
+            user_r15: 0xF0F0_F0F0_F0F0_F0F0,
+        }
+    }
+
     /// Verify every slot lands at the documented offset and carries the
     /// value the SYSRET trampoline expects. This guards against anyone
     /// silently re-ordering the `pop` sequence in `context_switch` /
     /// `fork_child_sysret` without updating the prime layout.
     #[test]
     fn prime_fork_child_stack_lays_out_sysret_regs_in_callee_save_slots() {
-        // 16-byte aligned backing store; stack top is `buf + len`.
-        let mut buf = [0usize; 16];
+        // Backing store sized for the full prime frame; stack top is
+        // `buf + len`.
+        let mut buf = [0usize; 32];
         let top = unsafe { buf.as_mut_ptr().add(buf.len()) } as usize;
 
-        let user_rip: u64 = 0xDEAD_BEEF_1234_5678;
-        let user_rflags: u64 = 0x0000_0000_0000_0202;
-        let user_rsp: u64 = 0x0000_7FFF_C0DE_0000;
+        let regs = sample_regs();
         let sysret_addr: usize = 0x0000_FFFF_FACE_B00C;
 
-        let rsp =
-            unsafe { prime_fork_child_stack(top, user_rip, user_rflags, user_rsp, sysret_addr) };
+        let rsp = unsafe { prime_fork_child_stack(top, &regs, sysret_addr) };
 
-        assert_eq!(rsp, top - 7 * 8, "rsp must leave 7 qwords on the stack");
+        assert_eq!(
+            rsp,
+            top - FORK_PRIME_BYTES,
+            "rsp must leave FORK_PRIME_BYTES on the stack"
+        );
 
         let slots = rsp as *const usize;
         unsafe {
-            assert_eq!(*slots.add(0), 0, "r15 must be zeroed");
-            assert_eq!(*slots.add(1), 0, "r14 must be zeroed");
-            assert_eq!(*slots.add(2), 0, "r13 must be zeroed");
-            assert_eq!(
-                *slots.add(3),
-                user_rip as usize,
-                "r12 slot carries user_rip → rcx"
-            );
-            assert_eq!(
-                *slots.add(4),
-                user_rsp as usize,
-                "rbp slot carries user_rsp → rsp"
-            );
-            assert_eq!(
-                *slots.add(5),
-                user_rflags as usize,
-                "rbx slot carries user_rflags → r11"
-            );
-            assert_eq!(
-                *slots.add(6),
-                sysret_addr,
-                "return slot must be fork_child_sysret"
-            );
+            // context_switch pop slots
+            assert_eq!(*slots.add(0), regs.user_r15 as usize, "r15 slot");
+            assert_eq!(*slots.add(1), regs.user_r14 as usize, "r14 slot");
+            assert_eq!(*slots.add(2), regs.user_r13 as usize, "r13 slot");
+            assert_eq!(*slots.add(3), regs.user_r12 as usize, "r12 slot");
+            assert_eq!(*slots.add(4), regs.user_rbp as usize, "rbp slot");
+            assert_eq!(*slots.add(5), regs.user_rbx as usize, "rbx slot");
+            assert_eq!(*slots.add(6), sysret_addr, "ret slot");
+            // fork_child_sysret consumes these
+            assert_eq!(*slots.add(7), regs.user_rip as usize, "user_rip slot");
+            assert_eq!(*slots.add(8), regs.user_rflags as usize, "user_rflags slot");
+            assert_eq!(*slots.add(9), regs.user_rsp as usize, "user_rsp slot");
+            assert_eq!(*slots.add(10), regs.user_rdi as usize, "user_rdi slot");
+            assert_eq!(*slots.add(11), regs.user_rsi as usize, "user_rsi slot");
+            assert_eq!(*slots.add(12), regs.user_rdx as usize, "user_rdx slot");
+            assert_eq!(*slots.add(13), regs.user_r10 as usize, "user_r10 slot");
+            assert_eq!(*slots.add(14), regs.user_r8 as usize, "user_r8 slot");
+            assert_eq!(*slots.add(15), regs.user_r9 as usize, "user_r9 slot");
         }
     }
 
@@ -121,33 +201,43 @@ mod tests {
     /// This is the regression test for #504: with the old global-atomic
     /// design, a concurrent second fork on another CPU could clobber
     /// FORK_USER_* between entry and the child's SYSRET. Here we
-    /// demonstrate both stacks retain independent values.
+    /// demonstrate both stacks retain independent values across the
+    /// extended #690 slot set too.
     #[test]
     fn prime_fork_child_stack_isolated_across_concurrent_children() {
-        let mut buf_a = [0usize; 16];
-        let mut buf_b = [0usize; 16];
+        let mut buf_a = [0usize; 32];
+        let mut buf_b = [0usize; 32];
 
         let top_a = unsafe { buf_a.as_mut_ptr().add(buf_a.len()) } as usize;
         let top_b = unsafe { buf_b.as_mut_ptr().add(buf_b.len()) } as usize;
 
-        let rsp_a =
-            unsafe { prime_fork_child_stack(top_a, 0x1111_1111, 0x202, 0xAAAA_AAAA, 0xF00D_F00D) };
-        let rsp_b =
-            unsafe { prime_fork_child_stack(top_b, 0x2222_2222, 0x246, 0xBBBB_BBBB, 0xF00D_F00D) };
+        let mut a_regs = sample_regs();
+        a_regs.user_rip = 0x1111_1111;
+        a_regs.user_rsp = 0xAAAA_AAAA;
+        a_regs.user_rbx = 0xA1A1_A1A1;
+        a_regs.user_r15 = 0xAFAF_AFAF;
+
+        let mut b_regs = sample_regs();
+        b_regs.user_rip = 0x2222_2222;
+        b_regs.user_rsp = 0xBBBB_BBBB;
+        b_regs.user_rbx = 0xB1B1_B1B1;
+        b_regs.user_r15 = 0xBFBF_BFBF;
+
+        let rsp_a = unsafe { prime_fork_child_stack(top_a, &a_regs, 0xF00D_F00D) };
+        let rsp_b = unsafe { prime_fork_child_stack(top_b, &b_regs, 0xF00D_F00D) };
 
         let a = rsp_a as *const usize;
         let b = rsp_b as *const usize;
 
         unsafe {
-            // r12 = user_rip
-            assert_eq!(*a.add(3), 0x1111_1111);
-            assert_eq!(*b.add(3), 0x2222_2222);
-            // rbp = user_rsp
-            assert_eq!(*a.add(4), 0xAAAA_AAAA);
-            assert_eq!(*b.add(4), 0xBBBB_BBBB);
-            // rbx = user_rflags
-            assert_eq!(*a.add(5), 0x202);
-            assert_eq!(*b.add(5), 0x246);
+            assert_eq!(*a.add(0), 0xAFAF_AFAF, "child A r15 slot");
+            assert_eq!(*b.add(0), 0xBFBF_BFBF, "child B r15 slot");
+            assert_eq!(*a.add(5), 0xA1A1_A1A1, "child A rbx slot");
+            assert_eq!(*b.add(5), 0xB1B1_B1B1, "child B rbx slot");
+            assert_eq!(*a.add(7), 0x1111_1111, "child A user_rip slot");
+            assert_eq!(*b.add(7), 0x2222_2222, "child B user_rip slot");
+            assert_eq!(*a.add(9), 0xAAAA_AAAA, "child A user_rsp slot");
+            assert_eq!(*b.add(9), 0xBBBB_BBBB, "child B user_rsp slot");
         }
     }
 }

--- a/kernel/src/signal/mod.rs
+++ b/kernel/src/signal/mod.rs
@@ -545,7 +545,23 @@ fn deliver_fault_terminate(sig: u8) -> ! {
 ///   `[rsp+56]`  = user RIP   (rcx at entry)
 ///   `[rsp+64]`  = user RFLAGS (r11 at entry)
 ///   `[rsp+72]`  = user RSP
+///   `[rsp+80]`  = saved user `rbx`  (callee-saved, #690)
+///   `[rsp+88]`  = saved user `rbp`  (callee-saved, #690)
+///   `[rsp+96]`  = saved user `r12`  (callee-saved, #690)
+///   `[rsp+104]` = saved user `r13`  (callee-saved, #690)
+///   `[rsp+112]` = saved user `r14`  (callee-saved, #690)
+///   `[rsp+120]` = saved user `r15`  (callee-saved, #690)
+///
+/// The six callee-saved slots (`rbx`, `rbp`, `r12`–`r15`) were added in
+/// #690 so the FORK syscall can publish the parent's full SysV
+/// callee-saved set into the forked child's user register state.
+/// Without these slots, `fork_child_sysret` only restored `rcx/r11/rsp`
+/// before SYSRETQ and the child resumed ring-3 with whatever the kernel
+/// happened to leave in `rbx/rbp/r12-r15` — silently corrupting any
+/// userspace local the compiler was holding in a callee-saved register
+/// across `sys_fork()`.
 #[repr(C)]
+#[derive(Default)]
 pub struct SyscallReturnContext {
     pub user_rax: u64,
     pub user_rdi: u64,
@@ -557,6 +573,12 @@ pub struct SyscallReturnContext {
     pub user_rip: u64,
     pub user_rflags: u64,
     pub user_rsp: u64,
+    pub user_rbx: u64,
+    pub user_rbp: u64,
+    pub user_r12: u64,
+    pub user_r13: u64,
+    pub user_r14: u64,
+    pub user_r15: u64,
 }
 
 /// Length of the `SYSCALL` opcode (0x0F 0x05) in bytes. Rewinding

--- a/kernel/src/task/sched_core.rs
+++ b/kernel/src/task/sched_core.rs
@@ -114,21 +114,22 @@ pub fn spawn_and_get_id(entry: fn() -> !) -> usize {
 /// allocate a new kernel stack, push the child onto the ready queue, and
 /// return the child's task ID.
 ///
-/// `user_rip`, `user_rflags`, `user_rsp` are the ring-3 register state
-/// saved by the SYSCALL entry before invoking `syscall_dispatch`.
+/// `regs` carries the ring-3 register state saved by the SYSCALL entry
+/// before invoking `syscall_dispatch` — full GPR set so the child sees
+/// the same callee-saved (rbx/rbp/r12-r15) and syscall-arg
+/// (rdi/rsi/rdx/r10/r8/r9) registers as the parent at the SYSRETQ point
+/// (#690).
 pub fn fork_current_task(
-    user_rip: u64,
-    user_rflags: u64,
-    user_rsp: u64,
+    regs: &crate::fork_abi::ForkUserRegs,
 ) -> Result<usize, crate::mem::addrspace::ForkError> {
     use alloc::sync::Arc;
     use spin::{Mutex, RwLock};
 
     crate::fork_trace!(
         "fork-trace: [fork_current_task enter] user_rip={:#x} user_rflags={:#x} user_rsp={:#x}",
-        user_rip,
-        user_rflags,
-        user_rsp
+        regs.user_rip,
+        regs.user_rflags,
+        regs.user_rsp
     );
 
     // Snapshot everything needed from the current task while holding
@@ -213,9 +214,7 @@ pub fn fork_current_task(
     crate::fork_trace!("fork-trace: [fork_current_task] → Task::new_forked()");
     let child = unsafe {
         Task::new_forked(
-            user_rip,
-            user_rflags,
-            user_rsp,
+            regs,
             parent_priority,
             parent_affinity,
             parent_fpu_ptr,

--- a/kernel/src/task/switch.rs
+++ b/kernel/src/task/switch.rs
@@ -40,11 +40,16 @@ unsafe extern "C" {
     pub fn task_entry_trampoline();
 
     /// First-entry trampoline for a fork child. Called by `context_switch`
-    /// when the child task is first scheduled. Callee-saved registers are
-    /// primed by `Task::new_forked` with the user-space context:
-    ///   r12 = user RIP  (→ rcx for SYSRETQ)
-    ///   rbp = user RSP  (→ rsp before SYSRETQ)
-    ///   rbx = user RFLAGS (→ r11 for SYSRETQ)
+    /// when the child task is first scheduled.
+    ///
+    /// Stack layout primed by `Task::new_forked` (see
+    /// `crate::fork_abi::prime_fork_child_stack`): on entry the
+    /// `context_switch` `ret` has already loaded the SysV callee-saved
+    /// registers (`rbx`, `rbp`, `r12`–`r15`) directly from the prime
+    /// frame, so they already hold the parent's user values. The
+    /// remaining 9 user GPRs (rip, rflags, rsp, rdi/rsi/rdx/r10/r8/r9)
+    /// sit at `[rsp]..[rsp+0x40]` and this trampoline pops/reads them
+    /// before issuing SYSRETQ.
     ///
     /// Returns to ring-3 with rax=0 so the child sees 0 from fork().
     pub fn fork_child_sysret();
@@ -120,11 +125,21 @@ fork_child_sysret:
     pop rdi
     pop rdx
     pop rax
-    // Standard fork-child SYSRETQ tail:
-    mov rcx, r12
-    mov r11, rbx
-    xor eax, eax
-    mov rsp, rbp
+    // Standard fork-child SYSRETQ tail (#690): pop the 9 user GPRs
+    // primed below the context_switch frame, then SYSRETQ. rbx/rbp/r12-r15
+    // already hold their user values from the context_switch pop sequence.
+    pop rcx              // user RIP   → rcx
+    pop r11              // user RFLAGS → r11
+    // rsp now points at user_rsp slot. Load arg regs via [rsp+N] before
+    // we abandon the kernel stack with `pop rsp`.
+    mov rdi, [rsp + 8]   // user rdi
+    mov rsi, [rsp + 16]  // user rsi
+    mov rdx, [rsp + 24]  // user rdx
+    mov r10, [rsp + 32]  // user r10
+    mov r8,  [rsp + 40]  // user r8
+    mov r9,  [rsp + 48]  // user r9
+    pop rsp              // user RSP   (last, switches to user stack)
+    xor eax, eax         // child fork() return value
     sysretq
 "#
 );
@@ -175,23 +190,42 @@ fork_child_sysret:
     // Called as the first instruction of a fork child after context_switch
     // loads its primed kernel stack.
     //
-    // Register state set by Task::new_forked priming:
-    //   r12 = user RIP   → loaded into rcx for SYSRETQ
-    //   rbp = user RSP   → loaded into rsp before SYSRETQ
-    //   rbx = user RFLAGS → loaded into r11 for SYSRETQ
+    // On entry, context_switch's pop sequence has already loaded the
+    // SysV callee-saved registers (rbx, rbp, r12-r15) directly with
+    // their final user values from the prime frame. The remaining 9
+    // user GPRs are stacked below us at [rsp]..[rsp+0x40] in this order:
+    //
+    //   [rsp+0x00] user RIP    → rcx (SYSRETQ jumps to rcx)
+    //   [rsp+0x08] user RFLAGS → r11 (SYSRETQ restores RFLAGS from r11)
+    //   [rsp+0x10] user RSP    → rsp (popped last to keep kernel stack
+    //                                  reachable while we load the rest)
+    //   [rsp+0x18] user rdi
+    //   [rsp+0x20] user rsi
+    //   [rsp+0x28] user rdx
+    //   [rsp+0x30] user r10
+    //   [rsp+0x38] user r8
+    //   [rsp+0x40] user r9
     //
     // SYSRETQ: rcx → RIP, r11 → RFLAGS, CS/SS switched to ring-3 selectors.
     //
-    // Do NOT sti here: rbx already holds the parent's saved RFLAGS which
+    // Do NOT sti here: r11 will hold the parent's saved RFLAGS which
     // includes IF=1 (user mode runs with interrupts enabled). SYSRETQ
     // restores RFLAGS from r11, so IF is re-enabled atomically when the CPU
     // transitions to ring-3. An explicit sti before the RSP switch would
     // allow an IRQ to fire with a kernel-mode CS but a user-mode RSP,
     // corrupting the user stack.
-    mov rcx, r12      // user RIP
-    mov r11, rbx      // user RFLAGS (IF=1 → interrupts re-enabled by SYSRETQ)
-    xor eax, eax      // return 0 — fork() child path
-    mov rsp, rbp      // restore user RSP (switch stack before SYSRETQ)
+    pop rcx              // user RIP
+    pop r11              // user RFLAGS (IF=1 → re-enabled by SYSRETQ)
+    // rsp now at user_rsp slot; load remaining args via [rsp+N] before
+    // pop rsp abandons the kernel stack.
+    mov rdi, [rsp + 8]
+    mov rsi, [rsp + 16]
+    mov rdx, [rsp + 24]
+    mov r10, [rsp + 32]
+    mov r8,  [rsp + 40]
+    mov r9,  [rsp + 48]
+    pop rsp              // user RSP — switches to user stack
+    xor eax, eax         // child fork() return value
     sysretq
 "#
 );

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -29,7 +29,7 @@ use x86_64::structures::paging::{Page, PageTableFlags, PhysFrame, Size4KiB};
 use x86_64::VirtAddr;
 
 use crate::arch::x86_64::fpu::FpuArea;
-use crate::fork_abi::prime_fork_child_stack;
+use crate::fork_abi::{prime_fork_child_stack, ForkUserRegs};
 use crate::fs::vfs::Credential;
 use crate::fs::FileDescTable;
 use crate::mem::addrspace::AddressSpace;
@@ -396,8 +396,11 @@ impl Task {
     /// returns to ring-3 via `fork_child_sysret` with rax=0 (the child's
     /// fork() return value).
     ///
-    /// `user_rip`, `user_rflags`, and `user_rsp` are the saved ring-3
-    /// register context from the parent's SYSCALL entry.
+    /// `regs` is the parent's full saved ring-3 GPR snapshot taken at the
+    /// FORK SYSCALL boundary — including the SysV callee-saved set
+    /// (`rbx`, `rbp`, `r12`–`r15`) per #690 so any userspace local the
+    /// compiler held in one of those across `sys_fork()` survives in the
+    /// child too.
     /// `parent_fpu` is the parent's current FPU save area (copied verbatim
     /// so the child inherits the same floating-point state at fork time).
     /// `parent_priority` / `parent_affinity` are copied directly.
@@ -406,9 +409,7 @@ impl Task {
     /// `parent_fpu` must be a valid, aligned `FpuArea` that remains live
     /// for the duration of this call (the FPU copy happens before return).
     pub unsafe fn new_forked(
-        user_rip: u64,
-        user_rflags: u64,
-        user_rsp: u64,
+        regs: &ForkUserRegs,
         parent_priority: u8,
         parent_affinity: u64,
         parent_fpu: *const crate::arch::x86_64::fpu::FpuArea,
@@ -420,8 +421,8 @@ impl Task {
     ) -> Result<Self, crate::mem::addrspace::ForkError> {
         crate::fork_trace!(
             "fork-trace: [Task::new_forked enter] user_rip={:#x} user_rsp={:#x}",
-            user_rip,
-            user_rsp
+            regs.user_rip,
+            regs.user_rsp
         );
         // Reserve a fresh guard+stack slot. Recycles a freed slot if
         // one is available, otherwise bumps `NEXT_STACK_VA` (#646).
@@ -477,24 +478,17 @@ impl Task {
         // SAFETY: the 56 bytes at the top of the freshly-mapped stack
         // were just made valid by `map_range` above and are owned
         // exclusively by this Task until the first context switch.
-        let rsp = unsafe {
-            prime_fork_child_stack(
-                top,
-                user_rip,
-                user_rflags,
-                user_rsp,
-                fork_child_sysret as *const () as usize,
-            )
-        };
+        let rsp =
+            unsafe { prime_fork_child_stack(top, regs, fork_child_sysret as *const () as usize) };
 
         let id = NEXT_TASK_ID.fetch_add(1, Ordering::Relaxed);
         crate::fork_trace!(
             "fork-trace: [Task::new_forked] child stack primed rsp={:#x} sysret_rip={:#x} \
              sysret_rsp={:#x} sysret_rflags={:#x} fork_child_sysret={:#x} child_id={}",
             rsp,
-            user_rip,
-            user_rsp,
-            user_rflags,
+            regs.user_rip,
+            regs.user_rsp,
+            regs.user_rflags,
             fork_child_sysret as *const () as usize,
             id
         );

--- a/kernel/tests/signal_sa_restart_preserves_args.rs
+++ b/kernel/tests/signal_sa_restart_preserves_args.rs
@@ -305,6 +305,7 @@ fn sigreturn_dispatch_writes_ctx_and_asserts_restart() {
         user_rip: SENTINEL,
         user_rflags: SENTINEL,
         user_rsp: new_rsp,
+        ..SyscallReturnContext::default()
     };
 
     SYSCALL_RESTART_PENDING.store(0, Ordering::Relaxed);
@@ -401,6 +402,7 @@ fn sigreturn_dispatch_leaves_ctx_alone_when_not_restart() {
         user_rip: 0,
         user_rflags: 0,
         user_rsp: new_rsp,
+        ..SyscallReturnContext::default()
     };
 
     SYSCALL_RESTART_PENDING.store(0, Ordering::Relaxed);

--- a/userspace/shell_pipeline/Cargo.toml
+++ b/userspace/shell_pipeline/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "userspace_shell_pipeline"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "userspace_shell_pipeline"
+path = "src/main.rs"

--- a/userspace/shell_pipeline/link.ld
+++ b/userspace/shell_pipeline/link.ld
@@ -1,0 +1,54 @@
+/* Linker script for the repro_fork userspace binary.
+ *
+ * Identical layout to `userspace/init/link.ld`: lower-half load base at
+ * 0x400000, page-aligned PT_LOAD segments so the kernel's ELF loader can
+ * map one page per page.  This binary is shipped in the ISO in place of
+ * `userspace_init.elf` when the xtask `repro-fork` subcommand is used;
+ * the kernel's loader is unchanged and sees what looks like a regular
+ * PID-1 init image.
+ */
+
+OUTPUT_FORMAT(elf64-x86-64)
+OUTPUT_ARCH(i386:x86-64)
+ENTRY(_start)
+
+PHDRS
+{
+    text   PT_LOAD FLAGS(5);   /* R+X */
+    rodata PT_LOAD FLAGS(4);   /* R   */
+    data   PT_LOAD FLAGS(6);   /* R+W */
+}
+
+SECTIONS
+{
+    . = 0x0000000000400000;
+
+    .text : {
+        *(.text .text.*)
+    } :text
+
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
+
+    .rodata : {
+        *(.rodata .rodata.*)
+    } :rodata
+
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
+
+    .data : {
+        *(.data .data.*)
+    } :data
+
+    .bss : {
+        *(COMMON)
+        *(.bss .bss.*)
+    } :data
+
+    /DISCARD/ : {
+        *(.eh_frame*)
+        *(.note.*)
+        *(.comment)
+        *(.dynamic)
+        *(.got .got.plt)
+    }
+}

--- a/userspace/shell_pipeline/src/main.rs
+++ b/userspace/shell_pipeline/src/main.rs
@@ -101,6 +101,13 @@ pub extern "C" fn _start() -> ! {
     // line for log triage.
     write_all(STDOUT, b"shell_pipeline: starting echo|cat|wc-c\n");
 
+    // Diagnostic preflight: confirm fd 0/1/2 are open in the supervisor
+    // before any pipe2/fork — if any of these are closed at PID-1 entry
+    // we'd see write_all to STDERR silently fail downstream.
+    diag_fd("supervisor.0", STDIN);
+    diag_fd("supervisor.1", STDOUT);
+    diag_fd("supervisor.2", STDERR);
+
     // Pipe 1: echo → cat
     let mut p1: [i32; 2] = [-1, -1];
     if sys_pipe2(p1.as_mut_ptr(), 0) < 0 {
@@ -109,6 +116,8 @@ pub extern "C" fn _start() -> ! {
     }
     let p1r = p1[0] as u64;
     let p1w = p1[1] as u64;
+    diag_kv(b"shell_pipeline: p1r=", p1r);
+    diag_kv(b"shell_pipeline: p1w=", p1w);
 
     // Pipe 2: cat → wc
     let mut p2: [i32; 2] = [-1, -1];
@@ -118,6 +127,8 @@ pub extern "C" fn _start() -> ! {
     }
     let p2r = p2[0] as u64;
     let p2w = p2[1] as u64;
+    diag_kv(b"shell_pipeline: p2r=", p2r);
+    diag_kv(b"shell_pipeline: p2w=", p2w);
 
     // ── Stage A: echo (writes ECHO_PAYLOAD to its stdout)
     let pid_echo = sys_fork();
@@ -126,12 +137,18 @@ pub extern "C" fn _start() -> ! {
         sys_exit(2);
     }
     if pid_echo == 0 {
+        // Probe pipe fds in the child to confirm fork-cloned fd table
+        // actually has them.
+        diag_fd("echo-child.p1r", p1r);
+        diag_fd("echo-child.p1w", p1w);
         // Child: stdout → p1w, then close every pipe fd we still hold.
         let r = sys_dup2(p1w, STDOUT);
+        diag_kvi(b"echo-child: dup2(p1w, STDOUT)=", r);
         if r < 0 {
             write_all(STDERR, b"shell_pipeline[echo-child]: dup2 stdout failed\n");
             sys_exit(11);
         }
+        diag_fd("echo-child.STDOUT-after-dup2", STDOUT);
         write_all(STDERR, b"shell_pipeline[echo-child]: dup2 stdout ok\n");
         sys_close(p1r);
         sys_close(p1w);
@@ -147,7 +164,13 @@ pub extern "C" fn _start() -> ! {
         sys_exit(2);
     }
     if pid_cat == 0 {
-        if sys_dup2(p1r, STDIN) < 0 {
+        diag_fd("cat-child.p1r", p1r);
+        diag_fd("cat-child.p1w", p1w);
+        diag_fd("cat-child.p2r", p2r);
+        diag_fd("cat-child.p2w", p2w);
+        let r = sys_dup2(p1r, STDIN);
+        diag_kvi(b"cat-child: dup2(p1r, STDIN)=", r);
+        if r < 0 {
             write_all(STDERR, b"shell_pipeline[cat-child]: dup2 stdin failed\n");
             sys_exit(12);
         }
@@ -171,6 +194,7 @@ pub extern "C" fn _start() -> ! {
         sys_exit(2);
     }
     if pid_wc == 0 {
+        diag_fd("wc-child.p2r", p2r);
         if sys_dup2(p2r, STDIN) < 0 {
             write_all(STDERR, b"shell_pipeline[wc-child]: dup2 stdin failed\n");
             sys_exit(14);
@@ -320,6 +344,57 @@ fn write_all(fd: u64, buf: &[u8]) -> bool {
         off += n as usize;
     }
     true
+}
+
+/// Probe whether `fd` is currently open in this task's fd table by doing
+/// a 0-length write — kernel returns EBADF if closed, 0 if open. Logs
+/// to STDERR; never panics.
+fn diag_fd(label: &str, fd: u64) {
+    let r = sys_write(fd, core::ptr::null(), 0);
+    write_all(STDERR, b"shell_pipeline: diag_fd[");
+    write_all(STDERR, label.as_bytes());
+    write_all(STDERR, b"=");
+    write_u64_to(STDERR, fd);
+    write_all(STDERR, b"] write0=");
+    write_i64_to(STDERR, r);
+    write_all(STDERR, b"\n");
+}
+
+fn diag_kv(label: &[u8], v: u64) {
+    write_all(STDERR, label);
+    write_u64_to(STDERR, v);
+    write_all(STDERR, b"\n");
+}
+
+fn diag_kvi(label: &[u8], v: i64) {
+    write_all(STDERR, label);
+    write_i64_to(STDERR, v);
+    write_all(STDERR, b"\n");
+}
+
+fn write_u64_to(fd: u64, mut n: u64) {
+    let mut buf = [0u8; 20];
+    let mut i = buf.len();
+    if n == 0 {
+        i -= 1;
+        buf[i] = b'0';
+    } else {
+        while n > 0 {
+            i -= 1;
+            buf[i] = b'0' + (n % 10) as u8;
+            n /= 10;
+        }
+    }
+    write_all(fd, &buf[i..]);
+}
+
+fn write_i64_to(fd: u64, n: i64) {
+    if n < 0 {
+        write_all(fd, b"-");
+        write_u64_to(fd, (-(n + 1)) as u64 + 1);
+    } else {
+        write_u64_to(fd, n as u64);
+    }
 }
 
 fn write_u32(mut n: u32) {

--- a/userspace/shell_pipeline/src/main.rs
+++ b/userspace/shell_pipeline/src/main.rs
@@ -101,6 +101,24 @@ pub extern "C" fn _start() -> ! {
     // line for log triage.
     write_all(STDOUT, b"shell_pipeline: starting echo|cat|wc-c\n");
 
+    // ── #690 regression: callee-saved GPR roundtrip across sys_fork().
+    //
+    // SysV AMD64 treats rbx, rbp, r12-r15 as callee-saved across function
+    // calls; sys_fork()'s asm here doesn't list them as clobbers (only
+    // the caller-saved set), so the compiler will happily hold a userspace
+    // local in one of them across the syscall in both parent and child.
+    // Pre-#690 fix, the kernel restored only rcx/r11/rsp on SYSRETQ from
+    // the child path, leaving rbx/rbp/r12-r15 with whatever the kernel
+    // last wrote — silently corrupting the local in the child.
+    //
+    // We force the compiler's hand with `core::hint::black_box` on a
+    // sentinel value so it has to be live across `sys_fork()`. If the
+    // child reads back the same sentinel we set in the parent, the full
+    // user-GPR snapshot survived. We also wait4() the child here so this
+    // probe runs to completion before the pipeline below — failure is
+    // a fast, isolated marker.
+    callee_saved_fork_probe();
+
     // Diagnostic preflight: confirm fd 0/1/2 are open in the supervisor
     // before any pipe2/fork — if any of these are closed at PID-1 entry
     // we'd see write_all to STDERR silently fail downstream.
@@ -513,6 +531,72 @@ fn sys_dup2(oldfd: u64, newfd: u64) -> i64 {
         );
     }
     ret
+}
+
+/// #690 regression probe.
+///
+/// Holds a sentinel value across `sys_fork()` and asserts that the
+/// child reads it back unchanged. `core::hint::black_box` on either
+/// side prevents the optimizer from dead-store-eliminating the local
+/// or replacing the post-fork load with the pre-fork constant — both
+/// of which would silently mask the bug.
+///
+/// On success, the parent emits `SHELL_PIPELINE_CALLEE_SAVED_OK`.
+/// On failure (parent value `!=` child value, modulo any nonzero diff),
+/// the child emits `SHELL_PIPELINE_FAIL: callee_saved=<observed>` and
+/// exits non-zero so the parent's `wait_zero` trips.
+fn callee_saved_fork_probe() {
+    const SENTINEL: u64 = 0xDEAD_C0DE_F00D_BABEu64;
+
+    // Anchor the local in scope across the syscall. The asm in
+    // sys_fork() does not list rbx/rbp/r12-r15 as clobbers, so the
+    // compiler can (and at -O does) keep `local` in one of those across
+    // the call. black_box makes this required, not optional.
+    let mut local: u64 = SENTINEL;
+    local = core::hint::black_box(local);
+
+    let pid = sys_fork();
+    if pid < 0 {
+        write_all(STDERR, b"SHELL_PIPELINE_FAIL: callee_saved fork\n");
+        sys_exit(2);
+    }
+
+    if pid == 0 {
+        // Child: black_box again so the load isn't constant-folded back
+        // to SENTINEL after the syscall.
+        let observed = core::hint::black_box(local);
+        if observed == SENTINEL {
+            // Parent will wait_zero on this. exit(0) on match.
+            sys_exit(0);
+        }
+        // Mismatch — emit a marker carrying the observed value, then
+        // exit non-zero.
+        write_all(STDOUT, b"SHELL_PIPELINE_FAIL: callee_saved=");
+        write_u64_to(STDOUT, observed);
+        write_all(STDOUT, b"\n");
+        sys_exit(41);
+    }
+
+    // Parent: wait for the probe child and require status 0.
+    if !wait_zero(
+        pid as u64,
+        b"SHELL_PIPELINE_FAIL: callee_saved wait\n",
+        b"SHELL_PIPELINE_FAIL: callee_saved nonzero\n",
+    ) {
+        sys_exit(3);
+    }
+    // Use `local` *after* wait4 so it is live across both fork() and
+    // wait4(); the parent path also exercises the callee-saved
+    // restore on the parent's SYSRETQ (which #690's fix makes uniform
+    // across the two paths).
+    let parent_observed = core::hint::black_box(local);
+    if parent_observed != SENTINEL {
+        write_all(STDOUT, b"SHELL_PIPELINE_FAIL: callee_saved parent=");
+        write_u64_to(STDOUT, parent_observed);
+        write_all(STDOUT, b"\n");
+        sys_exit(42);
+    }
+    write_all(STDOUT, b"SHELL_PIPELINE_CALLEE_SAVED_OK\n");
 }
 
 fn sys_fork() -> i64 {

--- a/userspace/shell_pipeline/src/main.rs
+++ b/userspace/shell_pipeline/src/main.rs
@@ -127,9 +127,12 @@ pub extern "C" fn _start() -> ! {
     }
     if pid_echo == 0 {
         // Child: stdout → p1w, then close every pipe fd we still hold.
-        if sys_dup2(p1w, STDOUT) < 0 {
+        let r = sys_dup2(p1w, STDOUT);
+        if r < 0 {
+            write_all(STDERR, b"shell_pipeline[echo-child]: dup2 stdout failed\n");
             sys_exit(11);
         }
+        write_all(STDERR, b"shell_pipeline[echo-child]: dup2 stdout ok\n");
         sys_close(p1r);
         sys_close(p1w);
         sys_close(p2r);
@@ -145,11 +148,15 @@ pub extern "C" fn _start() -> ! {
     }
     if pid_cat == 0 {
         if sys_dup2(p1r, STDIN) < 0 {
+            write_all(STDERR, b"shell_pipeline[cat-child]: dup2 stdin failed\n");
             sys_exit(12);
         }
+        write_all(STDERR, b"shell_pipeline[cat-child]: dup2 stdin ok\n");
         if sys_dup2(p2w, STDOUT) < 0 {
+            write_all(STDERR, b"shell_pipeline[cat-child]: dup2 stdout failed\n");
             sys_exit(13);
         }
+        write_all(STDERR, b"shell_pipeline[cat-child]: dup2 stdout ok\n");
         sys_close(p1r);
         sys_close(p1w);
         sys_close(p2r);
@@ -165,8 +172,10 @@ pub extern "C" fn _start() -> ! {
     }
     if pid_wc == 0 {
         if sys_dup2(p2r, STDIN) < 0 {
+            write_all(STDERR, b"shell_pipeline[wc-child]: dup2 stdin failed\n");
             sys_exit(14);
         }
+        write_all(STDERR, b"shell_pipeline[wc-child]: dup2 stdin ok\n");
         sys_close(p1r);
         sys_close(p1w);
         sys_close(p2r);
@@ -200,27 +209,35 @@ pub extern "C" fn _start() -> ! {
 
 /// echo: write the payload, exit 0.
 fn stage_echo() -> ! {
+    write_all(STDERR, b"shell_pipeline[echo]: enter\n");
     if write_all(STDOUT, ECHO_PAYLOAD) {
+        write_all(STDERR, b"shell_pipeline[echo]: wrote ok, exit 0\n");
         sys_exit(0);
     }
+    write_all(STDERR, b"shell_pipeline[echo]: write failed, exit 21\n");
     sys_exit(21);
 }
 
 /// cat: copy stdin → stdout until EOF, exit 0.
 fn stage_cat() -> ! {
+    write_all(STDERR, b"shell_pipeline[cat]: enter\n");
     let mut buf = [0u8; 64];
     loop {
         let n = sys_read(STDIN, buf.as_mut_ptr(), buf.len() as u64);
         if n == 0 {
+            write_all(STDERR, b"shell_pipeline[cat]: EOF, exit 0\n");
             sys_exit(0);
         }
         if n < 0 {
+            write_all(STDERR, b"shell_pipeline[cat]: read err, exit 22\n");
             sys_exit(22);
         }
         let n = n as usize;
         if !write_all(STDOUT, &buf[..n]) {
+            write_all(STDERR, b"shell_pipeline[cat]: write err, exit 23\n");
             sys_exit(23);
         }
+        write_all(STDERR, b"shell_pipeline[cat]: relayed chunk\n");
     }
 }
 
@@ -228,6 +245,7 @@ fn stage_cat() -> ! {
 /// fd 1 if the count matches the expected value, otherwise emit a
 /// failure line.
 fn stage_wc() -> ! {
+    write_all(STDERR, b"shell_pipeline[wc]: enter\n");
     let mut buf = [0u8; 64];
     let mut count: u32 = 0;
     loop {
@@ -236,6 +254,7 @@ fn stage_wc() -> ! {
             break;
         }
         if n < 0 {
+            write_all(STDERR, b"shell_pipeline[wc]: read err, exit 31\n");
             sys_exit(31);
         }
         // u32 is plenty — pipeline payload is 4 bytes.

--- a/userspace/shell_pipeline/src/main.rs
+++ b/userspace/shell_pipeline/src/main.rs
@@ -1,0 +1,481 @@
+//! Shell-pipeline integration test (issue #462) — verifies RFC 0003
+//! end-to-end by running `echo foo | cat | wc -c` entirely inside one
+//! ring-3 process tree.
+//!
+//! ## Why one binary, not three
+//!
+//! The vibix kernel's current `execve()` ignores its `path` argument and
+//! always reloads `/boot/userspace_hello.elf` (see
+//! `kernel/src/arch/x86_64/syscall.rs::EXECVE`). That makes a literal
+//! three-binary pipeline impossible today: every child of `execve()`
+//! ends up running the same hello-binary, not a real `cat` or `wc`.
+//!
+//! Rather than block this test on a multi-target ELF loader, this
+//! binary plays all three stages itself:
+//!
+//! ```text
+//!     PID 1 (this binary, "supervisor")
+//!         ├── fork → child A: dup2 pipe1.write → fd 1; "echo" foo
+//!         ├── fork → child B: dup2 pipe1.read → fd 0,
+//!         │                   dup2 pipe2.write → fd 1; "cat" loop
+//!         └── fork → child C: dup2 pipe2.read → fd 0; "wc -c" → fd 1
+//!                                                  emits SHELL_PIPELINE_OK: <count>
+//! ```
+//!
+//! All five real syscalls under test still get exercised on the
+//! pipeline-shape they implement in a real shell:
+//!   - `pipe2(2)` x2   — wires the three stages
+//!   - `fork(2)` x3    — one per stage
+//!   - `dup2(2)`       — re-points stdin/stdout per stage
+//!   - `close(2)`      — drops the unused pipe ends so EOF propagates
+//!   - `read/write(2)` — the bytes flow stage to stage
+//!   - `wait4(2)` x3   — supervisor reaps all three children
+//!
+//! When the kernel grows path-aware execve (follow-up after #462), the
+//! `stage_*` arms below can be split out into independent `cat`/`wc`
+//! binaries without touching the supervisor's pipeline-wiring logic.
+//!
+//! ## Marker contract
+//!
+//! On a clean run the supervisor emits exactly one
+//! `SHELL_PIPELINE_OK: 4` line on fd 1. Any failure path emits a
+//! `SHELL_PIPELINE_FAIL: <reason>` line so the xtask wrapper can fail
+//! fast with a concrete cause.
+//!
+//! ## Syscall ABI — see #531
+//!
+//! The vibix SYSCALL trampoline does **not** preserve user values of
+//! `rdi`, `rsi`, `rdx`, `r8`, `r9`, or `r10` across a syscall: only
+//! `rcx` (user RIP) and `r11` (user RFLAGS) are restored on SYSRETQ.
+//! Every asm block below therefore declares the full SysV caller-saved
+//! GPR set as `inlateout`/`lateout` so the compiler does not cache
+//! dead values across the syscall.
+
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+
+// ── Syscall numbers (Linux x86_64; pinned to kernel/src/arch/x86_64/syscall.rs)
+
+const SYS_READ: u64 = 0;
+const SYS_WRITE: u64 = 1;
+const SYS_CLOSE: u64 = 3;
+const SYS_PIPE2: u64 = 293;
+const SYS_DUP2: u64 = 33;
+const SYS_FORK: u64 = 57;
+const SYS_EXIT: u64 = 60;
+const SYS_WAIT4: u64 = 61;
+
+// ── Standard fds and constants
+
+const STDIN: u64 = 0;
+const STDOUT: u64 = 1;
+const STDERR: u64 = 2;
+
+// ── Pipeline payload — `echo foo` writes "foo\n" (4 bytes), so the
+// final `wc -c` count must be exactly 4.
+
+const ECHO_PAYLOAD: &[u8] = b"foo\n";
+const EXPECTED_COUNT: u32 = 4;
+
+// ── Markers asserted (or grepped for failure) by the xtask wrapper.
+
+const FAIL_FORK_PIPE1: &[u8] = b"SHELL_PIPELINE_FAIL: pipe1\n";
+const FAIL_FORK_PIPE2: &[u8] = b"SHELL_PIPELINE_FAIL: pipe2\n";
+const FAIL_FORK_ECHO: &[u8] = b"SHELL_PIPELINE_FAIL: fork echo\n";
+const FAIL_FORK_CAT: &[u8] = b"SHELL_PIPELINE_FAIL: fork cat\n";
+const FAIL_FORK_WC: &[u8] = b"SHELL_PIPELINE_FAIL: fork wc\n";
+const FAIL_WAIT_ECHO: &[u8] = b"SHELL_PIPELINE_FAIL: wait echo\n";
+const FAIL_WAIT_CAT: &[u8] = b"SHELL_PIPELINE_FAIL: wait cat\n";
+const FAIL_WAIT_WC: &[u8] = b"SHELL_PIPELINE_FAIL: wait wc\n";
+const FAIL_NONZERO_ECHO: &[u8] = b"SHELL_PIPELINE_FAIL: echo nonzero\n";
+const FAIL_NONZERO_CAT: &[u8] = b"SHELL_PIPELINE_FAIL: cat nonzero\n";
+const FAIL_NONZERO_WC: &[u8] = b"SHELL_PIPELINE_FAIL: wc nonzero\n";
+
+// ── _start: the supervisor
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    // Banner so a missing-marker run still has a recognizable starting
+    // line for log triage.
+    write_all(STDOUT, b"shell_pipeline: starting echo|cat|wc-c\n");
+
+    // Pipe 1: echo → cat
+    let mut p1: [i32; 2] = [-1, -1];
+    if sys_pipe2(p1.as_mut_ptr(), 0) < 0 {
+        write_all(STDERR, FAIL_FORK_PIPE1);
+        sys_exit(2);
+    }
+    let p1r = p1[0] as u64;
+    let p1w = p1[1] as u64;
+
+    // Pipe 2: cat → wc
+    let mut p2: [i32; 2] = [-1, -1];
+    if sys_pipe2(p2.as_mut_ptr(), 0) < 0 {
+        write_all(STDERR, FAIL_FORK_PIPE2);
+        sys_exit(2);
+    }
+    let p2r = p2[0] as u64;
+    let p2w = p2[1] as u64;
+
+    // ── Stage A: echo (writes ECHO_PAYLOAD to its stdout)
+    let pid_echo = sys_fork();
+    if pid_echo < 0 {
+        write_all(STDERR, FAIL_FORK_ECHO);
+        sys_exit(2);
+    }
+    if pid_echo == 0 {
+        // Child: stdout → p1w, then close every pipe fd we still hold.
+        if sys_dup2(p1w, STDOUT) < 0 {
+            sys_exit(11);
+        }
+        sys_close(p1r);
+        sys_close(p1w);
+        sys_close(p2r);
+        sys_close(p2w);
+        stage_echo();
+    }
+
+    // ── Stage B: cat (stdin from p1r, stdout to p2w)
+    let pid_cat = sys_fork();
+    if pid_cat < 0 {
+        write_all(STDERR, FAIL_FORK_CAT);
+        sys_exit(2);
+    }
+    if pid_cat == 0 {
+        if sys_dup2(p1r, STDIN) < 0 {
+            sys_exit(12);
+        }
+        if sys_dup2(p2w, STDOUT) < 0 {
+            sys_exit(13);
+        }
+        sys_close(p1r);
+        sys_close(p1w);
+        sys_close(p2r);
+        sys_close(p2w);
+        stage_cat();
+    }
+
+    // ── Stage C: wc -c (stdin from p2r)
+    let pid_wc = sys_fork();
+    if pid_wc < 0 {
+        write_all(STDERR, FAIL_FORK_WC);
+        sys_exit(2);
+    }
+    if pid_wc == 0 {
+        if sys_dup2(p2r, STDIN) < 0 {
+            sys_exit(14);
+        }
+        sys_close(p1r);
+        sys_close(p1w);
+        sys_close(p2r);
+        sys_close(p2w);
+        stage_wc();
+    }
+
+    // Supervisor: drop every pipe fd. Each pipe end must be closed in
+    // every process that still holds it for the readers to see EOF.
+    sys_close(p1r);
+    sys_close(p1w);
+    sys_close(p2r);
+    sys_close(p2w);
+
+    // Wait for all three children. Order matters only insofar as the
+    // pipeline must drain before the wc-stage exits; we wait in
+    // pipeline order for predictability.
+    if !wait_zero(pid_echo as u64, FAIL_WAIT_ECHO, FAIL_NONZERO_ECHO) {
+        sys_exit(3);
+    }
+    if !wait_zero(pid_cat as u64, FAIL_WAIT_CAT, FAIL_NONZERO_CAT) {
+        sys_exit(3);
+    }
+    if !wait_zero(pid_wc as u64, FAIL_WAIT_WC, FAIL_NONZERO_WC) {
+        sys_exit(3);
+    }
+
+    // PID 1 must not exit. The wc-stage already emitted the marker.
+    park()
+}
+
+/// echo: write the payload, exit 0.
+fn stage_echo() -> ! {
+    if write_all(STDOUT, ECHO_PAYLOAD) {
+        sys_exit(0);
+    }
+    sys_exit(21);
+}
+
+/// cat: copy stdin → stdout until EOF, exit 0.
+fn stage_cat() -> ! {
+    let mut buf = [0u8; 64];
+    loop {
+        let n = sys_read(STDIN, buf.as_mut_ptr(), buf.len() as u64);
+        if n == 0 {
+            sys_exit(0);
+        }
+        if n < 0 {
+            sys_exit(22);
+        }
+        let n = n as usize;
+        if !write_all(STDOUT, &buf[..n]) {
+            sys_exit(23);
+        }
+    }
+}
+
+/// wc -c: count stdin bytes, then write `SHELL_PIPELINE_OK: <count>` to
+/// fd 1 if the count matches the expected value, otherwise emit a
+/// failure line.
+fn stage_wc() -> ! {
+    let mut buf = [0u8; 64];
+    let mut count: u32 = 0;
+    loop {
+        let n = sys_read(STDIN, buf.as_mut_ptr(), buf.len() as u64);
+        if n == 0 {
+            break;
+        }
+        if n < 0 {
+            sys_exit(31);
+        }
+        // u32 is plenty — pipeline payload is 4 bytes.
+        count = count.saturating_add(n as u32);
+    }
+    if count == EXPECTED_COUNT {
+        write_all(STDOUT, b"SHELL_PIPELINE_OK: ");
+        write_u32(count);
+        write_all(STDOUT, b"\n");
+        sys_exit(0);
+    } else {
+        write_all(STDOUT, b"SHELL_PIPELINE_FAIL: count=");
+        write_u32(count);
+        write_all(STDOUT, b"\n");
+        sys_exit(32);
+    }
+}
+
+// ── Supervisor helpers
+
+/// Wait for `pid`, fail-marker on syscall error, separate fail-marker
+/// on non-zero exit. Returns true iff the child exited with status 0.
+fn wait_zero(pid: u64, syscall_err: &[u8], nonzero_err: &[u8]) -> bool {
+    let mut wstatus: i32 = 0;
+    let waited = sys_wait4(pid, &mut wstatus as *mut i32);
+    if waited < 0 {
+        write_all(STDERR, syscall_err);
+        return false;
+    }
+    // Linux wait4: `(exit_status & 0xFF) << 8`.
+    let exit_code = ((wstatus as u32) >> 8) & 0xFF;
+    if exit_code != 0 {
+        write_all(STDERR, nonzero_err);
+        return false;
+    }
+    true
+}
+
+/// Park forever with `core::hint::spin_loop()` so PID 1 never exits
+/// (which would otherwise panic the kernel).
+fn park() -> ! {
+    loop {
+        core::hint::spin_loop();
+    }
+}
+
+// ── write helpers
+
+/// Loop write_all — the kernel's pipe write may short-write on a full
+/// pipe; we stay in the loop until the whole buffer is drained or an
+/// error occurs. Returns true on success.
+fn write_all(fd: u64, buf: &[u8]) -> bool {
+    let mut off = 0;
+    while off < buf.len() {
+        let n = sys_write(
+            fd,
+            unsafe { buf.as_ptr().add(off) },
+            (buf.len() - off) as u64,
+        );
+        if n <= 0 {
+            return false;
+        }
+        off += n as usize;
+    }
+    true
+}
+
+fn write_u32(mut n: u32) {
+    let mut buf = [0u8; 10];
+    let mut i = buf.len();
+    if n == 0 {
+        i -= 1;
+        buf[i] = b'0';
+    } else {
+        while n > 0 {
+            i -= 1;
+            buf[i] = b'0' + (n % 10) as u8;
+            n /= 10;
+        }
+    }
+    write_all(STDOUT, &buf[i..]);
+}
+
+// ── Raw syscall wrappers
+
+fn sys_write(fd: u64, ptr: *const u8, len: u64) -> i64 {
+    let ret: i64;
+    unsafe {
+        core::arch::asm!(
+            "syscall",
+            inlateout("rax") SYS_WRITE => ret,
+            inlateout("rdi") fd => _,
+            inlateout("rsi") ptr as u64 => _,
+            inlateout("rdx") len => _,
+            lateout("rcx") _,
+            lateout("r8") _,
+            lateout("r9") _,
+            lateout("r10") _,
+            lateout("r11") _,
+            options(nostack, preserves_flags),
+        );
+    }
+    ret
+}
+
+fn sys_read(fd: u64, ptr: *mut u8, len: u64) -> i64 {
+    let ret: i64;
+    unsafe {
+        core::arch::asm!(
+            "syscall",
+            inlateout("rax") SYS_READ => ret,
+            inlateout("rdi") fd => _,
+            inlateout("rsi") ptr as u64 => _,
+            inlateout("rdx") len => _,
+            lateout("rcx") _,
+            lateout("r8") _,
+            lateout("r9") _,
+            lateout("r10") _,
+            lateout("r11") _,
+            options(nostack, preserves_flags),
+        );
+    }
+    ret
+}
+
+fn sys_close(fd: u64) -> i64 {
+    let ret: i64;
+    unsafe {
+        core::arch::asm!(
+            "syscall",
+            inlateout("rax") SYS_CLOSE => ret,
+            inlateout("rdi") fd => _,
+            lateout("rcx") _,
+            lateout("rdx") _,
+            lateout("rsi") _,
+            lateout("r8") _,
+            lateout("r9") _,
+            lateout("r10") _,
+            lateout("r11") _,
+            options(nostack, preserves_flags),
+        );
+    }
+    ret
+}
+
+fn sys_pipe2(fds: *mut i32, flags: u32) -> i64 {
+    let ret: i64;
+    unsafe {
+        core::arch::asm!(
+            "syscall",
+            inlateout("rax") SYS_PIPE2 => ret,
+            inlateout("rdi") fds as u64 => _,
+            inlateout("rsi") flags as u64 => _,
+            lateout("rcx") _,
+            lateout("rdx") _,
+            lateout("r8") _,
+            lateout("r9") _,
+            lateout("r10") _,
+            lateout("r11") _,
+            options(nostack, preserves_flags),
+        );
+    }
+    ret
+}
+
+fn sys_dup2(oldfd: u64, newfd: u64) -> i64 {
+    let ret: i64;
+    unsafe {
+        core::arch::asm!(
+            "syscall",
+            inlateout("rax") SYS_DUP2 => ret,
+            inlateout("rdi") oldfd => _,
+            inlateout("rsi") newfd => _,
+            lateout("rcx") _,
+            lateout("rdx") _,
+            lateout("r8") _,
+            lateout("r9") _,
+            lateout("r10") _,
+            lateout("r11") _,
+            options(nostack, preserves_flags),
+        );
+    }
+    ret
+}
+
+fn sys_fork() -> i64 {
+    let ret: i64;
+    unsafe {
+        core::arch::asm!(
+            "syscall",
+            inlateout("rax") SYS_FORK => ret,
+            lateout("rcx") _,
+            lateout("rdx") _,
+            lateout("rdi") _,
+            lateout("rsi") _,
+            lateout("r8") _,
+            lateout("r9") _,
+            lateout("r10") _,
+            lateout("r11") _,
+            options(nostack, preserves_flags),
+        );
+    }
+    ret
+}
+
+fn sys_wait4(pid: u64, wstatus: *mut i32) -> i64 {
+    let ret: i64;
+    unsafe {
+        core::arch::asm!(
+            "syscall",
+            inlateout("rax") SYS_WAIT4 => ret,
+            inlateout("rdi") pid => _,
+            inlateout("rsi") wstatus as u64 => _,
+            inlateout("rdx") 0u64 => _,
+            inlateout("r10") 0u64 => _,
+            lateout("rcx") _,
+            lateout("r8") _,
+            lateout("r9") _,
+            lateout("r11") _,
+            options(nostack),
+        );
+    }
+    ret
+}
+
+fn sys_exit(status: i32) -> ! {
+    unsafe {
+        core::arch::asm!(
+            "syscall",
+            in("rax") SYS_EXIT,
+            in("rdi") status as u64,
+            options(nostack, noreturn),
+        )
+    }
+}
+
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    write_all(STDERR, b"SHELL_PIPELINE_FAIL: panic\n");
+    loop {
+        core::hint::spin_loop();
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -16,6 +16,8 @@
 //!   repro-fork    — boot with the fork-loop reproducer harness as PID 1 (issue #506)
 //!   repro-fork-build — build-only variant of `repro-fork`: warm kernel + ISO
 //!                      without booting QEMU (issue #526, for CI pre-build)
+//!   shell-pipeline — boot with the shell-pipeline integration binary as PID 1
+//!                    and assert `SHELL_PIPELINE_OK: 4` on serial (issue #462)
 //!   lint          — run clippy on xtask (host) and vibix (kernel, no_std)
 //!   isr-audit     — scan ISR-reachable files for blocking-lock regressions
 //!   fuzz          — bounded-iteration host fuzz of an FS layer (#677)
@@ -222,6 +224,7 @@ fn main() -> R<()> {
         "repro-fork-build" => {
             repro_fork_build(&opts)?;
         }
+        "shell-pipeline" => shell_pipeline(&opts)?,
         "lint" => lint()?,
         "isr-audit" => isr_audit::run(&workspace_root())?,
         "initrd" => {
@@ -311,7 +314,7 @@ fn main() -> R<()> {
         other => {
             eprintln!("unknown subcommand: {other}");
             eprintln!(
-                "usage: cargo xtask [build|initrd|ext2-image|iso|run|test|test-unit|test-integration|smoke|pjdfstest|repro-fork|repro-fork-build|lint|isr-audit|fuzz|clean] [--release] [--fault-test] [--panic-test] [--bench] [--fork-trace]"
+                "usage: cargo xtask [build|initrd|ext2-image|iso|run|test|test-unit|test-integration|smoke|pjdfstest|repro-fork|repro-fork-build|shell-pipeline|lint|isr-audit|fuzz|clean] [--release] [--fault-test] [--panic-test] [--bench] [--fork-trace]"
             );
             std::process::exit(2);
         }
@@ -463,6 +466,20 @@ fn build_userspace_hello() -> R<PathBuf> {
 /// ~50 %-rate flake bisected to PR #206 into a deterministic repro.
 fn build_userspace_repro_fork() -> R<PathBuf> {
     build_userspace_binary("userspace_repro_fork", "userspace/repro_fork/link.ld")
+}
+
+/// Build the shell-pipeline integration binary (issue #462).
+///
+/// Shipped as `userspace_init.elf` when `cargo xtask shell-pipeline` is
+/// used — the binary internally simulates `echo foo | cat | wc -c`
+/// using pipe2/fork/dup2/close/wait4 and prints `SHELL_PIPELINE_OK: 4`
+/// on success. See `userspace/shell_pipeline/src/main.rs` for the
+/// rationale on why all three pipeline stages live in one binary.
+fn build_userspace_shell_pipeline() -> R<PathBuf> {
+    build_userspace_binary(
+        "userspace_shell_pipeline",
+        "userspace/shell_pipeline/link.ld",
+    )
 }
 
 /// Build the no_std pjdfstest runner (#642 option 2). Shipped as
@@ -1857,6 +1874,164 @@ fn repro_fork(opts: &BuildOpts) -> R<()> {
             Err(format!("repro-fork: {msg}").into())
         }
         (false, None) => Err("repro-fork: terminated with no success and no failure marker".into()),
+    }
+}
+
+/// Boot the shell-pipeline integration binary as PID 1 and assert
+/// the `SHELL_PIPELINE_OK: 4` marker on serial (issue #462).
+///
+/// Mirrors the `repro-fork` plumbing: builds an ISO that swaps
+/// `userspace_shell_pipeline` in for `userspace_init.elf`, boots it
+/// under QEMU, mirrors serial to stdout, and watches for either the
+/// success marker, a `SHELL_PIPELINE_FAIL:` line, or a kernel panic.
+fn shell_pipeline(opts: &BuildOpts) -> R<()> {
+    use std::collections::VecDeque;
+    use std::io::BufRead as _;
+    use std::time::Instant;
+
+    /// Hard ceiling on the whole run. Three forks plus a few pipe
+    /// reads should finish well inside one second on accelerated
+    /// hardware, but un-accelerated CI QEMU plus first-boot kernel
+    /// init can stretch to tens of seconds. 120 s is generous.
+    const HARD_CAP: Duration = Duration::from_secs(120);
+
+    const SUCCESS_MARKER: &str = "SHELL_PIPELINE_OK: 4";
+    const FAIL_MARKER: &str = "SHELL_PIPELINE_FAIL:";
+    const PANIC_MARKER: &str = "KERNEL PANIC:";
+
+    let kernel = build(opts)?;
+    let init_bin = build_userspace_shell_pipeline()?;
+    let iso = workspace_root()
+        .join("target")
+        .join("vibix-shell-pipeline.iso");
+    make_iso_with_init(&kernel, &init_bin, &iso, "iso_shell_pipeline")?;
+    let disk = ensure_test_disk()?;
+
+    let mut child = Command::new("qemu-system-x86_64")
+        .args([
+            "-M",
+            "q35",
+            "-cpu",
+            "max",
+            "-m",
+            "256M",
+            "-serial",
+            "stdio",
+            "-display",
+            "none",
+            "-no-reboot",
+            "-no-shutdown",
+            "-device",
+            "isa-debug-exit,iobase=0xf4,iosize=0x04",
+        ])
+        .args(virtio_blk_args(&disk))
+        .arg("-cdrom")
+        .arg(&iso)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    let pid = child.id();
+    let stdout = child.stdout.take().ok_or("no stdout pipe")?;
+
+    // Hard-cap watchdog (same cancel-channel pattern as repro_fork).
+    let hard_pid = pid;
+    let (cancel_tx, cancel_rx) = std::sync::mpsc::channel::<()>();
+    let hard_watchdog = std::thread::spawn(move || {
+        if let Err(std::sync::mpsc::RecvTimeoutError::Timeout) = cancel_rx.recv_timeout(HARD_CAP) {
+            let _ = Command::new("kill").arg(hard_pid.to_string()).status();
+        }
+    });
+
+    // Reader thread → channel; main thread polls with a short timeout
+    // so the absolute deadline stays accurate even if the kernel hangs
+    // before any line arrives.
+    let (tx, rx) = std::sync::mpsc::channel::<String>();
+    let reader_handle = std::thread::spawn(move || {
+        let mut reader = std::io::BufReader::new(stdout);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) => break,
+                Ok(_) => {
+                    if tx.send(line.clone()).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let start = Instant::now();
+    let mut success = false;
+    let mut failure: Option<String> = None;
+    let mut tail: VecDeque<String> = VecDeque::with_capacity(64);
+    const TICK: Duration = Duration::from_millis(200);
+
+    loop {
+        match rx.recv_timeout(TICK) {
+            Ok(line) => {
+                print!("{line}");
+                if tail.len() == 64 {
+                    tail.pop_front();
+                }
+                tail.push_back(line.clone());
+
+                if line.contains(PANIC_MARKER) {
+                    failure = Some(format!("kernel panic: {}", line.trim_end()));
+                    break;
+                }
+                if line.contains(FAIL_MARKER) {
+                    failure = Some(format!("harness failure: {}", line.trim_end()));
+                    break;
+                }
+                if line.contains(SUCCESS_MARKER) {
+                    success = true;
+                    break;
+                }
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                if start.elapsed() > HARD_CAP {
+                    failure = Some(format!("hard cap exceeded ({HARD_CAP:?}) without success"));
+                    break;
+                }
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                if !success && failure.is_none() {
+                    failure = Some(format!("QEMU exited before `{SUCCESS_MARKER}` marker"));
+                }
+                break;
+            }
+        }
+    }
+
+    let _ = Command::new("kill").arg(pid.to_string()).status();
+    drop(cancel_tx);
+    let _ = hard_watchdog.join();
+    let _ = reader_handle.join();
+    let _ = child.wait();
+
+    match (success, failure) {
+        (true, _) => {
+            println!(
+                "→ shell-pipeline: SHELL_PIPELINE_OK in {:?} ✓",
+                start.elapsed()
+            );
+            Ok(())
+        }
+        (false, Some(msg)) => {
+            eprintln!("--- captured serial (tail) ---");
+            for line in &tail {
+                eprint!("{line}");
+            }
+            eprintln!("------------------------------");
+            Err(format!("shell-pipeline: {msg}").into())
+        }
+        (false, None) => {
+            Err("shell-pipeline: terminated with no success and no failure marker".into())
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Userspace integration test for #462 plus the kernel fork-GPR fix it
surfaced (#690). Spawns a 3-stage pipeline (`echo foo | cat | wc -c`)
entirely inside one process tree and asserts the final byte count is 4.

Wires:
- new `userspace/shell_pipeline/` binary (lower-half load at 0x400000)
- `cargo xtask shell-pipeline` subcommand (kernel + binary + ISO via
  `make_iso_with_init`, QEMU boot, marker-watcher loop)
- new `shell-pipeline integration test` CI job mirroring the existing
  `smoke` job

Closes #462.
Closes #690.

## #690 fix

The pipeline test is the first userspace pattern that forks and
continues running its own code with carry-over locals; every other
fork test masked the bug behind execve's full-GPR reload.
`fork_child_sysret` only restored rcx/r11/rsp on SYSRETQ, leaving
rbx/rbp/r12-r15 (callee-saved per SysV) and the syscall-arg
registers with whatever the kernel happened to leave there. The fix:

- Extend `SyscallReturnContext` with the 6 callee-saved slots so
  `syscall_entry` captures the full user GPR set on every SYSCALL.
- New `ForkUserRegs` struct flows the 13-GPR snapshot from FORK's
  syscall-dispatch arm through `fork_current_task` -> `Task::new_forked`
  -> `prime_fork_child_stack`.
- Rewrite `fork_child_sysret` to pop/load the full GPR set before
  SYSRETQ. Host unit tests in `kernel/src/fork_abi.rs` cover the new
  16-qword prime layout.
- Add a `core::hint::black_box`-anchored callee-saved-roundtrip probe
  at the head of the shell-pipeline supervisor so a #690 regression
  surfaces as a single fast-failing marker instead of opaque dup2
  cascade output.

## Test plan

- [x] `cargo xtask build` green locally
- [x] `cargo xtask shell-pipeline` reproduces #690 deterministically (pre-fix)
- [x] After #690 fix: `cargo xtask shell-pipeline` emits
      `SHELL_PIPELINE_CALLEE_SAVED_OK` then `SHELL_PIPELINE_OK: 4`
- [x] `cargo xtask test` green (518 host unit + integration tests pass)
- [x] `cargo xtask smoke` green (41/41 markers)
- [ ] shell-pipeline CI job goes green