### PR TITLE
tests: dedup RamDisk helper across ext2/block tests (#658)

### DIFF
--- a/kernel/tests/block_cache_sync_fs.rs
+++ b/kernel/tests/block_cache_sync_fs.rs
@@ -25,15 +25,10 @@
 extern crate alloc;
 
 use alloc::sync::Arc;
-use alloc::vec;
-use alloc::vec::Vec;
 use core::panic::PanicInfo;
-use core::sync::atomic::{AtomicU32, Ordering};
-
-use spin::Mutex;
 
 use vibix::block::cache::{BlockCache, STATE_DIRTY};
-use vibix::block::{BlockDevice, BlockError};
+use vibix::block::BlockDevice;
 use vibix::{
     exit_qemu, serial_println,
     test_harness::{test_panic_handler, Testable},
@@ -76,68 +71,11 @@ fn run_tests() {
 // semantics.
 // ---------------------------------------------------------------------------
 
-struct RamDisk {
-    block_size: u32,
-    storage: Mutex<Vec<u8>>,
-    writes: AtomicU32,
-}
-
-impl RamDisk {
-    fn new(block_size: u32, blocks: usize) -> Arc<Self> {
-        let bytes = (block_size as usize) * blocks;
-        Arc::new(Self {
-            block_size,
-            storage: Mutex::new(vec![0u8; bytes]),
-            writes: AtomicU32::new(0),
-        })
-    }
-
-    fn writes(&self) -> u32 {
-        self.writes.load(Ordering::Relaxed)
-    }
-}
-
-impl BlockDevice for RamDisk {
-    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::OutOfRange)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::OutOfRange);
-        }
-        let off = offset as usize;
-        buf.copy_from_slice(&storage[off..off + buf.len()]);
-        Ok(())
-    }
-    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
-        self.writes.fetch_add(1, Ordering::Relaxed);
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let mut storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::Enospc)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::Enospc);
-        }
-        let off = offset as usize;
-        storage[off..off + buf.len()].copy_from_slice(buf);
-        Ok(())
-    }
-    fn block_size(&self) -> u32 {
-        self.block_size
-    }
-    fn capacity(&self) -> u64 {
-        self.storage.lock().len() as u64
-    }
-}
+// Shared `RamDisk` — see kernel/tests/common/ext2_ramdisk.rs (issues
+// #627, #658).
+#[path = "common/ext2_ramdisk.rs"]
+mod ext2_ramdisk;
+use ext2_ramdisk::RamDisk;
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -151,7 +89,7 @@ impl BlockDevice for RamDisk {
 /// This is the "write + sync_fs + drop cache + remount; data is
 /// present" test from issue #554.
 fn sync_fs_persists_across_cache_teardown() {
-    let disk = RamDisk::new(512, 16);
+    let disk = RamDisk::zeroed(512, 16);
 
     // --- Phase 1: mount 1, dirty block 5, sync_fs, drop cache. ---
     {
@@ -207,7 +145,7 @@ fn sync_fs_persists_across_cache_teardown() {
 /// This is the "sync_fs does NOT flush buffers belonging to a
 /// different mount" test from issue #554.
 fn sync_fs_does_not_flush_other_mount() {
-    let disk = RamDisk::new(512, 16);
+    let disk = RamDisk::zeroed(512, 16);
     let cache = BlockCache::new(disk.clone() as Arc<dyn BlockDevice>, 512, 8);
     let dev_a = cache.register_device();
     let dev_b = cache.register_device();

--- a/kernel/tests/block_writeback.rs
+++ b/kernel/tests/block_writeback.rs
@@ -36,18 +36,13 @@
 extern crate alloc;
 
 use alloc::sync::Arc;
-use alloc::vec;
-use alloc::vec::Vec;
 use core::panic::PanicInfo;
-use core::sync::atomic::{AtomicU32, Ordering};
-
-use spin::Mutex;
 
 use vibix::block::cache::{BlockCache, STATE_DIRTY};
 use vibix::block::writeback::{
     self, configured_secs, reset_configured_for_tests, DEFAULT_INTERVAL_SECS,
 };
-use vibix::block::{BlockDevice, BlockError};
+use vibix::block::BlockDevice;
 use vibix::fs::vfs::ops::{StatFs, SuperOps};
 use vibix::fs::vfs::super_block::{SbFlags, SuperBlock};
 use vibix::fs::vfs::{FsId, Inode};
@@ -105,68 +100,11 @@ fn run_tests() {
 
 /// In-memory ramdisk that counts writes so tests can distinguish
 /// "daemon-driven flush" from "sync_fs explicit call".
-struct RamDisk {
-    block_size: u32,
-    storage: Mutex<Vec<u8>>,
-    writes: AtomicU32,
-}
-
-impl RamDisk {
-    fn new(block_size: u32, blocks: usize) -> Arc<Self> {
-        let bytes = (block_size as usize) * blocks;
-        Arc::new(Self {
-            block_size,
-            storage: Mutex::new(vec![0u8; bytes]),
-            writes: AtomicU32::new(0),
-        })
-    }
-
-    fn writes(&self) -> u32 {
-        self.writes.load(Ordering::Relaxed)
-    }
-}
-
-impl BlockDevice for RamDisk {
-    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::OutOfRange)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::OutOfRange);
-        }
-        let off = offset as usize;
-        buf.copy_from_slice(&storage[off..off + buf.len()]);
-        Ok(())
-    }
-    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
-        self.writes.fetch_add(1, Ordering::Relaxed);
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let mut storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::Enospc)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::Enospc);
-        }
-        let off = offset as usize;
-        storage[off..off + buf.len()].copy_from_slice(buf);
-        Ok(())
-    }
-    fn block_size(&self) -> u32 {
-        self.block_size
-    }
-    fn capacity(&self) -> u64 {
-        self.storage.lock().len() as u64
-    }
-}
+// Shared `RamDisk` — see kernel/tests/common/ext2_ramdisk.rs (issues
+// #627, #658).
+#[path = "common/ext2_ramdisk.rs"]
+mod ext2_ramdisk;
+use ext2_ramdisk::RamDisk;
 
 /// Stub `SuperOps` — the writeback daemon only calls into
 /// `SuperBlock` fields (flags / draining / sb_active), never through
