### PR TITLE
vfs: harden FakeFs lookup stub with POSIX ENOTDIR semantics

### DIFF
--- a/kernel/src/fs/vfs/path_walk.rs
+++ b/kernel/src/fs/vfs/path_walk.rs
@@ -458,6 +458,14 @@ mod tests {
     struct FakeOps(Arc<FakeFs>);
     impl InodeOps for FakeOps {
         fn lookup(&self, dir: &Inode, name: &[u8]) -> Result<Arc<Inode>, i64> {
+            // POSIX §4.13: lookup must reject a non-directory parent
+            // with ENOTDIR before any name resolution. Real FS drivers
+            // are expected to honor this contract; a test stub that
+            // unconditionally returned ENOENT would mask a missing
+            // kind check elsewhere in the resolver chain.
+            if dir.kind != InodeKind::Dir {
+                return Err(ENOTDIR);
+            }
             self.0
                 .children
                 .lock()
@@ -672,6 +680,20 @@ mod tests {
         let fx = build();
         let mut nd = new_nd(&fx, LookupFlags::default());
         let e = path_walk(&mut nd, b"/a/b/", &NullMountResolver);
+        assert_eq!(e, Err(ENOTDIR));
+    }
+
+    #[test]
+    fn walk_through_nondir_parent_is_enotdir() {
+        // POSIX §4.13: when an intermediate component of a path is not
+        // a directory, resolution must fail with ENOTDIR. The fixture's
+        // /notadir is a regular file (ino=16, InodeKind::Reg); walking
+        // /notadir/foo asks the resolver to lookup "foo" inside a
+        // non-directory parent, and FakeOps::lookup must reject that
+        // with ENOTDIR rather than masking the violation with ENOENT.
+        let fx = build();
+        let mut nd = new_nd(&fx, LookupFlags::default());
+        let e = path_walk(&mut nd, b"/notadir/foo", &NullMountResolver);
         assert_eq!(e, Err(ENOTDIR));
     }
 


### PR DESCRIPTION
Closes #261

## Summary

- `FakeOps::lookup` (the host-side test stub in `kernel/src/fs/vfs/path_walk.rs`) now returns `ENOTDIR` when called on a non-directory parent inode, matching the POSIX §4.13 contract that real FS drivers must honor.
- Adds a `walk_through_nondir_parent_is_enotdir` unit test that walks `/notadir/foo` (where `/notadir` is the existing `ino=16`, `InodeKind::Reg` fixture entry) and asserts the result is `Err(ENOTDIR)` rather than `Err(ENOENT)`.
- Audited the other `InodeOps` test stubs across `kernel/src/fs/vfs/*.rs` (`backend.rs`, `dentry.rs`, `gc_queue.rs`, `inode.rs`, `mount_table.rs`, `open_file.rs`, `ops.rs`). None override `lookup`, so they inherit the trait default (`Err(ENOENT)`). That default is fine because none of those fixtures feeds a non-directory parent into a walk — only `path_walk`'s `FakeOps` did, and only that one needed hardening.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo xtask build` (clean — only pre-existing dead-code warnings)
- [x] `cargo xtask smoke` (all 41 markers present)
- [x] `cargo xtask test` — host-side `--lib` suite passes (544/544); the kernel-target integration suite is unchanged and surfaces the same pre-existing local flake (`wait4_condvar_race` 90 s timeout) noted in the spawn brief; CI on PR branches passes cleanly.