### PR TITLE
shell: add file-touching builtins (cd, pwd, ls, cat, mkdir, rm, touch, mv, cp, stat, rmdir)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -303,6 +303,10 @@ name = "shell_help"
 harness = false
 
 [[test]]
+name = "shell_files"
+harness = false
+
+[[test]]
 name = "syscall_mkfifo"
 harness = false
 

--- a/kernel/src/shell/mod.rs
+++ b/kernel/src/shell/mod.rs
@@ -12,6 +12,8 @@
 pub mod ansi;
 pub mod banner;
 pub mod line_editor;
+#[cfg(target_os = "none")]
+pub mod vfs_helpers;
 
 #[cfg(target_os = "none")]
 mod kernel_side {
@@ -190,12 +192,39 @@ mod kernel_side {
     /// a host-side unit test.
     const BUILTINS: &[Builtin] = &[
         Builtin {
+            name: "cat",
+            run: cmd_cat,
+            help: BuiltinHelp {
+                summary: "concatenate file contents to stdout",
+                usage: "cat <path>...",
+                examples: &["cat /etc/motd", "cat /dev/zero"],
+            },
+        },
+        Builtin {
+            name: "cd",
+            run: cmd_cd,
+            help: BuiltinHelp {
+                summary: "change the shell's working directory",
+                usage: "cd <path>",
+                examples: &["cd /tmp", "cd ..", "cd /"],
+            },
+        },
+        Builtin {
             name: "clear",
             run: cmd_clear_wrap,
             help: BuiltinHelp {
                 summary: "clear the screen (VT100)",
                 usage: "clear",
                 examples: &["clear"],
+            },
+        },
+        Builtin {
+            name: "cp",
+            run: cmd_cp,
+            help: BuiltinHelp {
+                summary: "copy a file (naive read-loop, no flags)",
+                usage: "cp <src> <dst>",
+                examples: &["cp /etc/motd /tmp/motd.bak"],
             },
         },
         Builtin {
@@ -214,6 +243,33 @@ mod kernel_side {
                 summary: "echo the rest of the line",
                 usage: "echo <args...>",
                 examples: &["echo hello world"],
+            },
+        },
+        Builtin {
+            name: "ls",
+            run: cmd_ls,
+            help: BuiltinHelp {
+                summary: "list directory entries (one per line)",
+                usage: "ls [path]",
+                examples: &["ls", "ls /dev"],
+            },
+        },
+        Builtin {
+            name: "mkdir",
+            run: cmd_mkdir,
+            help: BuiltinHelp {
+                summary: "create a directory (single-level only, no -p)",
+                usage: "mkdir <path>",
+                examples: &["mkdir /tmp/work"],
+            },
+        },
+        Builtin {
+            name: "mv",
+            run: cmd_mv,
+            help: BuiltinHelp {
+                summary: "rename or move a file (rename, falls back to link+unlink)",
+                usage: "mv <src> <dst>",
+                examples: &["mv /tmp/a /tmp/b"],
             },
         },
         Builtin {
@@ -253,6 +309,42 @@ mod kernel_side {
             },
         },
         Builtin {
+            name: "pwd",
+            run: cmd_pwd,
+            help: BuiltinHelp {
+                summary: "print the shell's working directory",
+                usage: "pwd",
+                examples: &["pwd"],
+            },
+        },
+        Builtin {
+            name: "rm",
+            run: cmd_rm,
+            help: BuiltinHelp {
+                summary: "remove a file (no -r in v1)",
+                usage: "rm <path>",
+                examples: &["rm /tmp/a"],
+            },
+        },
+        Builtin {
+            name: "rmdir",
+            run: cmd_rmdir,
+            help: BuiltinHelp {
+                summary: "remove an empty directory",
+                usage: "rmdir <path>",
+                examples: &["rmdir /tmp/work"],
+            },
+        },
+        Builtin {
+            name: "stat",
+            run: cmd_stat,
+            help: BuiltinHelp {
+                summary: "print stat(2) fields for a path",
+                usage: "stat <path>",
+                examples: &["stat /dev", "stat /tmp"],
+            },
+        },
+        Builtin {
             name: "tasks",
             run: cmd_tasks_wrap,
             help: BuiltinHelp {
@@ -268,6 +360,15 @@ mod kernel_side {
                 summary: "seconds since boot, ms precision",
                 usage: "time",
                 examples: &["time"],
+            },
+        },
+        Builtin {
+            name: "touch",
+            run: cmd_touch,
+            help: BuiltinHelp {
+                summary: "create an empty file if missing (no mtime update)",
+                usage: "touch <path>",
+                examples: &["touch /tmp/marker"],
             },
         },
         Builtin {
@@ -597,6 +698,415 @@ mod kernel_side {
                 t.nice,
             );
         });
+    }
+
+    // -- file-touching builtins (#395) ----------------------------------
+    //
+    // These builtins call straight into the in-kernel VFS via the
+    // `vfs_helpers` module. Errors come back as small negative `i64`
+    // errnos; `errno_msg` renders the common ones into a printable
+    // string. Anything unrecognised is shown as the raw number so the
+    // user can still triage.
+
+    use super::vfs_helpers;
+    use crate::fs::vfs::InodeKind;
+    use crate::fs::{
+        EACCES, EBUSY, EEXIST, EINVAL, EISDIR, ENAMETOOLONG, ENOENT, ENOSPC, ENOTDIR, ENOTEMPTY,
+        EPERM, EROFS, EXDEV,
+    };
+
+    fn errno_msg(e: i64) -> &'static str {
+        match e {
+            ENOENT => "no such file or directory",
+            ENOTDIR => "not a directory",
+            EISDIR => "is a directory",
+            EEXIST => "file exists",
+            EPERM => "operation not permitted",
+            EACCES => "permission denied",
+            EBUSY => "device or resource busy",
+            EINVAL => "invalid argument",
+            ENAMETOOLONG => "file name too long",
+            ENOTEMPTY => "directory not empty",
+            ENOSPC => "no space left on device",
+            EROFS => "read-only filesystem",
+            EXDEV => "cross-device link",
+            _ => "i/o error",
+        }
+    }
+
+    /// Trim leading whitespace and split off the first whitespace-delimited
+    /// token. Returns `(token, rest_unparsed)`.
+    fn first_arg(args: &str) -> (&str, &str) {
+        let trimmed = args.trim_start();
+        match trimmed.find(char::is_whitespace) {
+            Some(i) => (&trimmed[..i], trimmed[i..].trim_start()),
+            None => (trimmed, ""),
+        }
+    }
+
+    fn cmd_pwd(args: &str) {
+        if !args.trim().is_empty() {
+            serial_println!("pwd: too many arguments");
+            return;
+        }
+        let cwd_dentry = task::current_cwd();
+        let path = match cwd_dentry {
+            Some(d) => vfs_helpers::dentry_path(&d),
+            None => alloc::string::String::from("/"),
+        };
+        serial_println!("{}", path);
+    }
+
+    fn cmd_cd(args: &str) {
+        let (path, rest) = first_arg(args);
+        if path.is_empty() {
+            serial_println!("cd: missing path argument");
+            return;
+        }
+        if !rest.is_empty() {
+            serial_println!("cd: too many arguments");
+            return;
+        }
+        // Lexically normalize the input so `..` always means "drop the
+        // last component" — the kernel's `path_walk::step_dotdot` only
+        // crosses one mount edge per `..` and stops at the parent FS's
+        // mountpoint dentry without taking its parent, which would make
+        // `cd ..` from `/tmp` land back at `/tmp`. Resolving against an
+        // absolute, lexically-normalized path side-steps that.
+        let normalized = normalize_cd_path(path);
+        match vfs_helpers::resolve(normalized.as_bytes(), /* follow */ true) {
+            Ok(r) => {
+                if r.inode.kind != InodeKind::Dir {
+                    serial_println!("cd: {}: not a directory", path);
+                    return;
+                }
+                task::set_current_cwd(r.dentry.clone());
+            }
+            Err(e) => serial_println!("cd: {}: {}", path, errno_msg(e)),
+        }
+    }
+
+    /// Lexically resolve `path` to an absolute, normalized form using the
+    /// shell's CWD as the relative anchor. Strips `.` segments and pops
+    /// `..` segments at the string level. Always returns a path beginning
+    /// with `/`. Empty result collapses to `/`.
+    fn normalize_cd_path(path: &str) -> alloc::string::String {
+        use alloc::string::String;
+        use alloc::vec::Vec;
+        let mut buf: String = if path.starts_with('/') {
+            String::from(path)
+        } else {
+            let cwd_str = match task::current_cwd() {
+                Some(d) => vfs_helpers::dentry_path(&d),
+                None => String::from("/"),
+            };
+            let mut s = cwd_str;
+            if !s.ends_with('/') {
+                s.push('/');
+            }
+            s.push_str(path);
+            s
+        };
+        // Split, normalize, rejoin. Collect owned strings so we can
+        // safely clear and rebuild `buf`.
+        let mut stack: Vec<String> = Vec::new();
+        for comp in buf.split('/') {
+            match comp {
+                "" | "." => {}
+                ".." => {
+                    let _ = stack.pop();
+                }
+                other => stack.push(String::from(other)),
+            }
+        }
+        buf.clear();
+        if stack.is_empty() {
+            buf.push('/');
+        } else {
+            for c in &stack {
+                buf.push('/');
+                buf.push_str(c);
+            }
+        }
+        buf
+    }
+
+    fn cmd_ls(args: &str) {
+        let trimmed = args.trim();
+        let path: &str = if trimmed.is_empty() { "." } else { trimmed };
+        let r = match vfs_helpers::resolve(path.as_bytes(), /* follow */ true) {
+            Ok(r) => r,
+            Err(e) => {
+                serial_println!("ls: {}: {}", path, errno_msg(e));
+                return;
+            }
+        };
+        if r.inode.kind != InodeKind::Dir {
+            // For a non-dir path, `ls` of a single file just prints the
+            // basename — same as GNU coreutils minus the formatting.
+            serial_println!("{}", path);
+            return;
+        }
+        let mut had_err: Option<i64> = None;
+        let result = vfs_helpers::for_each_dirent(&r.inode, &r.dentry, |name, _kind| {
+            // Skip "." / ".." for a flag-free v1 to match GNU `ls`
+            // default behaviour.
+            if name == b"." || name == b".." {
+                return true;
+            }
+            match core::str::from_utf8(name) {
+                Ok(s) => serial_println!("{}", s),
+                Err(_) => serial_println!("?<non-utf8>"),
+            }
+            true
+        });
+        if let Err(e) = result {
+            had_err = Some(e);
+        }
+        if let Some(e) = had_err {
+            serial_println!("ls: {}: {}", path, errno_msg(e));
+        }
+    }
+
+    fn cmd_cat(args: &str) {
+        let trimmed = args.trim();
+        if trimmed.is_empty() {
+            serial_println!("cat: missing path argument");
+            return;
+        }
+        for tok in trimmed.split_whitespace() {
+            // Defensively cap at 64 KiB per `cat` invocation. The shell
+            // task runs in kernel context and a runaway read against
+            // /dev/zero would otherwise OOM the kernel heap.
+            const CAT_LIMIT: usize = 64 * 1024;
+            let r = match vfs_helpers::resolve(tok.as_bytes(), /* follow */ true) {
+                Ok(r) => r,
+                Err(e) => {
+                    serial_println!("cat: {}: {}", tok, errno_msg(e));
+                    continue;
+                }
+            };
+            if r.inode.kind == InodeKind::Dir {
+                serial_println!("cat: {}: {}", tok, errno_msg(EISDIR));
+                continue;
+            }
+            let of = match vfs_helpers::open_inode(&r.inode, &r.dentry) {
+                Ok(of) => of,
+                Err(e) => {
+                    serial_println!("cat: {}: {}", tok, errno_msg(e));
+                    continue;
+                }
+            };
+            let mut chunk = [0u8; 256];
+            let mut off: u64 = 0;
+            let mut total: usize = 0;
+            loop {
+                if total >= CAT_LIMIT {
+                    serial_println!("\ncat: {}: output truncated at {} bytes", tok, CAT_LIMIT);
+                    break;
+                }
+                let n = match r.inode.file_ops.read(&of, &mut chunk, off) {
+                    Ok(n) => n,
+                    Err(e) => {
+                        serial_println!("\ncat: {}: {}", tok, errno_msg(e));
+                        break;
+                    }
+                };
+                if n == 0 {
+                    break;
+                }
+                // Best-effort UTF-8 print; non-utf8 bytes get a `?`
+                // placeholder so the serial console doesn't choke.
+                match core::str::from_utf8(&chunk[..n]) {
+                    Ok(s) => serial_print!("{}", s),
+                    Err(_) => {
+                        for &b in &chunk[..n] {
+                            if b.is_ascii() && (b == b'\n' || !b.is_ascii_control()) {
+                                serial_print!("{}", b as char);
+                            } else {
+                                serial_print!("?");
+                            }
+                        }
+                    }
+                }
+                off += n as u64;
+                total += n;
+            }
+        }
+    }
+
+    fn cmd_mkdir(args: &str) {
+        let (path, rest) = first_arg(args);
+        if path.is_empty() {
+            serial_println!("mkdir: missing path argument");
+            return;
+        }
+        if !rest.is_empty() {
+            serial_println!("mkdir: too many arguments");
+            return;
+        }
+        if let Err(e) = vfs_helpers::mkdir(path.as_bytes(), 0o755) {
+            serial_println!("mkdir: {}: {}", path, errno_msg(e));
+        }
+    }
+
+    fn cmd_rmdir(args: &str) {
+        let (path, rest) = first_arg(args);
+        if path.is_empty() {
+            serial_println!("rmdir: missing path argument");
+            return;
+        }
+        if !rest.is_empty() {
+            serial_println!("rmdir: too many arguments");
+            return;
+        }
+        if let Err(e) = vfs_helpers::rmdir(path.as_bytes()) {
+            serial_println!("rmdir: {}: {}", path, errno_msg(e));
+        }
+    }
+
+    fn cmd_rm(args: &str) {
+        let (path, rest) = first_arg(args);
+        if path.is_empty() {
+            serial_println!("rm: missing path argument");
+            return;
+        }
+        if !rest.is_empty() {
+            serial_println!("rm: too many arguments (no -r in v1)");
+            return;
+        }
+        if let Err(e) = vfs_helpers::unlink(path.as_bytes()) {
+            serial_println!("rm: {}: {}", path, errno_msg(e));
+        }
+    }
+
+    fn cmd_touch(args: &str) {
+        let (path, rest) = first_arg(args);
+        if path.is_empty() {
+            serial_println!("touch: missing path argument");
+            return;
+        }
+        if !rest.is_empty() {
+            serial_println!("touch: too many arguments");
+            return;
+        }
+        // If the path resolves, touch is a no-op (no mtime bump in v1).
+        // Otherwise create an empty regular file.
+        match vfs_helpers::resolve(path.as_bytes(), /* follow */ true) {
+            Ok(_) => {}
+            Err(e) if e == ENOENT => {
+                if let Err(e2) = vfs_helpers::create_file(path.as_bytes(), 0o644) {
+                    serial_println!("touch: {}: {}", path, errno_msg(e2));
+                }
+            }
+            Err(e) => serial_println!("touch: {}: {}", path, errno_msg(e)),
+        }
+    }
+
+    fn cmd_mv(args: &str) {
+        let (src, rest) = first_arg(args);
+        let (dst, extra) = first_arg(rest);
+        if src.is_empty() || dst.is_empty() {
+            serial_println!("mv: usage: mv <src> <dst>");
+            return;
+        }
+        if !extra.is_empty() {
+            serial_println!("mv: too many arguments");
+            return;
+        }
+        // Try a real rename first. Most in-kernel filesystems implement
+        // `InodeOps::rename`; the default trait body returns EPERM, which
+        // we use as the signal to fall back to link+unlink. The fallback
+        // is best-effort and only valid for non-directory inputs.
+        match vfs_helpers::rename(src.as_bytes(), dst.as_bytes()) {
+            Ok(()) => return,
+            Err(e) if e == EPERM => {
+                // Fall through to link+unlink below.
+                serial_println!("mv: rename unsupported by FS, falling back to link+unlink");
+            }
+            Err(e) => {
+                serial_println!("mv: {} -> {}: {}", src, dst, errno_msg(e));
+                return;
+            }
+        }
+        if let Err(e) = vfs_helpers::link(src.as_bytes(), dst.as_bytes()) {
+            serial_println!("mv: link {} -> {}: {}", src, dst, errno_msg(e));
+            return;
+        }
+        if let Err(e) = vfs_helpers::unlink(src.as_bytes()) {
+            serial_println!("mv: unlink {}: {}", src, errno_msg(e));
+        }
+    }
+
+    fn cmd_cp(args: &str) {
+        let (src, rest) = first_arg(args);
+        let (dst, extra) = first_arg(rest);
+        if src.is_empty() || dst.is_empty() {
+            serial_println!("cp: usage: cp <src> <dst>");
+            return;
+        }
+        if !extra.is_empty() {
+            serial_println!("cp: too many arguments");
+            return;
+        }
+        let data = match vfs_helpers::read_all(src.as_bytes()) {
+            Ok(d) => d,
+            Err(e) => {
+                serial_println!("cp: {}: {}", src, errno_msg(e));
+                return;
+            }
+        };
+        if let Err(e) = vfs_helpers::write_all(dst.as_bytes(), &data) {
+            serial_println!("cp: {}: {}", dst, errno_msg(e));
+        }
+    }
+
+    fn cmd_stat(args: &str) {
+        let (path, rest) = first_arg(args);
+        if path.is_empty() {
+            serial_println!("stat: missing path argument");
+            return;
+        }
+        if !rest.is_empty() {
+            serial_println!("stat: too many arguments");
+            return;
+        }
+        let (st, kind) = match vfs_helpers::stat(path.as_bytes()) {
+            Ok(v) => v,
+            Err(e) => {
+                serial_println!("stat: {}: {}", path, errno_msg(e));
+                return;
+            }
+        };
+        let kind_str = match kind {
+            InodeKind::Reg => "regular file",
+            InodeKind::Dir => "directory",
+            InodeKind::Link => "symbolic link",
+            InodeKind::Chr => "character device",
+            InodeKind::Blk => "block device",
+            InodeKind::Fifo => "fifo",
+            InodeKind::Sock => "socket",
+        };
+        serial_println!("  File: {}", path);
+        serial_println!(
+            "  Size: {:<12} Blocks: {:<10} IO Block: {:<6} {}",
+            st.st_size,
+            st.st_blocks,
+            st.st_blksize,
+            kind_str,
+        );
+        serial_println!(
+            "Device: {:#x}      Inode: {:<10} Links: {}",
+            st.st_dev,
+            st.st_ino,
+            st.st_nlink,
+        );
+        serial_println!(
+            "Access: ({:04o})  Uid: {:<5}  Gid: {}",
+            st.st_mode & 0o7777,
+            st.st_uid,
+            st.st_gid,
+        );
     }
 }
 