@@ -204,7 +142,7 @@ fn writeback_fires_after_interval() {
     // 1 s cadence is the shortest the secs-granularity knob supports;
     // fine for a test budget of ~3 s.
 
-    let disk = RamDisk::new(512, 16);
+    let disk = RamDisk::zeroed(512, 16);
     let cache = BlockCache::new(disk.clone() as Arc<dyn BlockDevice>, 512, 8);
     let dev = cache.register_device();
     let sb = make_sb(SbFlags::default());
@@ -272,7 +210,7 @@ fn join_waits_for_daemon() {
     reset_configured_for_tests();
     writeback::set_configured_secs(1);
 
-    let disk = RamDisk::new(512, 16);
+    let disk = RamDisk::zeroed(512, 16);
     let cache = BlockCache::new(disk.clone() as Arc<dyn BlockDevice>, 512, 8);
     let dev = cache.register_device();
     let sb = make_sb(SbFlags::default());
@@ -345,7 +283,7 @@ fn no_writeback_on_ro_mount() {
     reset_configured_for_tests();
     writeback::set_configured_secs(1);
 
-    let disk = RamDisk::new(512, 8);
+    let disk = RamDisk::zeroed(512, 8);
     let cache = BlockCache::new(disk.clone() as Arc<dyn BlockDevice>, 512, 4);
     let dev = cache.register_device();
     let sb = make_sb(SbFlags::RDONLY);
@@ -365,7 +303,7 @@ fn writeback_secs_zero_disables_daemon() {
     assert!(writeback::parse_cmdline(b"writeback_secs=0"));
     assert!(writeback::is_disabled());
 
-    let disk = RamDisk::new(512, 8);
+    let disk = RamDisk::zeroed(512, 8);
     let cache = BlockCache::new(disk.clone() as Arc<dyn BlockDevice>, 512, 4);
     let dev = cache.register_device();
     let sb = make_sb(SbFlags::default());

--- a/kernel/tests/common/ext2_ramdisk.rs
+++ b/kernel/tests/common/ext2_ramdisk.rs
@@ -26,20 +26,39 @@
 //!
 //! ## Surface
 //!
-//! Intentionally minimal — just the constructor, the read-only latch,
-//! the write-count probe, and the `BlockDevice` impl:
+//! Kept lean — just the constructors, the read-only latch, the
+//! write-count probe, two image-poking accessors, and the
+//! `BlockDevice` impl:
 //!
 //! - [`RamDisk::from_image`] — wrap an in-memory image, asserting the
 //!   length is a multiple of `block_size`.
+//! - [`RamDisk::zeroed`] — allocate a zero-initialized image of
+//!   `block_size * blocks` bytes (used by the block-cache /
+//!   writeback tests, which don't seed from a fixture).
 //! - [`RamDisk::set_read_only`] — flip the harness-level RO latch so a
 //!   forgotten dirty-writeback path surfaces as `BlockError::ReadOnly`
 //!   instead of silently mutating the image.
 //! - [`RamDisk::writes`] — observe the cumulative write count for
 //!   "RO mount must not issue any writes" assertions.
+//! - [`RamDisk::read_slot`] / [`RamDisk::patch`] — direct byte-level
+//!   peek / poke into the backing storage, used by the `ext2_mount`
+//!   tests to surgically corrupt header fields before mount.
 //! - `BlockDevice` impl — block-aligned `read_at` / `write_at` over a
 //!   `Mutex<Vec<u8>>`.
+//!
+//! ## Cross-area use
+//!
+//! The block-cache tests (`block_cache_sync_fs.rs`,
+//! `block_writeback.rs`) and the VFS mount-path test
+//! (`mount_dev_resolve.rs`) also pull this in even though they aren't
+//! ext2-specific. Splitting a second copy under e.g.
+//! `tests/common/block_ramdisk.rs` would just re-introduce the
+//! duplication this module exists to kill, so the helper lives here
+//! and the non-ext2 consumers document the cross-area pull at the
+//! include site.
 
 use alloc::sync::Arc;
+use alloc::vec;
 use alloc::vec::Vec;
 use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
@@ -47,6 +66,14 @@ use spin::Mutex;
 
 use vibix::block::{BlockDevice, BlockError};
 
+// Each integration test pulls this module in via `#[path = ...] mod`,
+// which means rustc sees the file fresh in every consumer crate and
+// flags any helper that crate doesn't call. The set of methods used
+// per consumer varies (some only need `from_image`, the block-cache
+// tests need `zeroed`+`writes`, `ext2_mount` needs `patch`+`read_slot`,
+// etc.), so suppressing the dead-code warning at the module level is
+// simpler than chasing per-call-site allows.
+#[allow(dead_code)]
 pub struct RamDisk {
     block_size: u32,
     storage: Mutex<Vec<u8>>,
@@ -54,16 +81,35 @@ pub struct RamDisk {
     read_only: AtomicBool,
 }
 
+#[allow(dead_code)]
 impl RamDisk {
     /// Wrap `bytes` as an in-memory block device with the given
     /// `block_size`. The image length must be a multiple of the block
     /// size — otherwise `read_at` / `write_at` would have unreachable
     /// trailing bytes.
     pub fn from_image(bytes: &[u8], block_size: u32) -> Arc<Self> {
-        assert!(bytes.len() % block_size as usize == 0);
+        assert!(
+            bytes.len() % block_size as usize == 0,
+            "image size {} must be a multiple of block_size {}",
+            bytes.len(),
+            block_size,
+        );
         Arc::new(Self {
             block_size,
             storage: Mutex::new(bytes.to_vec()),
+            writes: AtomicU32::new(0),
+            read_only: AtomicBool::new(false),
+        })
+    }
+
+    /// Allocate a zero-initialized image of `block_size * blocks`
+    /// bytes. Used by the block-cache and writeback tests, which
+    /// don't seed from a fixture.
+    pub fn zeroed(block_size: u32, blocks: usize) -> Arc<Self> {
+        let bytes = (block_size as usize) * blocks;
+        Arc::new(Self {
+            block_size,
+            storage: Mutex::new(vec![0u8; bytes]),
             writes: AtomicU32::new(0),
             read_only: AtomicBool::new(false),
         })
@@ -80,6 +126,24 @@ impl RamDisk {
     /// Lets RO tests assert `writes() == 0`.
     pub fn writes(&self) -> u32 {
         self.writes.load(Ordering::Relaxed)
+    }
+
+    /// Copy `buf.len()` bytes out of the backing storage starting at
+    /// `offset`, with no alignment / block-size requirement. Lets a
+    /// test inspect a slice of the image directly (e.g. confirming an
+    /// on-disk header reverted after a failed mount).
+    pub fn read_slot(&self, offset: usize, buf: &mut [u8]) {
+        let storage = self.storage.lock();
+        buf.copy_from_slice(&storage[offset..offset + buf.len()]);
+    }
+
+    /// Run `f` against an exclusive view of the backing storage. Lets
+    /// a test surgically corrupt an on-disk field before mount
+    /// without going through the `BlockDevice` write path (so it
+    /// doesn't bump the `writes` counter or trip the RO latch).
+    pub fn patch<F: FnOnce(&mut [u8])>(&self, f: F) {
+        let mut storage = self.storage.lock();
+        f(&mut storage);
     }
 }
 

--- a/kernel/tests/ext2_block_alloc.rs
+++ b/kernel/tests/ext2_block_alloc.rs
@@ -31,11 +31,8 @@ extern crate alloc;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::panic::PanicInfo;
-use core::sync::atomic::{AtomicU32, Ordering};
 
-use spin::Mutex;
-
-use vibix::block::{BlockDevice, BlockError};
+use vibix::block::BlockDevice;
 use vibix::fs::ext2::{alloc_block, free_block, Ext2Fs, Ext2Super};
 use vibix::fs::vfs::ops::{FileSystem as _, MountSource};
 use vibix::fs::vfs::super_block::SuperBlock;
@@ -110,68 +107,11 @@ fn run_tests() {
     }
 }
 
-// ---------------------------------------------------------------------------
-// RamDisk copy — same pattern as the sibling ext2 tests.
-// ---------------------------------------------------------------------------
-
-struct RamDisk {
-    block_size: u32,
-    storage: Mutex<Vec<u8>>,
-    writes: AtomicU32,
-}
-
-impl RamDisk {
-    fn from_image(bytes: &[u8], block_size: u32) -> Arc<Self> {
-        assert!(bytes.len() % block_size as usize == 0);
-        Arc::new(Self {
-            block_size,
-            storage: Mutex::new(bytes.to_vec()),
-            writes: AtomicU32::new(0),
-        })
-    }
-}
-
-impl BlockDevice for RamDisk {
-    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::OutOfRange)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::OutOfRange);
-        }
-        let off = offset as usize;
-        buf.copy_from_slice(&storage[off..off + buf.len()]);
-        Ok(())
-    }
-    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let mut storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::Enospc)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::Enospc);
-        }
-        let off = offset as usize;
-        storage[off..off + buf.len()].copy_from_slice(buf);
-        self.writes.fetch_add(1, Ordering::Relaxed);
-        Ok(())
-    }
-    fn block_size(&self) -> u32 {
-        self.block_size
-    }
-    fn capacity(&self) -> u64 {
-        self.storage.lock().len() as u64
-    }
-}
+// Shared `RamDisk` — see kernel/tests/common/ext2_ramdisk.rs (issues
+// #627, #658).
+#[path = "common/ext2_ramdisk.rs"]
+mod ext2_ramdisk;
+use ext2_ramdisk::RamDisk;
 
 // ---------------------------------------------------------------------------
 // Mount helpers

