### PR TITLE
docs/RFC: renumber page-cache RFC 0006 → 0007 (collision with #712)

### DIFF
--- a/docs/RFC/0007-page-cache-file-mmap.md
+++ b/docs/RFC/0007-page-cache-file-mmap.md
@@ -1,11 +1,11 @@
 ---
-rfc: 0006
+rfc: 0007
 title: Demand-Paged File mmap and Page Cache for ext2
 status: Accepted
 created: 2026-04-28
 ---
 
-# RFC 0006: Demand-Paged File mmap and Page Cache for ext2
+# RFC 0007: Demand-Paged File mmap and Page Cache for ext2
 
 ## Abstract
 
@@ -41,7 +41,7 @@ a `PT_INTERP` returns `ENOEXEC` (RFC 0004 Workstream F). That blocks:
 
 The right shape for this is one design document, not three: every
 question of cache layering, locking, and writeback ordering recurs
-identically across mmap, read, and execve. RFC 0006 fixes the
+identically across mmap, read, and execve. RFC 0007 fixes the
 architecture and lets the three downstream epics ship as execution-only
 work.
 


### PR DESCRIPTION
## Summary

PR #712 (Host-Side DST simulator) and PR #732 (page-cache + file mmap) both landed on `main` numbered as RFC 0006. #712 merged first (2026-04-28 14:48 UTC) and keeps the 0006 slot; #732 merged ~13h later (2026-04-29 03:45 UTC) and is renumbered here to 0007 to resolve the collision.

## Changes

- `git mv docs/RFC/0006-page-cache-file-mmap.md docs/RFC/0007-page-cache-file-mmap.md`
- Frontmatter `rfc: 0006` → `rfc: 0007`
- H1: `# RFC 0006: Demand-Paged File mmap and Page Cache for ext2` → `# RFC 0007: …`
- One self-reference inside the abstract: "RFC 0006 fixes the …" → "RFC 0007 fixes the …"

The DST simulator RFC (`docs/RFC/0006-host-dst-simulator.md`) is intentionally untouched — it keeps the 0006 number.

A repo-wide grep for `0006-page-cache-file-mmap`, `RFC 0006.*page.cache`, and `RFC 0006.*mmap` confirms there are no other references in code, docs, READMEs, or comments.

Sub-issues under epic #734 will have their titles/bodies updated separately to point at "RFC 0007 / 0007-page-cache-file-mmap.md".

## Test plan

- [x] `cargo fmt --all` clean
- [ ] CI green