### PR TITLE
vfs: per-fd directory walks for *at(2) syscalls

### DIFF
--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -161,6 +161,83 @@ fn resolve_inode_as(
     Ok((inode, nd))
 }
 
+/// Resolve a `*at` syscall's `dfd` argument to the directory dentry the
+/// walk should start from for relative paths.
+///
+/// Per POSIX `*at(2)`:
+/// - `AT_FDCWD` → the caller's per-process cwd is the walk root. We
+///   surface this as `Ok(None)` so callers can use their existing
+///   `current_cwd()` fallback (matches the behaviour of `resolve_inode`).
+/// - any other value → looked up in the current task's fd table. The
+///   referenced file must be a directory; non-directory backings return
+///   `-ENOTDIR`. Closed or out-of-range fds return `-EBADF`. Backends
+///   that don't expose a VFS dentry (e.g. `SerialBackend`) also yield
+///   `-ENOTDIR` because they have no directory inode to walk under.
+///
+/// The returned dentry is reference-counted (`Arc`), so it remains
+/// alive across the subsequent `path_walk` even if the fd is closed
+/// concurrently. Absolute paths ignore `dfd` entirely (per POSIX) — the
+/// helper is still safe to call on them, and callers that know the
+/// path is absolute may skip the call to save the fd-table round trip.
+fn resolve_dirfd(dfd: i32) -> Result<Option<Arc<Dentry>>, i64> {
+    if dfd == AT_FDCWD {
+        return Ok(None);
+    }
+    if dfd < 0 {
+        // Negative fds other than AT_FDCWD are never valid.
+        return Err(EBADF);
+    }
+    let fd = dfd as u32;
+    let tbl = crate::task::current_fd_table();
+    let backend = tbl.lock().get(fd).map_err(|_| EBADF)?;
+    let vfs = match backend.as_vfs() {
+        Some(v) => v,
+        // Non-VFS backends (e.g. SerialBackend before execve) don't
+        // refer to any directory in the namespace.
+        None => return Err(ENOTDIR),
+    };
+    if vfs.open_file.inode.kind != InodeKind::Dir {
+        return Err(ENOTDIR);
+    }
+    Ok(Some(vfs.open_file.dentry.clone()))
+}
+
+/// Like [`resolve_inode_as`] but seeds the path walk from `start` when
+/// the path is relative. `start = None` falls back to the caller's cwd
+/// (the `*at(AT_FDCWD)` and plain-path cases). Absolute paths reseat to
+/// the namespace root inside `path_walk` regardless of `start`.
+fn resolve_inode_at(
+    start: Option<Arc<Dentry>>,
+    path: &[u8],
+    follow: bool,
+    cred: Credential,
+) -> Result<(Arc<Inode>, NameIdata), i64> {
+    let root = vfs_root().ok_or(ENOENT)?;
+    let cwd = if path.first() == Some(&b'/') {
+        // Absolute path: cwd is irrelevant — `path_walk` reseats at
+        // root on the leading `/`. Pass root as the conventional
+        // sentinel.
+        root.clone()
+    } else if let Some(d) = start {
+        // Relative path with a real dirfd: walk from there.
+        d
+    } else {
+        // Relative path with AT_FDCWD (or plain non-`*at` syscall):
+        // walk from the caller's cwd.
+        crate::task::current_cwd().unwrap_or_else(|| root.clone())
+    };
+    let mut flags = LookupFlags::default();
+    if follow {
+        flags = flags | LookupFlags::FOLLOW;
+    } else {
+        flags = flags | LookupFlags::NOFOLLOW;
+    }
+    let mut nd = NameIdata::new(root, cwd, cred, flags)?;
+    path_walk(&mut nd, path, &GlobalMountResolver)?;
+    let inode = nd.path.inode.clone();
+    Ok((inode, nd))
+}
+
 /// Fill `out` from `inode.ops.getattr`, then copy out to user.
 fn stat_into_user(inode: &Arc<Inode>, user_statbuf: u64) -> i64 {
     if user_statbuf == 0 {
@@ -295,17 +372,20 @@ pub unsafe fn sys_openat_impl(dfd: i32, path_uva: u64, flags: u64, mode: u64) ->
         return r;
     }
 
-    // 3. `*at` preconditions. Non-AT_FDCWD dfd is out of scope for the
-    //    read-path subset; absolute paths ignore dfd entirely.
-    let is_absolute = path.first() == Some(&b'/');
-    if dfd != AT_FDCWD && !is_absolute {
-        return EINVAL;
-    }
+    // 3. `*at` resolution. `AT_FDCWD` falls through to the caller's
+    //    cwd; a real dirfd seeds the walk from that directory. Absolute
+    //    paths ignore `dfd` per POSIX — `path_walk` reseats at root on
+    //    the leading `/` regardless of the start dentry.
+    let start = match resolve_dirfd(dfd) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
 
     // 4. Walk. If O_CREAT is set and the leaf does not exist, try to
     //    create it in the parent directory, then re-walk.
     let follow = flags32 & oflags::O_NOFOLLOW == 0;
-    let (inode, nd) = match resolve_inode(path, follow) {
+    let cred = (*crate::task::current_credentials()).clone();
+    let (inode, nd) = match resolve_inode_at(start.clone(), path, follow, cred.clone()) {
         Ok(v) => {
             // File exists. With O_CREAT|O_EXCL this is an error.
             if flags32 & oflags::O_CREAT != 0 && flags32 & oflags::O_EXCL != 0 {
@@ -318,7 +398,12 @@ pub unsafe fn sys_openat_impl(dfd: i32, path_uva: u64, flags: u64, mode: u64) ->
                 Ok(v) => v,
                 Err(e) => return e,
             };
-            let (parent_inode, _pnd) = match resolve_inode(parent_path, /* follow */ true) {
+            let (parent_inode, _pnd) = match resolve_inode_at(
+                start.clone(),
+                parent_path,
+                /* follow */ true,
+                cred.clone(),
+            ) {
                 Ok(v) => v,
                 Err(e) => return e,
             };
@@ -330,7 +415,7 @@ pub unsafe fn sys_openat_impl(dfd: i32, path_uva: u64, flags: u64, mode: u64) ->
                 return e;
             }
             // Re-resolve to pick up the freshly created dentry+inode.
-            match resolve_inode(path, follow) {
+            match resolve_inode_at(start.clone(), path, follow, cred.clone()) {
                 Ok(v) => v,
                 Err(e) => return e,
             }
@@ -579,13 +664,14 @@ pub unsafe fn sys_newfstatat_impl(dfd: i32, path_uva: u64, statbuf_uva: u64, fla
         return sys_fstat_impl(dfd as u64, statbuf_uva);
     }
 
-    let is_absolute = path.first() == Some(&b'/');
-    if dfd != AT_FDCWD && !is_absolute {
-        return EINVAL;
-    }
+    let start = match resolve_dirfd(dfd) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
 
     let follow = flags & AT_SYMLINK_NOFOLLOW == 0;
-    let (inode, _nd) = match resolve_inode(path, follow) {
+    let cred = (*crate::task::current_credentials()).clone();
+    let (inode, _nd) = match resolve_inode_at(start, path, follow, cred) {
         Ok(v) => v,
         Err(e) => return e,
     };
@@ -740,10 +826,10 @@ fn mknod_impl(dfd: i32, path_uva: u64, mode: u32, _dev: u64) -> i64 {
     };
     let path = buf.as_slice();
 
-    let is_absolute = path.first() == Some(&b'/');
-    if dfd != AT_FDCWD && !is_absolute {
-        return EINVAL;
-    }
+    let start = match resolve_dirfd(dfd) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
 
     // mknod never names a directory — a trailing slash on the leaf is
     // invalid. split_parent strips it silently, so the check has to
@@ -752,9 +838,10 @@ fn mknod_impl(dfd: i32, path_uva: u64, mode: u32, _dev: u64) -> i64 {
         return ENOTDIR;
     }
 
+    let cred = (*crate::task::current_credentials()).clone();
     // Refuse if the target already exists. Matches Linux mknod semantics
     // (EEXIST on pre-existing path).
-    if resolve_inode(path, /* follow */ false).is_ok() {
+    if resolve_inode_at(start.clone(), path, /* follow */ false, cred.clone()).is_ok() {
         return EEXIST;
     }
 
@@ -762,10 +849,11 @@ fn mknod_impl(dfd: i32, path_uva: u64, mode: u32, _dev: u64) -> i64 {
         Ok(v) => v,
         Err(e) => return e,
     };
-    let (parent_inode, _pnd) = match resolve_inode(parent_path, /* follow */ true) {
-        Ok(v) => v,
-        Err(e) => return e,
-    };
+    let (parent_inode, _pnd) =
+        match resolve_inode_at(start, parent_path, /* follow */ true, cred) {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
     if parent_inode.kind != InodeKind::Dir {
         return ENOTDIR;
     }
@@ -832,12 +920,11 @@ fn mkdir_impl(dfd: i32, path_uva: u64, mode: u32) -> i64 {
     };
     let path = buf.as_slice();
 
-    // Per-process cwd / fd-rooted walks don't exist yet — accept only
-    // AT_FDCWD for relative paths (same precondition as openat/mknodat).
-    let is_absolute = path.first() == Some(&b'/');
-    if dfd != AT_FDCWD && !is_absolute {
-        return EINVAL;
-    }
+    // `*at` resolution: AT_FDCWD → cwd, real fd → its dentry.
+    let start = match resolve_dirfd(dfd) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
 
     // `split_parent` strips a trailing slash from the leaf. Directories
     // are the one kind of thing where a trailing slash on the path is
@@ -855,19 +942,21 @@ fn mkdir_impl(dfd: i32, path_uva: u64, mode: u32) -> i64 {
         Err(e) => return e,
     };
 
+    let cred = (*crate::task::current_credentials()).clone();
     // Refuse if the target already exists. The pre-check races with a
     // concurrent creator, but the authoritative check is the FS driver's
     // own duplicate-insert path — RamFs returns EEXIST under the dir
     // rwsem (see `ramfs::InodeOps::mkdir`). The pre-walk just avoids
     // the more expensive permission-check + parent-resolution round-trip
     // when we already know the answer.
-    if resolve_inode(path, /* follow */ false).is_ok() {
+    if resolve_inode_at(start.clone(), path, /* follow */ false, cred.clone()).is_ok() {
         return EEXIST;
     }
-    let (parent_inode, _pnd) = match resolve_inode(parent_path, /* follow */ true) {
-        Ok(v) => v,
-        Err(e) => return e,
-    };
+    let (parent_inode, _pnd) =
+        match resolve_inode_at(start, parent_path, /* follow */ true, cred.clone()) {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
     if parent_inode.kind != InodeKind::Dir {
         return ENOTDIR;
     }
@@ -878,7 +967,6 @@ fn mkdir_impl(dfd: i32, path_uva: u64, mode: u32) -> i64 {
     // them. RFC 0004 Workstream B: caller's per-task credential snapshot
     // drives the check — root bypass falls out of `default_permission`
     // when `cred.euid == 0`.
-    let cred = (*crate::task::current_credentials()).clone();
     let access = Access::WRITE | Access::EXECUTE;
     if let Err(e) = parent_inode.ops.permission(&parent_inode, &cred, access) {
         return e;
@@ -1033,12 +1121,11 @@ fn unlinkat_impl(dfd: i32, path_uva: u64, flags: u32) -> i64 {
     };
     let path = buf.as_slice();
 
-    // `*at` preconditions mirror `openat`: non-AT_FDCWD dfd with a
-    // relative path is out of scope until per-fd cwd lands (#239).
-    let is_absolute = path.first() == Some(&b'/');
-    if dfd != AT_FDCWD && !is_absolute {
-        return EINVAL;
-    }
+    // `*at` resolution: AT_FDCWD → cwd, real fd → its dentry.
+    let start = match resolve_dirfd(dfd) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
 
     // Trailing-slash means the caller explicitly named a directory.
     // POSIX unlink(2) on a trailing-slash path returns EISDIR (or
@@ -1055,10 +1142,12 @@ fn unlinkat_impl(dfd: i32, path_uva: u64, flags: u32) -> i64 {
 
     // Resolve the parent (follow symlinks on every intermediate
     // component — standard POSIX behaviour).
-    let (parent_inode, pnd) = match resolve_inode(parent_path, /* follow */ true) {
-        Ok(v) => v,
-        Err(e) => return e,
-    };
+    let walk_cred = (*crate::task::current_credentials()).clone();
+    let (parent_inode, pnd) =
+        match resolve_inode_at(start, parent_path, /* follow */ true, walk_cred) {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
     if parent_inode.kind != InodeKind::Dir {
         return ENOTDIR;
     }
@@ -1347,10 +1436,10 @@ fn chmodat_impl(dfd: i32, path_uva: u64, mode: u32, flags: u32) -> i64 {
     };
     let path = buf.as_slice();
 
-    let is_absolute = path.first() == Some(&b'/');
-    if dfd != AT_FDCWD && !is_absolute {
-        return EINVAL;
-    }
+    let start = match resolve_dirfd(dfd) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
 
     let cred = crate::task::current_credentials();
     // chmod always resolves through a trailing symlink — the target
@@ -1358,7 +1447,7 @@ fn chmodat_impl(dfd: i32, path_uva: u64, mode: u32, flags: u32) -> i64 {
     // Linux returns EOPNOTSUPP; we accept-and-ignore it for simplicity
     // since the only sensible answer on an in-memory symlink is to
     // follow (there's nothing on a symlink inode to chmod).
-    let (inode, _nd) = match resolve_inode_as(path, /* follow */ true, (*cred).clone()) {
+    let (inode, _nd) = match resolve_inode_at(start, path, /* follow */ true, (*cred).clone()) {
         Ok(v) => v,
         Err(e) => return e,
     };
@@ -1401,14 +1490,14 @@ fn chownat_impl(dfd: i32, path_uva: u64, uid: u32, gid: u32, flags: u32) -> i64 
     };
     let path = buf.as_slice();
 
-    let is_absolute = path.first() == Some(&b'/');
-    if dfd != AT_FDCWD && !is_absolute {
-        return EINVAL;
-    }
+    let start = match resolve_dirfd(dfd) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
 
     let cred = crate::task::current_credentials();
     let follow = flags & AT_SYMLINK_NOFOLLOW == 0;
-    let (inode, _nd) = match resolve_inode_as(path, follow, (*cred).clone()) {
+    let (inode, _nd) = match resolve_inode_at(start, path, follow, (*cred).clone()) {
         Ok(v) => v,
         Err(e) => return e,
     };
@@ -1540,12 +1629,10 @@ fn faccessat_impl(dfd: i32, path_uva: u64, mode: u32, flags: u32) -> i64 {
     };
     let path = buf.as_slice();
 
-    let is_absolute = path.first() == Some(&b'/');
-    if dfd != AT_FDCWD && !is_absolute {
-        // Per-fd dfd resolution is tracked under #239; until then, only
-        // AT_FDCWD or absolute paths reach the inode.
-        return EINVAL;
-    }
+    let start = match resolve_dirfd(dfd) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
 
     let cur = crate::task::current_credentials();
     let use_effective = flags & AT_EACCESS != 0;
@@ -1560,7 +1647,7 @@ fn faccessat_impl(dfd: i32, path_uva: u64, mode: u32, flags: u32) -> i64 {
     // `default_permission` against link bits (typically 0o777) makes
     // the answer almost always "yes"; that mirrors Linux.
     let follow = flags & AT_SYMLINK_NOFOLLOW == 0;
-    let (inode, _nd) = match resolve_inode_as(path, follow, check_cred.clone()) {
+    let (inode, _nd) = match resolve_inode_at(start, path, follow, check_cred.clone()) {
         Ok(v) => v,
         Err(e) => return e,
     };
@@ -1991,12 +2078,12 @@ fn utimensat_impl(dfd: i32, path_uva: u64, times_uva: u64, flags: u32) -> i64 {
             Err(e) => return e,
         };
         let path = buf.as_slice();
-        let is_absolute = path.first() == Some(&b'/');
-        if dfd != AT_FDCWD && !is_absolute {
-            return EINVAL;
-        }
+        let start = match resolve_dirfd(dfd) {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
         let follow = flags & AT_SYMLINK_NOFOLLOW == 0;
-        let (i, _nd) = match resolve_inode_as(path, follow, (*cred).clone()) {
+        let (i, _nd) = match resolve_inode_at(start, path, follow, (*cred).clone()) {
             Ok(v) => v,
             Err(e) => return e,
         };
@@ -2146,20 +2233,20 @@ fn linkat_impl(
     };
     let new_path = new_buf.as_slice();
 
-    // Per-process cwd / fd-rooted walks don't exist yet — accept only
-    // AT_FDCWD for relative paths. AT_EMPTY_PATH would need an fd-rooted
-    // walk, so reject with EINVAL until #239 lands.
+    // AT_EMPTY_PATH would need fd-as-source semantics that aren't wired
+    // here yet — reject with EINVAL until that path lands. Real dirfds
+    // for relative paths are now honoured via `resolve_dirfd`.
     if empty_path {
         return EINVAL;
     }
-    let old_abs = old_path.first() == Some(&b'/');
-    if old_dfd != AT_FDCWD && !old_abs {
-        return EINVAL;
-    }
-    let new_abs = new_path.first() == Some(&b'/');
-    if new_dfd != AT_FDCWD && !new_abs {
-        return EINVAL;
-    }
+    let old_start = match resolve_dirfd(old_dfd) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    let new_start = match resolve_dirfd(new_dfd) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
 
     // Resolve the source. Hard-linking names the underlying inode, not
     // the link, so the default is NOT to follow a terminal symlink —
@@ -2169,8 +2256,14 @@ fn linkat_impl(
     // terminal symlink (correct for `O_NOFOLLOW`, wrong here), so we
     // walk with default flags when the caller asked for the default.
     // `AT_SYMLINK_FOLLOW` flips to POSIX-`link`-style following.
+    let walk_cred = (*crate::task::current_credentials()).clone();
     let src_inode = if follow_source {
-        match resolve_inode(old_path, /* follow */ true) {
+        match resolve_inode_at(
+            old_start.clone(),
+            old_path,
+            /* follow */ true,
+            walk_cred.clone(),
+        ) {
             Ok((i, _)) => i,
             Err(e) => return e,
         }
@@ -2185,12 +2278,13 @@ fn linkat_impl(
         };
         let cwd = if old_path.first() == Some(&b'/') {
             root.clone()
+        } else if let Some(d) = old_start.clone() {
+            d
         } else {
             crate::task::current_cwd().unwrap_or_else(|| root.clone())
         };
         let flags = LookupFlags::default();
-        let cred = (*crate::task::current_credentials()).clone();
-        let mut nd = match NameIdata::new(root, cwd, cred, flags) {
+        let mut nd = match NameIdata::new(root, cwd, walk_cred.clone(), flags) {
             Ok(n) => n,
             Err(e) => return e,
         };
@@ -2211,7 +2305,14 @@ fn linkat_impl(
     // and surfaces EEXIST on the losing side either way. Pre-checking
     // lets us skip the parent-resolve round-trip when the answer is
     // already known.
-    if resolve_inode(new_path, /* follow */ false).is_ok() {
+    if resolve_inode_at(
+        new_start.clone(),
+        new_path,
+        /* follow */ false,
+        walk_cred.clone(),
+    )
+    .is_ok()
+    {
         return EEXIST;
     }
 
@@ -2219,7 +2320,12 @@ fn linkat_impl(
         Ok(v) => v,
         Err(e) => return e,
     };
-    let (new_parent, _pnd) = match resolve_inode(new_parent_path, /* follow */ true) {
+    let (new_parent, _pnd) = match resolve_inode_at(
+        new_start,
+        new_parent_path,
+        /* follow */ true,
+        walk_cred.clone(),
+    ) {
         Ok(v) => v,
         Err(e) => return e,
     };
@@ -2309,12 +2415,20 @@ fn symlinkat_impl(target_uva: u64, new_dfd: i32, link_path_uva: u64) -> i64 {
     };
     let link_path = link_buf.as_slice();
 
-    let is_absolute = link_path.first() == Some(&b'/');
-    if new_dfd != AT_FDCWD && !is_absolute {
-        return EINVAL;
-    }
+    let start = match resolve_dirfd(new_dfd) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
 
-    if resolve_inode(link_path, /* follow */ false).is_ok() {
+    let walk_cred = (*crate::task::current_credentials()).clone();
+    if resolve_inode_at(
+        start.clone(),
+        link_path,
+        /* follow */ false,
+        walk_cred.clone(),
+    )
+    .is_ok()
+    {
         return EEXIST;
     }
 
@@ -2322,10 +2436,11 @@ fn symlinkat_impl(target_uva: u64, new_dfd: i32, link_path_uva: u64) -> i64 {
         Ok(v) => v,
         Err(e) => return e,
     };
-    let (parent, _pnd) = match resolve_inode(parent_path, /* follow */ true) {
-        Ok(v) => v,
-        Err(e) => return e,
-    };
+    let (parent, _pnd) =
+        match resolve_inode_at(start, parent_path, /* follow */ true, walk_cred) {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
     if parent.kind != InodeKind::Dir {
         return ENOTDIR;
     }
@@ -2394,10 +2509,10 @@ fn readlinkat_impl(dfd: i32, path_uva: u64, buf_uva: u64, bufsize: u64) -> i64 {
     };
     let path = pbuf.as_slice();
 
-    let is_absolute = path.first() == Some(&b'/');
-    if dfd != AT_FDCWD && !is_absolute {
-        return EINVAL;
-    }
+    let start = match resolve_dirfd(dfd) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
 
     // readlink(2) / readlinkat(2) operate on the symlink itself, so
     // the terminal component must NOT be followed. `resolve_inode`'s
@@ -2414,6 +2529,8 @@ fn readlinkat_impl(dfd: i32, path_uva: u64, buf_uva: u64, bufsize: u64) -> i64 {
     };
     let cwd = if path.first() == Some(&b'/') {
         root.clone()
+    } else if let Some(d) = start {
+        d
     } else {
         crate::task::current_cwd().unwrap_or_else(|| root.clone())
     };

--- a/kernel/tests/syscall_faccessat.rs
+++ b/kernel/tests/syscall_faccessat.rs
@@ -16,8 +16,8 @@
 //!   AT_EACCESS)` (effective ID) — the central distinguishing feature.
 //! - Unknown flag bits → `EINVAL`.
 //! - Mode bits outside `R_OK | W_OK | X_OK` → `EINVAL`.
-//! - Relative path with `dfd != AT_FDCWD` → `EINVAL` (per-fd dirfd
-//!   resolution is tracked under #239).
+//! - Relative path with a closed/invalid `dfd` → `EBADF` (per-fd dirfd
+//!   resolution landed in #588).
 //! - `faccessat2` returns the same answer as `faccessat` for
 //!   well-formed inputs.
 //! - Dispatch arms return `-ENOSYS` until `vfs_creds` flips on.
@@ -36,7 +36,7 @@ use vibix::arch::x86_64::syscalls::vfs::{
     AT_EACCESS, AT_FDCWD, AT_SYMLINK_NOFOLLOW, F_OK, R_OK, W_OK, X_OK,
 };
 use vibix::fs::vfs::Credential;
-use vibix::fs::{EACCES, EINVAL, ENOENT};
+use vibix::fs::{EACCES, EBADF, EINVAL, ENOENT};
 use vibix::mem::vmatree::{Share, Vma};
 use vibix::mem::vmobject::AnonObject;
 use vibix::{
@@ -104,8 +104,8 @@ fn run_tests() {
             &(faccessat_invalid_mode_einval as fn()),
         ),
         (
-            "faccessat_relative_with_dfd_einval",
-            &(faccessat_relative_with_dfd_einval as fn()),
+            "faccessat_relative_with_closed_dfd_ebadf",
+            &(faccessat_relative_with_closed_dfd_ebadf as fn()),
         ),
         (
             "faccessat2_matches_faccessat",
@@ -395,15 +395,16 @@ fn faccessat_invalid_mode_einval() {
     );
 }
 
-fn faccessat_relative_with_dfd_einval() {
+fn faccessat_relative_with_closed_dfd_ebadf() {
     set_root_creds();
-    // Per-fd dirfd resolution is #239; relative path + non-AT_FDCWD
-    // is rejected up front rather than silently resolving against
-    // the namespace root.
+    // Per-fd dirfd resolution landed in #588. A relative path with a
+    // dfd that is not AT_FDCWD and not currently open in the fd table
+    // must surface as EBADF, not silently resolve against the
+    // namespace root.
     let r = faccessat(7, b"relative/path", F_OK, 0);
     assert_eq!(
-        r, EINVAL,
-        "relative path with dfd != AT_FDCWD must be EINVAL, got {}",
+        r, EBADF,
+        "relative path with closed dfd must be EBADF, got {}",
         r
     );
 }

--- a/kernel/tests/syscall_mkdir.rs
+++ b/kernel/tests/syscall_mkdir.rs
@@ -12,9 +12,10 @@
 //! - `mkdir(".")` / `mkdir("..")` / `mkdir("")` return `-ENOENT`
 //!   (the leaf-normalizer rejects them).
 //! - `mkdirat(AT_FDCWD, path, mode)` creates a directory.
-//! - `mkdirat(some_fd, "rel/path", mode)` returns `-EINVAL` — relative
-//!   paths against a real fd aren't supported until per-fd walks land
-//!   (issue #239).
+//! - `mkdirat(real_dirfd, "child", mode)` resolves `child` inside the
+//!   directory referenced by `real_dirfd` (issue #588).
+//! - `mkdirat(non_dir_fd, "rel/path", mode)` returns `-ENOTDIR`.
+//! - `mkdirat(closed_fd, "rel/path", mode)` returns `-EBADF`.
 //!
 //! The test calls `sys_mkdir_impl` / `sys_mkdirat_impl` directly rather
 //! than through `syscall_dispatch`, because the dispatch arm is gated
@@ -33,7 +34,7 @@ use core::ptr;
 
 use vibix::arch::x86_64::syscalls::vfs::{sys_mkdir_impl, sys_mkdirat_impl, AT_FDCWD};
 use vibix::fs::vfs::ops::Stat;
-use vibix::fs::{EEXIST, EINVAL, ENOENT, ENOTDIR};
+use vibix::fs::{EBADF, EEXIST, ENOENT, ENOTDIR};
 use vibix::mem::vmatree::{Share, Vma};
 use vibix::mem::vmobject::AnonObject;
 use vibix::{
@@ -95,8 +96,16 @@ fn run_tests() {
             &(mkdirat_at_fdcwd_creates_directory as fn()),
         ),
         (
-            "mkdirat_real_fd_relative_path_einval",
-            &(mkdirat_real_fd_relative_path_einval as fn()),
+            "mkdirat_real_dirfd_creates_child",
+            &(mkdirat_real_dirfd_creates_child as fn()),
+        ),
+        (
+            "mkdirat_non_dir_fd_is_enotdir",
+            &(mkdirat_non_dir_fd_is_enotdir as fn()),
+        ),
+        (
+            "mkdirat_closed_fd_is_ebadf",
+            &(mkdirat_closed_fd_is_ebadf as fn()),
         ),
         (
             "mkdir_strips_non_permission_bits",
@@ -288,15 +297,86 @@ fn mkdirat_at_fdcwd_creates_directory() {
     assert_eq!(st.st_mode & S_IFMT, S_IFDIR);
 }
 
-fn mkdirat_real_fd_relative_path_einval() {
-    // Per-fd walks don't exist yet (#239) — a real fd + relative path
-    // must bounce with -EINVAL, not silently walk from somewhere else.
-    let r = mkdirat(3, b"rel/child", 0o755);
+// ---- helpers for *at(real-dirfd) tests ------------------------------
+
+const SYS_OPEN: u64 = 2;
+const SYS_CLOSE: u64 = 3;
+const O_RDONLY: u64 = 0;
+const O_DIRECTORY: u64 = 0o200_000;
+
+fn open_dir(path: &[u8]) -> i64 {
+    let uva = stage(path);
+    unsafe {
+        syscall_dispatch(
+            core::ptr::null_mut(),
+            SYS_OPEN,
+            uva,
+            O_RDONLY | O_DIRECTORY,
+            0,
+            0,
+            0,
+            0,
+        )
+    }
+}
+
+fn open_file(path: &[u8]) -> i64 {
+    let uva = stage(path);
+    unsafe { syscall_dispatch(core::ptr::null_mut(), SYS_OPEN, uva, O_RDONLY, 0, 0, 0, 0) }
+}
+
+fn close_fd(fd: u32) -> i64 {
+    unsafe { syscall_dispatch(core::ptr::null_mut(), SYS_CLOSE, fd as u64, 0, 0, 0, 0, 0) }
+}
+
+fn mkdirat_real_dirfd_creates_child() {
+    // Set up a parent directory, open it, then mkdirat a child name
+    // through that fd. The child must end up inside the opened parent.
+    let r = mkdir(b"/tmp/mkdirat-dirfd-parent", 0o755);
+    assert_eq!(r, 0, "parent mkdir must succeed, got {}", r);
+    let dfd = open_dir(b"/tmp/mkdirat-dirfd-parent");
+    assert!(
+        dfd >= 0,
+        "open(parent, O_RDONLY|O_DIRECTORY) failed: {}",
+        dfd
+    );
+
+    let r = mkdirat(dfd as i32, b"child", 0o755);
     assert_eq!(
-        r, EINVAL,
-        "mkdirat(real_fd, relative) must EINVAL, got {}",
+        r, 0,
+        "mkdirat(real_dirfd, \"child\") must succeed, got {}",
         r
     );
+
+    // The child must be visible at the parent's absolute path. If the
+    // walk had silently rooted at "/" instead of `dfd`, this stat would
+    // miss because the child would be at /child, not /tmp/.../child.
+    let r = stat(b"/tmp/mkdirat-dirfd-parent/child");
+    assert_eq!(
+        r, 0,
+        "child must be visible inside the dirfd's directory, got {}",
+        r
+    );
+    let st = read_stat();
+    assert_eq!(st.st_mode & S_IFMT, S_IFDIR);
+    let _ = close_fd(dfd as u32);
+}
+
+fn mkdirat_non_dir_fd_is_enotdir() {
+    // A real fd whose backing inode is not a directory must yield ENOTDIR.
+    let r = mknod_reg(b"/tmp/mkdirat-not-dir-file");
+    assert_eq!(r, 0);
+    let fd = open_file(b"/tmp/mkdirat-not-dir-file");
+    assert!(fd >= 0, "open(file) failed: {}", fd);
+    let r = mkdirat(fd as i32, b"child", 0o755);
+    assert_eq!(r, ENOTDIR, "mkdirat(file_fd, ...) must ENOTDIR, got {}", r);
+    let _ = close_fd(fd as u32);
+}
+
+fn mkdirat_closed_fd_is_ebadf() {
+    // A high fd that was never opened (or is closed) must yield EBADF.
+    let r = mkdirat(999, b"child", 0o755);
+    assert_eq!(r, EBADF, "mkdirat(closed_fd, ...) must EBADF, got {}", r);
 }
 
 fn mkdir_strips_non_permission_bits() {

--- a/kernel/tests/syscall_vfs.rs
+++ b/kernel/tests/syscall_vfs.rs
@@ -252,11 +252,12 @@ fn openat_atfdcwd_absolute() {
 }
 
 fn openat_rejects_relative_without_atfdcwd() {
-    // dfd != AT_FDCWD and path is relative: no per-process cwd yet, so
-    // return EINVAL rather than silently treating dfd as ignored.
+    // dfd != AT_FDCWD with a relative path must consult the fd table
+    // (issue #588). When the dfd is not currently open, the resolver
+    // surfaces `EBADF` rather than silently treating the fd as ignored.
     let path = stage_path(b"relative/path");
     let r = unsafe { syscall_dispatch(core::ptr::null_mut(), SYS_OPENAT, 5u64, path, 0, 0, 0, 0) };
-    assert_eq!(r, EINVAL, "expected EINVAL, got {}", r);
+    assert_eq!(r, EBADF, "expected EBADF for closed dfd, got {}", r);
 }
 
 fn newfstatat_rejects_unknown_flag() {


### PR DESCRIPTION
Closes #588

## Summary
- Replace the EINVAL relative-path stub in the VFS-layer `*at(2)` family with real per-fd directory walks: when `dfd != AT_FDCWD`, resolve the fd through the per-process fd table, require it to back a VFS directory inode, and start `path_walk` from that dentry.
- Affected syscalls: `openat`, `newfstatat`, `mknodat`, `mkdirat`, `unlinkat`, `fchmodat`, `fchownat`, `faccessat`, `utimensat`, `linkat` (both old/new dfds), `symlinkat`, `readlinkat`.
- Errno mapping: closed fd -> `EBADF`; non-VFS or non-directory fd -> `ENOTDIR`. Absolute paths still ignore `dfd` per POSIX.
- Two new helpers in `arch/x86_64/syscalls/vfs.rs`: `resolve_dirfd` (dfd -> `Option<Arc<Dentry>>`, `None` for `AT_FDCWD`) and `resolve_inode_at` (walk from a given start dentry).

## Test plan
- [x] `cargo xtask build`
- [x] `cargo xtask test` (host + QEMU integration; new dirfd cases included)
- [x] `cargo xtask smoke`
- [x] `syscall_mkdir`: `mkdirat_real_dirfd_creates_child`, `mkdirat_non_dir_fd_is_enotdir`, `mkdirat_closed_fd_is_ebadf`
- [x] `syscall_faccessat`: closed-dfd case asserts `EBADF`
- [x] `syscall_vfs`: openat closed-dfd case asserts `EBADF`