--- a/kernel/tests/ext2_create.rs
+++ b/kernel/tests/ext2_create.rs
@@ -23,13 +23,10 @@
 extern crate alloc;
 
 use alloc::sync::Arc;
-use alloc::vec::Vec;
 use core::panic::PanicInfo;
-use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU32};
 
-use spin::Mutex;
-
-use vibix::block::{BlockDevice, BlockError};
+use vibix::block::BlockDevice;
 use vibix::fs::ext2::{
     create_dir, create_file, dir, iget, mknod, Ext2Fs, Ext2Inode, Ext2InodeMeta, Ext2Super,
 };
@@ -86,81 +83,11 @@ fn run_tests() {
     }
 }
 
-// ---------------------------------------------------------------------------
-// RamDisk — shared with the other ext2 integration tests.
-// ---------------------------------------------------------------------------
-
-struct RamDisk {
-    block_size: u32,
-    storage: Mutex<Vec<u8>>,
-    writes: AtomicU32,
-    read_only: AtomicBool,
-}
-
-impl RamDisk {
-    fn from_image(bytes: &[u8], block_size: u32) -> Arc<Self> {
-        assert!(bytes.len() % block_size as usize == 0);
-        Arc::new(Self {
-            block_size,
-            storage: Mutex::new(bytes.to_vec()),
-            writes: AtomicU32::new(0),
-            read_only: AtomicBool::new(false),
-        })
-    }
-
-    fn set_read_only(&self, ro: bool) {
-        self.read_only.store(ro, Ordering::Relaxed);
-    }
-
-    fn writes(&self) -> u32 {
-        self.writes.load(Ordering::Relaxed)
-    }
-}
-
-impl BlockDevice for RamDisk {
-    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::OutOfRange)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::OutOfRange);
-        }
-        let off = offset as usize;
-        buf.copy_from_slice(&storage[off..off + buf.len()]);
-        Ok(())
-    }
-    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
-        if self.read_only.load(Ordering::Relaxed) {
-            return Err(BlockError::ReadOnly);
-        }
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let mut storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::Enospc)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::Enospc);
-        }
-        let off = offset as usize;
-        storage[off..off + buf.len()].copy_from_slice(buf);
-        self.writes.fetch_add(1, Ordering::Relaxed);
-        Ok(())
-    }
-    fn block_size(&self) -> u32 {
-        self.block_size
-    }
-    fn capacity(&self) -> u64 {
-        self.storage.lock().len() as u64
-    }
-}
+// Shared `RamDisk` — see kernel/tests/common/ext2_ramdisk.rs (issues
+// #627, #658).
+#[path = "common/ext2_ramdisk.rs"]
+mod ext2_ramdisk;
+use ext2_ramdisk::RamDisk;
 
 fn mount_golden_rw() -> (
     Arc<vibix::fs::vfs::super_block::SuperBlock>,

--- a/kernel/tests/ext2_file_read.rs
+++ b/kernel/tests/ext2_file_read.rs
@@ -34,11 +34,8 @@ use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::panic::PanicInfo;
-use core::sync::atomic::{AtomicU32, Ordering};
 
-use spin::Mutex;
-
-use vibix::block::{BlockDevice, BlockError};
+use vibix::block::BlockDevice;
 use vibix::fs::ext2::{iget, Ext2Fs};
 use vibix::fs::vfs::dentry::Dentry;
 use vibix::fs::vfs::inode::Inode;
@@ -119,68 +116,11 @@ fn run_tests() {
     }
 }
 