--- a/kernel/src/shell/mod.rs
+++ b/kernel/src/shell/mod.rs
@@ -715,8 +715,10 @@ mod kernel_side {
         EPERM, EROFS, EXDEV,
     };
 
-    fn errno_msg(e: i64) -> &'static str {
-        match e {
+    fn errno_msg(e: i64) -> alloc::string::String {
+        use alloc::format;
+        use alloc::string::ToString;
+        let s: &'static str = match e {
             ENOENT => "no such file or directory",
             ENOTDIR => "not a directory",
             EISDIR => "is a directory",
@@ -730,8 +732,12 @@ mod kernel_side {
             ENOSPC => "no space left on device",
             EROFS => "read-only filesystem",
             EXDEV => "cross-device link",
-            _ => "i/o error",
-        }
+            // Unknown / unmapped errno: keep the raw number visible so a
+            // VFS code path that returns something we don't have a string
+            // for is still debuggable.
+            _ => return format!("errno {}", e),
+        };
+        s.to_string()
     }
 
     /// Trim leading whitespace and split off the first whitespace-delimited
@@ -1049,15 +1055,14 @@ mod kernel_side {
             serial_println!("cp: too many arguments");
             return;
         }
-        let data = match vfs_helpers::read_all(src.as_bytes()) {
-            Ok(d) => d,
-            Err(e) => {
-                serial_println!("cp: {}: {}", src, errno_msg(e));
-                return;
-            }
-        };
-        if let Err(e) = vfs_helpers::write_all(dst.as_bytes(), &data) {
-            serial_println!("cp: {}: {}", dst, errno_msg(e));
+        // Stream the copy in fixed-size chunks rather than slurping
+        // the whole source into the kernel heap. The 64 MiB cap keeps
+        // pathological inputs (e.g. `cp /dev/zero ...`) from wedging
+        // the box; a real coreutils-style `cp` would just keep going,
+        // but this is a kernel-resident debug shell.
+        const CP_LIMIT: u64 = 64 * 1024 * 1024;
+        if let Err(e) = vfs_helpers::stream_copy(src.as_bytes(), dst.as_bytes(), CP_LIMIT) {
+            serial_println!("cp: {} -> {}: {}", src, dst, errno_msg(e));
         }
     }
 

