### PR TITLE
DST Phase 2 (1): Host-target buildability of kernel/ + nightly pin + lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,51 @@ jobs:
       - name: RFC 0005 nm-check (no MockClock/MockIrqSource in release)
         run: cargo xtask nm-check --release
 
+  # RFC 0006 / issue #714: host-target buildability of the kernel crate.
+  # Phase 2 (host-side DST simulator) sits on top of `cargo build -p
+  # vibix --lib --target x86_64-unknown-linux-gnu --features sched-mock`
+  # actually compiling — every other Phase-2 issue waits on this gate
+  # holding. If a future PR re-introduces a `target_os = "none"`-only
+  # API into a host-buildable code path, this job fails fast,
+  # independent of the bare-metal build and the nm-check.
+  host-build:
+    name: host build (sched-mock)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y --no-install-recommends \
+            build-essential
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: nightly
+          components: rust-src, llvm-tools, rustfmt, clippy
+          targets: x86_64-unknown-none, x86_64-unknown-linux-gnu
+
+      - name: Cache cargo
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-host-build-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-host-build-
+            ${{ runner.os }}-cargo-
+
+      - name: cargo build --target x86_64-unknown-linux-gnu --features sched-mock
+        run: |
+          cargo build -p vibix --lib \
+            --target x86_64-unknown-linux-gnu \
+            --features sched-mock
+
   unit-tests:
     name: host unit tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,11 @@ jobs:
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: nightly
+          # Match the dated nightly in `rust-toolchain.toml` so the
+          # action and rustup don't briefly disagree on which nightly
+          # to install (a floating `nightly` here would still work via
+          # rustup auto-fetch, but installs two toolchains per run).
+          toolchain: nightly-2026-04-16
           components: rust-src, llvm-tools, rustfmt, clippy
           targets: x86_64-unknown-none, x86_64-unknown-linux-gnu
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,31 @@
+# RFC 0006 / issue #714 — host-side DST simulator determinism guard.
+#
+# `std::collections::HashMap`'s default `RandomState` reads OS entropy
+# at `HashMap::new()`, which means iteration order varies between
+# `cargo test` runs even when every other input is byte-identical. The
+# host-side DST simulator (RFC 0006) relies on every `cargo test` worker
+# producing the same trace from the same seed; a stray `HashMap`
+# anywhere in the kernel `sched-mock` build path or in the future
+# `simulator/` crate would silently destroy that property.
+#
+# This lint forbids `std::collections::HashMap` (and `HashSet`)
+# workspace-wide. Determinism-sensitive callers should reach for
+# `BTreeMap` (deterministic iteration by key) or, when hashing is
+# genuinely needed, `hashbrown::HashMap` with an explicit seeded
+# hasher (e.g. `FxHasher`).
+#
+# `xtask` is host tooling whose output is the build artefact, not a
+# kernel trace, so a few existing `HashSet`/`HashMap` sites in there
+# carry an `#[allow(clippy::disallowed_types)]` with a brief comment.
+# Determinism-sensitive code in the kernel (under `#[cfg(feature =
+# "sched-mock")]`) and the future `simulator/` crate must not allow
+# the lint without re-justifying it.
+#
+# Toolchain pinning (`rust-toolchain.toml`) and this lint are
+# complementary: the pin nails libcore so `BTreeMap` ordering does not
+# drift across nightlies; the lint stops `HashMap` from being the
+# determinism leak the pin can't fix.
+disallowed-types = [
+    { path = "std::collections::HashMap", reason = "HashMap's RandomState reads OS entropy and breaks DST simulator determinism (RFC 0006). Use BTreeMap, or hashbrown::HashMap with a seeded hasher." },
+    { path = "std::collections::HashSet", reason = "HashSet inherits HashMap's nondeterministic iteration order. Use BTreeSet, or hashbrown::HashSet with a seeded hasher." },
+]