-// ---------------------------------------------------------------------------
-// RamDisk — same shape as the other ext2 integration tests.
-// ---------------------------------------------------------------------------
-
-struct RamDisk {
-    block_size: u32,
-    storage: Mutex<Vec<u8>>,
-    writes: AtomicU32,
-}
-
-impl RamDisk {
-    fn from_image(bytes: &[u8], block_size: u32) -> Arc<Self> {
-        assert!(bytes.len() % block_size as usize == 0);
-        Arc::new(Self {
-            block_size,
-            storage: Mutex::new(bytes.to_vec()),
-            writes: AtomicU32::new(0),
-        })
-    }
-}
-
-impl BlockDevice for RamDisk {
-    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::OutOfRange)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::OutOfRange);
-        }
-        let off = offset as usize;
-        buf.copy_from_slice(&storage[off..off + buf.len()]);
-        Ok(())
-    }
-    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let mut storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::Enospc)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::Enospc);
-        }
-        let off = offset as usize;
-        storage[off..off + buf.len()].copy_from_slice(buf);
-        self.writes.fetch_add(1, Ordering::Relaxed);
-        Ok(())
-    }
-    fn block_size(&self) -> u32 {
-        self.block_size
-    }
-    fn capacity(&self) -> u64 {
-        self.storage.lock().len() as u64
-    }
-}
+// Shared `RamDisk` — see kernel/tests/common/ext2_ramdisk.rs (issues
+// #627, #658).
+#[path = "common/ext2_ramdisk.rs"]
+mod ext2_ramdisk;
+use ext2_ramdisk::RamDisk;
 
 /// Mount `read_test.img` RO.
 fn mount_ro() -> (

--- a/kernel/tests/ext2_file_write.rs
+++ b/kernel/tests/ext2_file_write.rs
@@ -38,13 +38,9 @@ extern crate alloc;
 
 use alloc::sync::Arc;
 use alloc::vec;
-use alloc::vec::Vec;
 use core::panic::PanicInfo;
-use core::sync::atomic::{AtomicU32, Ordering};
 
-use spin::Mutex;
-
-use vibix::block::{BlockDevice, BlockError};
+use vibix::block::BlockDevice;
 use vibix::fs::ext2::{alloc_block, alloc_inode, iget, Ext2Fs, Ext2Super};
 use vibix::fs::vfs::dentry::Dentry;
 use vibix::fs::vfs::inode::Inode;
@@ -105,68 +101,11 @@ fn run_tests() {
     }
 }
 
-// ---------------------------------------------------------------------------
-// RamDisk — mirrors the copy in the other ext2 integration tests.
-// ---------------------------------------------------------------------------
-
-struct RamDisk {
-    block_size: u32,
-    storage: Mutex<Vec<u8>>,
-    writes: AtomicU32,
-}
-
-impl RamDisk {
-    fn from_image(bytes: &[u8], block_size: u32) -> Arc<Self> {
-        assert!(bytes.len() % block_size as usize == 0);
-        Arc::new(Self {
-            block_size,
-            storage: Mutex::new(bytes.to_vec()),
-            writes: AtomicU32::new(0),
-        })
-    }
-}
-
-impl BlockDevice for RamDisk {
-    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::OutOfRange)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::OutOfRange);
-        }
-        let off = offset as usize;
-        buf.copy_from_slice(&storage[off..off + buf.len()]);
-        Ok(())
-    }
-    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let mut storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::Enospc)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::Enospc);
-        }
-        let off = offset as usize;
-        storage[off..off + buf.len()].copy_from_slice(buf);
-        self.writes.fetch_add(1, Ordering::Relaxed);
-        Ok(())
-    }
-    fn block_size(&self) -> u32 {
-        self.block_size
-    }
-    fn capacity(&self) -> u64 {
-        self.storage.lock().len() as u64
-    }
-}
+// Shared `RamDisk` — see kernel/tests/common/ext2_ramdisk.rs (issues
+// #627, #658).
+#[path = "common/ext2_ramdisk.rs"]
+mod ext2_ramdisk;
+use ext2_ramdisk::RamDisk;
 
 fn mount_rw() -> (Arc<SuperBlock>, Arc<Ext2Fs>, Arc<Ext2Super>) {
     let disk = RamDisk::from_image(BALLOC_IMG.as_slice(), 512);

--- a/kernel/tests/ext2_inode_iget.rs
+++ b/kernel/tests/ext2_inode_iget.rs
@@ -31,13 +31,9 @@
 extern crate alloc;
 
 use alloc::sync::Arc;
-use alloc::vec::Vec;
 use core::panic::PanicInfo;
-use core::sync::atomic::{AtomicU32, Ordering};
 
-use spin::Mutex;
-
-use vibix::block::{BlockDevice, BlockError};
+use vibix::block::BlockDevice;
 use vibix::fs::ext2::{iget, Ext2Fs};
 use vibix::fs::vfs::ops::{FileSystem as _, MountSource, Stat};
 use vibix::fs::vfs::MountFlags;
@@ -89,69 +85,11 @@ fn run_tests() {
     }
 }
 
