### PR TITLE
ext2/tests: cover setattr SIZE on slow (indirect) symlinks (#683)

### DIFF
--- a/kernel/tests/ext2_setattr.rs
+++ b/kernel/tests/ext2_setattr.rs
@@ -36,15 +36,18 @@ use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::panic::PanicInfo;
-use core::sync::atomic::{AtomicU32, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use spin::Mutex;
 
 use vibix::block::{BlockDevice, BlockError};
-use vibix::fs::ext2::{iget, Ext2Fs, Ext2Super};
+use vibix::fs::ext2::symlink::{is_fast_symlink, is_symlink};
+use vibix::fs::ext2::{iget, symlink as ext2_symlink, Ext2Fs, Ext2Inode, Ext2InodeMeta, Ext2Super};
+use vibix::fs::vfs::inode::{Inode, InodeKind};
 use vibix::fs::vfs::ops::{FileSystem as _, MountSource, SetAttr, SetAttrMask};
 use vibix::fs::vfs::super_block::SuperBlock;
 use vibix::fs::vfs::{MountFlags, Timespec};
+use vibix::sync::BlockingRwLock;
 use vibix::{
     exit_qemu, serial_println,
     test_harness::{test_panic_handler, Testable},
@@ -116,6 +119,22 @@ fn run_tests() {
         (
             "setattr_size_on_dir_is_eisdir",
             &(setattr_size_on_dir_is_eisdir as fn()),
+        ),
+        (
+            "truncate_shrink_slow_symlink_is_einval",
+            &(truncate_shrink_slow_symlink_is_einval as fn()),
+        ),
+        (
+            "truncate_grow_slow_symlink_is_einval",
+            &(truncate_grow_slow_symlink_is_einval as fn()),
+        ),
+        (
+            "truncate_zero_slow_symlink_is_einval",
+            &(truncate_zero_slow_symlink_is_einval as fn()),
+        ),
+        (
+            "non_size_setattr_on_slow_symlink_succeeds",
+            &(non_size_setattr_on_slow_symlink_succeeds as fn()),
         ),
     ];
     serial_println!("running {} tests", tests.len());
@@ -462,6 +481,342 @@ fn setattr_size_on_dir_is_eisdir() {
     );
 
     drop(dir);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+// ---------------------------------------------------------------------------
+// Slow-symlink truncate coverage (issue #683).
+//
+// `truncate(2)` semantics on a symlink: POSIX path-walk follows the link,
+// so the syscall surface never reaches the symlink inode itself. The
+// driver-internal `setattr` entry point is the only way to drive a SIZE
+// setattr at a symlink ino, and it must refuse with EINVAL — mirroring
+// Linux's behavior for non-regular SIZE targets.
+//
+// These tests build a slow (indirect / > 60-byte) symlink at runtime via
+// the public `ext2_symlink` helper, then drive each variant of a
+// SIZE setattr against the symlink's `Arc<Inode>`:
+//
+// - shrink (target shrinks but still slow): rejected with EINVAL.
+// - shrink past the fast-symlink boundary: rejected with EINVAL.
+// - grow (target above current size): rejected with EINVAL.
+// - truncate to zero: rejected with EINVAL.
+//
+// For every case the test additionally asserts:
+// - The block-allocator free-count is unchanged (no data block was
+//   freed, no indirect block leaked).
+// - The inode metadata (size, blocks, mode S_IFMT bits) is unchanged
+//   so a successful chmod / chown / utimensat path on a symlink can
+//   still proceed without seeing torn truncate-half-applied state.
+// ---------------------------------------------------------------------------
+
+/// Long enough to land in the slow path (> 60 bytes). 200 bytes mirrors
+/// `ext2_link.rs::symlink_slow_200_bytes_walker`: well past the
+/// boundary, still fits in a single 1 KiB data block so the write side
+/// is happy.
+const SLOW_SYMLINK_TARGET_LEN: usize = 200;
+
+fn slow_symlink_target() -> [u8; SLOW_SYMLINK_TARGET_LEN] {
+    core::array::from_fn(|i| ((i as u32 * 131 + 17) & 0xff) as u8)
+}
+
+/// Build the driver-level `Ext2Inode` shape for a given live ino by
+/// re-decoding the on-disk slot. Mirrors `make_ext2_inode_from_disk` in
+/// `ext2_link.rs`. Used only as the `parent` argument to `ext2_symlink`,
+/// which needs the ext2-specific shape rather than the VFS `Inode`.
+fn ext2_inode_from_disk(super_arc: &Arc<Ext2Super>, ino: u32) -> Ext2Inode {
+    let inodes_per_group = super_arc.sb_disk.lock().s_inodes_per_group;
+    let group = (ino - 1) / inodes_per_group;
+    let index_in_group = (ino - 1) % inodes_per_group;
+    let bg_inode_table = {
+        let bgdt = super_arc.bgdt.lock();
+        bgdt[group as usize].bg_inode_table
+    };
+    let byte_offset = (index_in_group as u64) * (super_arc.inode_size as u64);
+    let block_in_table = byte_offset / (super_arc.block_size as u64);
+    let offset_in_block = (byte_offset % (super_arc.block_size as u64)) as usize;
+    let absolute_block = bg_inode_table as u64 + block_in_table;
+
+    let bh = super_arc
+        .cache
+        .bread(super_arc.device_id, absolute_block)
+        .expect("bread inode table");
+    let data = bh.data.read();
+    let mut slot = [0u8; 128];
+    slot.copy_from_slice(&data[offset_in_block..offset_in_block + 128]);
+    drop(data);
+    let disk_inode = vibix::fs::ext2::disk::Ext2Inode::decode(&slot);
+
+    let meta = Ext2InodeMeta {
+        mode: disk_inode.i_mode,
+        uid: disk_inode.uid(),
+        gid: disk_inode.gid(),
+        size: disk_inode.i_size as u64,
+        atime: disk_inode.i_atime,
+        ctime: disk_inode.i_ctime,
+        mtime: disk_inode.i_mtime,
+        dtime: disk_inode.i_dtime,
+        links_count: disk_inode.i_links_count,
+        i_blocks: disk_inode.i_blocks,
+        flags: disk_inode.i_flags,
+        i_block: disk_inode.i_block,
+    };
+
+    Ext2Inode {
+        super_ref: Arc::downgrade(super_arc),
+        ino,
+        meta: BlockingRwLock::new(meta),
+        block_map: BlockingRwLock::new(None),
+        unlinked: AtomicBool::new(false),
+        open_count: AtomicU32::new(0),
+    }
+}
+
+/// Re-decode the raw on-disk inode for a given ino. Used by the
+/// slow-symlink tests to assert `is_symlink` / `is_fast_symlink`
+/// invariants against the persisted slot.
+fn read_disk_inode(super_arc: &Arc<Ext2Super>, ino: u32) -> vibix::fs::ext2::disk::Ext2Inode {
+    let inodes_per_group = super_arc.sb_disk.lock().s_inodes_per_group;
+    let group = (ino - 1) / inodes_per_group;
+    let index_in_group = (ino - 1) % inodes_per_group;
+    let bg_inode_table = {
+        let bgdt = super_arc.bgdt.lock();
+        bgdt[group as usize].bg_inode_table
+    };
+    let byte_offset = (index_in_group as u64) * (super_arc.inode_size as u64);
+    let block_in_table = byte_offset / (super_arc.block_size as u64);
+    let offset_in_block = (byte_offset % (super_arc.block_size as u64)) as usize;
+    let absolute_block = bg_inode_table as u64 + block_in_table;
+
+    let bh = super_arc
+        .cache
+        .bread(super_arc.device_id, absolute_block)
+        .expect("bread inode table");
+    let data = bh.data.read();
+    let mut slot = [0u8; 128];
+    slot.copy_from_slice(&data[offset_in_block..offset_in_block + 128]);
+    vibix::fs::ext2::disk::Ext2Inode::decode(&slot)
+}
+
+/// Mount RW, materialise a slow symlink under the root with `name` ->
+/// 200-byte target, return everything callers need: the VFS handles,
+/// the symlink's `Arc<Inode>`, and the freshly-recorded free-block
+/// counter snapshot taken *after* the symlink allocation so a follow-up
+/// truncate's accounting is testable independently of the create.
+fn setup_slow_symlink(name: &[u8]) -> (Arc<SuperBlock>, Arc<Ext2Super>, Arc<Inode>, u32) {
+    let (sb, _fs, super_arc) = mount_rw();
+    // Build the parent ext2-shape and VFS handle for the root dir.
+    let parent_vfs = iget(&super_arc, &sb, 2).expect("iget root");
+    let parent = ext2_inode_from_disk(&super_arc, 2);
+
+    let target = slow_symlink_target();
+    let sl = ext2_symlink(&super_arc, &parent, &parent_vfs, &sb, name, &target)
+        .expect("create slow symlink");
+    assert_eq!(sl.kind, InodeKind::Link);
+
+    // Cross-check the persisted slot lives on the slow path.
+    let d = read_disk_inode(&super_arc, sl.ino as u32);
+    assert!(
+        is_symlink(&d),
+        "newly-created symlink must read back as a symlink"
+    );
+    assert!(
+        !is_fast_symlink(&d),
+        "200-byte target must land in the slow (indirect) path"
+    );
+    assert_eq!(d.i_size as usize, target.len());
+    assert_ne!(
+        d.i_blocks, 0,
+        "slow symlink must have at least one allocated block"
+    );
+
+    let free_after_create = sb_free_blocks(&super_arc);
+    (sb, super_arc, sl, free_after_create)
+}
+
+/// Drive a SIZE setattr against `link`, assert it returns EINVAL, and
+/// confirm the inode and superblock state was *not* perturbed.
+fn assert_size_setattr_rejected(
+    sb: &Arc<SuperBlock>,
+    super_arc: &Arc<Ext2Super>,
+    link: &Arc<Inode>,
+    new_size: u64,
+) {
+    let ino = link.ino as u32;
+    let pre_disk = read_disk_inode(super_arc, ino);
+    let pre_size = pre_disk.i_size;
+    let pre_iblocks = pre_disk.i_blocks;
+    let pre_iblock = pre_disk.i_block;
+    let pre_mode = pre_disk.i_mode;
+    let pre_free = sb_free_blocks(super_arc);
+
+    let attr = SetAttr {
+        mask: SetAttrMask::SIZE,
+        size: new_size,
+        ..SetAttr::default()
+    };
+    let r = link.ops.setattr(link, &attr);
+    assert!(
+        matches!(r, Err(e) if e == vibix::fs::EINVAL),
+        "SIZE setattr on a symlink → EINVAL; got {r:?}",
+    );
+
+    // Free-block counter unchanged: no data + no indirect block was
+    // released. This is the load-bearing assertion for issue #683 — a
+    // half-applied truncate that returned an error mid-walk would leak
+    // blocks to the allocator.
+    let post_free = sb_free_blocks(super_arc);
+    assert_eq!(
+        post_free, pre_free,
+        "rejected truncate must not perturb s_free_blocks_count: {pre_free} -> {post_free}",
+    );
+
+    // VFS-level meta on the symlink inode reports the unchanged size
+    // and the symlink type. The driver's `setattr` doesn't even reach
+    // the meta-mutation phase for a Link inode, so size and blocks
+    // must read identical to the create-time values.
+    let m = link.meta.read();
+    assert_eq!(
+        m.size as u32, pre_size,
+        "VFS-meta size must not move on a refused setattr",
+    );
+    drop(m);
+
+    // On-disk slot must be byte-stable across the refused setattr —
+    // size, i_blocks, i_block[] all unchanged. The fast-symlink-gate
+    // legs (i_blocks > 0, i_size > 60, mode == S_IFLNK) keep this
+    // inode classified as slow.
+    let post_disk = read_disk_inode(super_arc, ino);
+    assert_eq!(
+        post_disk.i_size, pre_size,
+        "i_size unchanged on refused setattr"
+    );
+    assert_eq!(
+        post_disk.i_blocks, pre_iblocks,
+        "i_blocks unchanged on refused setattr",
+    );
+    assert_eq!(
+        post_disk.i_block, pre_iblock,
+        "i_block[] unchanged on refused setattr",
+    );
+    assert_eq!(
+        post_disk.i_mode, pre_mode,
+        "i_mode (incl. S_IFLNK type bits) unchanged on refused setattr",
+    );
+    assert!(
+        is_symlink(&post_disk) && !is_fast_symlink(&post_disk),
+        "symlink remains classified as slow after refused setattr",
+    );
+
+    // Holding `sb` keeps the mount alive across the assertions; the
+    // caller drops it after returning.
+    let _ = sb;
+}
+
+fn truncate_shrink_slow_symlink_is_einval() {
+    // Shrink a 200-byte slow symlink to 100 bytes — still slow (above
+    // the 60-byte boundary). Linux refuses; vibix mirrors that with
+    // EINVAL.
+    let (sb, super_arc, sl, _free) = setup_slow_symlink(b"slow_shrink");
+    assert_size_setattr_rejected(&sb, &super_arc, &sl, 100);
+
+    drop(sl);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn truncate_grow_slow_symlink_is_einval() {
+    // Grow a 200-byte slow symlink past its current size. The driver
+    // doesn't reach the grow logic — SIZE on a Link is rejected at the
+    // mask-validation gate.
+    let (sb, super_arc, sl, _free) = setup_slow_symlink(b"slow_grow");
+    assert_size_setattr_rejected(&sb, &super_arc, &sl, 4096);
+
+    drop(sl);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn truncate_zero_slow_symlink_is_einval() {
+    // Truncate-to-zero is the variant most likely to leak blocks if
+    // the SIZE-on-Link gate ever regressed: free walk + zero-fill of
+    // i_block[] would silently succeed and then the persisted slot
+    // would be a half-formed empty symlink. Lock the rejection in.
+    let (sb, super_arc, sl, _free) = setup_slow_symlink(b"slow_zero");
+    assert_size_setattr_rejected(&sb, &super_arc, &sl, 0);
+
+    drop(sl);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+fn non_size_setattr_on_slow_symlink_succeeds() {
+    // Sanity check that the SIZE-on-Link gate doesn't accidentally
+    // also block other setattr fields. chmod and utimensat against a
+    // slow symlink must still go through, and they must not perturb
+    // the data blocks or the free-block counter.
+    let (sb, super_arc, sl, free_before) = setup_slow_symlink(b"slow_chmod");
+
+    let pre_disk = read_disk_inode(&super_arc, sl.ino as u32);
+    let pre_iblock = pre_disk.i_block;
+    let pre_iblocks = pre_disk.i_blocks;
+    let pre_size = pre_disk.i_size;
+
+    // chmod 0o600.
+    let attr = SetAttr {
+        mask: SetAttrMask::MODE,
+        mode: 0o600,
+        ..SetAttr::default()
+    };
+    sl.ops.setattr(&sl, &attr).expect("chmod on slow symlink");
+
+    // utimensat — independent attributes, must round-trip.
+    let atime = Timespec {
+        sec: 1_700_000_000,
+        nsec: 0,
+    };
+    let mtime = Timespec {
+        sec: 1_700_000_100,
+        nsec: 0,
+    };
+    let attr = SetAttr {
+        mask: SetAttrMask::ATIME | SetAttrMask::MTIME,
+        atime,
+        mtime,
+        ..SetAttr::default()
+    };
+    sl.ops
+        .setattr(&sl, &attr)
+        .expect("utimensat on slow symlink");
+
+    // Body bytes (i_block[], i_blocks, i_size) untouched by chmod /
+    // utimensat — the symlink target still resolves the same way.
+    let post_disk = read_disk_inode(&super_arc, sl.ino as u32);
+    assert_eq!(
+        post_disk.i_size, pre_size,
+        "chmod/utime must not touch i_size"
+    );
+    assert_eq!(
+        post_disk.i_blocks, pre_iblocks,
+        "chmod/utime must not free or allocate blocks",
+    );
+    assert_eq!(
+        post_disk.i_block, pre_iblock,
+        "chmod/utime must not perturb i_block[]",
+    );
+    assert!(
+        is_symlink(&post_disk) && !is_fast_symlink(&post_disk),
+        "post-chmod inode is still a slow symlink",
+    );
+    // Free-block counter unchanged.
+    let free_after = sb_free_blocks(&super_arc);
+    assert_eq!(
+        free_after, free_before,
+        "non-SIZE setattr must not perturb the free-block counter",
+    );
+
+    drop(sl);
     sb.ops.unmount();
     drop(super_arc);
 }


### PR DESCRIPTION
Closes #683.

## Summary

Slow symlinks (target > 60 bytes, stored via the indirect-block walker rather than inline in `i_block[]`) are a corner of the truncate path the integration suite did not previously exercise. POSIX `truncate(2)` follows the link at the path-walk layer, so a SIZE-bearing setattr only reaches the symlink inode through a direct driver call — and the driver mirrors Linux by returning `EINVAL` for any non-regular SIZE target.

This PR extends `kernel/tests/ext2_setattr.rs` rather than adding a new test crate file — that keeps `kernel/Cargo.toml`'s `[[test]]` table stable while another PR is adding an entry there.

Four new cases:

- `truncate_shrink_slow_symlink_is_einval`: 200-byte slow symlink, SIZE -> 100. EINVAL; balloc free count, `i_size`, `i_blocks`, `i_block[]` byte-stable.
- `truncate_grow_slow_symlink_is_einval`: same shape, SIZE -> 4096.
- `truncate_zero_slow_symlink_is_einval`: SIZE -> 0. The variant most likely to leak blocks if the SIZE-on-Link gate ever regressed.
- `non_size_setattr_on_slow_symlink_succeeds`: chmod + utimensat on a slow symlink go through; the data block, `i_blocks`, and free-block counter remain untouched.

Each rejection case asserts the symlink inode stays classified as slow afterward (`is_symlink && !is_fast_symlink`), so a half-applied truncate that happened to clear `i_block[]` would surface immediately. The slow-symlink fixture is built at runtime via `ext2_symlink` with a 200-byte deterministic target, mirroring `ext2_link.rs::symlink_slow_200_bytes_walker`.

## Test plan

- [x] `cargo xtask build`
- [x] `cargo +nightly test -p vibix --test ext2_setattr --target x86_64-unknown-none --features=ext2 -Zbuild-std=...` (all 13 tests pass, including 4 new)
- [x] `cargo fmt --all`

Note: `cargo xtask test` and `cargo xtask smoke` panic on `main` at `kernel/src/task/mod.rs:97` (`HW_CLOCK`/`HW_IRQ` env-pointer assertion) for unrelated reasons; the `ext2_setattr` test binary itself runs clean under qemu. CI will resolve once the env-pointer regression is fixed.