--- a/docs/design/scheduler-seam.md
+++ b/docs/design/scheduler-seam.md
@@ -183,6 +183,30 @@ be *sufficient* — softirq ordering (above) is the known suspect. The
 Phase-2 RFC must validate sufficiency before relying on the v1 trait
 surface; this note flags it so the validation is not forgotten.
 
+## Host-buildable arm (RFC 0006 / issue #714)
+
+The seam now has a parallel host-build arm:
+`#[cfg(all(not(target_os = "none"), feature = "sched-mock"))] fn env()`
+in `kernel/src/task/env.rs`. It reads from a `thread_local!`
+`OnceCell<(&'static dyn Clock, &'static dyn TimerIrq)>` that the
+caller installs via `task::env::install_sim_env(clock, irq)` before
+the first kernel call on a worker thread. Per-thread (not global) so
+parallel `cargo test` workers do not serialize on a shared mutex.
+
+The bare-metal arm (`#[cfg(target_os = "none")]`) is unchanged —
+production still hands out `&HW_CLOCK` / `&HW_IRQ` with no `Once`,
+no `Mutex`, no atomic load. The host arm exists only when both
+`target_os != "none"` and `feature = "sched-mock"` are set; release
+builds cannot reach it, and the RFC 0005 nm-check guards the mock
+symbols out of the release ELF independently.
+
+CI gates host buildability with a dedicated job
+(`cargo build -p vibix --lib --target x86_64-unknown-linux-gnu
+--features sched-mock`) so a future PR that re-introduces a
+`target_os = "none"`-only call into a host-buildable code path fails
+fast. See [RFC 0006](../RFC/0006-host-dst-simulator.md)
+§"Host-target buildability of `kernel/`".
+
 ## Cross-references
 
 - [RFC 0005 — Scheduler / IRQ Seam](../RFC/0005-scheduler-irq-seam.md)

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -5,8 +5,19 @@
 //! same code. The `#![no_std]` attribute is gated on `not(test)` so
 //! host unit tests (`cargo test --lib`) compile against the standard
 //! library and can run on the development machine.
+//!
+//! RFC 0006 (host-side DST simulator) adds a second host-build path:
+//! `cargo build --target x86_64-unknown-linux-gnu --features sched-mock`.
+//! That build also needs `std` because the host arm of `task::env::env()`
+//! is implemented with `thread_local!` (issue #714). The exception is
+//! kept narrow — only the host triple **plus** the explicit `sched-mock`
+//! feature pulls `std` in; production bare-metal (`target_os = "none"`)
+//! and feature-off host builds stay `#![no_std]`.
 
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(
+    all(not(test), not(all(not(target_os = "none"), feature = "sched-mock"))),
+    no_std
+)]
 #![cfg_attr(target_os = "none", feature(abi_x86_interrupt))]
 
 extern crate alloc;
@@ -69,10 +80,14 @@ pub mod sync;
 // "none"`. The exception is the `task::env` submodule (RFC 0005
 // scheduler / IRQ seam), whose trait definitions and `MockClock` /
 // `MockTimerIrq` impls (gated behind `feature = "sched-mock"`) are
-// host-buildable so the seam has CI-runnable host unit tests. Hence
-// the wider gate here; the body of `task/mod.rs` stays gated to
-// `target_os = "none"` internally.
-#[cfg(any(target_os = "none", all(test, feature = "sched-mock")))]
+// host-buildable so the seam has CI-runnable host unit tests. RFC 0006
+// (issue #714) extends the host-build arm to plain `cargo build`
+// (not just `cargo test`) so the future `simulator/` crate can link
+// the kernel with `--features sched-mock` without depending on the
+// `cfg(test)` hack — hence the `feature = "sched-mock"` arm covers
+// both. The body of `task/mod.rs` stays gated to `target_os = "none"`
+// internally; only `task::env` is reachable from a host build.
+#[cfg(any(target_os = "none", feature = "sched-mock"))]
 pub mod task;
 #[cfg(target_os = "none")]
 pub mod test_harness;