-// ---------------------------------------------------------------------------
-// RamDisk copy — matches ext2_mount.rs. Kept here (rather than extracted)
-// so each integration test stays self-contained.
-// ---------------------------------------------------------------------------
-
-struct RamDisk {
-    block_size: u32,
-    storage: Mutex<Vec<u8>>,
-    writes: AtomicU32,
-}
-
-impl RamDisk {
-    fn from_image(bytes: &[u8], block_size: u32) -> Arc<Self> {
-        assert!(bytes.len() % block_size as usize == 0);
-        Arc::new(Self {
-            block_size,
-            storage: Mutex::new(bytes.to_vec()),
-            writes: AtomicU32::new(0),
-        })
-    }
-}
-
-impl BlockDevice for RamDisk {
-    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::OutOfRange)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::OutOfRange);
-        }
-        let off = offset as usize;
-        buf.copy_from_slice(&storage[off..off + buf.len()]);
-        Ok(())
-    }
-    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let mut storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::Enospc)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::Enospc);
-        }
-        let off = offset as usize;
-        storage[off..off + buf.len()].copy_from_slice(buf);
-        self.writes.fetch_add(1, Ordering::Relaxed);
-        Ok(())
-    }
-    fn block_size(&self) -> u32 {
-        self.block_size
-    }
-    fn capacity(&self) -> u64 {
-        self.storage.lock().len() as u64
-    }
-}
+// Shared `RamDisk` — see kernel/tests/common/ext2_ramdisk.rs (issues
+// #627, #658).
+#[path = "common/ext2_ramdisk.rs"]
+mod ext2_ramdisk;
+use ext2_ramdisk::RamDisk;
 
 /// Mount the golden image RO and hand back `(Arc<SuperBlock>, Arc<Ext2Super>)`.
 /// RO mount because the tests only exercise the read path and don't

--- a/kernel/tests/ext2_link.rs
+++ b/kernel/tests/ext2_link.rs
@@ -20,13 +20,10 @@
 extern crate alloc;
 
 use alloc::sync::Arc;
-use alloc::vec::Vec;
 use core::panic::PanicInfo;
-use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU32};
 
-use spin::Mutex;
-
-use vibix::block::{BlockDevice, BlockError};
+use vibix::block::BlockDevice;
 use vibix::fs::ext2::symlink::{is_fast_symlink, is_symlink, read_symlink, EXT2_FAST_SYMLINK_MAX};
 use vibix::fs::ext2::{
     create_dir, create_file, dir, iget, link as ext2_link, symlink as ext2_symlink, Ext2Fs,
@@ -113,79 +110,11 @@ fn run_tests() {
     }
 }
 
-// ---------------------------------------------------------------------------
-// RamDisk — identical shape to ext2_create.rs / ext2_unlink.rs.
-// ---------------------------------------------------------------------------
-
-struct RamDisk {
-    block_size: u32,
-    storage: Mutex<Vec<u8>>,
-    writes: AtomicU32,
-    read_only: AtomicBool,
-}
-
-impl RamDisk {
-    fn from_image(bytes: &[u8], block_size: u32) -> Arc<Self> {
-        assert!(bytes.len() % block_size as usize == 0);
-        Arc::new(Self {
-            block_size,
-            storage: Mutex::new(bytes.to_vec()),
-            writes: AtomicU32::new(0),
-            read_only: AtomicBool::new(false),
-        })
-    }
-    fn set_read_only(&self, ro: bool) {
-        self.read_only.store(ro, Ordering::Relaxed);
-    }
-    fn writes(&self) -> u32 {
-        self.writes.load(Ordering::Relaxed)
-    }
-}
-
-impl BlockDevice for RamDisk {
-    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::OutOfRange)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::OutOfRange);
-        }
-        let off = offset as usize;
-        buf.copy_from_slice(&storage[off..off + buf.len()]);
-        Ok(())
-    }
-    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
-        if self.read_only.load(Ordering::Relaxed) {
-            return Err(BlockError::ReadOnly);
-        }
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let mut storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::Enospc)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::Enospc);
-        }
-        let off = offset as usize;
-        storage[off..off + buf.len()].copy_from_slice(buf);
-        self.writes.fetch_add(1, Ordering::Relaxed);
-        Ok(())
-    }
-    fn block_size(&self) -> u32 {
-        self.block_size
-    }
-    fn capacity(&self) -> u64 {
-        self.storage.lock().len() as u64
-    }
-}
+// Shared `RamDisk` — see kernel/tests/common/ext2_ramdisk.rs (issues
+// #627, #658).
+#[path = "common/ext2_ramdisk.rs"]
+mod ext2_ramdisk;
+use ext2_ramdisk::RamDisk;
 
 fn mount_golden_rw() -> (
     Arc<vibix::fs::vfs::super_block::SuperBlock>,

--- a/kernel/tests/ext2_mount.rs
+++ b/kernel/tests/ext2_mount.rs
@@ -32,13 +32,9 @@ extern crate alloc;
 
 use alloc::sync::Arc;
 use alloc::vec;
-use alloc::vec::Vec;
 use core::panic::PanicInfo;
-use core::sync::atomic::{AtomicU32, Ordering};
 
-use spin::Mutex;
-
-use vibix::block::{BlockDevice, BlockError};
+use vibix::block::BlockDevice;
 use vibix::fs::ext2::disk::{
     Ext2SuperBlock, EXT2_ERROR_FS, EXT2_MAGIC, EXT2_SB_OFF_MAGIC, EXT2_SUPERBLOCK_SIZE,
     EXT2_VALID_FS,
@@ -128,95 +124,11 @@ fn run_tests() {
     }
 }
 
-// ---------------------------------------------------------------------------
-// RamDisk: in-memory `BlockDevice` that counts writes so tests can
-// assert "RO mount drove zero writes". Matches the `RamDisk` in
-// `block_cache_sync_fs.rs` but with a constructor that takes an initial
-// byte blob (so we can seed it with the `mkfs.ext2` image).
-// ---------------------------------------------------------------------------
-
-struct RamDisk {
-    block_size: u32,
-    storage: Mutex<Vec<u8>>,
-    writes: AtomicU32,
-}
-
-impl RamDisk {
-    fn from_image(bytes: &[u8], block_size: u32) -> Arc<Self> {
-        assert!(
-            bytes.len() % block_size as usize == 0,
-            "image size {} must be a multiple of block_size {}",
-            bytes.len(),
-            block_size,
-        );
-        Arc::new(Self {
-            block_size,
-            storage: Mutex::new(bytes.to_vec()),
-            writes: AtomicU32::new(0),
-        })
-    }
-
-    fn writes(&self) -> u32 {
-        self.writes.load(Ordering::Relaxed)
-    }
-
-    fn read_slot(&self, offset: usize, buf: &mut [u8]) {
-        let storage = self.storage.lock();
-        buf.copy_from_slice(&storage[offset..offset + buf.len()]);
-    }
-
-    fn patch<F: FnOnce(&mut [u8])>(&self, f: F) {
-        let mut storage = self.storage.lock();
-        f(&mut storage);
-    }
-}
-
-impl BlockDevice for RamDisk {
-    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::OutOfRange)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::OutOfRange);
-        }
-        let off = offset as usize;
-        buf.copy_from_slice(&storage[off..off + buf.len()]);
-        Ok(())
-    }
-    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
-        // Note: the counter is bumped only on a *successful* write. A
-        // malformed/out-of-range write returns an error without
-        // touching it, so assertions like "failed mount must not write
-        // to device" can't false-positive on a bad call that the
-        // driver should never issue anyway.
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let mut storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::Enospc)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::Enospc);
-        }
-        let off = offset as usize;
-        storage[off..off + buf.len()].copy_from_slice(buf);
-        self.writes.fetch_add(1, Ordering::Relaxed);
-        Ok(())
-    }
-    fn block_size(&self) -> u32 {
-        self.block_size
-    }
-    fn capacity(&self) -> u64 {
-        self.storage.lock().len() as u64
-    }
-}
+// Shared `RamDisk` — see kernel/tests/common/ext2_ramdisk.rs (issues
+// #627, #658).
+#[path = "common/ext2_ramdisk.rs"]
+mod ext2_ramdisk;
+use ext2_ramdisk::RamDisk;
 
 // ---------------------------------------------------------------------------
 // Test helpers

