### PR TITLE
shell: decode CSI modifier params into distinct editor inputs

### DIFF
--- a/kernel/src/shell/ansi.rs
+++ b/kernel/src/shell/ansi.rs
@@ -16,24 +16,93 @@
 //! - `0x30..=0x3F` — parameter bytes (digits, `;`, `?`, etc.).
 //! - `0x40..=0x7E` — final byte that terminates the CSI.
 
-/// Current position in the escape-sequence grammar. Stored outside the
-/// state machine because serial bytes are consumed across many calls
-/// (each one is a fresh [`step`]).
+/// Maximum number of `;`-separated numeric parameters retained per CSI
+/// sequence. xterm's modified-key encoding only ever uses two
+/// (`ESC [ 1 ; <mod> <final>`); a small cap keeps the state struct
+/// `Copy`-cheap and bounds work per byte.
+pub const MAX_PARAMS: usize = 4;
+
+/// xterm parameter byte encoding for keyboard modifiers (bit-flags
+/// applied to a base of 1). E.g. Shift = 2, Alt = 3, Shift+Alt = 4,
+/// Ctrl = 5. We decode this into a flat [`Modifiers`] for the caller.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub enum State {
+pub struct Modifiers {
+    pub shift: bool,
+    pub alt: bool,
+    pub ctrl: bool,
+}
+
+impl Modifiers {
+    /// `true` when no modifier keys were held.
+    pub fn is_none(&self) -> bool {
+        !self.shift && !self.alt && !self.ctrl
+    }
+
+    /// Decode an xterm parameter value (1 = none, 2 = shift, 3 = alt,
+    /// 5 = ctrl, etc.) into modifier flags. Values that don't map to a
+    /// known modifier yield [`Modifiers::default`] — callers treating an
+    /// unknown modifier as "no modifier" preserves the pre-#336
+    /// behaviour where modified arrows degraded to plain arrows.
+    fn from_xterm_param(p: u16) -> Self {
+        if p < 2 {
+            return Modifiers::default();
+        }
+        let bits = p - 1;
+        Self {
+            shift: bits & 0b001 != 0,
+            alt: bits & 0b010 != 0,
+            ctrl: bits & 0b100 != 0,
+        }
+    }
+}
+
+/// Current position in the escape-sequence grammar plus a small param
+/// buffer used while a CSI is in flight. Stored outside the dispatch
+/// loop because serial bytes are consumed across many calls (each one
+/// is a fresh [`step`]).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct State {
+    phase: Phase,
+    /// Numeric `;`-separated parameter values seen so far. Entries past
+    /// `params_len` are stale.
+    params: [u16; MAX_PARAMS],
+    /// Number of populated entries in `params`.
+    params_len: usize,
+    /// `true` once the current parameter slot has accepted at least one
+    /// digit. Distinguishes "empty" from "0", and lets `;` terminate a
+    /// slot (advancing `params_len`) without inserting a phantom value
+    /// for a leading separator.
+    cur_started: bool,
+    /// `true` once we've seen any parameter byte that exceeds the
+    /// retained capacity (param overflow, individual value overflow, or
+    /// an unknown param byte like `?`). The sequence is still consumed
+    /// to its final byte; modifiers are reported as default and the
+    /// caller can act on the bare final.
+    overflow: bool,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            phase: Phase::Ground,
+            params: [0; MAX_PARAMS],
+            params_len: 0,
+            cur_started: false,
+            overflow: false,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Phase {
     /// No escape in progress.
-    #[default]
     Ground,
     /// Saw `ESC`, waiting for `[` or `O`.
     Esc,
-    /// In a CSI body, no parameter / intermediate bytes seen yet.
+    /// Inside a CSI body. The param buffer on [`State`] tells us
+    /// whether anything has been accumulated yet — we don't need a
+    /// separate `CsiParam` phase the way the pre-#336 enum did.
     Csi,
-    /// In a CSI body, at least one parameter or intermediate byte
-    /// accumulated. Treated identically to [`State::Csi`] for
-    /// dispatch — we only care about the final byte today — but kept
-    /// distinct so a future richer decoder can attach a small param
-    /// buffer without touching callers.
-    CsiParam,
 }
 
 /// Final byte of a CSI sequence, classified for the caller.
