### PR TITLE
ci: nm-check release kernel ELF for MockClock/MockIrqSource symbols (#669)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,20 @@ jobs:
       - name: cargo xtask build --release
         run: cargo xtask build --release
 
+      # RFC 0005 Phase 1 hardening (#669). Static guard that the
+      # `#[cfg(feature = "sched-mock")]` gate around `MockClock` /
+      # `MockIrqSource` from #668 actually holds: even if a future PR
+      # accidentally enables `sched-mock` in the default feature set or
+      # a non-gated `pub use` re-exports a mock type, this step fails
+      # the release pipeline before the binary ships. Runs `llvm-nm`
+      # over the freshly-built release kernel ELF (and the ISO-bundled
+      # ELF as defense-in-depth) and fails on any forbidden symbol.
+      #
+      # See `docs/RFC/0005-scheduler-irq-seam.md` "Test-time wiring"
+      # and Security review B1.
+      - name: RFC 0005 nm-check (no MockClock/MockIrqSource in release)
+        run: cargo xtask nm-check --release
+
   unit-tests:
     name: host unit tests
     runs-on: ubuntu-latest

--- a/docs/agent-playbooks/testing.md
+++ b/docs/agent-playbooks/testing.md
@@ -85,6 +85,22 @@ yet, so the runner boots as a placeholder. The CI gate still earns its keep by f
 on harness regressions (kernel panic, QEMU watchdog timeout, ext2 image builder
 break). Real conformance signal arrives when #642 ports the runner to vibix userspace.
 
+## Layer 5 - RFC 0005 nm-check (release-symbol guard)
+
+`cargo xtask nm-check --release` builds the release kernel and ISO and runs
+`llvm-nm` over the resulting ELF, failing if any `MockClock` / `MockIrqSource`
+symbol (or any other `sched-mock`-gated type) appears. This is the static guard
+that the `#[cfg(feature = "sched-mock")]` source-level gate around the mocks in
+`kernel/src/task/env.rs` actually holds — even if a future PR accidentally
+flips `sched-mock` on by default, or a non-gated `pub use` re-exports a mock
+type, this step fails the release pipeline before the binary ships.
+
+CI runs this in the `fmt + build (release)` job (`.github/workflows/ci.yml`).
+Do not disable or weaken the check without an RFC update — it is the
+"physically excluded from production" evidence Security review B1 asked for.
+When the mocks rename (e.g. #670: `MockIrqSource` → `MockTimerIrq`), update the
+`FORBIDDEN` list in `xtask/src/main.rs::nm_check_no_mocks` in the same PR.
+
 ## Gotchas
 
 - Do not add `-no-shutdown` to the `test_runner` QEMU args. It breaks the

--- a/docs/agent-playbooks/testing.md
+++ b/docs/agent-playbooks/testing.md
@@ -99,7 +99,7 @@ CI runs this in the `fmt + build (release)` job (`.github/workflows/ci.yml`).
 Do not disable or weaken the check without an RFC update — it is the
 "physically excluded from production" evidence Security review B1 asked for.
 When the mocks rename (e.g. #670: `MockIrqSource` → `MockTimerIrq`), update the
-`FORBIDDEN` list in `xtask/src/main.rs::nm_check_no_mocks` in the same PR.
+`NM_CHECK_FORBIDDEN` list in `xtask/src/main.rs` in the same PR.
 
 ## Gotchas
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -234,8 +234,21 @@ fn main() -> R<()> {
         "isr-audit" => isr_audit::run(&workspace_root())?,
         "nm-check" => {
             // RFC 0005 Phase 1 hardening (#669). Build the release
-            // kernel first, then run the static guard. We force
-            // `--release` regardless of `--release` on the CLI: this
+            // kernel first, then run the static guard. Reject any
+            // trailing positional arg up front: `nm-check` takes no
+            // arguments, and silently dropping unknown ones (e.g. a
+            // typo'd `nm-check release` instead of `--release`)
+            // would let an unintended invocation pass for the wrong
+            // reason — exactly the kind of fail-open behaviour this
+            // gate exists to prevent.
+            if !rest.is_empty() {
+                return Err(format!(
+                    "nm-check: unexpected positional arg(s): {:?}; nm-check takes only build flags before the subcommand",
+                    rest,
+                )
+                .into());
+            }
+            // We force `--release` regardless of `--release` on the CLI: this
             // subcommand's whole purpose is to verify the release
             // build, and a debug-build pass would silently
             // misrepresent the answer. We also pin every diagnostic

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -236,13 +236,21 @@ fn main() -> R<()> {
             // `--release` regardless of `--release` on the CLI: this
             // subcommand's whole purpose is to verify the release
             // build, and a debug-build pass would silently
-            // misrepresent the answer.
+            // misrepresent the answer. We also pin every diagnostic
+            // feature off (`fault-test`, `panic-test`, `bench`,
+            // `fork-trace`) — those toggles are for hand-driven
+            // debugging only and would have the gate validating a
+            // non-production variant. A caller passing them gets a
+            // hard error rather than silent acceptance.
+            if opts.fault_test || opts.panic_test || opts.bench || opts.fork_trace {
+                return Err("nm-check: --fault-test / --panic-test / --bench / --fork-trace are incompatible with the production-build guard; rerun with no diagnostic features".into());
+            }
             let release_opts = BuildOpts {
                 release: true,
-                fault_test: opts.fault_test,
-                panic_test: opts.panic_test,
-                bench: opts.bench,
-                fork_trace: opts.fork_trace,
+                fault_test: false,
+                panic_test: false,
+                bench: false,
+                fork_trace: false,
             };
             let kernel = build(&release_opts)?;
             nm_check_no_mocks(&kernel)?;
@@ -689,7 +697,8 @@ fn nm_check_no_mocks(kernel: &Path) -> R<()> {
             eprintln!("  {line}");
         }
         eprintln!(
-            "RFC 0005 Phase 1 (#669): release kernels must not contain MockClock/MockIrqSource."
+            "RFC 0005 Phase 1 (#669): release kernels must not contain sched-mock symbols ({}).",
+            NM_CHECK_FORBIDDEN.join(", "),
         );
         eprintln!(
             "If you intentionally enabled `sched-mock` for a non-release pipeline, run nm-check against a default-features build."
@@ -697,8 +706,9 @@ fn nm_check_no_mocks(kernel: &Path) -> R<()> {
         return Err("nm-check: forbidden sched-mock symbol present in release ELF".into());
     }
     println!(
-        "→ nm-check: no MockClock/MockIrqSource symbols in {}",
-        kernel.display()
+        "→ nm-check: no sched-mock symbols ({}) in {}",
+        NM_CHECK_FORBIDDEN.join(", "),
+        kernel.display(),
     );
     Ok(())
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -247,15 +247,18 @@ fn main() -> R<()> {
             let kernel = build(&release_opts)?;
             nm_check_no_mocks(&kernel)?;
 
-            // Defense-in-depth: also re-check after the ISO bundling
-            // step has run, in case any future ISO post-processing
-            // (e.g. compression or relink) ever changes symbol
-            // visibility. The ISO itself is a CD9660 image — we
-            // re-check the kernel ELF that gets embedded, which is the
-            // same path `make_iso` consumes.
+            // Defense-in-depth: also re-check the ISO-staged ELF.
+            // `make_iso` copies the kernel into
+            // `build/<staging>/boot/vibix`, and that staged file — not
+            // the workspace `target/.../release/vibix` — is what
+            // actually ships inside the ISO. Scanning the staged copy
+            // catches a hypothetical future ISO post-processing step
+            // (compression, signing, relink) that mutates the bundled
+            // ELF away from the original.
             let iso_path = iso(&release_opts)?;
             println!("→ nm-check: iso built at {}", iso_path.display());
-            nm_check_no_mocks(&kernel)?;
+            let staged_kernel = workspace_root().join("build/iso_root/boot/vibix");
+            nm_check_no_mocks(&staged_kernel)?;
         }
         "initrd" => {
             let path = ensure_initrd()?;
@@ -2487,6 +2490,27 @@ ffffffff80010100 t <vibix::task::env::MockTimerIrq as vibix::task::env::IrqSourc
 ";
         let hits = scan_nm_output_for_mocks(stdout, NM_CHECK_FORBIDDEN);
         assert_eq!(hits.len(), 2, "both irq mock names must match: {hits:?}");
+    }
+
+    /// RFC 0005 nm-check (#669): the interior `MockClockState` and
+    /// `MockIrqState` types are listed in `NM_CHECK_FORBIDDEN` even
+    /// though substring matching catches them transitively today via
+    /// Drop glue and field paths. Pin both names with explicit
+    /// fixtures so a refactor that splits them into a free-standing
+    /// module path (no longer transitively named through `MockClock`/
+    /// `MockIrqSource`) keeps biting.
+    #[test]
+    fn nm_check_catches_interior_state_types() {
+        let stdout = "\
+ffffffff80020000 t core::ptr::drop_in_place::<vibix::task::env::MockClockState>
+ffffffff80020100 t core::ptr::drop_in_place::<vibix::task::env::MockIrqState>
+";
+        let hits = scan_nm_output_for_mocks(stdout, NM_CHECK_FORBIDDEN);
+        assert_eq!(
+            hits.len(),
+            2,
+            "both interior state types must match: {hits:?}"
+        );
     }
 
     #[test]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -21,8 +21,10 @@
 //!   lint          — run clippy on xtask (host) and vibix (kernel, no_std)
 //!   isr-audit     — scan ISR-reachable files for blocking-lock regressions
 //!   nm-check      — RFC 0005 Phase 1 (#669): build the release kernel + ISO
-//!                   and fail if any `MockClock` / `MockIrqSource` symbol
-//!                   leaks past the `sched-mock` cfg gate
+//!                   and fail if any `sched-mock`-gated symbol
+//!                   (`MockClock`, `MockClockState`, `MockIrqSource`,
+//!                   `MockIrqState`, `MockTimerIrq`) leaks past the
+//!                   `#[cfg(feature = "sched-mock")]` gate
 //!   fuzz          — bounded-iteration host fuzz of an FS layer (#677)
 //!                   `cargo xtask fuzz ext2 [--iters=N]` (defaults to 2000)
 //!   clean         — remove build artifacts
@@ -263,7 +265,14 @@ fn main() -> R<()> {
             // catches a hypothetical future ISO post-processing step
             // (compression, signing, relink) that mutates the bundled
             // ELF away from the original.
-            let iso_path = iso(&release_opts)?;
+            //
+            // We call `make_iso` directly with the already-built
+            // `kernel` rather than `iso(&release_opts)` to avoid a
+            // second cargo-build of the same release ELF (it's the
+            // same bytes both times — `iso()` would re-invoke
+            // `build()`).
+            let iso_path = workspace_root().join("target").join("vibix.iso");
+            make_iso(&kernel, &iso_path, "iso_root")?;
             println!("→ nm-check: iso built at {}", iso_path.display());
             let staged_kernel = workspace_root().join("build/iso_root/boot/vibix");
             nm_check_no_mocks(&staged_kernel)?;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -640,7 +640,13 @@ fn find_llvm_tool(name: &str) -> Option<std::ffi::OsString> {
 ///
 /// Per #670, `MockIrqSource` may rename to `MockTimerIrq`; add the
 /// new name here when that lands so the gate keeps biting.
-const NM_CHECK_FORBIDDEN: &[&str] = &["MockClock", "MockIrqSource", "MockTimerIrq"];
+const NM_CHECK_FORBIDDEN: &[&str] = &[
+    "MockClock",
+    "MockClockState",
+    "MockIrqSource",
+    "MockIrqState",
+    "MockTimerIrq",
+];
 
 /// Pure scan over `nm --demangle` stdout: returns the lines that name a
 /// forbidden mock symbol. Pulled out as a free function so the host

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -20,6 +20,9 @@
 //!                    and assert `SHELL_PIPELINE_OK: 4` on serial (issue #462)
 //!   lint          — run clippy on xtask (host) and vibix (kernel, no_std)
 //!   isr-audit     — scan ISR-reachable files for blocking-lock regressions
+//!   nm-check      — RFC 0005 Phase 1 (#669): build the release kernel + ISO
+//!                   and fail if any `MockClock` / `MockIrqSource` symbol
+//!                   leaks past the `sched-mock` cfg gate
 //!   fuzz          — bounded-iteration host fuzz of an FS layer (#677)
 //!                   `cargo xtask fuzz ext2 [--iters=N]` (defaults to 2000)
 //!   clean         — remove build artifacts
@@ -227,6 +230,33 @@ fn main() -> R<()> {
         "shell-pipeline" => shell_pipeline(&opts)?,
         "lint" => lint()?,
         "isr-audit" => isr_audit::run(&workspace_root())?,
+        "nm-check" => {
+            // RFC 0005 Phase 1 hardening (#669). Build the release
+            // kernel first, then run the static guard. We force
+            // `--release` regardless of `--release` on the CLI: this
+            // subcommand's whole purpose is to verify the release
+            // build, and a debug-build pass would silently
+            // misrepresent the answer.
+            let release_opts = BuildOpts {
+                release: true,
+                fault_test: opts.fault_test,
+                panic_test: opts.panic_test,
+                bench: opts.bench,
+                fork_trace: opts.fork_trace,
+            };
+            let kernel = build(&release_opts)?;
+            nm_check_no_mocks(&kernel)?;
+
+            // Defense-in-depth: also re-check after the ISO bundling
+            // step has run, in case any future ISO post-processing
+            // (e.g. compression or relink) ever changes symbol
+            // visibility. The ISO itself is a CD9660 image — we
+            // re-check the kernel ELF that gets embedded, which is the
+            // same path `make_iso` consumes.
+            let iso_path = iso(&release_opts)?;
+            println!("→ nm-check: iso built at {}", iso_path.display());
+            nm_check_no_mocks(&kernel)?;
+        }
         "initrd" => {
             let path = ensure_initrd()?;
             println!("→ initrd: {}", path.display());
@@ -314,7 +344,7 @@ fn main() -> R<()> {
         other => {
             eprintln!("unknown subcommand: {other}");
             eprintln!(
-                "usage: cargo xtask [build|initrd|ext2-image|iso|run|test|test-unit|test-integration|smoke|pjdfstest|repro-fork|repro-fork-build|shell-pipeline|lint|isr-audit|fuzz|clean] [--release] [--fault-test] [--panic-test] [--bench] [--fork-trace]"
+                "usage: cargo xtask [build|initrd|ext2-image|iso|run|test|test-unit|test-integration|smoke|pjdfstest|repro-fork|repro-fork-build|shell-pipeline|lint|isr-audit|nm-check|fuzz|clean] [--release] [--fault-test] [--panic-test] [--bench] [--fork-trace]"
             );
             std::process::exit(2);
         }
@@ -558,6 +588,12 @@ fn strip_debug(kernel: &Path) -> R<()> {
 /// component.  Returns `None` if `rustc` is not on PATH or the binary is not
 /// found (caller falls back to system `objcopy`).
 fn find_llvm_objcopy() -> Option<std::ffi::OsString> {
+    find_llvm_tool("llvm-objcopy")
+}
+
+/// Locate a binary from the active rustup toolchain's `llvm-tools` component.
+/// Returns `None` if `rustc` is not on PATH or the binary is not found.
+fn find_llvm_tool(name: &str) -> Option<std::ffi::OsString> {
     // Ask rustc for its sysroot (e.g.
     // ~/.rustup/toolchains/nightly-aarch64-unknown-linux-gnu).
     let output = Command::new("rustc")
@@ -569,17 +605,93 @@ fn find_llvm_objcopy() -> Option<std::ffi::OsString> {
     }
     let sysroot = std::path::PathBuf::from(String::from_utf8(output.stdout).ok()?.trim());
     // llvm-tools are installed under
-    // <sysroot>/lib/rustlib/<host-triple>/bin/llvm-objcopy.
+    // <sysroot>/lib/rustlib/<host-triple>/bin/<name>.
     // Use a glob-style search so we don't need to hard-code the host triple.
     let bin_glob = sysroot.join("lib").join("rustlib");
     for entry in fs::read_dir(&bin_glob).ok()? {
         let entry = entry.ok()?;
-        let candidate = entry.path().join("bin").join("llvm-objcopy");
+        let candidate = entry.path().join("bin").join(name);
         if candidate.exists() {
             return Some(candidate.into_os_string());
         }
     }
     None
+}
+
+/// RFC 0005 Phase 1 hardening (#669). Statically verify that no
+/// `sched-mock`-gated symbols (`MockClock`, `MockIrqSource`, plus
+/// `MockClockState` / `MockIrqState` interior types) leak into the
+/// release-built kernel ELF. Belt-and-suspenders behind the
+/// `#[cfg(feature = "sched-mock")]` source-level gate from #668: if
+/// someone accidentally enables the feature in a release pipeline, or
+/// adds a non-gated `pub use` that re-exports a mock type, this guard
+/// fires before the binary ships.
+///
+/// Runs `llvm-nm` (preferred — bundled with the rustup `llvm-tools`
+/// component, host-architecture agnostic) over the freshly-built
+/// release kernel ELF and fails on any symbol whose demangled name
+/// contains a forbidden mock substring. Falls back to system `nm` if
+/// `llvm-nm` is not on PATH.
+/// Forbidden symbol substrings — must stay in lockstep with the
+/// `#[cfg(feature = "sched-mock")]`-gated public types in
+/// `kernel/src/task/env.rs`. Substring (not exact) match so we catch
+/// monomorphized impl symbols (`<…MockClock as Clock>::now`), Drop
+/// glue, and `MockClockState` / `MockIrqState` interior types.
+///
+/// Per #670, `MockIrqSource` may rename to `MockTimerIrq`; add the
+/// new name here when that lands so the gate keeps biting.
+const NM_CHECK_FORBIDDEN: &[&str] = &["MockClock", "MockIrqSource", "MockTimerIrq"];
+
+/// Pure scan over `nm --demangle` stdout: returns the lines that name a
+/// forbidden mock symbol. Pulled out as a free function so the host
+/// unit-test suite can exercise the matcher against a synthetic
+/// nm-output fixture without needing a real release ELF.
+fn scan_nm_output_for_mocks<'a>(stdout: &'a str, forbidden: &[&str]) -> Vec<&'a str> {
+    let mut hits: Vec<&'a str> = Vec::new();
+    for line in stdout.lines() {
+        if forbidden.iter().any(|needle| line.contains(needle)) {
+            hits.push(line);
+        }
+    }
+    hits
+}
+
+fn nm_check_no_mocks(kernel: &Path) -> R<()> {
+    let tool = find_llvm_tool("llvm-nm").unwrap_or_else(|| std::ffi::OsString::from("nm"));
+    let output = Command::new(&tool).arg("--demangle").arg(kernel).output()?;
+    if !output.status.success() {
+        return Err(format!(
+            "nm-check: {} {} failed: {}",
+            std::path::Path::new(&tool).display(),
+            kernel.display(),
+            String::from_utf8_lossy(&output.stderr),
+        )
+        .into());
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let hits = scan_nm_output_for_mocks(&stdout, NM_CHECK_FORBIDDEN);
+    if !hits.is_empty() {
+        eprintln!(
+            "nm-check: forbidden sched-mock symbol(s) found in {} ({} match(es)):",
+            kernel.display(),
+            hits.len(),
+        );
+        for line in &hits {
+            eprintln!("  {line}");
+        }
+        eprintln!(
+            "RFC 0005 Phase 1 (#669): release kernels must not contain MockClock/MockIrqSource."
+        );
+        eprintln!(
+            "If you intentionally enabled `sched-mock` for a non-release pipeline, run nm-check against a default-features build."
+        );
+        return Err("nm-check: forbidden sched-mock symbol present in release ELF".into());
+    }
+    println!(
+        "→ nm-check: no MockClock/MockIrqSource symbols in {}",
+        kernel.display()
+    );
+    Ok(())
 }
 
 /// Post-link step: read the freshly-linked ELF's own symbol table and
@@ -2328,6 +2440,48 @@ serial: yes
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// RFC 0005 nm-check (#669): a nm-output fixture with no forbidden
+    /// substrings must yield zero hits.
+    #[test]
+    fn nm_check_clean_output_has_no_hits() {
+        let stdout = "\
+ffffffff80001000 T _start
+ffffffff80002000 t vibix::task::env::HwClock::now
+ffffffff80003000 T main
+";
+        let hits = scan_nm_output_for_mocks(stdout, NM_CHECK_FORBIDDEN);
+        assert!(hits.is_empty(), "unexpected hits: {hits:?}");
+    }
+
+    /// RFC 0005 nm-check (#669): the matcher must catch monomorphized
+    /// trait-impl symbols — the form the linker actually emits if a
+    /// release build accidentally references a `MockClock`.
+    #[test]
+    fn nm_check_catches_monomorphized_mock_impl() {
+        let stdout = "\
+ffffffff80001110 t core::ptr::drop_in_place::<vibix::task::env::MockClock>
+ffffffff8007e510 t <vibix::task::env::MockClock as vibix::task::env::Clock>::drain_expired
+ffffffff8007f4d0 t <vibix::task::env::MockClock as vibix::task::env::Clock>::enqueue_wakeup
+ffffffff80080300 t <vibix::task::env::MockClock as vibix::task::env::Clock>::now
+ffffffff80002000 T _start
+";
+        let hits = scan_nm_output_for_mocks(stdout, NM_CHECK_FORBIDDEN);
+        assert_eq!(hits.len(), 4, "every MockClock line must match: {hits:?}");
+    }
+
+    /// RFC 0005 nm-check (#669): both `MockIrqSource` (today) and
+    /// `MockTimerIrq` (post-#670 rename) must be caught — the rename is
+    /// pre-authorized in the spawn prompt for #669.
+    #[test]
+    fn nm_check_catches_both_irq_mock_names() {
+        let stdout = "\
+ffffffff80010000 t <vibix::task::env::MockIrqSource as vibix::task::env::IrqSource>::ack_timer
+ffffffff80010100 t <vibix::task::env::MockTimerIrq as vibix::task::env::IrqSource>::ack_timer
+";
+        let hits = scan_nm_output_for_mocks(stdout, NM_CHECK_FORBIDDEN);
+        assert_eq!(hits.len(), 2, "both irq mock names must match: {hits:?}");
+    }
 
     #[test]
     fn ustar_dir_block_checksum_valid() {


### PR DESCRIPTION
Closes #669.

## Summary

RFC 0005 Phase 1 hardening — belt-and-suspenders behind the
`#[cfg(feature = "sched-mock")]` source-level gate from #668 (PR #691).
Even if a future PR flips `sched-mock` on by default, or a non-gated
`pub use` re-exports a mock type, this static guard fails the release
pipeline before the binary ships. Implements Security review B1's
ask: the "physically excluded from production" claim is now verified
rather than asserted.

- New `cargo xtask nm-check --release` subcommand: builds the release
  kernel + ISO and runs `llvm-nm --demangle` over the freshly-built
  kernel ELF, failing on any symbol whose demangled name contains
  `MockClock`, `MockIrqSource`, or `MockTimerIrq` (post-#670 rename).
  Falls back to system `nm` when `llvm-tools` isn't on the toolchain.
- Wired into the existing `fmt + build (release)` CI job in
  `.github/workflows/ci.yml`, modeled on the `RFC 0004 vfs_creds gate`
  pattern that landed earlier this sprint.
- Matcher factored as a pure `scan_nm_output_for_mocks` function with
  three host unit tests (clean output, monomorphized impl symbols,
  both irq-mock names) so a regression in the matcher itself fails
  xtask host tests in CI before any kernel build runs.
- Documented in `docs/agent-playbooks/testing.md` so future
  contributors know not to disable the check.

## Verification

- `cargo fmt --all -- --check` clean.
- `cargo clippy -p xtask --all-targets -- -D warnings` clean.
- `cargo test -p xtask` — 62 passed (including 3 new
  `nm_check_*` tests).
- `cargo xtask nm-check --release` locally — release kernel builds,
  ISO builds, no forbidden symbols reported.
- Manually verified the negative case by temporarily forcing a static
  `MockClock` reference into `_start` and rebuilding with
  `--features sched-mock`: `nm --demangle` then emits
  `<vibix::task::env::MockClock as Clock>::{now,drain_expired,enqueue_wakeup}`
  plus the `drop_in_place::<MockClock>` glue, which the matcher
  catches. The temp ref was reverted before commit; the fixture-based
  unit tests pin the matcher behaviour going forward.

## Test plan

- [x] Host unit tests cover the matcher logic (clean output, monomorphized impls, both irq-mock names).
- [x] CI fmt-build job runs `cargo xtask nm-check --release` against the release ELF and the ISO-bundled ELF.
- [x] Manually verified negative case — guard fires when a static `MockClock` reference is forced into `_start` with `--features sched-mock`.

## Follow-ups (deferred)

- Issue #669's optional roadmap item: `static_assertions::assert_cfg!`-style compile-time check that fails to build the release kernel if `sched-mock` is on (Security cycle-2 advisory A1). Not in scope for this PR; can be a separate small follow-up.
- When #670 lands the `MockIrqSource` → `MockTimerIrq` rename, no change is needed here — the matcher already lists both names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)