### PR TITLE
sched: rename IrqSource to TimerIrq for honest scope (#670)

### DIFF
--- a/docs/RFC/0005-scheduler-irq-seam.md
+++ b/docs/RFC/0005-scheduler-irq-seam.md
@@ -7,6 +7,16 @@ created: 2026-04-27
 
 # RFC 0005: Scheduler / IRQ Seam for Deterministic Simulation Testing
 
+> **Post-acceptance rename (#670):** the `IrqSource` trait described
+> throughout this RFC was renamed to `TimerIrq` (and `MockIrqSource` to
+> `MockTimerIrq`) before any Phase 2 work depends on the name, per
+> roadmap item 6 / OS-engineer advisory A1. Broader IRQ routing is
+> explicitly Phase 2; the old name overpromised. The RFC text below
+> retains the historical name to preserve the proposal record — the
+> design note at [`docs/design/scheduler-seam.md`](../design/scheduler-seam.md)
+> describes the as-shipped names. Where the two disagree, the design
+> note wins.
+
 ## Abstract
 
 Extract the scheduler core in `kernel/src/task/` from its direct dependence on
@@ -578,10 +588,9 @@ in a half-migrated state.
       fails if any `MockClock` or `MockIrqSource` symbol is present.
       This makes the "physically excluded from production" claim
       enforced rather than asserted.
-- [ ] Rename `IrqSource` → `TimerIrq` (or `PreemptionIrq`) before any
-      Phase-2 simulator work depends on the name (per OS-engineer
-      advisory A1). Mechanical rename, one PR, deferred to last so the
-      earlier PRs don't churn it twice.
+- [x] Rename `IrqSource` → `TimerIrq` (#670). Mechanical rename, one
+      PR, landed before any Phase-2 simulator work depends on the name
+      (per OS-engineer advisory A1).
 - [x] Document the seam in [`docs/design/scheduler-seam.md`](../design/scheduler-seam.md)
       (one-page; links here) including: trait shape, IRQ-context contract,
       init-order contract, equivalence property, the

--- a/docs/design/scheduler-seam.md
+++ b/docs/design/scheduler-seam.md
@@ -20,7 +20,9 @@ through (once caller migration lands) instead of reaching directly into
 `crate::time::*` and `crate::arch::*`:
 
 - `Clock` — monotonic time + one-shot future-tick wakeups.
-- `IrqSource` — preemption-relevant IRQ acknowledgement.
+- `TimerIrq` — preemption-driving timer IRQ acknowledgement. (Renamed
+  from `IrqSource` per #670 — broader IRQ routing is explicitly Phase 2;
+  the old name overpromised.)
 
 Production wires both to the existing PIT/LAPIC/`time::WAKEUPS`
 machinery via zero-sized adapters. Tests and the future host-side
@@ -34,7 +36,7 @@ site.
 
 | Path | Status | Contents |
 |---|---|---|
-| `kernel/src/task/env.rs` | landed (#672) | `Tick`, `Clock`, `IrqSource`, `TaskId` |
+| `kernel/src/task/env.rs` | landed (#672) | `Tick`, `Clock`, `TimerIrq`, `TaskId` |
 | `kernel/src/task/mod.rs` | landed (#672, `pub mod env;` only) | will host `HwClock`, `HwIrq`, `env()` (#666) |
 | `kernel/src/time.rs` | unchanged today | will drop to `pub(crate)` after caller migration (#667) |
 
@@ -58,7 +60,7 @@ pub trait Clock: Sync {
     fn enqueue_wakeup(&self, deadline: Tick, id: TaskId);
 }
 
-pub trait IrqSource: Sync {
+pub trait TimerIrq: Sync {
     fn ack_timer(&self);
 }
 ```
@@ -76,7 +78,7 @@ underlying type in one place without breaking impls.
 
 ### IRQ-context safety
 
-All `Clock` and `IrqSource` methods MUST be safe to call from both task
+All `Clock` and `TimerIrq` methods MUST be safe to call from both task
 context and interrupt context. Implementors that hold internal state
 across methods MUST mask IRQs while held (the existing `time::WAKEUPS`
 already uses `crate::sync::IrqLock`). A non-IRQ-safe impl is a soundness
@@ -103,7 +105,7 @@ correctness bug, not a performance one.
 
 ### `env()` accessor (not yet landed — issue #666)
 
-`task::env()` returns `(&'static dyn Clock, &'static dyn IrqSource)`.
+`task::env()` returns `(&'static dyn Clock, &'static dyn TimerIrq)`.
 The production accessor body MUST contain no `Once`, no `Mutex`, no
 atomic load other than the `&'static` reference materialization — see
 the equivalence property below for why. Test/sim builds may swap the
@@ -152,7 +154,7 @@ Explicitly out of scope for Phase 1, by RFC §"Alternatives Considered":
 
 ## The discipline
 
-> **A `Clock` or `IrqSource` trait method is added only when a second
+> **A `Clock` or `TimerIrq` trait method is added only when a second
 > implementation actually needs it.**
 
 Speculative methods ("we'll probably want this when…") are rejected.
@@ -175,7 +177,7 @@ each one lands.
 
 The Phase-2 simulator RFC will need the scheduler's
 externally-observable behavior to be expressible as a labeled
-transition system over `(Clock-event, IrqSource-event) → state
+transition system over `(Clock-event, TimerIrq-event) → state
 transition`. The seam shape here is *necessary* for this but may not
 be *sufficient* — softirq ordering (above) is the known suspect. The
 Phase-2 RFC must validate sufficiency before relying on the v1 trait

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -50,7 +50,7 @@ bench = []
 # `--features fork-trace` on any xtask subcommand).
 fork-trace = []
 # RFC 0005 Phase 1 wave 3 (#668). Enables `MockClock` /
-# `MockIrqSource` in `task::env` for deterministic scheduler tests and
+# `MockTimerIrq` in `task::env` for deterministic scheduler tests and
 # the future host-side simulator (Phase 2). Off by default; the
 # nm-check guard (#669) statically verifies the symbols don't appear
 # in a release-built kernel ELF — keep this strictly opt-in so that

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -68,7 +68,7 @@ pub mod sync;
 // touches `arch`, `sync`, and `x86_64` which are all `target_os =
 // "none"`. The exception is the `task::env` submodule (RFC 0005
 // scheduler / IRQ seam), whose trait definitions and `MockClock` /
-// `MockIrqSource` impls (gated behind `feature = "sched-mock"`) are
+// `MockTimerIrq` impls (gated behind `feature = "sched-mock"`) are
 // host-buildable so the seam has CI-runnable host unit tests. Hence
 // the wider gate here; the body of `task/mod.rs` stays gated to
 // `target_os = "none"` internally.

--- a/kernel/src/task/env.rs
+++ b/kernel/src/task/env.rs
@@ -10,11 +10,11 @@
 //! adapters, no `env()` accessor, no callers migrated. Issue #666
 //! lands the `HwClock` / `HwIrq` adapters and the `env()` accessor;
 //! issue #667 migrates `preempt_tick` / `sleep_ms` / signal callers
-//! through the seam; issue #668 lands `MockClock` / `MockIrqSource`.
+//! through the seam; issue #668 lands `MockClock` / `MockTimerIrq`.
 //!
 //! ## Discipline (RFC 0005, "Discipline" section)
 //!
-//! > A `Clock` or `IrqSource` trait method is added only when a
+//! > A `Clock` or `TimerIrq` trait method is added only when a
 //! > second implementation actually needs it.
 //!
 //! Speculative methods are rejected. The first new method that
@@ -125,15 +125,16 @@ pub trait Clock: Sync {
     fn enqueue_wakeup(&self, deadline: Tick, id: TaskId);
 }
 
-/// Source of preemption-relevant interrupts for the scheduler.
+/// Source of the preemption-driving timer IRQ for the scheduler.
 ///
-/// Scoped to the *scheduler's* view of IRQs only: device drivers
-/// continue to ack their own IRQs through `crate::arch::*` directly.
-/// One-shot IDT install, IOAPIC redirection programming, and IPI
-/// send are **not** part of this trait (RFC 0005 §"Alternatives
-/// Considered" — wider trait surface rejected for v1). Despite the
-/// generic-sounding name, today this means a single method.
-pub trait IrqSource: Sync {
+/// Scoped to the *scheduler's* timer IRQ only: device drivers continue
+/// to ack their own IRQs through `crate::arch::*` directly. Broader IRQ
+/// routing — one-shot IDT install, IOAPIC redirection programming, IPI
+/// send — is **not** part of this trait (RFC 0005 §"Alternatives
+/// Considered" — wider trait surface rejected for v1, and explicitly
+/// Phase 2). The name reflects what the trait abstracts today: the
+/// single ack-timer method that `preempt_tick` invokes.
+pub trait TimerIrq: Sync {
     /// Acknowledge the timer IRQ that drove the current
     /// `preempt_tick` call. Today: LAPIC EOI write; on legacy PIC:
     /// PIC EOI. Called from the timer ISR — must be IRQ-safe.
@@ -154,7 +155,7 @@ pub trait IrqSource: Sync {
 //
 // `HwIrq` and `env()` depend on `crate::arch::*` and so are gated to
 // `target_os = "none"` builds; the trait definitions above stay
-// host-buildable for the future `MockClock` / `MockIrqSource`
+// host-buildable for the future `MockClock` / `MockTimerIrq`
 // (issue #668).
 // ---------------------------------------------------------------------------
 
@@ -176,12 +177,12 @@ impl Clock for HwClock {
     }
 }
 
-/// Production `IrqSource` over the LAPIC end-of-interrupt path.
+/// Production `TimerIrq` over the LAPIC end-of-interrupt path.
 #[cfg(target_os = "none")]
 pub struct HwIrq;
 
 #[cfg(target_os = "none")]
-impl IrqSource for HwIrq {
+impl TimerIrq for HwIrq {
     fn ack_timer(&self) {
         crate::arch::ack_timer_irq();
     }
@@ -196,14 +197,14 @@ pub static HW_IRQ: HwIrq = HwIrq;
 
 /// Production wire-up of the scheduler / IRQ seam.
 ///
-/// Returns the singleton `Clock` + `IrqSource` pair that the scheduler
+/// Returns the singleton `Clock` + `TimerIrq` pair that the scheduler
 /// and the timer ISR will route through once issue #667 migrates the
 /// callers. Body is intentionally a single tuple of two `&'static`
 /// references — no `Once`, no `Mutex`, no atomic load — so that the
 /// production path adds zero synchronization vs. the pre-seam direct
 /// calls (RFC 0005 Equivalence condition 2).
 #[cfg(target_os = "none")]
-pub fn env() -> (&'static dyn Clock, &'static dyn IrqSource) {
+pub fn env() -> (&'static dyn Clock, &'static dyn TimerIrq) {
     (&HW_CLOCK, &HW_IRQ)
 }
 
@@ -225,15 +226,15 @@ pub fn env() -> (&'static dyn Clock, &'static dyn IrqSource) {
 pub fn assert_production_env() -> bool {
     let (clock, irq) = env();
     let hw_clock: &dyn Clock = &HW_CLOCK;
-    let hw_irq: &dyn IrqSource = &HW_IRQ;
+    let hw_irq: &dyn TimerIrq = &HW_IRQ;
     core::ptr::eq(clock, hw_clock) && core::ptr::eq(irq, hw_irq)
 }
 
 // ---------------------------------------------------------------------------
 // Mock impls (Phase 1 wave 3, issue #668).
 //
-// `MockClock` and `MockIrqSource` are non-production `Clock` /
-// `IrqSource` implementations used by host-side unit tests, future
+// `MockClock` and `MockTimerIrq` are non-production `Clock` /
+// `TimerIrq` implementations used by host-side unit tests, future
 // in-kernel `sched-mock`-gated integration tests, and (eventually) the
 // Phase 2 host-side simulator. They are gated by the `sched-mock`
 // Cargo feature *only* (no `target_os` exception) so a release kernel
@@ -339,16 +340,16 @@ impl Clock for MockClock {
     }
 }
 
-/// Mock `IrqSource` for deterministic scheduler tests.
+/// Mock `TimerIrq` for deterministic scheduler tests.
 ///
 /// `ack_timer` is a no-op on the wire (there is no LAPIC / PIC behind
 /// the mock to acknowledge), but the call is recorded for assertions and
-/// a separate [`MockIrqSource::inject_timer`] entry point lets tests
+/// a separate [`MockTimerIrq::inject_timer`] entry point lets tests
 /// simulate a timer IRQ landing — for the v1 trait surface that just
 /// records an inject; future trait methods (post-Phase 2) may grow
 /// observable side effects.
 #[cfg(feature = "sched-mock")]
-pub struct MockIrqSource {
+pub struct MockTimerIrq {
     inner: spin::Mutex<MockIrqState>,
 }
 
@@ -360,7 +361,7 @@ struct MockIrqState {
 }
 
 #[cfg(feature = "sched-mock")]
-impl MockIrqSource {
+impl MockTimerIrq {
     /// Construct a fresh mock IRQ source with both counters at zero.
     pub const fn new() -> Self {
         Self {
@@ -379,12 +380,12 @@ impl MockIrqSource {
         self.inner.lock().pending_timer_injects += 1;
     }
 
-    /// Number of times [`IrqSource::ack_timer`] has been called.
+    /// Number of times [`TimerIrq::ack_timer`] has been called.
     pub fn ack_count(&self) -> u64 {
         self.inner.lock().ack_calls
     }
 
-    /// Number of timer IRQs injected by [`MockIrqSource::inject_timer`]
+    /// Number of timer IRQs injected by [`MockTimerIrq::inject_timer`]
     /// minus the number acknowledged. Should drop to zero after the
     /// scheduler processes every injected tick.
     pub fn pending_timers(&self) -> u64 {
@@ -394,14 +395,14 @@ impl MockIrqSource {
 }
 
 #[cfg(feature = "sched-mock")]
-impl Default for MockIrqSource {
+impl Default for MockTimerIrq {
     fn default() -> Self {
         Self::new()
     }
 }
 
 #[cfg(feature = "sched-mock")]
-impl IrqSource for MockIrqSource {
+impl TimerIrq for MockTimerIrq {
     fn ack_timer(&self) {
         self.inner.lock().ack_calls += 1;
     }
@@ -469,7 +470,7 @@ mod mock_tests {
 
     #[test]
     fn mock_irq_records_ack_and_inject() {
-        let irq = MockIrqSource::new();
+        let irq = MockTimerIrq::new();
         assert_eq!(irq.ack_count(), 0);
         assert_eq!(irq.pending_timers(), 0);
 
@@ -491,7 +492,7 @@ mod mock_tests {
     #[test]
     fn end_to_end_advance_inject_observe_wakeup() {
         let clock = MockClock::new(0);
-        let irq = MockIrqSource::new();
+        let irq = MockTimerIrq::new();
 
         // A task arms a wakeup three ticks out.
         let task_id: TaskId = 42;

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -38,7 +38,7 @@ pub mod env;
 // and `crate::time` features that don't compile on the host, so they
 // are gated to bare-metal builds. Host builds reach `task::env` only
 // (RFC 0005 seam) so the `sched-mock` test path can compile and
-// exercise `MockClock` / `MockIrqSource` without dragging the real
+// exercise `MockClock` / `MockTimerIrq` without dragging the real
 // scheduler in.
 #[cfg(target_os = "none")]
 pub mod priority;


### PR DESCRIPTION
Closes #670.

## Summary

Phase 1 hardening of RFC 0005 — mechanical rename, no semantic changes. The trait abstracts only the timer IRQ ack today; broader IRQ routing (IDT install, IOAPIC redirection, IPI send) is explicitly Phase 2 per RFC 0005. The old `IrqSource` name overpromised; `TimerIrq` reflects what the trait actually does (OS-engineer advisory A1).

- trait `IrqSource` -> `TimerIrq`
- struct `MockIrqSource` -> `MockTimerIrq`
- `HwIrq` unchanged (production adapter, not the trait)
- `env()` return type, all impls, doc comments, design note updated
- RFC body retains historical name with a top-of-doc rename note pointing readers to the design note (the design note tracks as-shipped names)

## Coordination

`/auto-engineer #669` (nm-check guard) is in flight; its regex must match `MockTimerIrq` after this lands. If #669 lands first I'll rebase its pattern; if this lands first, the #669 author will rebase.

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --features sched-mock --lib` (kernel host tests) — 545 passed
- [x] `cargo xtask build` — kernel-target build green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)