--- a/kernel/src/shell/vfs_helpers.rs
+++ b/kernel/src/shell/vfs_helpers.rs
@@ -111,7 +111,12 @@ pub fn open_inode(inode: &Arc<Inode>, dentry: &Arc<Dentry>) -> Result<Arc<OpenFi
 }
 
 /// Read the entire contents of a regular file at `path` into a
-/// heap-allocated buffer.
+/// heap-allocated buffer. Hard-capped at [`READ_ALL_MAX`] bytes to
+/// keep callers honest — a kernel-side `cp` or `cat` should stream
+/// instead (see [`stream_copy`]). Returns `EFBIG` if the source
+/// exceeds the cap.
+pub const READ_ALL_MAX: usize = 1 * 1024 * 1024;
+
 pub fn read_all(path: &[u8]) -> Result<Vec<u8>, i64> {
     let r = resolve(path, /* follow */ true)?;
     if r.inode.kind == InodeKind::Dir {
@@ -122,7 +127,18 @@ pub fn read_all(path: &[u8]) -> Result<Vec<u8>, i64> {
     let mut off: u64 = 0;
     let mut chunk = [0u8; 512];
     loop {
-        let n = match r.inode.file_ops.read(&of, &mut chunk, off) {
+        if out.len() >= READ_ALL_MAX {
+            // Probe once more: a file whose size is exactly
+            // READ_ALL_MAX should still succeed.
+            let mut probe = [0u8; 1];
+            let n = r.inode.file_ops.read(&of, &mut probe, off)?;
+            if n == 0 {
+                break;
+            }
+            return Err(crate::fs::EFBIG);
+        }
+        let want = core::cmp::min(chunk.len(), READ_ALL_MAX - out.len());
+        let n = match r.inode.file_ops.read(&of, &mut chunk[..want], off) {
             Ok(n) => n,
             Err(e) => return Err(e),
         };
@@ -131,11 +147,6 @@ pub fn read_all(path: &[u8]) -> Result<Vec<u8>, i64> {
         }
         out.extend_from_slice(&chunk[..n]);
         off += n as u64;
-        if n < chunk.len() {
-            // Some FOps return a short read at EOF without a follow-up
-            // zero. Probe once more to catch the genuine zero so we
-            // don't loop forever on a saturated buffer.
-        }
     }
     Ok(out)
 }
@@ -239,6 +250,17 @@ pub fn stream_copy(src_path: &[u8], dst_path: &[u8], max_bytes: u64) -> Result<u
     };
     if dst.inode.kind == InodeKind::Dir {
         return Err(crate::fs::EISDIR);
+    }
+    // Same-file guard: refuse `cp foo foo` (and hardlinked aliases)
+    // before we truncate. Without this we would zero the source and
+    // then "successfully" copy nothing.
+    let same_file = src.inode.ino == dst.inode.ino
+        && match (src.inode.sb.upgrade(), dst.inode.sb.upgrade()) {
+            (Some(s), Some(d)) => Arc::ptr_eq(&s, &d),
+            _ => false,
+        };
+    if same_file {
+        return Err(crate::fs::EINVAL);
     }
     // Truncate destination.
     let attr = crate::fs::vfs::ops::SetAttr {

--- a/kernel/src/shell/vfs_helpers.rs
+++ b/kernel/src/shell/vfs_helpers.rs
@@ -1,0 +1,351 @@
+//! Kernel-context VFS helpers used by the shell's file-touching builtins.
+//!
+//! The userspace `sys_*` arms in [`crate::arch::x86_64::syscalls::vfs`]
+//! deal in user pointers, fd tables, and per-task credentials; the
+//! shell already runs in the kernel as a privileged task and just
+//! needs simple "given a path string, do X" entry points. Putting them
+//! here keeps the dispatch in [`super`] surgical and avoids reinventing
+//! the path-walk wheel inside every builtin.
+//!
+//! Every helper resolves relative paths against [`crate::task::current_cwd`]
+//! (the shell task's CWD, mutable via `cd`) and uses
+//! [`super::super::fs::vfs::Credential::kernel`] for permission checks —
+//! the kernel-resident shell is root by construction.
+//!
+//! The integration test harness drives these helpers directly. They
+//! never panic on error; failures are surfaced as `i64` errnos so the
+//! caller can render a useful message.
+
+#![cfg(target_os = "none")]
+
+use alloc::string::String;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+
+use crate::fs::vfs::dentry::Dentry;
+use crate::fs::vfs::inode::Inode;
+use crate::fs::vfs::open_file::OpenFile;
+use crate::fs::vfs::ops::Stat;
+use crate::fs::vfs::path_walk::{path_walk, LookupFlags, NameIdata};
+use crate::fs::vfs::super_block::SbActiveGuard;
+use crate::fs::vfs::{root as vfs_root, Credential, GlobalMountResolver, InodeKind};
+use crate::fs::{ENOENT, ENOTDIR};
+
+/// Path resolution result: the resolved inode plus a `NameIdata` whose
+/// `edges` field keeps the traversed mounts pinned for as long as the
+/// caller holds the result.
+pub struct Resolved {
+    pub inode: Arc<Inode>,
+    pub dentry: Arc<Dentry>,
+    pub _nd: NameIdata,
+}
+
+/// Walk `path` from the shell's CWD (or root for absolute paths) using
+/// the kernel root credential.
+pub fn resolve(path: &[u8], follow: bool) -> Result<Resolved, i64> {
+    let root = vfs_root().ok_or(ENOENT)?;
+    let cwd = if path.first() == Some(&b'/') {
+        root.clone()
+    } else {
+        crate::task::current_cwd().unwrap_or_else(|| root.clone())
+    };
+    let mut flags = LookupFlags::default();
+    if follow {
+        flags = flags | LookupFlags::FOLLOW;
+    } else {
+        flags = flags | LookupFlags::NOFOLLOW;
+    }
+    let mut nd = NameIdata::new(root, cwd, Credential::kernel(), flags)?;
+    path_walk(&mut nd, path, &GlobalMountResolver)?;
+    let inode = nd.path.inode.clone();
+    let dentry = nd.path.dentry.clone();
+    Ok(Resolved {
+        inode,
+        dentry,
+        _nd: nd,
+    })
+}
+
+/// Resolve the parent directory of `path`, returning `(parent_inode,
+/// parent_dentry, leaf_bytes)`. Rejects empty / `/` / `.` / `..`
+/// trailing-component inputs with `ENOENT`.
+pub fn split_and_resolve_parent(path: &[u8]) -> Result<(Arc<Inode>, Arc<Dentry>, Vec<u8>), i64> {
+    if path.is_empty() {
+        return Err(ENOENT);
+    }
+    let trimmed: &[u8] = if path.len() > 1 && *path.last().unwrap() == b'/' {
+        &path[..path.len() - 1]
+    } else {
+        path
+    };
+    let (parent_path, leaf) = match trimmed.iter().rposition(|&b| b == b'/') {
+        Some(0) => (&b"/"[..], &trimmed[1..]),
+        Some(i) => (&trimmed[..i], &trimmed[i + 1..]),
+        None => (&b"."[..], trimmed),
+    };
+    if leaf.is_empty() || leaf == b"." || leaf == b".." {
+        return Err(ENOENT);
+    }
+    let parent = resolve(parent_path, /* follow */ true)?;
+    if parent.inode.kind != InodeKind::Dir {
+        return Err(ENOTDIR);
+    }
+    Ok((parent.inode, parent.dentry, leaf.to_vec()))
+}
+
+/// Build an `OpenFile` for the resolved inode. Used for read/write/
+/// getdents loops in the builtins.
+pub fn open_inode(inode: &Arc<Inode>, dentry: &Arc<Dentry>) -> Result<Arc<OpenFile>, i64> {
+    let sb = inode.sb.upgrade().ok_or(ENOENT)?;
+    let guard = SbActiveGuard::try_acquire(&sb)?;
+    let sb_for_of = sb.clone();
+    let of = OpenFile::new(
+        dentry.clone(),
+        inode.clone(),
+        inode.file_ops.clone(),
+        sb_for_of,
+        0,
+        guard,
+    );
+    Ok(of)
+}
+
+/// Read the entire contents of a regular file at `path` into a
+/// heap-allocated buffer.
+pub fn read_all(path: &[u8]) -> Result<Vec<u8>, i64> {
+    let r = resolve(path, /* follow */ true)?;
+    if r.inode.kind == InodeKind::Dir {
+        return Err(crate::fs::EISDIR);
+    }
+    let of = open_inode(&r.inode, &r.dentry)?;
+    let mut out = Vec::new();
+    let mut off: u64 = 0;
+    let mut chunk = [0u8; 512];
+    loop {
+        let n = match r.inode.file_ops.read(&of, &mut chunk, off) {
+            Ok(n) => n,
+            Err(e) => return Err(e),
+        };
+        if n == 0 {
+            break;
+        }
+        out.extend_from_slice(&chunk[..n]);
+        off += n as u64;
+        if n < chunk.len() {
+            // Some FOps return a short read at EOF without a follow-up
+            // zero. Probe once more to catch the genuine zero so we
+            // don't loop forever on a saturated buffer.
+        }
+    }
+    Ok(out)
+}
+
+/// Write `data` to a freshly-truncated file at `path`. Creates the file
+/// if it does not exist (mode 0o644).
+pub fn write_all(path: &[u8], data: &[u8]) -> Result<(), i64> {
+    // Try to resolve first; if missing, create.
+    let r = match resolve(path, /* follow */ true) {
+        Ok(r) => r,
+        Err(e) if e == ENOENT => {
+            create_file(path, 0o644)?;
+            resolve(path, true)?
+        }
+        Err(e) => return Err(e),
+    };
+    if r.inode.kind == InodeKind::Dir {
+        return Err(crate::fs::EISDIR);
+    }
+    // Truncate before write.
+    let attr = crate::fs::vfs::ops::SetAttr {
+        mask: crate::fs::vfs::ops::SetAttrMask::SIZE,
+        size: 0,
+        ..crate::fs::vfs::ops::SetAttr::default()
+    };
+    r.inode.ops.setattr(&r.inode, &attr)?;
+    let of = open_inode(&r.inode, &r.dentry)?;
+    let mut off: u64 = 0;
+    while off < data.len() as u64 {
+        let n = r.inode.file_ops.write(&of, &data[off as usize..], off)?;
+        if n == 0 {
+            return Err(crate::fs::EIO);
+        }
+        off += n as u64;
+    }
+    Ok(())
+}
+
+/// Create a regular file (no overwrite). Returns `EEXIST` if it
+/// already exists.
+pub fn create_file(path: &[u8], mode: u16) -> Result<(), i64> {
+    let (parent_inode, _parent_dentry, leaf) = split_and_resolve_parent(path)?;
+    parent_inode
+        .ops
+        .create(&parent_inode, &leaf, mode & 0o7777)?;
+    Ok(())
+}
+
+/// `mkdir` a directory at `path`. No `-p`.
+pub fn mkdir(path: &[u8], mode: u16) -> Result<(), i64> {
+    let (parent_inode, _, leaf) = split_and_resolve_parent(path)?;
+    parent_inode
+        .ops
+        .mkdir(&parent_inode, &leaf, mode & 0o7777)?;
+    Ok(())
+}
+
+/// Unlink a file (regular file or symlink) at `path`.
+pub fn unlink(path: &[u8]) -> Result<(), i64> {
+    let (parent_inode, _, leaf) = split_and_resolve_parent(path)?;
+    parent_inode.ops.unlink(&parent_inode, &leaf)
+}
+
+/// Remove an empty directory at `path`.
+pub fn rmdir(path: &[u8]) -> Result<(), i64> {
+    let (parent_inode, _, leaf) = split_and_resolve_parent(path)?;
+    parent_inode.ops.rmdir(&parent_inode, &leaf)
+}
+
+/// Hardlink `target` to `link_path`.
+pub fn link(target_path: &[u8], link_path: &[u8]) -> Result<(), i64> {
+    let target = resolve(target_path, /* follow */ false)?;
+    if target.inode.kind == InodeKind::Dir {
+        // POSIX forbids hardlinking directories.
+        return Err(crate::fs::EPERM);
+    }
+    let (parent_inode, _, leaf) = split_and_resolve_parent(link_path)?;
+    parent_inode.ops.link(&parent_inode, &leaf, &target.inode)
+}
+
+/// Rename `old_path` to `new_path`. Tries `InodeOps::rename` first;
+/// if the driver returns `EPERM` (no rename support) the caller can
+/// fall back to `link` + `unlink`.
+pub fn rename(old_path: &[u8], new_path: &[u8]) -> Result<(), i64> {
+    let (old_parent, _, old_leaf) = split_and_resolve_parent(old_path)?;
+    let (new_parent, _, new_leaf) = split_and_resolve_parent(new_path)?;
+    old_parent
+        .ops
+        .rename(&old_parent, &old_leaf, &new_parent, &new_leaf)
+}
+
+/// `getattr` for `stat`. Follows trailing symlinks.
+pub fn stat(path: &[u8]) -> Result<(Stat, InodeKind), i64> {
+    let r = resolve(path, /* follow */ true)?;
+    let mut st = Stat::default();
+    r.inode.ops.getattr(&r.inode, &mut st)?;
+    if st.st_ino == 0 {
+        let meta = r.inode.meta.read();
+        let fs_id = r.inode.sb.upgrade().map(|s| s.fs_id.0).unwrap_or(0);
+        crate::fs::vfs::ops::meta_into_stat(&meta, r.inode.kind, fs_id, r.inode.ino, &mut st);
+    }
+    Ok((st, r.inode.kind))
+}
+
+/// Compute the absolute path of `dentry` by walking parent pointers.
+/// Returns "/" for the root dentry. Used by `pwd` / `getcwd`.
+///
+/// Mount roots: each mounted filesystem's root dentry is self-parenting
+/// and named `.`, so a naive walk would terminate at the wrong place
+/// and produce names like `/.` for `/tmp`. We detect a mount-root by
+/// flag (`DFlags::IS_ROOT`) and consult [`GlobalMountResolver`] to jump
+/// up to the parent-side mountpoint dentry instead. The mountpoint
+/// dentry's name is the user-visible component (e.g. `tmp`).
+pub fn dentry_path(dentry: &Arc<Dentry>) -> String {
+    use crate::fs::vfs::dentry::DFlags;
+    use crate::fs::vfs::path_walk::MountResolver;
+    let root = match vfs_root() {
+        Some(r) => r,
+        None => return String::from("/"),
+    };
+    if Arc::ptr_eq(dentry, &root) {
+        return String::from("/");
+    }
+    let mounts = GlobalMountResolver;
+    let mut parts: Vec<Vec<u8>> = Vec::new();
+    let mut cur = dentry.clone();
+    let mut hops = 0;
+    while !Arc::ptr_eq(&cur, &root) && hops < 256 {
+        // Cross up through any mount edges first: the top-of-mount
+        // dentry has the placeholder name `.`; its mountpoint on the
+        // parent FS carries the user-visible name.
+        if cur.flags.contains(DFlags::IS_ROOT) {
+            if let Some(edge) = mounts.mount_above(&cur) {
+                if let Some(mp) = edge.mountpoint.upgrade() {
+                    cur = mp;
+                    continue;
+                }
+            }
+            // No mount edge to cross: bail out at the namespace root
+            // (the only IS_ROOT dentry without a mount above).
+            break;
+        }
+        parts.push(cur.name.as_bytes().to_vec());
+        let parent = match cur.parent.upgrade() {
+            Some(p) => p,
+            None => break,
+        };
+        if Arc::ptr_eq(&parent, &cur) {
+            // self-parent: we hit the namespace root via the
+            // self-cycle convention. Stop.
+            break;
+        }
+        cur = parent;
+        hops += 1;
+    }
+    let mut out = String::new();
+    for chunk in parts.iter().rev() {
+        out.push('/');
+        match core::str::from_utf8(chunk) {
+            Ok(s) => out.push_str(s),
+            Err(_) => out.push_str("?"),
+        }
+    }
+    if out.is_empty() {
+        out.push('/');
+    }
+    out
+}
+
+/// Iterate directory entries via `getdents`. Calls `cb(name, kind)` for
+/// each entry, including `.` and `..`. `cb` returning `false` stops
+/// iteration early.
+pub fn for_each_dirent<F: FnMut(&[u8], u8) -> bool>(
+    inode: &Arc<Inode>,
+    dentry: &Arc<Dentry>,
+    mut cb: F,
+) -> Result<(), i64> {
+    if inode.kind != InodeKind::Dir {
+        return Err(ENOTDIR);
+    }
+    let of = open_inode(inode, dentry)?;
+    let mut cookie: u64 = 0;
+    let mut buf = [0u8; 1024];
+    loop {
+        let n = inode.file_ops.getdents(&of, &mut buf, &mut cookie)?;
+        if n == 0 {
+            break;
+        }
+        let mut off = 0usize;
+        while off + 19 <= n {
+            // linux_dirent64 header layout — see `emit_dirent` in
+            // ramfs.rs for the canonical writer.
+            let reclen = u16::from_ne_bytes([buf[off + 16], buf[off + 17]]) as usize;
+            if reclen == 0 || off + reclen > n {
+                break;
+            }
+            let d_type = buf[off + 18];
+            // Name runs from off+19 to the first NUL within the record.
+            let name_start = off + 19;
+            let name_end_max = off + reclen;
+            let mut name_end = name_start;
+            while name_end < name_end_max && buf[name_end] != 0 {
+                name_end += 1;
+            }
+            let name = &buf[name_start..name_end];
+            if !cb(name, d_type) {
+                return Ok(());
+            }
+            off += reclen;
+        }
+    }
+    Ok(())
+}

--- a/kernel/src/shell/vfs_helpers.rs
+++ b/kernel/src/shell/vfs_helpers.rs
@@ -216,6 +216,70 @@ pub fn link(target_path: &[u8], link_path: &[u8]) -> Result<(), i64> {
     parent_inode.ops.link(&parent_inode, &leaf, &target.inode)
 }
 
+/// Stream the contents of `src_path` to `dst_path` without ever
+/// holding the whole file in memory. Truncates / creates the
+/// destination, then reads `src` in fixed-size chunks and writes each
+/// chunk straight to `dst`. Caps the total bytes copied at
+/// `max_bytes` and returns `EFBIG` if the source exceeds that — this
+/// is the kernel-shell guardrail against `cp /dev/zero …` taking the
+/// box down.
+pub fn stream_copy(src_path: &[u8], dst_path: &[u8], max_bytes: u64) -> Result<u64, i64> {
+    let src = resolve(src_path, /* follow */ true)?;
+    if src.inode.kind == InodeKind::Dir {
+        return Err(crate::fs::EISDIR);
+    }
+    // Resolve-or-create the destination.
+    let dst = match resolve(dst_path, /* follow */ true) {
+        Ok(r) => r,
+        Err(e) if e == ENOENT => {
+            create_file(dst_path, 0o644)?;
+            resolve(dst_path, /* follow */ true)?
+        }
+        Err(e) => return Err(e),
+    };
+    if dst.inode.kind == InodeKind::Dir {
+        return Err(crate::fs::EISDIR);
+    }
+    // Truncate destination.
+    let attr = crate::fs::vfs::ops::SetAttr {
+        mask: crate::fs::vfs::ops::SetAttrMask::SIZE,
+        size: 0,
+        ..crate::fs::vfs::ops::SetAttr::default()
+    };
+    dst.inode.ops.setattr(&dst.inode, &attr)?;
+
+    let src_of = open_inode(&src.inode, &src.dentry)?;
+    let dst_of = open_inode(&dst.inode, &dst.dentry)?;
+
+    let mut buf = [0u8; 4096];
+    let mut copied: u64 = 0;
+    let mut roff: u64 = 0;
+    let mut woff: u64 = 0;
+    loop {
+        let remaining = max_bytes.saturating_sub(copied);
+        if remaining == 0 {
+            return Err(crate::fs::EFBIG);
+        }
+        let take = core::cmp::min(remaining as usize, buf.len());
+        let n = src.inode.file_ops.read(&src_of, &mut buf[..take], roff)?;
+        if n == 0 {
+            break;
+        }
+        roff += n as u64;
+        let mut written = 0usize;
+        while written < n {
+            let w = dst.inode.file_ops.write(&dst_of, &buf[written..n], woff)?;
+            if w == 0 {
+                return Err(crate::fs::EIO);
+            }
+            woff += w as u64;
+            written += w;
+        }
+        copied += n as u64;
+    }
+    Ok(copied)
+}
+
 /// Rename `old_path` to `new_path`. Tries `InodeOps::rename` first;
 /// if the driver returns `EPERM` (no rename support) the caller can
 /// fall back to `link` + `unlink`.

--- a/kernel/src/shell/vfs_helpers.rs
+++ b/kernel/src/shell/vfs_helpers.rs
@@ -258,6 +258,14 @@ pub fn stream_copy(src_path: &[u8], dst_path: &[u8], max_bytes: u64) -> Result<u
     loop {
         let remaining = max_bytes.saturating_sub(copied);
         if remaining == 0 {
+            // We've copied exactly `max_bytes`. Probe one more byte
+            // to see whether the source is at EOF — a file whose size
+            // is exactly `max_bytes` is a successful copy, not EFBIG.
+            let mut probe = [0u8; 1];
+            let n = src.inode.file_ops.read(&src_of, &mut probe, roff)?;
+            if n == 0 {
+                break;
+            }
             return Err(crate::fs::EFBIG);
         }
         let take = core::cmp::min(remaining as usize, buf.len());

--- a/kernel/tests/shell_files.rs
+++ b/kernel/tests/shell_files.rs
@@ -1,0 +1,226 @@
+//! Integration test: file-touching shell builtins (#395).
+//!
+//! Boots the kernel, runs each new builtin (`cd`, `pwd`, `ls`, `cat`,
+//! `mkdir`, `rmdir`, `rm`, `touch`, `mv`, `cp`, `stat`) through
+//! `dispatch_for_test`, and asserts the side-effects via direct VFS
+//! observation rather than serial loopback. Serial loopback would be
+//! ideal but every command's printed output is too long for the 16-byte
+//! 16550 RX FIFO that `shell_introspection` relies on; we follow the
+//! `shell_help` convention of "verify behaviour by side-effect, not
+//! captured stdout" for the larger commands.
+//!
+//! Coverage:
+//! - `pwd` / `cd` / `cd ..` round-trip leaves the task at root.
+//! - `mkdir` + `ls` + `rmdir` of a fresh directory under `/tmp`.
+//! - `touch` + `stat` + `rm` of a regular file under `/tmp`.
+//! - `cp` copies file contents from `/tmp/src` to `/tmp/dst`.
+//! - `mv` renames a file under `/tmp`.
+//! - `cat` of `/tmp/<file>` after `cp` (smoke; reads via VFS to verify).
+//! - `ls /dev` does not panic and contains at least one entry.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::panic::PanicInfo;
+
+use vibix::{
+    exit_qemu, serial_println,
+    shell::{dispatch_for_test, vfs_helpers},
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    // The shell's `cd` builtin updates per-task CWD via
+    // `task::set_current_cwd`, which is a no-op when no task is
+    // installed as `current`. Install the bootstrap task so the test
+    // runs under a real scheduler context — same approach as
+    // `shell_smoke`.
+    vibix::task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("pwd_and_cd_roundtrip", &(pwd_and_cd_roundtrip as fn())),
+        ("mkdir_then_rmdir", &(mkdir_then_rmdir as fn())),
+        ("touch_stat_rm", &(touch_stat_rm as fn())),
+        ("cp_roundtrip", &(cp_roundtrip as fn())),
+        ("mv_renames", &(mv_renames as fn())),
+        ("cat_smokes", &(cat_smokes as fn())),
+        ("ls_dev", &(ls_dev as fn())),
+        ("cd_nonexistent_errors", &(cd_nonexistent_errors as fn())),
+        ("rmdir_nonempty_errors", &(rmdir_nonempty_errors as fn())),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+/// Resolve a path and return whether it exists.
+fn exists(path: &[u8]) -> bool {
+    vfs_helpers::resolve(path, true).is_ok()
+}
+
+fn read_to_string(path: &[u8]) -> Option<Vec<u8>> {
+    vfs_helpers::read_all(path).ok()
+}
+
+fn pwd_and_cd_roundtrip() {
+    // Reset to root so we have a known starting point.
+    dispatch_for_test("cd /");
+    dispatch_for_test("pwd");
+    // Move to /tmp (always a ramfs mount per vfs/init.rs).
+    dispatch_for_test("cd /tmp");
+    let cwd = vibix::task::current_cwd().expect("cwd set after cd /tmp");
+    let path = vfs_helpers::dentry_path(&cwd);
+    assert_eq!(path, "/tmp", "cd /tmp must move CWD; got {:?}", path);
+    // .. back to root.
+    dispatch_for_test("cd ..");
+    let cwd2 = vibix::task::current_cwd().expect("cwd set after cd ..");
+    let p2 = vfs_helpers::dentry_path(&cwd2);
+    assert_eq!(p2, "/", "cd .. from /tmp must land at /; got {:?}", p2);
+}
+
+fn mkdir_then_rmdir() {
+    dispatch_for_test("cd /");
+    let dir: &str = "/tmp/shell_test_mkdir";
+    // Pre-clean from any prior test partial run.
+    let _ = vfs_helpers::rmdir(dir.as_bytes());
+    dispatch_for_test("mkdir /tmp/shell_test_mkdir");
+    assert!(exists(dir.as_bytes()), "mkdir should have created {}", dir);
+    // ls of /tmp should now mention shell_test_mkdir; we verify via
+    // direct getdents rather than serial capture.
+    let r = vfs_helpers::resolve(b"/tmp", true).expect("/tmp resolves");
+    let mut found = false;
+    let _ = vfs_helpers::for_each_dirent(&r.inode, &r.dentry, |name, _kind| {
+        if name == b"shell_test_mkdir" {
+            found = true;
+            return false;
+        }
+        true
+    });
+    assert!(found, "shell_test_mkdir missing from /tmp listing");
+    dispatch_for_test("rmdir /tmp/shell_test_mkdir");
+    assert!(!exists(dir.as_bytes()), "rmdir should have removed {}", dir);
+}
+
+fn touch_stat_rm() {
+    dispatch_for_test("cd /");
+    let path: &str = "/tmp/shell_test_touch";
+    let _ = vfs_helpers::unlink(path.as_bytes());
+    dispatch_for_test("touch /tmp/shell_test_touch");
+    assert!(
+        exists(path.as_bytes()),
+        "touch should have created {}",
+        path
+    );
+    // stat: just exercise the dispatch path; output goes to serial.
+    dispatch_for_test("stat /tmp/shell_test_touch");
+    dispatch_for_test("rm /tmp/shell_test_touch");
+    assert!(!exists(path.as_bytes()), "rm should have removed {}", path);
+}
+
+fn cp_roundtrip() {
+    dispatch_for_test("cd /");
+    let src: &str = "/tmp/shell_test_src";
+    let dst: &str = "/tmp/shell_test_dst";
+    let _ = vfs_helpers::unlink(src.as_bytes());
+    let _ = vfs_helpers::unlink(dst.as_bytes());
+    // Seed src directly through the VFS helper (the shell has no
+    // `echo > file` redirection yet).
+    vfs_helpers::write_all(src.as_bytes(), b"hello-cp\n").expect("seed src");
+    dispatch_for_test("cp /tmp/shell_test_src /tmp/shell_test_dst");
+    let dst_bytes = read_to_string(dst.as_bytes()).expect("dst readable after cp");
+    assert_eq!(
+        &dst_bytes[..],
+        b"hello-cp\n",
+        "cp must copy contents byte-for-byte"
+    );
+    let _ = vfs_helpers::unlink(src.as_bytes());
+    let _ = vfs_helpers::unlink(dst.as_bytes());
+}
+
+fn mv_renames() {
+    dispatch_for_test("cd /");
+    let src: &str = "/tmp/shell_test_mv_src";
+    let dst: &str = "/tmp/shell_test_mv_dst";
+    let _ = vfs_helpers::unlink(src.as_bytes());
+    let _ = vfs_helpers::unlink(dst.as_bytes());
+    vfs_helpers::write_all(src.as_bytes(), b"renameme\n").expect("seed mv src");
+    dispatch_for_test("mv /tmp/shell_test_mv_src /tmp/shell_test_mv_dst");
+    assert!(!exists(src.as_bytes()), "mv must remove source");
+    let dst_bytes = read_to_string(dst.as_bytes()).expect("dst readable after mv");
+    assert_eq!(&dst_bytes[..], b"renameme\n", "mv must preserve contents");
+    let _ = vfs_helpers::unlink(dst.as_bytes());
+}
+
+fn cat_smokes() {
+    dispatch_for_test("cd /");
+    let path: &str = "/tmp/shell_test_cat";
+    let _ = vfs_helpers::unlink(path.as_bytes());
+    vfs_helpers::write_all(path.as_bytes(), b"one\ntwo\n").expect("seed cat target");
+    // Smoke: cat must dispatch without panicking. Output goes to
+    // serial; we confirm post-conditions on the file haven't changed.
+    dispatch_for_test("cat /tmp/shell_test_cat");
+    let bytes = read_to_string(path.as_bytes()).expect("cat must not modify file");
+    assert_eq!(&bytes[..], b"one\ntwo\n");
+    let _ = vfs_helpers::unlink(path.as_bytes());
+}
+
+fn ls_dev() {
+    dispatch_for_test("cd /");
+    // Just ensure ls /dev dispatches and the directory itself contains
+    // at least the canonical "." / ".." pair plus one device.
+    dispatch_for_test("ls /dev");
+    let r = vfs_helpers::resolve(b"/dev", true).expect("/dev resolves");
+    let mut count = 0usize;
+    let _ = vfs_helpers::for_each_dirent(&r.inode, &r.dentry, |_name, _kind| {
+        count += 1;
+        true
+    });
+    assert!(count >= 2, "/dev should have at least . and ..");
+}
+
+fn cd_nonexistent_errors() {
+    dispatch_for_test("cd /");
+    // Should print an error but not panic, and CWD should stay at /.
+    dispatch_for_test("cd /no/such/dir");
+    let cwd = vibix::task::current_cwd().expect("cwd preserved");
+    let p = vfs_helpers::dentry_path(&cwd);
+    assert_eq!(p, "/", "failed cd must not move the CWD; got {:?}", p);
+}
+
+fn rmdir_nonempty_errors() {
+    dispatch_for_test("cd /");
+    let parent: &str = "/tmp/shell_test_nonempty";
+    let child: &str = "/tmp/shell_test_nonempty/child";
+    let _ = vfs_helpers::unlink(child.as_bytes());
+    let _ = vfs_helpers::rmdir(parent.as_bytes());
+    vfs_helpers::mkdir(parent.as_bytes(), 0o755).expect("mk parent");
+    vfs_helpers::create_file(child.as_bytes(), 0o644).expect("mk child");
+    dispatch_for_test("rmdir /tmp/shell_test_nonempty");
+    assert!(exists(parent.as_bytes()), "rmdir must refuse non-empty dir");
+    // Cleanup.
+    let _ = vfs_helpers::unlink(child.as_bytes());
+    let _ = vfs_helpers::rmdir(parent.as_bytes());
+}
+
+// Silence unused warnings in case rustc disagrees about `String` usage.
+#[allow(dead_code)]
+fn _string_unused(_s: String) {}

--- a/kernel/tests/shell_files.rs
+++ b/kernel/tests/shell_files.rs
@@ -186,15 +186,19 @@ fn cat_smokes() {
 fn ls_dev() {
     dispatch_for_test("cd /");
     // Just ensure ls /dev dispatches and the directory itself contains
-    // at least the canonical "." / ".." pair plus one device.
+    // at least one real device entry. Counting `.` / `..` would let
+    // an empty /dev pass — skip them so the assert actually means
+    // "devfs is mounted with content."
     dispatch_for_test("ls /dev");
     let r = vfs_helpers::resolve(b"/dev", true).expect("/dev resolves");
     let mut count = 0usize;
-    let _ = vfs_helpers::for_each_dirent(&r.inode, &r.dentry, |_name, _kind| {
-        count += 1;
+    let _ = vfs_helpers::for_each_dirent(&r.inode, &r.dentry, |name, _kind| {
+        if name != b"." && name != b".." {
+            count += 1;
+        }
         true
     });
-    assert!(count >= 2, "/dev should have at least . and ..");
+    assert!(count >= 1, "/dev should have at least one real entry");
 }
 
 fn cd_nonexistent_errors() {


### PR DESCRIPTION
Closes #395

## Summary
- Adds 11 new kernel-resident shell builtins (`cd`, `pwd`, `ls`, `cat`, `mkdir`, `rmdir`, `rm`, `touch`, `mv`, `cp`, `stat`) that poke the VFS directly via a new `kernel/src/shell/vfs_helpers.rs` module — small wrappers around `path_walk`, `OpenFile`, `getdents`, and the inode ops.
- Each builtin gets a one-line `help` entry in the existing dispatch table.
- New integration test `kernel/tests/shell_files.rs` drives every builtin through `dispatch_for_test` and verifies side effects via direct VFS observation (the 16-byte 16550 RX FIFO is too small for serial loopback on the larger commands — same convention as `shell_help`).

## Notes for reviewers
- `cd` lexically normalizes its argument (resolving `.` and `..` at the string level against `task::current_cwd`) before handing it to `path_walk`. The kernel's `step_dotdot` only crosses one mount edge per `..` and stops at the parent FS's mountpoint dentry without taking its parent — without this normalization, `cd ..` from `/tmp` lands back at `/tmp`. Lexical normalization side-steps the issue without changing VFS semantics. Worth a follow-up issue to fix `step_dotdot` directly.
- `dentry_path` (used by `pwd`) detects mount-root dentries via `DFlags::IS_ROOT` and crosses up through `GlobalMountResolver::mount_above` to pick up the user-visible mountpoint name. A naive parent walk would terminate at the `.` sentinel name on a mount root and produce `/.` for `/tmp`.
- `mv` tries `InodeOps::rename` first and falls back to `link` + `unlink` on `EPERM` so it works on filesystems whose drivers don't implement rename yet (currently the rootfs tarfs).
- The shell runs as `Credential::kernel()` so all permission checks pass; relative paths resolve against `task::current_cwd`.

## Test plan
- [x] `cargo xtask build`
- [x] `cargo xtask test` — all green; new `shell_files` test runs 9 cases (`pwd_and_cd_roundtrip`, `mkdir_then_rmdir`, `touch_stat_rm`, `cp_roundtrip`, `mv_renames`, `cat_smokes`, `ls_dev`, `cd_nonexistent_errors`, `rmdir_nonempty_errors`).
- [x] `cargo xtask smoke` — all 41 markers present.
- [x] `cargo fmt --all`