@@ -58,8 +127,11 @@ pub enum Event {
     /// A ground-state byte the caller should interpret as literal
     /// input. Not emitted for bytes consumed inside an escape.
     Byte(u8),
-    /// A CSI sequence terminated on this byte.
-    Csi(CsiFinal),
+    /// A CSI sequence terminated on this byte. The [`Modifiers`] are
+    /// decoded from xterm's `ESC [ 1 ; <mod> <final>` convention; for
+    /// unparameterised sequences (or when overflow forced us to drop
+    /// the param buffer) every flag is `false`.
+    Csi(CsiFinal, Modifiers),
 }
 
 /// Feed one serial byte into the state machine. Returns `Some(event)`
@@ -67,61 +139,144 @@ pub enum Event {
 /// the byte was consumed mid-sequence (or a malformed sequence was
 /// dropped) and the caller should wait for more bytes.
 pub fn step(state: &mut State, b: u8) -> Option<Event> {
-    match (*state, b) {
-        (State::Ground, 0x1b) => {
-            *state = State::Esc;
+    match (state.phase, b) {
+        (Phase::Ground, 0x1b) => {
+            state.phase = Phase::Esc;
             None
         }
-        (State::Ground, _) => Some(Event::Byte(b)),
+        (Phase::Ground, _) => Some(Event::Byte(b)),
 
-        (State::Esc, b'[') | (State::Esc, b'O') => {
-            *state = State::Csi;
+        (Phase::Esc, b'[') | (Phase::Esc, b'O') => {
+            enter_csi(state);
             None
         }
         // A fresh ESC mid-recovery restarts parsing rather than
         // dropping the new introducer along with the stale one.
-        (State::Esc, 0x1b) => None,
-        (State::Esc, _) => {
+        (Phase::Esc, 0x1b) => None,
+        (Phase::Esc, _) => {
             // Bare ESC followed by something that isn't the CSI
             // introducer: drop and resync.
-            *state = State::Ground;
+            reset(state);
             None
         }
 
-        (State::Csi, _) | (State::CsiParam, _) => csi_byte(state, b),
+        (Phase::Csi, _) => csi_byte(state, b),
     }
 }
 
-/// Inner CSI handler. Split out so the two in-CSI states share the
-/// param / intermediate / final classification in one place.
+/// Reset to ground and wipe the param buffer.
+fn reset(state: &mut State) {
+    *state = State::default();
+}
+
+/// Transition into the CSI body, clearing any prior param accumulator.
+fn enter_csi(state: &mut State) {
+    state.phase = Phase::Csi;
+    state.params = [0; MAX_PARAMS];
+    state.params_len = 0;
+    state.cur_started = false;
+    state.overflow = false;
+}
+
+/// Inner CSI handler. Splits each in-CSI byte into param accumulation,
+/// intermediate bytes, final-byte dispatch, or malformed-byte resync.
 fn csi_byte(state: &mut State, b: u8) -> Option<Event> {
     match b {
         // A fresh ESC inside a CSI body abandons the in-progress
         // sequence and starts a new one — the next byte is treated as
         // the introducer.
         0x1b => {
-            *state = State::Esc;
+            state.params = [0; MAX_PARAMS];
+            state.params_len = 0;
+            state.cur_started = false;
+            state.overflow = false;
+            state.phase = Phase::Esc;
             None
         }
-        // Parameter or intermediate byte: keep accumulating. Upgrades
-        // the state to `CsiParam` so future callers can tell a "plain"
-        // CSI from a parameterised one without re-scanning.
-        0x20..=0x3F => {
-            *state = State::CsiParam;
+        // Numeric parameter digit: fold into the current slot.
+        b'0'..=b'9' => {
+            accumulate_digit(state, b - b'0');
+            None
+        }
+        // `;` separator: advance to the next slot (or mark overflow if
+        // we've already filled the buffer). A leading or repeated `;`
+        // commits a default-zero entry, matching ECMA-48 semantics.
+        b';' => {
+            commit_param(state);
+            None
+        }
+        // Other parameter bytes (`:`, `<`, `=`, `>`, `?`) and any
+        // intermediate byte (`0x20..=0x2F`): we don't decode them, but
+        // they don't malform the sequence — keep accumulating and let
+        // the final byte still dispatch with default modifiers.
+        0x20..=0x2F | 0x3A | 0x3C..=0x3F => {
+            state.overflow = true;
             None
         }
         // Final byte: dispatch and reset.
         0x40..=0x7E => {
-            *state = State::Ground;
-            Some(Event::Csi(classify_final(b)))
+            let modifiers = decode_modifiers(state);
+            let final_byte = b;
+            reset(state);
+            Some(Event::Csi(classify_final(final_byte), modifiers))
         }
         // Anything else (C0 control char mid-sequence, 8-bit byte):
         // malformed, drop and resync to Ground.
         _ => {
-            *state = State::Ground;
+            reset(state);
             None
         }
     }
+}
+
+/// Fold a decimal digit into the current parameter slot, capping at
+/// `u16::MAX` to keep arithmetic infallible. Slots beyond `MAX_PARAMS`
+/// trip the overflow flag so the caller still gets the final byte.
+fn accumulate_digit(state: &mut State, digit: u8) {
+    if state.params_len >= MAX_PARAMS {
+        state.overflow = true;
+        return;
+    }
+    let slot = &mut state.params[state.params_len];
+    *slot = slot.saturating_mul(10).saturating_add(u16::from(digit));
+    state.cur_started = true;
+}
+
+/// Close out the current parameter slot on a `;` separator. Empty
+/// slots commit a 0 (per ECMA-48) so positions stay aligned with the
+/// caller's expectations (e.g. `ESC [ ; 5 A` → `[0, 5]`). Once the
+/// buffer is full, further separators count as overflow but don't
+/// abort the sequence.
+fn commit_param(state: &mut State) {
+    if state.params_len < MAX_PARAMS {
+        state.params_len += 1;
+        state.cur_started = false;
+    } else {
+        state.overflow = true;
+    }
+}
+
+/// Snapshot the modifier value out of the param buffer at dispatch
+/// time. xterm encodes modified keys as `ESC [ 1 ; <mod> <final>`, so
+/// we read the second slot. Overflowed sequences degrade to default
+/// modifiers — preserves the pre-#336 behaviour where weird parameter
+/// shapes still let the final byte route as a plain key.
+fn decode_modifiers(state: &State) -> Modifiers {
+    if state.overflow {
+        return Modifiers::default();
+    }
+    // Number of populated slots: every `;` advances `params_len`, plus
+    // one for the in-progress slot if it accumulated digits.
+    let total = state.params_len + usize::from(state.cur_started);
+    if total < 2 {
+        return Modifiers::default();
+    }
+    // The second slot lives at index 1 regardless of whether it's
+    // closed off (params_len >= 2) or still in progress (cur_started
+    // with params_len == 1) — `accumulate_digit` writes into
+    // `params[params_len]` either way.
+    let raw = state.params[1];
+    Modifiers::from_xterm_param(raw)
 }
 
 fn classify_final(b: u8) -> CsiFinal {
@@ -148,6 +303,12 @@ mod tests {
         out
     }
 
+    const NOMOD: Modifiers = Modifiers {
+        shift: false,
+        alt: false,
+        ctrl: false,
+    };
+
     #[test]
     fn printable_ascii_passthrough() {
         let mut s = State::default();
@@ -155,101 +316,152 @@ mod tests {
             feed(&mut s, b"hi!"),
             vec![Event::Byte(b'h'), Event::Byte(b'i'), Event::Byte(b'!'),]
         );
-        assert_eq!(s, State::Ground);
+        assert_eq!(s, State::default());
     }
 
     #[test]
-    fn plain_up_arrow_dispatches_up() {
+    fn plain_up_arrow_dispatches_up_no_mod() {
         let mut s = State::default();
-        assert_eq!(feed(&mut s, b"\x1b[A"), vec![Event::Csi(CsiFinal::Up)],);
-        assert_eq!(s, State::Ground);
+        assert_eq!(
+            feed(&mut s, b"\x1b[A"),
+            vec![Event::Csi(CsiFinal::Up, NOMOD)],
+        );
+        assert_eq!(s, State::default());
     }
 
     #[test]
-    fn plain_down_arrow_dispatches_down() {
+    fn plain_down_arrow_dispatches_down_no_mod() {
         let mut s = State::default();
-        assert_eq!(feed(&mut s, b"\x1b[B"), vec![Event::Csi(CsiFinal::Down)],);
+        assert_eq!(
+            feed(&mut s, b"\x1b[B"),
+            vec![Event::Csi(CsiFinal::Down, NOMOD)],
+        );
     }
 
     #[test]
     fn xterm_o_introducer_accepted() {
         // Some xterm modes use `ESC O A` for arrows.
         let mut s = State::default();
-        assert_eq!(feed(&mut s, b"\x1bOA"), vec![Event::Csi(CsiFinal::Up)],);
+        assert_eq!(
+            feed(&mut s, b"\x1bOA"),
+            vec![Event::Csi(CsiFinal::Up, NOMOD)],
+        );
     }
 
     #[test]
-    fn ctrl_up_with_params_dispatches_up() {
-        // xterm Ctrl+Up: ESC [ 1 ; 5 A. Issue #310 policy is to map
-        // modified arrows onto the same final-byte classification as
-        // plain arrows for now.
+    fn ctrl_up_carries_ctrl_modifier() {
+        // xterm Ctrl+Up: ESC [ 1 ; 5 A.
         let mut s = State::default();
-        assert_eq!(feed(&mut s, b"\x1b[1;5A"), vec![Event::Csi(CsiFinal::Up)],);
-        assert_eq!(s, State::Ground);
+        let ctrl = Modifiers {
+            ctrl: true,
+            ..Modifiers::default()
+        };
+        assert_eq!(
+            feed(&mut s, b"\x1b[1;5A"),
+            vec![Event::Csi(CsiFinal::Up, ctrl)],
+        );
+        assert_eq!(s, State::default());
+    }
+
+    #[test]
+    fn shift_left_carries_shift_modifier() {
+        let mut s = State::default();
+        let shift = Modifiers {
+            shift: true,
+            ..Modifiers::default()
+        };
+        assert_eq!(
+            feed(&mut s, b"\x1b[1;2D"),
+            vec![Event::Csi(CsiFinal::Left, shift)],
+        );
+    }
+
+    #[test]
+    fn alt_right_carries_alt_modifier() {
+        let mut s = State::default();
+        let alt = Modifiers {
+            alt: true,
+            ..Modifiers::default()
+        };
+        assert_eq!(
+            feed(&mut s, b"\x1b[1;3C"),
+            vec![Event::Csi(CsiFinal::Right, alt)],
+        );
+    }
+
+    #[test]
+    fn shift_alt_combo_decodes_both() {
+        // xterm encodes Shift+Alt as modifier value 4 (1 + 0b011).
+        let mut s = State::default();
+        let m = Modifiers {
+            shift: true,
+            alt: true,
+            ctrl: false,
+        };
+        assert_eq!(
+            feed(&mut s, b"\x1b[1;4A"),
+            vec![Event::Csi(CsiFinal::Up, m)],
+        );
     }
 
     #[test]
     fn intermediate_byte_does_not_drop_sequence() {
         // `ESC [ ! p` is a valid DECSTR soft reset; we don't act on
         // it, but the state machine must consume it without stranding
-        // the next arrow.
+        // the next arrow. Intermediate bytes set the overflow flag, so
+        // the dispatched event reports default modifiers.
         let mut s = State::default();
         assert_eq!(
             feed(&mut s, b"\x1b[!p"),
-            vec![Event::Csi(CsiFinal::Other(b'p'))],
+            vec![Event::Csi(CsiFinal::Other(b'p'), NOMOD)],
         );
-        assert_eq!(feed(&mut s, b"\x1b[A"), vec![Event::Csi(CsiFinal::Up)],);
+        assert_eq!(
+            feed(&mut s, b"\x1b[A"),
+            vec![Event::Csi(CsiFinal::Up, NOMOD)],
+        );
     }
 
     #[test]
     fn csi_with_control_byte_mid_sequence_resyncs() {
-        // A stray control byte inside a CSI body is malformed; drop
-        // the in-progress sequence and resync. The following plain
-        // arrow must still dispatch.
         let mut s = State::default();
         assert_eq!(feed(&mut s, b"\x1b[1\x07"), Vec::<Event>::new());
-        assert_eq!(s, State::Ground);
-        assert_eq!(feed(&mut s, b"\x1b[B"), vec![Event::Csi(CsiFinal::Down)],);
+        assert_eq!(s, State::default());
+        assert_eq!(
+            feed(&mut s, b"\x1b[B"),
+            vec![Event::Csi(CsiFinal::Down, NOMOD)],
+        );
     }
 
     #[test]
     fn fresh_esc_after_bare_esc_starts_new_sequence() {
-        // `ESC ESC [ A` should dispatch Up, not lose the second ESC
-        // along with the first as "bare ESC + non-introducer".
         let mut s = State::default();
-        assert_eq!(feed(&mut s, b"\x1b\x1b[A"), vec![Event::Csi(CsiFinal::Up)],);
-        assert_eq!(s, State::Ground);
+        assert_eq!(
+            feed(&mut s, b"\x1b\x1b[A"),
+            vec![Event::Csi(CsiFinal::Up, NOMOD)],
+        );
+        assert_eq!(s, State::default());
     }
 
     #[test]
     fn fresh_esc_inside_csi_starts_new_sequence() {
-        // `ESC [ 1 ESC [ A` should dispatch Up: the new ESC abandons
-        // the in-progress CSI and re-enters Esc so `[ A` completes.
         let mut s = State::default();
         assert_eq!(
             feed(&mut s, b"\x1b[1\x1b[A"),
-            vec![Event::Csi(CsiFinal::Up)],
+            vec![Event::Csi(CsiFinal::Up, NOMOD)],
         );
-        assert_eq!(s, State::Ground);
+        assert_eq!(s, State::default());
     }
 
     #[test]
     fn bare_esc_followed_by_letter_resets() {
-        // ESC followed by a non-CSI-introducer byte: drop and resync;
-        // the trailing letter is not delivered as a ground byte
-        // (matches the pre-existing Esc/_ behaviour).
         let mut s = State::default();
         assert_eq!(feed(&mut s, b"\x1bX"), Vec::<Event>::new());
-        assert_eq!(s, State::Ground);
-        // Next printable byte passes through normally.
+        assert_eq!(s, State::default());
         assert_eq!(feed(&mut s, b"y"), vec![Event::Byte(b'y')]);
     }
 
     #[test]
     fn high_bit_byte_in_ground_surfaces_as_byte() {
-        // The state machine itself passes 8-bit bytes through; it's
-        // the shell's caller that guards against `b as char`
-        // producing replacement chars.
         let mut s = State::default();
         assert_eq!(feed(&mut s, &[0xC3]), vec![Event::Byte(0xC3)]);
     }
@@ -257,8 +469,14 @@ mod tests {
     #[test]
     fn left_right_finals_classified() {
         let mut s = State::default();
-        assert_eq!(feed(&mut s, b"\x1b[C"), vec![Event::Csi(CsiFinal::Right)],);
-        assert_eq!(feed(&mut s, b"\x1b[D"), vec![Event::Csi(CsiFinal::Left)],);
+        assert_eq!(
+            feed(&mut s, b"\x1b[C"),
+            vec![Event::Csi(CsiFinal::Right, NOMOD)],
+        );
+        assert_eq!(
+            feed(&mut s, b"\x1b[D"),
+            vec![Event::Csi(CsiFinal::Left, NOMOD)],
+        );
     }
 
     #[test]
@@ -266,7 +484,52 @@ mod tests {
         let mut s = State::default();
         assert_eq!(
             feed(&mut s, b"\x1b[H"),
-            vec![Event::Csi(CsiFinal::Other(b'H'))],
+            vec![Event::Csi(CsiFinal::Other(b'H'), NOMOD)],
         );
+    }
+
+    #[test]
+    fn excess_params_drop_cleanly_with_default_modifiers() {
+        // Five params overflow the four-slot buffer; the sequence is
+        // still consumed and the final byte still classified, but the
+        // modifier decode reports default (no modifiers held) so the
+        // caller behaves as if it were a plain arrow.
+        let mut s = State::default();
+        assert_eq!(
+            feed(&mut s, b"\x1b[1;2;3;4;5A"),
+            vec![Event::Csi(CsiFinal::Up, NOMOD)],
+        );
+        assert_eq!(s, State::default());
+        // The state machine recovers — a follow-up plain arrow still
+        // dispatches.
+        assert_eq!(
+            feed(&mut s, b"\x1b[A"),
+            vec![Event::Csi(CsiFinal::Up, NOMOD)],
+        );
+    }
+
+    #[test]
+    fn very_long_param_value_saturates_without_panic() {
+        let mut s = State::default();
+        // 10 digits would overflow u16 mid-multiply; saturating math
+        // keeps the parser honest. Modifier slot is empty so we still
+        // get default modifiers.
+        let evs = feed(&mut s, b"\x1b[9999999999A");
+        assert_eq!(evs, vec![Event::Csi(CsiFinal::Up, NOMOD)]);
+        // And we can still parse a normal sequence afterwards.
+        assert_eq!(
+            feed(&mut s, b"\x1b[A"),
+            vec![Event::Csi(CsiFinal::Up, NOMOD)],
+        );
+    }
+
+    #[test]
+    fn modifiers_is_none_helper() {
+        assert!(NOMOD.is_none());
+        assert!(!Modifiers {
+            ctrl: true,
+            ..Modifiers::default()
+        }
+        .is_none());
     }
 }

--- a/kernel/src/shell/mod.rs
+++ b/kernel/src/shell/mod.rs
@@ -92,13 +92,20 @@ mod kernel_side {
     /// completion of an arrow escape, return the corresponding `Input`.
     /// Unrecognised finals and parameterised sequences with non-arrow
     /// finals drop silently.
+    ///
+    /// The modifier flags (per #336) are decoded but the line editor
+    /// doesn't yet have bindings for Ctrl/Shift/Alt + arrow, so the
+    /// initial routing keeps Up/Down → history regardless of modifier
+    /// state (preserving the #310 fix where Ctrl+Up didn't strand) and
+    /// drops Left/Right. Future PRs can add `Input` variants and route
+    /// modified arrows here without re-touching the state machine.
     fn serial_byte(b: u8, state: &mut ansi::State) -> Option<Input> {
         match ansi::step(state, b)? {
             Event::Byte(b) => byte_to_input(b),
-            Event::Csi(CsiFinal::Up) => Some(Input::HistoryPrev),
-            Event::Csi(CsiFinal::Down) => Some(Input::HistoryNext),
+            Event::Csi(CsiFinal::Up, _mods) => Some(Input::HistoryPrev),
+            Event::Csi(CsiFinal::Down, _mods) => Some(Input::HistoryNext),
             // Left/right and other finals: deferred per issue #112.
-            Event::Csi(_) => None,
+            Event::Csi(_, _) => None,
         }
     }
 


### PR DESCRIPTION
Closes #336

## Summary

- Adds a small fixed-size param buffer (`MAX_PARAMS = 4`, u16 slots) to `shell::ansi::State` so the second `;`-separated value in xterm's `ESC [ 1 ; <mod> <final>` survives to dispatch time.
- Decodes that value into a flat `Modifiers { shift, alt, ctrl }` (xterm's 1-based bit-flag encoding: `2 = Shift`, `3 = Alt`, `5 = Ctrl`, `4 = Shift+Alt`, ...) and threads it through `Event::Csi(CsiFinal, Modifiers)`.
- Param accumulation is bounded — too many `;`-separated values, an individual value past `u16::MAX` (saturating arithmetic), or any unknown param byte (`?`, `:`, `<`, `=`, `>`, intermediates) trips an overflow flag that degrades the dispatch to default modifiers; the final byte still classifies and the caller behaves as if the arrow were plain. Sequence-resync and ESC-restart semantics from #333 are preserved verbatim.
- `shell::serial_byte` routing is intentionally minimal (Up/Down → history regardless of modifiers, Left/Right still dropped) — the issue scopes binding selection to "further key-binding work". Public `Modifiers` is now on the `ansi` surface for follow-up PRs to wire word-motion etc. without revisiting the state machine.

## Test plan

Host unit tests in `kernel/src/shell/ansi.rs` cover everything the issue called out plus a few more:

- [x] `ESC [ 1 ; 5 A` → `Csi(Up, Modifiers{ctrl})`
- [x] `ESC [ 1 ; 2 D` → `Csi(Left, Modifiers{shift})`
- [x] `ESC [ 1 ; 3 C` → `Csi(Right, Modifiers{alt})`
- [x] plain `ESC [ A` → `Csi(Up, NOMOD)`
- [x] `ESC [ 1 ; 4 A` → `Csi(Up, Modifiers{shift, alt})` (combo encoding sanity check)
- [x] overflow: `ESC [ 1 ; 2 ; 3 ; 4 ; 5 A` drops to `NOMOD` and the next plain arrow still dispatches
- [x] saturating digit accumulation: `ESC [ 9999999999 A` doesn't panic and still dispatches
- [x] all pre-existing tests (resync on stray control byte, `ESC ESC [ A`, `ESC [ 1 ESC [ A`, `ESC O A`, intermediate `ESC [ ! p`, etc.) still pass with the new tuple shape
- [x] `cargo xtask build` / `cargo xtask test` / `cargo xtask smoke` (41/41 markers)