--- a/kernel/tests/ext2_orphan_chain.rs
+++ b/kernel/tests/ext2_orphan_chain.rs
@@ -34,11 +34,8 @@ extern crate alloc;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::panic::PanicInfo;
-use core::sync::atomic::{AtomicU32, Ordering};
 
-use spin::Mutex;
-
-use vibix::block::{BlockDevice, BlockError};
+use vibix::block::BlockDevice;
 use vibix::fs::ext2::Ext2Fs;
 use vibix::fs::vfs::ops::{FileSystem as _, MountSource};
 use vibix::fs::vfs::super_block::SbFlags;
@@ -115,70 +112,11 @@ fn run_tests() {
     }
 }
 
-// ---------------------------------------------------------------------------
-// RamDisk (mirrors ext2_mount.rs / ext2_inode_iget.rs, simplified to a
-// single owning constructor since every test here patches the image
-// in-place before mount).
-// ---------------------------------------------------------------------------
-
-struct RamDisk {
-    block_size: u32,
-    storage: Mutex<Vec<u8>>,
-    writes: AtomicU32,
-}
-
-impl RamDisk {
-    fn new(bytes: Vec<u8>, block_size: u32) -> Arc<Self> {
-        assert!(bytes.len() % block_size as usize == 0);
-        Arc::new(Self {
-            block_size,
-            storage: Mutex::new(bytes),
-            writes: AtomicU32::new(0),
-        })
-    }
-}
-
-impl BlockDevice for RamDisk {
-    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::OutOfRange)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::OutOfRange);
-        }
-        let off = offset as usize;
-        buf.copy_from_slice(&storage[off..off + buf.len()]);
-        Ok(())
-    }
-    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let mut storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::Enospc)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::Enospc);
-        }
-        let off = offset as usize;
-        storage[off..off + buf.len()].copy_from_slice(buf);
-        self.writes.fetch_add(1, Ordering::Relaxed);
-        Ok(())
-    }
-    fn block_size(&self) -> u32 {
-        self.block_size
-    }
-    fn capacity(&self) -> u64 {
-        self.storage.lock().len() as u64
-    }
-}
+// Shared `RamDisk` — see kernel/tests/common/ext2_ramdisk.rs (issues
+// #627, #658).
+#[path = "common/ext2_ramdisk.rs"]
+mod ext2_ramdisk;
+use ext2_ramdisk::RamDisk;
 
 // ---------------------------------------------------------------------------
 // Image-patching helpers. The fixture is a 1 KiB-block, 16-inode,
@@ -232,7 +170,7 @@ fn mount_with(
     Arc<vibix::fs::ext2::Ext2Fs>,
     Arc<vibix::fs::ext2::Ext2Super>,
 ) {
-    let disk = RamDisk::new(img, 512);
+    let disk = RamDisk::from_image(&img, 512);
     let fs = Ext2Fs::new_with_device(disk as Arc<dyn BlockDevice>);
     let sb = fs
         .mount(MountSource::None, flags)

--- a/kernel/tests/ext2_orphan_finalize.rs
+++ b/kernel/tests/ext2_orphan_finalize.rs
@@ -27,13 +27,9 @@
 extern crate alloc;
 
 use alloc::sync::Arc;
-use alloc::vec::Vec;
 use core::panic::PanicInfo;
-use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
-use spin::Mutex;
-
-use vibix::block::{BlockDevice, BlockError};
+use vibix::block::BlockDevice;
 use vibix::fs::ext2::{finalize_orphan, iget, Ext2Fs, Ext2Super};
 use vibix::fs::vfs::ops::{FileSystem as _, MountSource};
 use vibix::fs::vfs::super_block::SuperBlock;
@@ -81,77 +77,11 @@ fn run_tests() {
     }
 }
 
