### PR TITLE
sched: migrate time/IRQ callers through env() and tighten time::* to pub(crate) (#667)

### DIFF
--- a/kernel/src/arch/x86_64/interrupts.rs
+++ b/kernel/src/arch/x86_64/interrupts.rs
@@ -32,7 +32,14 @@ pub extern "x86-interrupt" fn timer_interrupt(_frame: InterruptStackFrame) {
     // task first and *that* task ever re-entered this ISR, the PIC
     // would be carrying an un-acked IRQ and subsequent ticks would
     // stall.
-    notify_eoi(InterruptIndex::Timer.as_u8());
+    //
+    // Routed through the scheduler/IRQ seam (RFC 0005) so the
+    // simulator and mock test wiring can substitute the EOI; in
+    // production this resolves to `notify_eoi(Timer)` →
+    // `apic::lapic_eoi()`. The ordering (EOI before `preempt_tick`)
+    // is preserved deliberately — see equivalence note in PR body.
+    let (_clock, irq) = crate::task::env::env();
+    irq.ack_timer();
     #[cfg(feature = "bench")]
     crate::bench::irq::record_exit();
     crate::task::preempt_tick();

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -249,8 +249,9 @@ pub unsafe fn jump_to_ring3(entry: u64, stack_top: u64) -> ! {
     // simulator's clock — when we ever drive the ring-3 jump under it
     // — sees the same `Tick` source the scheduler does.
     let (clock, _irq) = crate::task::env::env();
-    INIT_IRQ_PRE_RING3_TICKS.store(clock.now().raw(), core::sync::atomic::Ordering::Release);
-    crate::serial_println!("irq-pre-ring3: ticks={}", clock.now().raw());
+    let pre_ticks = clock.now().raw();
+    INIT_IRQ_PRE_RING3_TICKS.store(pre_ticks, core::sync::atomic::Ordering::Release);
+    crate::serial_println!("irq-pre-ring3: ticks={}", pre_ticks);
     // #478 diagnostic step 1: emit a single-byte marker on the QEMU debug
     // console (port 0xe9) *immediately* before the iretq, and a second
     // byte in the same asm block *after* the iretq frame is pushed but

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -245,8 +245,12 @@ pub unsafe fn jump_to_ring3(entry: u64, stack_top: u64) -> ! {
     // matching `irq-post-ring3` snapshot taken on the first SYSCALL
     // from userspace and fails when too few timer interrupts fire in
     // between (the #478 starvation signature).
-    INIT_IRQ_PRE_RING3_TICKS.store(crate::time::ticks(), core::sync::atomic::Ordering::Release);
-    crate::serial_println!("irq-pre-ring3: ticks={}", crate::time::ticks());
+    // Route the diagnostic snapshot through `env()` (RFC 0005) so the
+    // simulator's clock — when we ever drive the ring-3 jump under it
+    // — sees the same `Tick` source the scheduler does.
+    let (clock, _irq) = crate::task::env::env();
+    INIT_IRQ_PRE_RING3_TICKS.store(clock.now().raw(), core::sync::atomic::Ordering::Release);
+    crate::serial_println!("irq-pre-ring3: ticks={}", clock.now().raw());
     // #478 diagnostic step 1: emit a single-byte marker on the QEMU debug
     // console (port 0xe9) *immediately* before the iretq, and a second
     // byte in the same asm block *after* the iretq frame is pushed but
@@ -339,7 +343,9 @@ pub unsafe extern "C" fn syscall_dispatch(
     // missing marker.
     if !INIT_IRQ_POST_FIRED.swap(true, core::sync::atomic::Ordering::AcqRel) {
         let pre = INIT_IRQ_PRE_RING3_TICKS.load(core::sync::atomic::Ordering::Acquire);
-        let now = crate::time::ticks();
+        // Same seam as the pre-ring3 snapshot above.
+        let (clock, _irq) = crate::task::env::env();
+        let now = clock.now().raw();
         let delta = now.saturating_sub(pre);
         crate::serial_println!("irq-post-ring3: ticks={} pre={} delta={}", now, pre, delta);
     }

--- a/kernel/src/block/writeback.rs
+++ b/kernel/src/block/writeback.rs
@@ -437,16 +437,22 @@ mod daemon {
         if state.stop.load(Ordering::SeqCst) {
             return;
         }
-        use crate::time::{self, TICK_MS};
+        // Routed through the scheduler/IRQ seam (RFC 0005) so the
+        // simulator and mock tests can drive the writeback daemon's
+        // sleep deterministically. Production resolves to `HwClock`
+        // over `crate::time::*` — semantically identical.
+        use crate::task::env;
+        use crate::time::TICK_MS;
+        let (clock, _irq) = env::env();
         let ticks_to_wait = ms.div_ceil(TICK_MS).max(1);
-        let deadline = time::ticks().saturating_add(ticks_to_wait);
-        time::enqueue_wakeup(deadline, task::current_id());
+        let deadline = clock.now().saturating_add(ticks_to_wait);
+        clock.enqueue_wakeup(deadline, task::current_id());
 
         state.sleep_wq.wait_while(|| {
             if state.stop.load(Ordering::SeqCst) {
                 return false;
             }
-            time::ticks() < deadline
+            clock.now() < deadline
         });
     }
 }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -271,9 +271,12 @@ pub extern "C" fn _start() -> ! {
 
 /// Blink the framebuffer cursor at approximately 1 Hz (toggle every 500 ms).
 fn cursor_blink_task() -> ! {
-    let mut next = vibix::time::ticks() + CURSOR_BLINK_TICKS;
+    // Route through the scheduler/IRQ seam (RFC 0005) so the future
+    // simulator builds use the same clock the scheduler does.
+    let (clock, _irq) = vibix::task::env::env();
+    let mut next = clock.now().raw() + CURSOR_BLINK_TICKS;
     loop {
-        while vibix::time::ticks() < next {
+        while clock.now().raw() < next {
             // Wake on the next timer tick, recheck. Preemption
             // rotates other tasks in and out while we sleep.
             x86_64::instructions::hlt();

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -1209,7 +1209,14 @@ pub fn preempt_tick() {
     // Drain any tick-deadline wakeups (see `task::sleep_ms`) and
     // promote their targets. Runs before the preemption decision so a
     // freshly-unparked task is visible in the highest-ready check.
-    for id in crate::time::drain_expired(crate::time::ticks()) {
+    //
+    // Routed through `env()` (RFC 0005) so the host-side simulator and
+    // mock tests can substitute their own clock. Production resolves
+    // to `HwClock` over `crate::time::*` — pure forwarding, no added
+    // synchronization (see `env::HwClock`).
+    let (clock, _irq) = env::env();
+    let now = clock.now();
+    for id in clock.drain_expired(now) {
         wake_in_sched(&mut sched, id);
     }
 
@@ -1468,9 +1475,14 @@ fn wake_in_sched(sched: &mut Scheduler, id: usize) {
 /// Resolution is the PIT tick (10 ms at 100 Hz); callers asking for
 /// less will sleep for at least one full tick.
 pub fn sleep_ms(ms: u64) {
+    // Routed through `env()` (RFC 0005) so simulator/mock builds can
+    // drive sleeps deterministically. Production resolves to
+    // `HwClock` — semantically identical to the previous direct
+    // `time::ticks` / `time::enqueue_wakeup` pair.
+    let (clock, _irq) = env::env();
     let ticks_to_wait = ms.div_ceil(crate::time::TICK_MS).max(1);
-    let deadline = crate::time::ticks().saturating_add(ticks_to_wait);
+    let deadline = clock.now().saturating_add(ticks_to_wait);
     let id = current_id();
-    crate::time::enqueue_wakeup(deadline, id);
+    clock.enqueue_wakeup(deadline, id);
     block_current();
 }

--- a/kernel/src/time.rs
+++ b/kernel/src/time.rs
@@ -146,7 +146,15 @@ pub fn on_tick() {
     TICKS.fetch_add(1, Ordering::Relaxed);
 }
 
-pub fn ticks() -> u64 {
+/// Monotonic PIT tick count since boot.
+///
+/// `pub(crate)` per RFC 0005 — the only intended caller is
+/// [`crate::task::env::HwClock::now`]; every other in-tree reader
+/// goes through `task::env::env()` so the simulator/mock builds can
+/// substitute a deterministic clock. A future PR that reintroduces
+/// a direct caller fails at compile time, which is the intended
+/// regression gate.
+pub(crate) fn ticks() -> u64 {
     TICKS.load(Ordering::Relaxed)
 }
 
@@ -247,7 +255,9 @@ pub fn calibrate_tsc() {}
 /// `deadline_ticks`. Callers are task context only — uses a blocking
 /// lock. A deadline of `0` or one already in the past will be drained
 /// on the very next `preempt_tick`.
-pub fn enqueue_wakeup(deadline_ticks: u64, id: usize) {
+/// `pub(crate)` per RFC 0005 — only intended caller is
+/// [`crate::task::env::HwClock::enqueue_wakeup`]. See `ticks()`.
+pub(crate) fn enqueue_wakeup(deadline_ticks: u64, id: usize) {
     WAKEUPS.lock().entry(deadline_ticks).or_default().push(id);
 }
 
@@ -258,7 +268,9 @@ pub fn enqueue_wakeup(deadline_ticks: u64, id: usize) {
 /// Safe to call from an interrupt context: uses `try_lock` and bails
 /// cleanly on contention. A missed drain is self-healing — the next
 /// tick's call picks the same entries up.
-pub fn drain_expired(now: u64) -> Vec<usize> {
+/// `pub(crate)` per RFC 0005 — only intended caller is
+/// [`crate::task::env::HwClock::drain_expired`]. See `ticks()`.
+pub(crate) fn drain_expired(now: u64) -> Vec<usize> {
     let Some(mut wakeups) = WAKEUPS.try_lock() else {
         return Vec::new();
     };

--- a/kernel/tests/block_writeback.rs
+++ b/kernel/tests/block_writeback.rs
@@ -54,7 +54,7 @@ use vibix::fs::vfs::{FsId, Inode};
 use vibix::{
     exit_qemu, serial_println, task,
     test_harness::{test_panic_handler, Testable},
-    time, QemuExitCode,
+    QemuExitCode,
 };
 
 #[no_mangle]
@@ -223,10 +223,13 @@ fn writeback_fires_after_interval() {
     let handle = writeback::start(sb.clone(), cache.clone(), dev)
         .expect("writeback daemon must start for a RW mount");
 
-    // Wait up to ~3 s for at least one sweep to land.
-    let start_ticks = time::ticks();
+    // Wait up to ~3 s for at least one sweep to land. Route through
+    // the scheduler/IRQ seam (RFC 0005); production resolves to the
+    // same `time::ticks()` source.
+    let (clock, _irq) = vibix::task::env::env();
+    let start_ticks = clock.now().raw();
     let deadline = start_ticks + 300; // 3 s at 100 Hz
-    while time::ticks() < deadline {
+    while clock.now().raw() < deadline {
         if handle.sweeps() >= 1 {
             break;
         }
@@ -237,7 +240,7 @@ fn writeback_fires_after_interval() {
         handle.sweeps() >= 1,
         "writeback daemon never swept — sweeps={} after {} ticks",
         handle.sweeps(),
-        time::ticks() - start_ticks,
+        clock.now().raw() - start_ticks,
     );
     assert!(
         !bh.state_has(STATE_DIRTY),
@@ -312,8 +315,10 @@ fn join_waits_for_daemon() {
     // with no ready task panics. Busy-wait on `time::ticks` instead;
     // `hlt` yields CPU to the timer ISR so the wait actually advances.
     let sweeps_after = handle.sweeps();
-    let deadline = time::ticks() + 20; // ~200 ms at 100 Hz
-    while time::ticks() < deadline {
+    // Route through the scheduler/IRQ seam (RFC 0005).
+    let (clock, _irq) = vibix::task::env::env();
+    let deadline = clock.now().raw() + 20; // ~200 ms at 100 Hz
+    while clock.now().raw() < deadline {
         x86_64::instructions::hlt();
     }
     assert_eq!(

--- a/kernel/tests/timer_tick.rs
+++ b/kernel/tests/timer_tick.rs
@@ -40,14 +40,17 @@ fn run_tests() {
 }
 
 fn ticks_advance() {
-    let start = vibix::time::ticks();
+    // Route through the scheduler/IRQ seam (RFC 0005); production
+    // resolves to the same `crate::time::ticks()` source.
+    let (clock, _irq) = vibix::task::env::env();
+    let start = clock.now().raw();
     // Wait for at least ~50 ms worth of ticks (5 @ 100 Hz). Use hlt
     // so the CPU actually sleeps between interrupts — a busy loop
     // under QEMU can race the first tick.
-    while vibix::time::ticks() < start + 5 {
+    while clock.now().raw() < start + 5 {
         x86_64::instructions::hlt();
     }
-    assert!(vibix::time::ticks() >= start + 5);
+    assert!(clock.now().raw() >= start + 5);
 }
 
 fn uptime_monotonic() {


### PR DESCRIPTION
## Summary

Implements RFC 0005 Phase 1 wave 3 (issue #667). Every in-tree caller of `time::ticks` / `time::drain_expired` / `time::enqueue_wakeup` and the timer-IRQ EOI now goes through `task::env::env()`; the three `time` fns are tightened to `pub(crate)` so a future direct-access leak fails at compile time.

Closes #667.

## Migrated callers

- `task::preempt_tick` — `clock.drain_expired(clock.now())`.
- `task::sleep_ms` — `clock.now()` + `clock.enqueue_wakeup`.
- `arch::x86_64::interrupts::timer_interrupt` — `irq.ack_timer()` replaces the `notify_eoi(Timer)` call. **Ordering preserved**: ack still happens before `preempt_tick` (the comment about PIC stalling on un-acked re-entry stays accurate).
- `arch::x86_64::syscall::jump_to_ring3` and `syscall_dispatch` — the `irq-pre-ring3` / `irq-post-ring3` diagnostic snapshots route through the seam.
- `block::writeback::park_ms_interruptible` — writeback daemon's deadline.
- `kernel/src/main.rs` (cursor_blink) and `kernel/tests/{timer_tick, block_writeback}.rs` — external callers now use `vibix::task::env::env()` since `time::*` is `pub(crate)`.

## Visibility tightening

`kernel/src/time.rs`: `ticks`, `drain_expired`, `enqueue_wakeup` → `pub(crate)` with doc comments pointing at the seam as the only intended caller. `on_tick` (write side, called from the ISR) and the `TICK_MS` / `TICK_HZ` consts stay `pub`.

## Equivalence audit (RFC 0005 §Equivalence)

1. **Pure forwarding.** `HwClock::{now, drain_expired, enqueue_wakeup}` and `HwIrq::ack_timer` are unchanged from #676 — single forwarding call each into the existing global. No early returns, no transformations beyond `Tick`/`u64` boxing.
2. **No added synchronization.** `env()` returns two `&'static dyn` refs to ZST statics. Zero locks/atomics/once-cells between caller and the underlying global vs. pre-seam direct calls.
3. **EOI ordering preserved.** `timer_interrupt` ack→`preempt_tick` ordering is unchanged. `irq.ack_timer()` resolves to the same `lapic_eoi()` that `notify_eoi(Timer)` did (via `arch::ack_timer_irq` → `apic::lapic_eoi`).

**Behavioral diff vs. pre-seam main:** none expected. The seam adds one indirect call per `preempt_tick` (vtable lookup, cache-resident at 100 Hz) and one per `sleep_ms` / writeback park / syscall diagnostic. RFC §"Generics vs trait objects" rates this as in the noise vs. the context-switch cache misses on the same path. No callsite was identified where routing through `env()` would cause a measurable timing change.

## Notes for reviewers

- Issue #668 (mock wiring) is intentionally untouched — this PR is production-side migration only.
- The `task::init()` `debug_assert!` from #676 (vtable identity check on `env()`) is left untouched; it continues to assert the production path resolves to the singleton adapters.
- Local `cargo xtask test-integration` on this worktree fails the existing #676 `debug_assert` on an older rustc nightly (1.97.0-nightly 7af3402cd, 2026-04-16) due to known trait-object-pointer-equality vtable-dedup differences. CI uses the latest nightly (52b6e2c20, 2026-04-27) where it passes — this is unrelated to this PR's diff.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo xtask test-unit` (518 passed)
- [ ] CI green: `cargo xtask test-integration`, smoke, build
- [ ] Equivalence test: byte-identical QEMU serial-log diff vs pre-seam main on the integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)