--- a/kernel/src/task/env.rs
+++ b/kernel/src/task/env.rs
@@ -161,8 +161,18 @@ pub trait TimerIrq: Sync {
 
 /// Production `Clock` over the PIT tick counter and the
 /// `crate::time::WAKEUPS` deadline map.
+///
+/// The `Clock` impl reaches into `crate::time::*`, which is itself
+/// gated to `cfg(any(test, target_os = "none"))` (see
+/// `kernel/src/lib.rs`). Under a plain host build with `--features
+/// sched-mock` the `time` module is configured out and the production
+/// adapter is unreachable — only the host arm of [`env`] (which hands
+/// out the simulator's mocks) is callable. Mirror that gate here so
+/// the host-build CI lane (RFC 0006 / issue #714) compiles.
+#[cfg(any(test, target_os = "none"))]
 pub struct HwClock;
 
+#[cfg(any(test, target_os = "none"))]
 impl Clock for HwClock {
     fn now(&self) -> Tick {
         Tick(crate::time::ticks())
@@ -189,6 +199,7 @@ impl TimerIrq for HwIrq {
 }
 
 /// Singleton `HwClock` handed out by [`env`].
+#[cfg(any(test, target_os = "none"))]
 pub static HW_CLOCK: HwClock = HwClock;
 
 /// Singleton `HwIrq` handed out by [`env`].
@@ -206,6 +217,66 @@ pub static HW_IRQ: HwIrq = HwIrq;
 #[cfg(target_os = "none")]
 pub fn env() -> (&'static dyn Clock, &'static dyn TimerIrq) {
     (&HW_CLOCK, &HW_IRQ)
+}
+
+// ---------------------------------------------------------------------------
+// Host-build arm (RFC 0006, issue #714).
+//
+// `cargo build --target x86_64-unknown-linux-gnu --features sched-mock` is
+// the build the Phase-2 host-side simulator (DST) sits on top of. The
+// production `env()` above is gated to `target_os = "none"` because it
+// reaches into `crate::arch::*`; on the host triple, the arch module does
+// not exist. In its place, the host arm hands out a thread-local
+// `(&'static dyn Clock, &'static dyn TimerIrq)` pair that the simulator
+// installs once per worker thread via [`install_sim_env`].
+//
+// Per-thread (not global) so parallel `cargo test` workers do not
+// serialize on a shared mutex — every worker constructs its own
+// `Simulator` with its own seed and installs its own mocks. A second
+// `install_sim_env` call on the same thread panics rather than silently
+// swapping mocks under a running test.
+//
+// Today, the only callers of `env()` from host-buildable code paths
+// live in tests under the `sched-mock` feature; the future
+// `simulator/` crate (RFC 0006) calls into the kernel through this
+// same accessor.
+// ---------------------------------------------------------------------------
+
+#[cfg(all(not(target_os = "none"), feature = "sched-mock"))]
+std::thread_local! {
+    static SIM_ENV: core::cell::OnceCell<(&'static dyn Clock, &'static dyn TimerIrq)>
+        = const { core::cell::OnceCell::new() };
+}
+
+/// Host-build arm of [`env`]. Returns the simulator-installed
+/// `(Clock, TimerIrq)` pair for the current thread.
+///
+/// Panics if called before [`install_sim_env`] on this thread — the
+/// simulator's `Simulator::with_seed` constructor is responsible for
+/// installing the pair before any kernel code reaches `env()`.
+#[cfg(all(not(target_os = "none"), feature = "sched-mock"))]
+pub fn env() -> (&'static dyn Clock, &'static dyn TimerIrq) {
+    SIM_ENV.with(|c| {
+        *c.get()
+            .expect("task::env::install_sim_env must be called before env()")
+    })
+}
+
+/// Install the simulator's `(Clock, TimerIrq)` pair for the current
+/// thread. Panics if called twice on the same thread — every test /
+/// simulator worker installs exactly one pair for its lifetime.
+///
+/// The pair is `&'static` so the thread-local can store plain
+/// references; in practice the simulator owns its `MockClock` and
+/// `MockTimerIrq` in `Box::leak`-style `'static` storage for the
+/// duration of one seeded run.
+#[cfg(all(not(target_os = "none"), feature = "sched-mock"))]
+pub fn install_sim_env(clock: &'static dyn Clock, irq: &'static dyn TimerIrq) {
+    SIM_ENV.with(|c| {
+        c.set((clock, irq))
+            .map_err(|_| "task::env::install_sim_env called twice on the same thread")
+            .unwrap()
+    });
 }
 
 /// Debug-only invariant: the references returned by [`env`] are the
@@ -405,6 +476,81 @@ impl Default for MockTimerIrq {
 impl TimerIrq for MockTimerIrq {
     fn ack_timer(&self) {
         self.inner.lock().ack_calls += 1;
+    }
+}
+
+#[cfg(all(test, feature = "sched-mock", not(target_os = "none")))]
+mod host_env_tests {
+    use super::*;
+
+    /// Each test thread starts with a fresh `SIM_ENV` thread-local;
+    /// installing once and reading back hands the same pair out
+    /// for the lifetime of the thread.
+    #[test]
+    fn install_then_env_returns_installed_pair() {
+        // Use Box::leak so the references are genuinely 'static —
+        // matches the real simulator's storage shape.
+        let clock: &'static MockClock = Box::leak(Box::new(MockClock::new(0)));
+        let irq: &'static MockTimerIrq = Box::leak(Box::new(MockTimerIrq::new()));
+        install_sim_env(clock, irq);
+
+        let (got_clock, got_irq) = env();
+        // Step the clock through the trait object and observe through the
+        // concrete reference — proves `env()` and the installed pair point
+        // to the same underlying state.
+        clock.advance(7);
+        assert_eq!(got_clock.now().raw(), 7);
+
+        got_irq.ack_timer();
+        assert_eq!(irq.ack_count(), 1);
+    }
+
+    /// Second install on the same thread panics rather than silently
+    /// swapping mocks under a running test.
+    #[test]
+    #[should_panic(expected = "install_sim_env called twice")]
+    fn install_twice_on_same_thread_panics() {
+        let clock: &'static MockClock = Box::leak(Box::new(MockClock::new(0)));
+        let irq: &'static MockTimerIrq = Box::leak(Box::new(MockTimerIrq::new()));
+        install_sim_env(clock, irq);
+
+        let clock2: &'static MockClock = Box::leak(Box::new(MockClock::new(99)));
+        let irq2: &'static MockTimerIrq = Box::leak(Box::new(MockTimerIrq::new()));
+        install_sim_env(clock2, irq2);
+    }
+
+    /// `env()` before any install on this thread panics with a clear
+    /// message — the simulator must install before the first kernel
+    /// call reaches the seam.
+    #[test]
+    #[should_panic(expected = "install_sim_env must be called before env()")]
+    fn env_without_install_panics() {
+        let _ = env();
+    }
+
+    /// Cargo test workers each get their own thread-local — installs on
+    /// one thread are not visible to another. This is the property the
+    /// RFC requires so parallel seeds do not serialize on a global lock.
+    #[test]
+    fn install_is_per_thread() {
+        let clock_a: &'static MockClock = Box::leak(Box::new(MockClock::new(11)));
+        let irq_a: &'static MockTimerIrq = Box::leak(Box::new(MockTimerIrq::new()));
+        install_sim_env(clock_a, irq_a);
+        assert_eq!(env().0.now().raw(), 11);
+
+        // A fresh thread has an uninstalled `SIM_ENV` and can install
+        // its own pair without colliding with the outer install.
+        let handle = std::thread::spawn(|| {
+            let clock_b: &'static MockClock = Box::leak(Box::new(MockClock::new(22)));
+            let irq_b: &'static MockTimerIrq = Box::leak(Box::new(MockTimerIrq::new()));
+            install_sim_env(clock_b, irq_b);
+            env().0.now().raw()
+        });
+        let inner = handle.join().expect("worker thread panicked");
+        assert_eq!(inner, 22);
+
+        // Outer thread still sees its own pair.
+        assert_eq!(env().0.now().raw(), 11);
     }
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,10 @@
+# RFC 0006 (issue #714) pins the nightly to a specific date. Without a
+# date pin, a different nightly is a different libcore — and a different
+# libcore can mean a different `BTreeMap` iteration order, which is the
+# single most likely silent-determinism vector for the host-side DST
+# simulator (RFC 0006 §"Reproducibility Envelope"). Bump deliberately,
+# in a dedicated PR that re-runs the full nightly soak.
 [toolchain]
-channel = "nightly"
+channel = "nightly-2026-04-16"
 components = ["rust-src", "llvm-tools", "rustfmt", "clippy"]
-targets = ["x86_64-unknown-none"]
+targets = ["x86_64-unknown-none", "x86_64-unknown-linux-gnu"]

--- a/xtask/src/lntab.rs
+++ b/xtask/src/lntab.rs
@@ -5,6 +5,13 @@
 //! location, and patches the result into the kernel's `LNTAB_RESERVATION`
 //! section. See `kernel/src/lntab.rs` for the on-wire format.
 
+// xtask is host build tooling — its output is a build artefact, not a
+// kernel trace. The DST-simulator determinism lint (RFC 0006 / issue
+// #714) targets kernel `sched-mock` paths and the `simulator/` crate;
+// the file-offset cache below is a pure lookup table whose iteration
+// order does not feed any seeded run.
+#![allow(clippy::disallowed_types)]
+
 use std::collections::HashMap;
 use std::fs;
 use std::io::{Seek, SeekFrom, Write};

--- a/xtask/src/lntab.rs
+++ b/xtask/src/lntab.rs
@@ -8,10 +8,11 @@
 // xtask is host build tooling — its output is a build artefact, not a
 // kernel trace. The DST-simulator determinism lint (RFC 0006 / issue
 // #714) targets kernel `sched-mock` paths and the `simulator/` crate;
-// the file-offset cache below is a pure lookup table whose iteration
-// order does not feed any seeded run.
-#![allow(clippy::disallowed_types)]
+// `HashMap` here is just a per-call lookup cache. Allows are kept on
+// the two specific fns that construct one so a future addition does
+// not silently inherit the exemption.
 
+#[allow(clippy::disallowed_types)] // see fn-level allows on `collect_rows` / `build_blob`
 use std::collections::HashMap;
 use std::fs;
 use std::io::{Seek, SeekFrom, Write};
@@ -42,6 +43,7 @@ struct LnRow {
 
 /// Parse `.debug_line` across all compilation units, returning one row
 /// per (pc, file, line) triple. The caller sorts and deduplicates.
+#[allow(clippy::disallowed_types)] // per-call file_index cache; not a seeded trace
 fn collect_rows(obj: &object::File<'_>) -> R<Vec<LnRow>> {
     let endian = gimli::RunTimeEndian::Little;
 
@@ -232,6 +234,7 @@ fn sort_and_dedup(rows: &mut Vec<LnRow>) {
 }
 
 /// Serialize collected rows into the on-wire blob the kernel decodes.
+#[allow(clippy::disallowed_types)] // per-call string-dedup table; not a seeded trace
 fn build_blob(rows: &[LnRow], workspace_root: &Path) -> Vec<u8> {
     let mut strtab: Vec<u8> = Vec::new();
     let mut file_offsets: HashMap<String, (u32, u32)> = HashMap::new();

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1573,6 +1573,11 @@ fn test_all() -> R<()> {
     Ok(())
 }
 
+// xtask is host build tooling — the `HashSet`s in this function track
+// marker membership for a single smoke run, not a deterministic seeded
+// trace. The DST-simulator determinism lint (RFC 0006 / issue #714)
+// does not apply to xtask scaffolding.
+#[allow(clippy::disallowed_types)]
 fn smoke(opts: &BuildOpts) -> R<()> {
     use std::collections::HashSet;
     use std::time::Instant;
@@ -2602,7 +2607,11 @@ ffffffff80020100 t core::ptr::drop_in_place::<vibix::task::env::MockIrqState>
         );
     }
 
+    // xtask test scaffolding — see `fn smoke` for why
+    // `clippy::disallowed_types` is allowed for these `HashSet`s
+    // (RFC 0006 / issue #714).
     #[test]
+    #[allow(clippy::disallowed_types)]
     fn smoke_markers_satisfied_only_when_every_hard_marker_seen() {
         // Mirrors the retain+contains loop in `fn smoke`: an accumulated
         // serial-capture string drives the hard/soft marker sets to empty.


### PR DESCRIPTION
Closes #714

## Summary

RFC 0006 Phase 2 keystone. Lands the host-target buildability slice **before** any simulator code exists, so the rest of Phase 2 builds on a verified host-buildable kernel:

- `kernel/src/task/env.rs` grows a parallel `#[cfg(all(not(target_os = "none"), feature = "sched-mock"))] fn env()` that hands out a thread-local `(&'static dyn Clock, &'static dyn TimerIrq)` pair the simulator installs via `install_sim_env(clock, irq)`. Per-thread (not global) so parallel `cargo test` workers each get their own seeded simulator without serializing on a shared mutex; second install on the same thread panics rather than silently swapping mocks.
- `pub mod task` widens to `cfg(any(target_os = "none", feature = "sched-mock"))` so plain `cargo build --features sched-mock` (not just `cargo test`) reaches `task::env`. The body of `task/mod.rs` stays bare-metal-only; only `task::env` is exposed to host builds.
- `#![no_std]` exception narrowed: under host triple **plus** `sched-mock`, std is linked because `std::thread_local!` is the ergonomic way to express per-thread `OnceCell`. Production bare-metal and feature-off host builds stay `#![no_std]`.
- `HwClock`'s impl + `HW_CLOCK` static gate to `cfg(any(test, target_os = "none"))` to match where `crate::time::*` exists. Under a plain host build the production adapter is unreachable — only the host arm of `env()` is callable.
- `rust-toolchain.toml` pins `nightly-2026-04-16` and adds `x86_64-unknown-linux-gnu` to targets. RFC 0006 §"Reproducibility Envelope" requires it — without a date pin, a different libcore can mean a different `BTreeMap` iteration order.
- Workspace `clippy.toml` bans `std::collections::HashMap` / `HashSet` via `disallowed_types`. RandomState reads OS entropy and breaks DST determinism; toolchain pin alone doesn't save you. xtask's existing call sites carry narrow `#[allow(clippy::disallowed_types)]` annotations because xtask is host build tooling, not a seeded kernel trace path.
- New CI job `host-build` runs `cargo build -p vibix --lib --target x86_64-unknown-linux-gnu --features sched-mock` on every PR, gating that the host-buildability invariant holds going forward.
- `docs/design/scheduler-seam.md` extends with a host-buildable-arm note pointing at the per-thread thread_local rationale and cross-referencing RFC 0006.

## Test plan

- [x] `cargo build -p vibix --lib --target x86_64-unknown-linux-gnu --features sched-mock` — clean
- [x] `cargo xtask build` (bare-metal) — clean
- [x] `cargo xtask test` — clean (no regressions)
- [x] `cargo xtask smoke` — all 42 markers, clean
- [x] `cargo test -p vibix --lib --features sched-mock` — 555 passed (4 new `host_env_tests`)
- [x] `cargo clippy -p xtask --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

The four new `host_env_tests` cover: install→env round-trip through the trait object; double-install panics; pre-install env() panics; per-thread isolation across `std::thread::spawn`.