-// ---------------------------------------------------------------------------
-// RamDisk — matches ext2_unlink.rs.
-// ---------------------------------------------------------------------------
-
-struct RamDisk {
-    block_size: u32,
-    storage: Mutex<Vec<u8>>,
-    writes: AtomicU32,
-    read_only: AtomicBool,
-}
-
-impl RamDisk {
-    fn from_image(bytes: &[u8], block_size: u32) -> Arc<Self> {
-        assert!(bytes.len() % block_size as usize == 0);
-        Arc::new(Self {
-            block_size,
-            storage: Mutex::new(bytes.to_vec()),
-            writes: AtomicU32::new(0),
-            read_only: AtomicBool::new(false),
-        })
-    }
-
-    fn set_read_only(&self, ro: bool) {
-        self.read_only.store(ro, Ordering::Relaxed);
-    }
-}
-
-impl BlockDevice for RamDisk {
-    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::OutOfRange)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::OutOfRange);
-        }
-        let off = offset as usize;
-        buf.copy_from_slice(&storage[off..off + buf.len()]);
-        Ok(())
-    }
-    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
-        if self.read_only.load(Ordering::Relaxed) {
-            return Err(BlockError::ReadOnly);
-        }
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let mut storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::Enospc)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::Enospc);
-        }
-        let off = offset as usize;
-        storage[off..off + buf.len()].copy_from_slice(buf);
-        self.writes.fetch_add(1, Ordering::Relaxed);
-        Ok(())
-    }
-    fn block_size(&self) -> u32 {
-        self.block_size
-    }
-    fn capacity(&self) -> u64 {
-        self.storage.lock().len() as u64
-    }
-}
+// Shared `RamDisk` — see kernel/tests/common/ext2_ramdisk.rs (issues
+// #627, #658).
+#[path = "common/ext2_ramdisk.rs"]
+mod ext2_ramdisk;
+use ext2_ramdisk::RamDisk;
 
 fn mount_rw() -> (Arc<SuperBlock>, Arc<Ext2Fs>, Arc<Ext2Super>, Arc<RamDisk>) {
     let disk = RamDisk::from_image(GOLDEN_IMG.as_slice(), 512);
@@ -288,7 +218,13 @@ fn finalize_rmdir_orphan_frees_blocks_and_chain_head() {
     //    directly off the RamDisk storage so we bypass any in-memory
     //    cache of the Ext2Inode.
     {
-        let storage = _disk.storage.lock();
+        // Snapshot the full image out of the shared `RamDisk` so we
+        // can reuse the existing offset helpers, which are written
+        // against `&[u8]`. The image is only 64 KiB, so the copy is
+        // cheap and keeps this site honest with the helper's public
+        // surface (no peeking through `pub(crate)` storage).
+        let mut storage = [0u8; 65_536];
+        _disk.read_slot(0, &mut storage);
         let slot_off = inode_slot_offset(&storage, 11);
         let links = u16_le(&storage, slot_off + INODE_OFF_LINKS_COUNT);
         let dtime = u32_le(&storage, slot_off + INODE_OFF_DTIME);

--- a/kernel/tests/ext2_rename.rs
+++ b/kernel/tests/ext2_rename.rs
@@ -33,13 +33,10 @@
 extern crate alloc;
 
 use alloc::sync::Arc;
-use alloc::vec::Vec;
 use core::panic::PanicInfo;
-use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU32};
 
-use spin::Mutex;
-
-use vibix::block::{BlockDevice, BlockError};
+use vibix::block::BlockDevice;
 use vibix::fs::ext2::{dir, iget, Ext2Fs, Ext2Inode, Ext2InodeMeta, Ext2Super};
 use vibix::fs::vfs::ops::{FileSystem as _, MountSource};
 use vibix::fs::vfs::MountFlags;
@@ -102,77 +99,11 @@ fn run_tests() {
     }
 }
 
-// ---------------------------------------------------------------------------
-// RamDisk — matches the other ext2 integration tests.
-// ---------------------------------------------------------------------------
-
-struct RamDisk {
-    block_size: u32,
-    storage: Mutex<Vec<u8>>,
-    writes: AtomicU32,
-    read_only: AtomicBool,
-}
-
-impl RamDisk {
-    fn from_image(bytes: &[u8], block_size: u32) -> Arc<Self> {
-        assert!(bytes.len() % block_size as usize == 0);
-        Arc::new(Self {
-            block_size,
-            storage: Mutex::new(bytes.to_vec()),
-            writes: AtomicU32::new(0),
-            read_only: AtomicBool::new(false),
-        })
-    }
-
-    fn set_read_only(&self, ro: bool) {
-        self.read_only.store(ro, Ordering::Relaxed);
-    }
-}
-
-impl BlockDevice for RamDisk {
-    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::OutOfRange)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::OutOfRange);
-        }
-        let off = offset as usize;
-        buf.copy_from_slice(&storage[off..off + buf.len()]);
-        Ok(())
-    }
-    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
-        if self.read_only.load(Ordering::Relaxed) {
-            return Err(BlockError::ReadOnly);
-        }
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let mut storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::Enospc)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::Enospc);
-        }
-        let off = offset as usize;
-        storage[off..off + buf.len()].copy_from_slice(buf);
-        self.writes.fetch_add(1, Ordering::Relaxed);
-        Ok(())
-    }
-    fn block_size(&self) -> u32 {
-        self.block_size
-    }
-    fn capacity(&self) -> u64 {
-        self.storage.lock().len() as u64
-    }
-}
+// Shared `RamDisk` — see kernel/tests/common/ext2_ramdisk.rs (issues
+// #627, #658).
+#[path = "common/ext2_ramdisk.rs"]
+mod ext2_ramdisk;
+use ext2_ramdisk::RamDisk;
 
 fn mount_rw() -> (
     Arc<vibix::fs::vfs::super_block::SuperBlock>,

--- a/kernel/tests/ext2_setattr.rs
+++ b/kernel/tests/ext2_setattr.rs
@@ -34,13 +34,10 @@ extern crate alloc;
 
 use alloc::sync::Arc;
 use alloc::vec;
-use alloc::vec::Vec;
 use core::panic::PanicInfo;
-use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU32};
 
