### PR TITLE
ext2: mount-time BGDT/bitmap consistency checks (#678)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -465,3 +465,8 @@ required-features = ["ext2"]
 name = "ext2_rename"
 harness = false
 required-features = ["ext2"]
+
+[[test]]
+name = "ext2_validate_bgdt"
+harness = false
+required-features = ["ext2"]

--- a/kernel/src/fs/ext2/fs.rs
+++ b/kernel/src/fs/ext2/fs.rs
@@ -384,6 +384,21 @@ impl FileSystem for Ext2Fs {
             ext2_flags |= Ext2MountFlags::FORCED_RDONLY;
         }
 
+        // 7c. Mount-time BGDT / bitmap consistency checks (issue #678,
+        //     RFC 0004 §Robustness / §Security). Cross-checks per-group
+        //     bitmap clear-bit counts against `bg_free_*_count`,
+        //     verifies the reserved-inode range is allocated in group
+        //     0, and that the superblock totals equal the BGDT sums. A
+        //     `Yes` verdict demotes the mount to RO before the
+        //     `s_state := ERROR_FS` stamp, so a corrupt image never
+        //     accepts a write.
+        let bgdt_verdict =
+            super::validate::validate_bgdt(&cache, device_id, &on_disk_sb, &bgdt, first_ino);
+        if bgdt_verdict == super::orphan::ForceRo::Yes {
+            effective_rdonly = true;
+            ext2_flags |= Ext2MountFlags::FORCED_RDONLY;
+        }
+
         // 8. RW bring-up: stamp `s_state := ERROR_FS` so an unclean
         //    crash is detectable on the next mount. The canonical
         //    `VALID_FS` is rewritten only by a clean unmount. RO

--- a/kernel/src/fs/ext2/mod.rs
+++ b/kernel/src/fs/ext2/mod.rs
@@ -74,6 +74,15 @@ pub mod file;
 #[cfg(all(feature = "ext2", target_os = "none"))]
 pub mod orphan;
 
+// Mount-time BGDT / bitmap consistency checks (#678). Same feature
+// gate as `orphan` — uses the BlockCache to read bitmap blocks before
+// the `Arc<SuperBlock>` is built. Host unit tests for pure helpers
+// (clear-bit counting, per-group size) live behind `#[cfg(test)]`
+// inside the module; the full surface is exercised by the QEMU
+// integration test `kernel/tests/ext2_validate_bgdt.rs`.
+#[cfg(all(feature = "ext2", target_os = "none"))]
+pub mod validate;
+
 // Block bitmap allocator (#565). Same gate as `fs` / `inode` — it
 // mutates `Ext2Super::bgdt` + `Ext2Super::sb_disk` through the buffer
 // cache, both of which are gated on `target_os = "none"`. The pure
@@ -95,6 +104,9 @@ pub use file::{read_file_at, write_file_at};
 
 #[cfg(all(feature = "ext2", target_os = "none"))]
 pub use orphan::{validate_orphan_chain, ForceRo};
+
+#[cfg(all(feature = "ext2", target_os = "none"))]
+pub use validate::validate_bgdt;
 
 #[cfg(all(feature = "ext2", target_os = "none"))]
 pub use balloc::{alloc_block, free_block};

--- a/kernel/src/fs/ext2/validate.rs
+++ b/kernel/src/fs/ext2/validate.rs
@@ -1,0 +1,417 @@
+//! Mount-time block-group / bitmap consistency checks.
+//!
+//! RFC 0004 §Robustness / §Security require that the driver reject —
+//! or at minimum demote to RO — images whose on-disk bookkeeping is
+//! detectably inconsistent. `Ext2Fs::mount` already validates the
+//! superblock magic, geometry, and feature-flag triple; this module
+//! adds the cross-checks between the block-group descriptor table
+//! (BGDT) and the bitmaps it indexes:
+//!
+//! 1. Per group: count clear bits in the block bitmap; the value must
+//!    equal `bg_free_blocks_count`. Same for the inode bitmap and
+//!    `bg_free_inodes_count`.
+//! 2. Group 0's inode bitmap must mark the reserved-inode range
+//!    (inos `1..first_ino`, including ino 2 = `EXT2_ROOT_INO`) as
+//!    *allocated*.
+//! 3. The superblock's `s_free_blocks_count` / `s_free_inodes_count`
+//!    must equal the sum of the per-group counters.
+//!
+//! On any mismatch the validator logs (via `kwarn!`) the group and the
+//! observed-vs-expected counts and returns [`ForceRo::Yes`]; the mount
+//! path then sets `Ext2MountFlags::FORCED_RDONLY` so subsequent writes
+//! are refused. Reads are still safe: a desync between the bitmap and
+//! the counter only matters when we try to allocate or free.
+//!
+//! The validator runs as a raw walk *before* the `Arc<SuperBlock>` is
+//! built, mirroring the orphan-chain validator (`super::orphan`). The
+//! `ForceRo` verdict is collapsed into the same `effective_rdonly` path
+//! that handles the unknown-RO_COMPAT and corrupt-orphan-chain cases.
+//!
+//! Out of scope (per #678): online repair, cross-checking inode
+//! `i_blocks` totals against actual block-bitmap usage, validating the
+//! BGDT block-bitmap / inode-bitmap / inode-table block numbers point
+//! into sane locations (the allocator already refuses to hand out
+//! metadata blocks via `is_metadata_block`).
+
+use alloc::vec;
+
+use crate::block::cache::{BlockCache, DeviceId};
+use crate::kwarn;
+
+use super::disk::{Ext2GroupDesc, Ext2SuperBlock, EXT2_GOOD_OLD_FIRST_INO, EXT2_GOOD_OLD_REV};
+use super::orphan::ForceRo;
+
+/// Mount-time BGDT / bitmap consistency check. See module docs.
+///
+/// `first_ino` is the resolved first user-allocatable inode number
+/// (rev-0: 11; rev-1: `s_first_ino`). The mount path computes it once
+/// during feature-flag gating and passes it in; we accept it as a
+/// parameter rather than re-deriving from `sb_disk` so the validator
+/// can't drift from the rest of the mount pipeline.
+///
+/// Returns:
+/// - [`ForceRo::No`] when every cross-check passes.
+/// - [`ForceRo::Yes`] on any mismatch. A `kwarn!` line per failed
+///   check identifies the group + the observed-vs-expected values,
+///   so a human can use `dumpe2fs` against the same image to confirm.
+pub fn validate_bgdt(
+    cache: &BlockCache,
+    device_id: DeviceId,
+    sb_disk: &Ext2SuperBlock,
+    bgdt: &[Ext2GroupDesc],
+    first_ino: u32,
+) -> ForceRo {
+    if bgdt.is_empty() {
+        // The mount path already rejects a zero-group filesystem with
+        // EINVAL before we run, so reaching this branch implies a
+        // sequencing bug. Be loud and force RO rather than silently
+        // pass.
+        kwarn!("ext2: validate_bgdt: empty BGDT, forcing RO");
+        return ForceRo::Yes;
+    }
+
+    let group_count = bgdt.len() as u32;
+    let s_blocks_per_group = sb_disk.s_blocks_per_group;
+    let s_inodes_per_group = sb_disk.s_inodes_per_group;
+    let s_blocks_count = sb_disk.s_blocks_count;
+    let s_inodes_count = sb_disk.s_inodes_count;
+    let s_first_data_block = sb_disk.s_first_data_block;
+
+    if s_blocks_per_group == 0 || s_inodes_per_group == 0 {
+        // Geometry is checked by the mount path before we run; keep a
+        // belt-and-braces guard so a future caller can't drive us into
+        // a div-by-zero.
+        kwarn!(
+            "ext2: validate_bgdt: zero blocks_per_group ({}) or inodes_per_group ({}), forcing RO",
+            s_blocks_per_group,
+            s_inodes_per_group,
+        );
+        return ForceRo::Yes;
+    }
+
+    // Sums for the superblock-vs-BGDT cross-check at the end. The
+    // per-group counter is u16 on disk; sum into u64 so a hostile
+    // image with `0xffff` in every group can't overflow even at the
+    // u32::MAX-group ceiling.
+    let mut sum_free_blocks: u64 = 0;
+    let mut sum_free_inodes: u64 = 0;
+
+    for (idx, bg) in bgdt.iter().enumerate() {
+        let group = idx as u32;
+
+        let blocks_in_this_group = blocks_in_group(
+            group,
+            group_count,
+            s_blocks_per_group,
+            s_blocks_count,
+            s_first_data_block,
+        );
+        let inodes_in_this_group =
+            inodes_in_group(group, group_count, s_inodes_per_group, s_inodes_count);
+
+        // ---- block bitmap ----
+        let bb_clear = match read_and_count_clear_bits(
+            cache,
+            device_id,
+            bg.bg_block_bitmap as u64,
+            blocks_in_this_group,
+        ) {
+            Some(n) => n,
+            None => {
+                kwarn!(
+                    "ext2: validate_bgdt: group {}: unreadable block bitmap at block {}, forcing RO",
+                    group,
+                    bg.bg_block_bitmap,
+                );
+                return ForceRo::Yes;
+            }
+        };
+        if bb_clear != bg.bg_free_blocks_count as u32 {
+            kwarn!(
+                "ext2: validate_bgdt: group {}: block bitmap has {} clear bits, BGDT says bg_free_blocks_count={}; forcing RO",
+                group,
+                bb_clear,
+                bg.bg_free_blocks_count,
+            );
+            return ForceRo::Yes;
+        }
+
+        // ---- inode bitmap ----
+        let ib_clear = match read_and_count_clear_bits(
+            cache,
+            device_id,
+            bg.bg_inode_bitmap as u64,
+            inodes_in_this_group,
+        ) {
+            Some(n) => n,
+            None => {
+                kwarn!(
+                    "ext2: validate_bgdt: group {}: unreadable inode bitmap at block {}, forcing RO",
+                    group,
+                    bg.bg_inode_bitmap,
+                );
+                return ForceRo::Yes;
+            }
+        };
+        if ib_clear != bg.bg_free_inodes_count as u32 {
+            kwarn!(
+                "ext2: validate_bgdt: group {}: inode bitmap has {} clear bits, BGDT says bg_free_inodes_count={}; forcing RO",
+                group,
+                ib_clear,
+                bg.bg_free_inodes_count,
+            );
+            return ForceRo::Yes;
+        }
+
+        // ---- reserved-inode-range check (group 0 only) ----
+        // Inos `1..first_ino` are reserved (root=2 lives in there).
+        // They map to bits `0..first_ino-1` of group 0's inode bitmap;
+        // every one of those bits MUST be set.
+        if group == 0 {
+            if let Some(ino) =
+                first_clear_reserved_ino(cache, device_id, bg.bg_inode_bitmap as u64, first_ino)
+            {
+                kwarn!(
+                    "ext2: validate_bgdt: group 0: reserved inode {} is unallocated in inode bitmap, forcing RO",
+                    ino,
+                );
+                return ForceRo::Yes;
+            }
+        }
+
+        sum_free_blocks = sum_free_blocks.saturating_add(bg.bg_free_blocks_count as u64);
+        sum_free_inodes = sum_free_inodes.saturating_add(bg.bg_free_inodes_count as u64);
+    }
+
+    // ---- superblock totals vs BGDT sums ----
+    if sum_free_blocks != sb_disk.s_free_blocks_count as u64 {
+        kwarn!(
+            "ext2: validate_bgdt: sum of bg_free_blocks_count = {} but s_free_blocks_count = {}; forcing RO",
+            sum_free_blocks,
+            sb_disk.s_free_blocks_count,
+        );
+        return ForceRo::Yes;
+    }
+    if sum_free_inodes != sb_disk.s_free_inodes_count as u64 {
+        kwarn!(
+            "ext2: validate_bgdt: sum of bg_free_inodes_count = {} but s_free_inodes_count = {}; forcing RO",
+            sum_free_inodes,
+            sb_disk.s_free_inodes_count,
+        );
+        return ForceRo::Yes;
+    }
+
+    let _ = EXT2_GOOD_OLD_REV; // doc-import keep-alive
+    let _ = EXT2_GOOD_OLD_FIRST_INO;
+
+    ForceRo::No
+}
+
+/// Read `bitmap_block` through `cache` and count the number of clear
+/// bits in `[0, bit_limit)`. Returns `None` on a `bread` error so the
+/// caller can demote to RO with a meaningful error rather than burying
+/// the EIO in a panic.
+fn read_and_count_clear_bits(
+    cache: &BlockCache,
+    device_id: DeviceId,
+    bitmap_block: u64,
+    bit_limit: u32,
+) -> Option<u32> {
+    let bh = cache.bread(device_id, bitmap_block).ok()?;
+    let data = bh.data.read();
+    Some(count_clear_bits(&data, bit_limit))
+}
+
+/// Count clear bits in `[0, bit_limit)` of `bitmap` (LSB-first within
+/// each byte — standard ext2 layout). Bits past `bit_limit` are
+/// ignored, matching how the allocator caps its scan to
+/// `blocks_in_group` / `inodes_in_group`: mkfs.ext2 sets the tail bits
+/// to 1 to mark "past end of group," and we treat anything beyond
+/// `bit_limit` as not-our-business.
+///
+/// Public-but-unexported (via `pub(crate)`) so the kernel-target
+/// `#[cfg(test)]` module below and a future allocator-side reuse can
+/// share the same implementation.
+pub(crate) fn count_clear_bits(bitmap: &[u8], bit_limit: u32) -> u32 {
+    let bit_limit = bit_limit as usize;
+    if bit_limit == 0 {
+        return 0;
+    }
+    let bytes_full = bit_limit / 8;
+    let tail_bits = bit_limit % 8;
+
+    // Cap by `bitmap.len()` so a corrupt-but-short bitmap block (e.g.
+    // a buffer-cache short read on a malformed image) doesn't index
+    // past the end. The truncation is itself a corruption signal but
+    // the per-bit clear-count would still be defined.
+    let mut count: u32 = 0;
+    let full_iter_end = bytes_full.min(bitmap.len());
+    for &b in &bitmap[..full_iter_end] {
+        // count_zeros() on u8 returns the number of zero bits across
+        // all 8 positions. u32 conversion is fine — max 8 per byte.
+        count += b.count_zeros();
+    }
+    // Treat any bytes the bitmap is missing (because it's too short)
+    // as fully "set" (worst-case for the caller — they'll see a
+    // smaller free-bit count than the BGDT claims and force RO via
+    // the count mismatch rather than via this helper). This matches
+    // mkfs.ext2's tail-byte convention.
+    //
+    // The partial trailing byte only contributes its `tail_bits` low
+    // positions; bits at and above `tail_bits` are off-bitmap and
+    // don't count.
+    if tail_bits > 0 && bytes_full < bitmap.len() {
+        let b = bitmap[bytes_full];
+        for off in 0..tail_bits {
+            if b & (1u8 << off) == 0 {
+                count += 1;
+            }
+        }
+    }
+    count
+}
+
+/// Return the first reserved-inode number (1-based, in
+/// `1..first_ino`) whose bit in `inode_bitmap_block` is *clear* —
+/// i.e. the bitmap claims it's free, which is a corruption.
+///
+/// Returns `None` if every reserved bit is set (the healthy case) or
+/// if `first_ino <= 1` (no reserved range, which a mount-path geometry
+/// check should already have rejected).
+fn first_clear_reserved_ino(
+    cache: &BlockCache,
+    device_id: DeviceId,
+    inode_bitmap_block: u64,
+    first_ino: u32,
+) -> Option<u32> {
+    if first_ino <= 1 {
+        return None;
+    }
+    let bh = cache.bread(device_id, inode_bitmap_block).ok()?;
+    let data = bh.data.read();
+    // Inos are 1-based; bit `i` in the bitmap corresponds to ino `i+1`.
+    let bits_to_check = (first_ino - 1) as usize;
+    for bit in 0..bits_to_check {
+        let byte = bit / 8;
+        let mask = 1u8 << (bit % 8);
+        if byte >= data.len() {
+            // Bitmap shorter than the reserved range → corruption.
+            return Some((bit as u32) + 1);
+        }
+        if data[byte] & mask == 0 {
+            return Some((bit as u32) + 1);
+        }
+    }
+    None
+}
+
+/// Number of blocks in the given group. Mirrors the allocator's
+/// `blocks_in_group` (private to `balloc.rs`); duplicated here so the
+/// validator can run before the allocator is in scope.
+fn blocks_in_group(
+    group: u32,
+    group_count: u32,
+    s_blocks_per_group: u32,
+    s_blocks_count: u32,
+    s_first_data_block: u32,
+) -> u32 {
+    if group + 1 < group_count {
+        s_blocks_per_group
+    } else {
+        let total_data_blocks = s_blocks_count.saturating_sub(s_first_data_block) as u64;
+        let full_groups_blocks = (group_count - 1) as u64 * s_blocks_per_group as u64;
+        total_data_blocks
+            .saturating_sub(full_groups_blocks)
+            .min(s_blocks_per_group as u64) as u32
+    }
+}
+
+/// Number of inodes in the given group. Mirrors the allocator's
+/// per-group inode count: every group except possibly the last is a
+/// full `s_inodes_per_group`; the last group's count is the remainder
+/// from `s_inodes_count`.
+fn inodes_in_group(
+    group: u32,
+    group_count: u32,
+    s_inodes_per_group: u32,
+    s_inodes_count: u32,
+) -> u32 {
+    if group + 1 < group_count {
+        s_inodes_per_group
+    } else {
+        let total = s_inodes_count as u64;
+        let full = (group_count - 1) as u64 * s_inodes_per_group as u64;
+        total.saturating_sub(full).min(s_inodes_per_group as u64) as u32
+    }
+}
+
+// Keep `vec!` reachable for the host-test module below.
+const _: fn() = || {
+    let _ = vec![0u8; 0];
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn count_clear_bits_empty_limit() {
+        assert_eq!(count_clear_bits(&[0xff, 0xff], 0), 0);
+        assert_eq!(count_clear_bits(&[0x00, 0x00], 0), 0);
+    }
+
+    #[test]
+    fn count_clear_bits_all_set_full_byte() {
+        // Every bit set → zero clear bits.
+        assert_eq!(count_clear_bits(&[0xff, 0xff], 16), 0);
+        // First byte clear, second set → 8 clear bits.
+        assert_eq!(count_clear_bits(&[0x00, 0xff], 16), 8);
+        // First set, second clear → 8 clear bits.
+        assert_eq!(count_clear_bits(&[0xff, 0x00], 16), 8);
+    }
+
+    #[test]
+    fn count_clear_bits_respects_limit() {
+        // Whole byte is clear, but limit only covers the low 3 bits.
+        assert_eq!(count_clear_bits(&[0x00], 3), 3);
+        // Limit straddles a byte boundary: low byte is 0xff, high byte
+        // bit 0 is clear (rest don't matter past limit=9).
+        assert_eq!(count_clear_bits(&[0xff, 0xfe], 9), 0);
+        assert_eq!(count_clear_bits(&[0xff, 0xfe], 10), 1);
+    }
+
+    #[test]
+    fn count_clear_bits_mixed_pattern() {
+        // 0xa5 = 0b1010_0101 — 4 clear bits (positions 1, 3, 4, 6).
+        assert_eq!(count_clear_bits(&[0xa5], 8), 4);
+        // 0xa5 0x5a — total 8 clear bits.
+        assert_eq!(count_clear_bits(&[0xa5, 0x5a], 16), 8);
+    }
+
+    #[test]
+    fn count_clear_bits_short_bitmap_caps_at_end() {
+        // Bitmap shorter than limit: bits past the bitmap aren't
+        // considered clear. This matches the convention "missing tail
+        // = padded with 1-bits."
+        assert_eq!(count_clear_bits(&[0x00], 16), 8);
+    }
+
+    #[test]
+    fn blocks_in_group_matches_allocator() {
+        // 1024 total data blocks (s_first_data_block=0), 512 per group → 2 groups, both full.
+        assert_eq!(blocks_in_group(0, 2, 512, 1024, 0), 512);
+        assert_eq!(blocks_in_group(1, 2, 512, 1024, 0), 512);
+        // 1 KiB ext2: 1024 blocks, 1 first_data_block → 2 groups: 512 + 511.
+        assert_eq!(blocks_in_group(0, 2, 512, 1024, 1), 512);
+        assert_eq!(blocks_in_group(1, 2, 512, 1024, 1), 511);
+    }
+
+    #[test]
+    fn inodes_in_group_short_last_group() {
+        // 100 inodes total, 64 per group → group 0 = 64, group 1 = 36.
+        assert_eq!(inodes_in_group(0, 2, 64, 100), 64);
+        assert_eq!(inodes_in_group(1, 2, 64, 100), 36);
+        // Single group: clamps.
+        assert_eq!(inodes_in_group(0, 1, 64, 50), 50);
+    }
+}

--- a/kernel/src/fs/ext2/validate.rs
+++ b/kernel/src/fs/ext2/validate.rs
@@ -275,22 +275,26 @@ pub(crate) fn count_clear_bits(bitmap: &[u8], bit_limit: u32) -> u32 {
 /// `1..first_ino`) whose bit in `inode_bitmap_block` is *clear* —
 /// i.e. the bitmap claims it's free, which is a corruption.
 ///
-/// Returns `None` if every reserved bit is set (the healthy case) or
-/// if `first_ino <= 1` (no reserved range, which a mount-path geometry
-/// check should already have rejected).
+/// Returns `None` if every reserved bit is set (the healthy case).
+///
+/// `EXT2_ROOT_INO` (= 2) is **always** validated, even if a malformed
+/// rev-1 image sets `s_first_ino` to `0`, `1`, or `2` — losing the root
+/// inode is a corruption regardless of what the superblock claims about
+/// the reserved range.
 fn first_clear_reserved_ino(
     cache: &BlockCache,
     device_id: DeviceId,
     inode_bitmap_block: u64,
     first_ino: u32,
 ) -> Option<u32> {
-    if first_ino <= 1 {
-        return None;
-    }
     let bh = cache.bread(device_id, inode_bitmap_block).ok()?;
     let data = bh.data.read();
     // Inos are 1-based; bit `i` in the bitmap corresponds to ino `i+1`.
-    let bits_to_check = (first_ino - 1) as usize;
+    // Validate `1..s_first_ino` plus `EXT2_ROOT_INO` (= 2) unconditionally,
+    // so a malformed superblock that lies about `s_first_ino` can't smuggle
+    // a cleared root-inode bit past us.
+    let bits_to_check =
+        core::cmp::max(first_ino.saturating_sub(1), super::disk::EXT2_ROOT_INO) as usize;
     for bit in 0..bits_to_check {
         let byte = bit / 8;
         let mask = 1u8 << (bit % 8);
@@ -374,9 +378,12 @@ mod tests {
     fn count_clear_bits_respects_limit() {
         // Whole byte is clear, but limit only covers the low 3 bits.
         assert_eq!(count_clear_bits(&[0x00], 3), 3);
-        // Limit straddles a byte boundary: low byte is 0xff, high byte
-        // bit 0 is clear (rest don't matter past limit=9).
-        assert_eq!(count_clear_bits(&[0xff, 0xfe], 9), 0);
+        // Limit straddles a byte boundary. Low byte is 0xff (no clear
+        // bits). High byte 0xfe = 0b1111_1110 — LSB-first, so bit 0 is
+        // clear and bits 1..=7 are set. With limit=9 we examine bits
+        // 0..=8 (i.e. all of byte 0 plus bit 0 of byte 1) → 1 clear
+        // bit. With limit=10 we add bit 1 of byte 1 (set), so still 1.
+        assert_eq!(count_clear_bits(&[0xff, 0xfe], 9), 1);
         assert_eq!(count_clear_bits(&[0xff, 0xfe], 10), 1);
     }
 

--- a/kernel/src/fs/ext2/validate.rs
+++ b/kernel/src/fs/ext2/validate.rs
@@ -137,14 +137,13 @@ pub fn validate_bgdt(
         }
 
         // ---- inode bitmap ----
-        let ib_clear = match read_and_count_clear_bits(
-            cache,
-            device_id,
-            bg.bg_inode_bitmap as u64,
-            inodes_in_this_group,
-        ) {
-            Some(n) => n,
-            None => {
+        // Read the inode bitmap block once and reuse the buffer for both
+        // the clear-bit count and the group-0 reserved-inode walk below,
+        // so an I/O failure on a re-read can't silently downgrade to "all
+        // reserved bits set" via `Option::None` (CodeRabbit #694).
+        let ib_bh = match cache.bread(device_id, bg.bg_inode_bitmap as u64) {
+            Ok(bh) => bh,
+            Err(_) => {
                 kwarn!(
                     "ext2: validate_bgdt: group {}: unreadable inode bitmap at block {}, forcing RO",
                     group,
@@ -153,6 +152,8 @@ pub fn validate_bgdt(
                 return ForceRo::Yes;
             }
         };
+        let ib_data = ib_bh.data.read();
+        let ib_clear = count_clear_bits(&ib_data, inodes_in_this_group);
         if ib_clear != bg.bg_free_inodes_count as u32 {
             kwarn!(
                 "ext2: validate_bgdt: group {}: inode bitmap has {} clear bits, BGDT says bg_free_inodes_count={}; forcing RO",
@@ -168,9 +169,7 @@ pub fn validate_bgdt(
         // They map to bits `0..first_ino-1` of group 0's inode bitmap;
         // every one of those bits MUST be set.
         if group == 0 {
-            if let Some(ino) =
-                first_clear_reserved_ino(cache, device_id, bg.bg_inode_bitmap as u64, first_ino)
-            {
+            if let Some(ino) = first_clear_reserved_ino(&ib_data, first_ino) {
                 kwarn!(
                     "ext2: validate_bgdt: group 0: reserved inode {} is unallocated in inode bitmap, forcing RO",
                     ino,
@@ -272,8 +271,12 @@ pub(crate) fn count_clear_bits(bitmap: &[u8], bit_limit: u32) -> u32 {
 }
 
 /// Return the first reserved-inode number (1-based, in
-/// `1..first_ino`) whose bit in `inode_bitmap_block` is *clear* —
-/// i.e. the bitmap claims it's free, which is a corruption.
+/// `1..first_ino`) whose bit in `data` is *clear* — i.e. the bitmap
+/// claims it's free, which is a corruption.
+///
+/// Takes the already-loaded inode-bitmap block bytes so the caller's
+/// `bread` failure can't be confused with "no clear reserved inode";
+/// I/O failures must be handled at the call site (forcing RO).
 ///
 /// Returns `None` if every reserved bit is set (the healthy case).
 ///
@@ -281,14 +284,7 @@ pub(crate) fn count_clear_bits(bitmap: &[u8], bit_limit: u32) -> u32 {
 /// rev-1 image sets `s_first_ino` to `0`, `1`, or `2` — losing the root
 /// inode is a corruption regardless of what the superblock claims about
 /// the reserved range.
-fn first_clear_reserved_ino(
-    cache: &BlockCache,
-    device_id: DeviceId,
-    inode_bitmap_block: u64,
-    first_ino: u32,
-) -> Option<u32> {
-    let bh = cache.bread(device_id, inode_bitmap_block).ok()?;
-    let data = bh.data.read();
+fn first_clear_reserved_ino(data: &[u8], first_ino: u32) -> Option<u32> {
     // Inos are 1-based; bit `i` in the bitmap corresponds to ino `i+1`.
     // Validate `1..s_first_ino` plus `EXT2_ROOT_INO` (= 2) unconditionally,
     // so a malformed superblock that lies about `s_first_ino` can't smuggle

--- a/kernel/tests/ext2_validate_bgdt.rs
+++ b/kernel/tests/ext2_validate_bgdt.rs
@@ -1,0 +1,319 @@
+//! Integration test for issue #678: mount-time BGDT / bitmap
+//! consistency checks.
+//!
+//! Runs the real kernel under QEMU, in-process: starts from the 64 KiB
+//! `golden.img` mkfs.ext2 fixture (16 inodes, 1024 blocks, 1 KiB
+//! blocks, one block group, block bitmap at block 3, inode bitmap at
+//! block 4), patches the on-disk bitmap / counter bytes to simulate
+//! each mismatch class, then mounts through [`Ext2Fs`] and asserts
+//! that:
+//!
+//! - **Healthy fixture** — mounts RW cleanly, `SbFlags::RDONLY` is not
+//!   set; the validator agreed with the BGDT.
+//! - **Block-bitmap clear-bit count != bg_free_blocks_count** — mount
+//!   succeeds but is demoted to RO (`SbFlags::RDONLY` set) and the
+//!   ramdisk records zero writes (the `s_state := ERROR_FS` stamp is
+//!   gated behind `effective_rdonly`).
+//! - **Inode-bitmap clear-bit count != bg_free_inodes_count** — same
+//!   demote-to-RO behaviour.
+//! - **Reserved ino bit unset (root ino 2 marked free)** — mount
+//!   demoted to RO.
+//! - **`s_free_blocks_count` lies (sum of BGDT counters disagrees)**
+//!   — mount demoted to RO.
+//! - **`s_free_inodes_count` lies** — same.
+//!
+//! The fixture image is the same `golden.img` `ext2_mount.rs` and
+//! `ext2_orphan_chain.rs` use; see `kernel/src/fs/ext2/fixtures/README.md`
+//! for how it is generated.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use core::panic::PanicInfo;
+
+use vibix::block::BlockDevice;
+use vibix::fs::ext2::Ext2Fs;
+use vibix::fs::vfs::ops::{FileSystem as _, MountSource};
+use vibix::fs::vfs::super_block::SbFlags;
+use vibix::fs::vfs::MountFlags;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[path = "common/ext2_ramdisk.rs"]
+mod ext2_ramdisk;
+use ext2_ramdisk::RamDisk;
+
+/// 64 KiB `mkfs.ext2` image. See `kernel/src/fs/ext2/fixtures/README.md`.
+const GOLDEN_IMG: &[u8; 65_536] = include_bytes!("../src/fs/ext2/fixtures/golden.img");
+
+// On-disk byte offsets we need. The fixture is 1 KiB-block ext2,
+// `s_first_data_block == 1`, so:
+//   - superblock lives at byte 1024 (block 1)
+//   - BGDT lives at byte 2048 (block 2)
+//   - block bitmap at byte 3072 (block 3)
+//   - inode bitmap at byte 4096 (block 4)
+const SB_BYTE_OFFSET: usize = 1024;
+const SB_OFF_FREE_BLOCKS_COUNT: usize = 12;
+const SB_OFF_FREE_INODES_COUNT: usize = 16;
+
+const BGDT_BYTE_OFFSET_1K: usize = 2048;
+const BGD_OFF_FREE_BLOCKS_COUNT: usize = 12;
+const BGD_OFF_FREE_INODES_COUNT: usize = 14;
+
+const INODE_BITMAP_BYTE_OFFSET_1K: usize = 4096;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "healthy_fixture_mounts_rw",
+            &(healthy_fixture_mounts_rw as fn()),
+        ),
+        (
+            "block_bitmap_count_mismatch_forces_ro",
+            &(block_bitmap_count_mismatch_forces_ro as fn()),
+        ),
+        (
+            "inode_bitmap_count_mismatch_forces_ro",
+            &(inode_bitmap_count_mismatch_forces_ro as fn()),
+        ),
+        (
+            "reserved_ino_unallocated_forces_ro",
+            &(reserved_ino_unallocated_forces_ro as fn()),
+        ),
+        (
+            "sb_free_blocks_lies_forces_ro",
+            &(sb_free_blocks_lies_forces_ro as fn()),
+        ),
+        (
+            "sb_free_inodes_lies_forces_ro",
+            &(sb_free_inodes_lies_forces_ro as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Construct a `RamDisk` from `bytes`, exposing 512-byte sectors so
+/// the `read_at` alignment matches a real virtio-blk.
+fn disk_from_bytes(bytes: &[u8]) -> Arc<RamDisk> {
+    RamDisk::from_image(bytes, 512)
+}
+
+/// Patch a 16-bit little-endian field at byte `offset` in `image`.
+fn patch_u16_le(image: &mut [u8], offset: usize, value: u16) {
+    image[offset..offset + 2].copy_from_slice(&value.to_le_bytes());
+}
+
+/// Patch a 32-bit little-endian field at byte `offset` in `image`.
+fn patch_u32_le(image: &mut [u8], offset: usize, value: u32) {
+    image[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
+}
+
+/// Mount through `Ext2Fs::new_with_device` with the requested
+/// `MountFlags`. Returns the resulting `SbFlags::RDONLY` bit and the
+/// number of writes the disk recorded over the mount call. The
+/// `SuperBlock` is unmounted before return so a subsequent test can
+/// reuse the factory pattern cleanly.
+fn mount_and_observe(disk: Arc<RamDisk>, flags: MountFlags) -> (bool, u32) {
+    let fs = Ext2Fs::new_with_device(disk.clone() as Arc<dyn BlockDevice>);
+    let writes_before = disk.writes();
+    let sb = fs
+        .mount(MountSource::None, flags)
+        .expect("mount must succeed");
+    let rdonly = sb.flags.contains(SbFlags::RDONLY);
+    let writes_after = disk.writes();
+    sb.ops.unmount();
+    (rdonly, writes_after - writes_before)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// The unmodified golden image must mount RW cleanly: every BGDT
+/// counter agrees with its bitmap, the reserved-inode range is
+/// allocated, and the superblock totals match the BGDT sums. If this
+/// regresses, every other test in this file is invalid (they all
+/// start by validating that the un-patched fixture is healthy).
+fn healthy_fixture_mounts_rw() {
+    let disk = disk_from_bytes(GOLDEN_IMG.as_slice());
+    let (rdonly, _writes) = mount_and_observe(disk, MountFlags::default());
+    assert!(
+        !rdonly,
+        "healthy fixture must mount RW (not forced to RDONLY)",
+    );
+}
+
+/// Lie about the block-bitmap free count: bump
+/// `bg_free_blocks_count` by 1 without changing the bitmap. The
+/// validator should observe the discrepancy and force RO.
+fn block_bitmap_count_mismatch_forces_ro() {
+    let mut image = GOLDEN_IMG.to_vec();
+    let off = BGDT_BYTE_OFFSET_1K + BGD_OFF_FREE_BLOCKS_COUNT;
+    let cur = u16::from_le_bytes([image[off], image[off + 1]]);
+    let bumped = cur.wrapping_add(1);
+    patch_u16_le(&mut image, off, bumped);
+    // Also bump `s_free_blocks_count` in lockstep so the per-group
+    // counter check trips first (without this the sb-vs-sum check
+    // would also trip; either way we'd force RO, but pinning the
+    // primary cause makes the test specific to the bitmap path).
+    let sb_off = SB_BYTE_OFFSET + SB_OFF_FREE_BLOCKS_COUNT;
+    let sb_cur = u32::from_le_bytes([
+        image[sb_off],
+        image[sb_off + 1],
+        image[sb_off + 2],
+        image[sb_off + 3],
+    ]);
+    patch_u32_le(&mut image, sb_off, sb_cur.wrapping_add(1));
+
+    let disk = disk_from_bytes(&image);
+    let (rdonly, writes) = mount_and_observe(disk, MountFlags::default());
+    assert!(
+        rdonly,
+        "block-bitmap counter mismatch must demote mount to RDONLY",
+    );
+    assert_eq!(
+        writes, 0,
+        "RO-demoted mount must not write to device (got {writes} writes)",
+    );
+}
+
+/// Lie about the inode-bitmap free count.
+fn inode_bitmap_count_mismatch_forces_ro() {
+    let mut image = GOLDEN_IMG.to_vec();
+    let off = BGDT_BYTE_OFFSET_1K + BGD_OFF_FREE_INODES_COUNT;
+    let cur = u16::from_le_bytes([image[off], image[off + 1]]);
+    patch_u16_le(&mut image, off, cur.wrapping_add(1));
+    // Lockstep on the sb so the per-group check is the primary trip.
+    let sb_off = SB_BYTE_OFFSET + SB_OFF_FREE_INODES_COUNT;
+    let sb_cur = u32::from_le_bytes([
+        image[sb_off],
+        image[sb_off + 1],
+        image[sb_off + 2],
+        image[sb_off + 3],
+    ]);
+    patch_u32_le(&mut image, sb_off, sb_cur.wrapping_add(1));
+
+    let disk = disk_from_bytes(&image);
+    let (rdonly, writes) = mount_and_observe(disk, MountFlags::default());
+    assert!(
+        rdonly,
+        "inode-bitmap counter mismatch must demote mount to RDONLY",
+    );
+    assert_eq!(
+        writes, 0,
+        "RO-demoted mount must not write to device (got {writes} writes)",
+    );
+}
+
+/// Clear bit 1 of the inode bitmap (= ino 2 = `EXT2_ROOT_INO`). The
+/// reserved-range check must catch this: ino 2 is in the reserved
+/// range (inos 1..first_ino=11) and MUST be marked allocated.
+///
+/// We also bump `bg_free_inodes_count` and `s_free_inodes_count` by 1
+/// so the per-group bitmap-vs-counter check passes (otherwise that
+/// check trips first). The test then attributes the force-RO verdict
+/// specifically to the reserved-range check.
+fn reserved_ino_unallocated_forces_ro() {
+    let mut image = GOLDEN_IMG.to_vec();
+
+    // Clear bit 1 of byte 0 of the inode bitmap (ino 2).
+    let bm_byte = INODE_BITMAP_BYTE_OFFSET_1K;
+    image[bm_byte] &= !(1u8 << 1);
+
+    // Bump the free-inode counters in BGDT + SB so the bitmap
+    // clear-bit count still matches the BGDT.
+    let bg_off = BGDT_BYTE_OFFSET_1K + BGD_OFF_FREE_INODES_COUNT;
+    let bg_cur = u16::from_le_bytes([image[bg_off], image[bg_off + 1]]);
+    patch_u16_le(&mut image, bg_off, bg_cur + 1);
+    let sb_off = SB_BYTE_OFFSET + SB_OFF_FREE_INODES_COUNT;
+    let sb_cur = u32::from_le_bytes([
+        image[sb_off],
+        image[sb_off + 1],
+        image[sb_off + 2],
+        image[sb_off + 3],
+    ]);
+    patch_u32_le(&mut image, sb_off, sb_cur + 1);
+
+    let disk = disk_from_bytes(&image);
+    let (rdonly, writes) = mount_and_observe(disk, MountFlags::default());
+    assert!(
+        rdonly,
+        "unallocated reserved ino must demote mount to RDONLY",
+    );
+    assert_eq!(
+        writes, 0,
+        "RO-demoted mount must not write to device (got {writes} writes)",
+    );
+}
+
+/// Lie only about `s_free_blocks_count` (in the superblock) without
+/// touching the BGDT. The sum-of-BGDT-counters cross-check must catch
+/// the discrepancy.
+fn sb_free_blocks_lies_forces_ro() {
+    let mut image = GOLDEN_IMG.to_vec();
+    let sb_off = SB_BYTE_OFFSET + SB_OFF_FREE_BLOCKS_COUNT;
+    let cur = u32::from_le_bytes([
+        image[sb_off],
+        image[sb_off + 1],
+        image[sb_off + 2],
+        image[sb_off + 3],
+    ]);
+    // Bump by something that won't underflow on a u32 and is
+    // unambiguously different from the BGDT sum.
+    patch_u32_le(&mut image, sb_off, cur.wrapping_add(7));
+
+    let disk = disk_from_bytes(&image);
+    let (rdonly, writes) = mount_and_observe(disk, MountFlags::default());
+    assert!(
+        rdonly,
+        "s_free_blocks_count != sum(bg_free_blocks_count) must demote to RDONLY",
+    );
+    assert_eq!(writes, 0);
+}
+
+/// Lie about `s_free_inodes_count`.
+fn sb_free_inodes_lies_forces_ro() {
+    let mut image = GOLDEN_IMG.to_vec();
+    let sb_off = SB_BYTE_OFFSET + SB_OFF_FREE_INODES_COUNT;
+    let cur = u32::from_le_bytes([
+        image[sb_off],
+        image[sb_off + 1],
+        image[sb_off + 2],
+        image[sb_off + 3],
+    ]);
+    patch_u32_le(&mut image, sb_off, cur.wrapping_add(3));
+
+    let disk = disk_from_bytes(&image);
+    let (rdonly, writes) = mount_and_observe(disk, MountFlags::default());
+    assert!(
+        rdonly,
+        "s_free_inodes_count != sum(bg_free_inodes_count) must demote to RDONLY",
+    );
+    assert_eq!(writes, 0);
+}


### PR DESCRIPTION
Closes #678

## Summary

Adds a `validate_bgdt(...)` helper called from `Ext2Fs::mount` that cross-checks the block-group descriptor table against the bitmaps it indexes:

- **Per group**: count clear bits in the block + inode bitmaps and compare to `bg_free_blocks_count` / `bg_free_inodes_count`.
- **Group 0 reserved range**: verify inos `1..first_ino` (including ino 2 = `EXT2_ROOT_INO`) are marked allocated in the inode bitmap.
- **Superblock totals**: verify `s_free_blocks_count` / `s_free_inodes_count` equal the sums across BGDT entries.

On any mismatch the validator logs the group + observed-vs-expected counts via `kwarn!` and returns `ForceRo::Yes`. The mount path collapses that verdict into the same `effective_rdonly` branch that already handles unknown RO_COMPAT bits and corrupt orphan chains, so a detectably-inconsistent image mounts RO and never accepts a write.

The validator runs as a raw walk *before* the `Arc<SuperBlock>` is built, mirroring `super::orphan::walk_orphan_chain_raw` — `SbFlags` is immutable post-construction, so the RO decision has to settle first.

## Test plan

New integration test `kernel/tests/ext2_validate_bgdt.rs` patches each mismatch class onto the existing `golden.img` fixture and asserts the mount is demoted to RO with zero writes:

- [x] Healthy fixture mounts RW cleanly
- [x] Block-bitmap clear-bit count != `bg_free_blocks_count` → forces RO
- [x] Inode-bitmap clear-bit count != `bg_free_inodes_count` → forces RO
- [x] Root ino 2 cleared in bitmap → reserved-range check forces RO
- [x] `s_free_blocks_count` lies → forces RO
- [x] `s_free_inodes_count` lies → forces RO
- [x] Existing `ext2_mount`, `ext2_orphan_chain`, `ext2_block_alloc`, `ext2_ialloc` integration tests still pass
- [x] `cargo fmt --all` clean
- [x] Host unit tests (`cargo test -p vibix --lib`): 530 passed

Out of scope per the issue: online repair, cross-checking inode `i_blocks` totals against actual block-bitmap usage.