-use spin::Mutex;
-
-use vibix::block::{BlockDevice, BlockError};
+use vibix::block::BlockDevice;
 use vibix::fs::ext2::symlink::{is_fast_symlink, is_symlink};
 use vibix::fs::ext2::{iget, symlink as ext2_symlink, Ext2Fs, Ext2Inode, Ext2InodeMeta, Ext2Super};
 use vibix::fs::vfs::inode::{Inode, InodeKind};
@@ -144,68 +141,11 @@ fn run_tests() {
     }
 }
 
-// ---------------------------------------------------------------------------
-// RamDisk — same shape as the sibling ext2 integration tests.
-// ---------------------------------------------------------------------------
-
-struct RamDisk {
-    block_size: u32,
-    storage: Mutex<Vec<u8>>,
-    writes: AtomicU32,
-}
-
-impl RamDisk {
-    fn from_image(bytes: &[u8], block_size: u32) -> Arc<Self> {
-        assert!(bytes.len() % block_size as usize == 0);
-        Arc::new(Self {
-            block_size,
-            storage: Mutex::new(bytes.to_vec()),
-            writes: AtomicU32::new(0),
-        })
-    }
-}
-
-impl BlockDevice for RamDisk {
-    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::OutOfRange)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::OutOfRange);
-        }
-        let off = offset as usize;
-        buf.copy_from_slice(&storage[off..off + buf.len()]);
-        Ok(())
-    }
-    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let mut storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::Enospc)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::Enospc);
-        }
-        let off = offset as usize;
-        storage[off..off + buf.len()].copy_from_slice(buf);
-        self.writes.fetch_add(1, Ordering::Relaxed);
-        Ok(())
-    }
-    fn block_size(&self) -> u32 {
-        self.block_size
-    }
-    fn capacity(&self) -> u64 {
-        self.storage.lock().len() as u64
-    }
-}
+// Shared `RamDisk` — see kernel/tests/common/ext2_ramdisk.rs (issues
+// #627, #658).
+#[path = "common/ext2_ramdisk.rs"]
+mod ext2_ramdisk;
+use ext2_ramdisk::RamDisk;
 
 fn mount_rw() -> (Arc<SuperBlock>, Arc<Ext2Fs>, Arc<Ext2Super>) {
     let disk = RamDisk::from_image(READ_IMG.as_slice(), 512);

--- a/kernel/tests/mount_dev_resolve.rs
+++ b/kernel/tests/mount_dev_resolve.rs
@@ -36,9 +36,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::panic::PanicInfo;
 
-use spin::Mutex;
-
-use vibix::block::{BlockDevice, BlockError};
+use vibix::block::BlockDevice;
 use vibix::fs::vfs::devfs::register_block_device;
 use vibix::fs::vfs::ops::MountSource;
 use vibix::fs::vfs::MountFlags;
@@ -95,60 +93,11 @@ fn run_tests() {
 // in `ext2_mount.rs` but slimmer — no write counter, no patch hook.
 // ---------------------------------------------------------------------------
 
-struct RamDisk {
-    block_size: u32,
-    storage: Mutex<Vec<u8>>,
-}
-
-impl RamDisk {
-    fn from_image(bytes: &[u8], block_size: u32) -> Arc<Self> {
-        Arc::new(Self {
-            block_size,
-            storage: Mutex::new(bytes.to_vec()),
-        })
-    }
-}
-
-impl BlockDevice for RamDisk {
-    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BlockError> {
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::OutOfRange)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::OutOfRange);
-        }
-        let off = offset as usize;
-        buf.copy_from_slice(&storage[off..off + buf.len()]);
-        Ok(())
-    }
-    fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), BlockError> {
-        let bs = self.block_size as u64;
-        if buf.is_empty() || (buf.len() as u64) % bs != 0 || offset % bs != 0 {
-            return Err(BlockError::BadAlign);
-        }
-        let mut storage = self.storage.lock();
-        let end = offset
-            .checked_add(buf.len() as u64)
-            .ok_or(BlockError::Enospc)?;
-        if end > storage.len() as u64 {
-            return Err(BlockError::Enospc);
-        }
-        let off = offset as usize;
-        storage[off..off + buf.len()].copy_from_slice(buf);
-        Ok(())
-    }
-    fn block_size(&self) -> u32 {
-        self.block_size
-    }
-    fn capacity(&self) -> u64 {
-        self.storage.lock().len() as u64
-    }
-}
+// Shared `RamDisk` — see kernel/tests/common/ext2_ramdisk.rs (issues
+// #627, #658).
+#[path = "common/ext2_ramdisk.rs"]
+mod ext2_ramdisk;
+use ext2_ramdisk::RamDisk;
 
 // ---------------------------------------------------------------------------
 // Tests


### PR DESCRIPTION
Closes #658

## Summary
- Replace inline `RamDisk` + `BlockDevice` impl in 14 ext2/block integration tests with the shared `kernel/tests/common/ext2_ramdisk.rs` module (introduced for #627 in PR #657).
- Extend the shared helper with `zeroed(block_size, blocks)`, `read_slot(offset, buf)`, and `patch<F>(f)` to cover all previously-inlined call sites without exposing internal `Mutex<Vec<u8>>` storage.
- Net -842 LoC of duplicated test scaffolding; no behavior changes.

Migrated files: `block_cache_sync_fs.rs`, `block_writeback.rs`, `ext2_block_alloc.rs`, `ext2_create.rs`, `ext2_file_read.rs`, `ext2_file_write.rs`, `ext2_inode_iget.rs`, `ext2_link.rs`, `ext2_mount.rs`, `ext2_orphan_chain.rs`, `ext2_orphan_finalize.rs`, `ext2_rename.rs`, `ext2_setattr.rs`, `mount_dev_resolve.rs`.

Each migrated file now uses the established include pattern:

```rust
#[path = "common/ext2_ramdisk.rs"]
mod ext2_ramdisk;
use ext2_ramdisk::RamDisk;
```

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo xtask test` green (host unit + QEMU integration)
- [ ] CI green