### PR TITLE
simulator: skeleton + panic hook + replay binary stub (#715)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,13 @@
 [workspace]
 members = [
     "kernel",
+    # `simulator/` is the host-side DST simulator (RFC 0006). It is part
+    # of the workspace so plain `cargo build` / `cargo test` exercise
+    # the host-target build path that future Phase 2 work depends on,
+    # but its only kernel dependency is gated on
+    # `cfg(not(target_os = "none"))` so a bare-metal build of `vibix`
+    # never pulls it in. See `simulator/Cargo.toml`.
+    "simulator",
     "xtask",
     "userspace/hello",
     "userspace/init",

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -1,0 +1,34 @@
+# Host-side DST simulator (RFC 0006). This crate is host-only by design —
+# it consumes the `sched-mock` seam from the kernel crate (`vibix`) to
+# drive `kernel::task::preempt_tick()` one tick at a time under a seeded
+# `MockClock` + `MockTimerIrq` pair. See `docs/RFC/0006-host-dst-simulator.md`.
+#
+# Issue #715 lands this skeleton only; the run loop (#716), trace recorder
+# (#717), `sched_mock_trace!` macro (#718), invariant checker (#722), and
+# CI sweep (#723) all stack on top.
+[package]
+name = "simulator"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+publish = false
+description = "Host-side deterministic simulator for the vibix kernel (RFC 0006)."
+
+[lib]
+name = "simulator"
+path = "src/lib.rs"
+
+[[bin]]
+name = "replay"
+path = "src/bin/replay.rs"
+
+# The kernel crate (`vibix`) is `#![no_std]` and host-buildable under the
+# `sched-mock` feature as of #714. We gate the dependency on
+# `cfg(not(target_os = "none"))` so that the bare-metal kernel-image
+# build graph (target `x86_64-unknown-none`) cannot accidentally pull
+# this crate in — the simulator is host-only and must never appear in a
+# shipping kernel ELF. The `host-build (sched-mock)` CI job uses target
+# `x86_64-unknown-linux-gnu`, which matches the gate.
+[target.'cfg(not(target_os = "none"))'.dependencies]
+vibix = { path = "../kernel", features = ["sched-mock"] }

--- a/simulator/src/bin/replay.rs
+++ b/simulator/src/bin/replay.rs
@@ -125,12 +125,22 @@ fn parse_args(args: &[String]) -> Result<ParseOutcome, CliError> {
                 let raw = iter.next().ok_or_else(|| {
                     CliError::Usage(String::from("replay: --seed requires a value"))
                 })?;
+                if seed.is_some() {
+                    return Err(CliError::Usage(String::from(
+                        "replay: --seed may be specified only once",
+                    )));
+                }
                 seed = Some(parse_seed(raw)?);
             }
             "--trace-out" => {
                 let raw = iter.next().ok_or_else(|| {
                     CliError::Usage(String::from("replay: --trace-out requires a value"))
                 })?;
+                if trace_out.is_some() {
+                    return Err(CliError::Usage(String::from(
+                        "replay: --trace-out may be specified only once",
+                    )));
+                }
                 if raw.is_empty() {
                     return Err(CliError::Usage(String::from(
                         "replay: --trace-out requires a non-empty path",
@@ -262,6 +272,34 @@ mod tests {
         // `--help` and `-h` must succeed (clap convention, exit 0).
         assert_eq!(parse_args(&args(&["-h"])).unwrap(), ParseOutcome::Help);
         assert_eq!(parse_args(&args(&["--help"])).unwrap(), ParseOutcome::Help);
+    }
+
+    #[test]
+    fn duplicate_seed_is_usage_error() {
+        let err = parse_args(&args(&["--seed", "1", "--seed", "2"])).unwrap_err();
+        let CliError::Usage(msg) = err;
+        assert!(
+            msg.contains("--seed may be specified only once"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn duplicate_trace_out_is_usage_error() {
+        let err = parse_args(&args(&[
+            "--seed",
+            "1",
+            "--trace-out",
+            "/tmp/a.json",
+            "--trace-out",
+            "/tmp/b.json",
+        ]))
+        .unwrap_err();
+        let CliError::Usage(msg) = err;
+        assert!(
+            msg.contains("--trace-out may be specified only once"),
+            "got: {msg}"
+        );
     }
 
     #[test]

--- a/simulator/src/bin/replay.rs
+++ b/simulator/src/bin/replay.rs
@@ -1,0 +1,227 @@
+//! `replay` — host-side simulator CLI stub (RFC 0006, issue #715).
+//!
+//! The committed argument shape is
+//!
+//! ```text
+//! cargo run -p simulator --bin replay -- --seed <u64> [--trace-out <path>]
+//! ```
+//!
+//! Today this binary parses those flags, prints `unimplemented`, and
+//! exits 0. The real replay path lands in #716 (run loop) and #717
+//! (trace dump). The argument shape is part of the API contract per
+//! RFC 0006 §"Local repro" — downstream auto-engineer tooling and
+//! human-facing documentation already cite it, so the names must not
+//! drift.
+//!
+//! `--seed` accepts decimal, `0x`-prefixed hex, and underscored forms
+//! (e.g. `0xDEAD_BEEF`, `1234_5678`). Anything else is a usage error
+//! that exits with status `2` so shell-side tooling can distinguish a
+//! caller mistake from a real simulator failure (which the run-loop
+//! PR will surface as exit `1` plus `SIMULATOR PANIC ...`).
+
+use std::process::ExitCode;
+
+const USAGE: &str = "\
+usage: replay --seed <u64> [--trace-out <path>]
+
+The host-side DST simulator's replay binary. Today this is a stub
+that only parses arguments and prints \"unimplemented\"; the real
+run-loop body lands in #716 and the trace dump in #717.
+
+Options:
+  --seed <u64>          Master seed for the run. Accepts decimal,
+                        0x-prefixed hex, and underscore separators
+                        (e.g. 0xDEAD_BEEF, 1_234_567).
+  --trace-out <path>    Path to write the JSON trace dump. Stub
+                        accepts and validates this argument but does
+                        not yet write a file.
+  -h, --help            Print this message.
+
+Exit codes:
+  0   Success (today: always, since the body is unimplemented).
+  1   Reserved for simulator failures (run loop, #716).
+  2   CLI usage error (missing required flag, parse failure).";
+
+fn main() -> ExitCode {
+    match run(std::env::args().skip(1).collect()) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(CliError::Usage(msg)) => {
+            eprintln!("{msg}");
+            eprintln!();
+            eprintln!("{USAGE}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+#[derive(Debug)]
+enum CliError {
+    Usage(String),
+}
+
+fn run(args: Vec<String>) -> Result<(), CliError> {
+    let parsed = parse_args(&args)?;
+    println!(
+        "replay: unimplemented (seed={:#x}, trace_out={})",
+        parsed.seed,
+        parsed.trace_out.as_deref().unwrap_or("<none>")
+    );
+    Ok(())
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ParsedArgs {
+    seed: u64,
+    trace_out: Option<String>,
+}
+
+fn parse_args(args: &[String]) -> Result<ParsedArgs, CliError> {
+    // Bare `--help` / `-h` short-circuits to a usage error so the help
+    // text gets printed and the process exits non-zero — matches the
+    // convention `clap` uses by default and keeps the stub honest
+    // about not being a real CLI yet.
+    if args.iter().any(|a| a == "-h" || a == "--help") {
+        return Err(CliError::Usage(String::from("replay: help requested")));
+    }
+
+    let mut seed: Option<u64> = None;
+    let mut trace_out: Option<String> = None;
+
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--seed" => {
+                let raw = iter.next().ok_or_else(|| {
+                    CliError::Usage(String::from("replay: --seed requires a value"))
+                })?;
+                seed = Some(parse_seed(raw)?);
+            }
+            "--trace-out" => {
+                let raw = iter.next().ok_or_else(|| {
+                    CliError::Usage(String::from("replay: --trace-out requires a value"))
+                })?;
+                if raw.is_empty() {
+                    return Err(CliError::Usage(String::from(
+                        "replay: --trace-out requires a non-empty path",
+                    )));
+                }
+                trace_out = Some(raw.clone());
+            }
+            other => {
+                return Err(CliError::Usage(format!(
+                    "replay: unrecognised argument `{other}`"
+                )));
+            }
+        }
+    }
+
+    let seed = seed.ok_or_else(|| CliError::Usage(String::from("replay: --seed is required")))?;
+
+    Ok(ParsedArgs { seed, trace_out })
+}
+
+fn parse_seed(raw: &str) -> Result<u64, CliError> {
+    // Strip underscores so `0xDEAD_BEEF` and `1_234_567` parse the
+    // same way Rust integer literals do. The replay seed is always
+    // copy-pasted from a panic message or a tracked seed file, so
+    // matching the source-literal form is the path of least
+    // friction for humans.
+    let cleaned: String = raw.chars().filter(|c| *c != '_').collect();
+
+    let parsed = if let Some(hex) = cleaned
+        .strip_prefix("0x")
+        .or_else(|| cleaned.strip_prefix("0X"))
+    {
+        u64::from_str_radix(hex, 16)
+    } else {
+        cleaned.parse::<u64>()
+    };
+
+    parsed.map_err(|e| CliError::Usage(format!("replay: --seed `{raw}` is not a valid u64: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn parses_decimal_seed() {
+        let parsed = parse_args(&args(&["--seed", "42"])).unwrap();
+        assert_eq!(parsed.seed, 42);
+        assert_eq!(parsed.trace_out, None);
+    }
+
+    #[test]
+    fn parses_hex_seed_with_underscores() {
+        let parsed = parse_args(&args(&["--seed", "0xDEAD_BEEF"])).unwrap();
+        assert_eq!(parsed.seed, 0xDEAD_BEEF);
+    }
+
+    #[test]
+    fn parses_decimal_seed_with_underscores() {
+        let parsed = parse_args(&args(&["--seed", "1_234_567"])).unwrap();
+        assert_eq!(parsed.seed, 1_234_567);
+    }
+
+    #[test]
+    fn parses_uppercase_hex_prefix() {
+        let parsed = parse_args(&args(&["--seed", "0XAA"])).unwrap();
+        assert_eq!(parsed.seed, 0xAA);
+    }
+
+    #[test]
+    fn parses_trace_out() {
+        let parsed = parse_args(&args(&["--seed", "1", "--trace-out", "/tmp/t.json"])).unwrap();
+        assert_eq!(parsed.seed, 1);
+        assert_eq!(parsed.trace_out.as_deref(), Some("/tmp/t.json"));
+    }
+
+    #[test]
+    fn missing_seed_is_usage_error() {
+        let err = parse_args(&args(&[])).unwrap_err();
+        let CliError::Usage(msg) = err;
+        assert!(msg.contains("--seed is required"), "got: {msg}");
+    }
+
+    #[test]
+    fn unknown_flag_is_usage_error() {
+        let err = parse_args(&args(&["--seed", "1", "--bogus"])).unwrap_err();
+        let CliError::Usage(msg) = err;
+        assert!(msg.contains("unrecognised argument"), "got: {msg}");
+    }
+
+    #[test]
+    fn dangling_seed_flag_is_usage_error() {
+        let err = parse_args(&args(&["--seed"])).unwrap_err();
+        let CliError::Usage(msg) = err;
+        assert!(msg.contains("--seed requires a value"), "got: {msg}");
+    }
+
+    #[test]
+    fn empty_trace_out_is_usage_error() {
+        let err = parse_args(&args(&["--seed", "1", "--trace-out", ""])).unwrap_err();
+        let CliError::Usage(msg) = err;
+        assert!(
+            msg.contains("--trace-out requires a non-empty path"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn bad_seed_is_usage_error() {
+        let err = parse_args(&args(&["--seed", "notanint"])).unwrap_err();
+        let CliError::Usage(msg) = err;
+        assert!(msg.contains("not a valid u64"), "got: {msg}");
+    }
+
+    #[test]
+    fn help_flag_short_circuits() {
+        let err = parse_args(&args(&["-h"])).unwrap_err();
+        let CliError::Usage(msg) = err;
+        assert!(msg.contains("help requested"), "got: {msg}");
+    }
+}

--- a/simulator/src/bin/replay.rs
+++ b/simulator/src/bin/replay.rs
@@ -18,6 +18,12 @@
 //! that exits with status `2` so shell-side tooling can distinguish a
 //! caller mistake from a real simulator failure (which the run-loop
 //! PR will surface as exit `1` plus `SIMULATOR PANIC ...`).
+//!
+//! `--help` / `-h` is treated as a success path (exit `0`, help on
+//! stdout) — matching `clap`'s default and the GNU/POSIX convention.
+//! It is recognised only when it stands alone as an argument, not
+//! when consumed as the value of `--trace-out` (so a literal path of
+//! `--help` is still legal, awkward as that may be).
 
 use std::process::ExitCode;
 
@@ -44,7 +50,14 @@ Exit codes:
 
 fn main() -> ExitCode {
     match run(std::env::args().skip(1).collect()) {
-        Ok(()) => ExitCode::SUCCESS,
+        Ok(Outcome::Ran) => ExitCode::SUCCESS,
+        Ok(Outcome::Help) => {
+            // Help goes to stdout (clap convention) and exits 0 so a
+            // shell wrapper that asks `replay --help` doesn't see a
+            // failure status.
+            println!("{USAGE}");
+            ExitCode::SUCCESS
+        }
         Err(CliError::Usage(msg)) => {
             eprintln!("{msg}");
             eprintln!();
@@ -59,14 +72,27 @@ enum CliError {
     Usage(String),
 }
 
-fn run(args: Vec<String>) -> Result<(), CliError> {
-    let parsed = parse_args(&args)?;
-    println!(
-        "replay: unimplemented (seed={:#x}, trace_out={})",
-        parsed.seed,
-        parsed.trace_out.as_deref().unwrap_or("<none>")
-    );
-    Ok(())
+/// Result of a successful CLI parse + run.
+#[derive(Debug, PartialEq, Eq)]
+enum Outcome {
+    /// `--help` / `-h` was requested.
+    Help,
+    /// The stub ran (and printed `unimplemented`).
+    Ran,
+}
+
+fn run(args: Vec<String>) -> Result<Outcome, CliError> {
+    match parse_args(&args)? {
+        ParseOutcome::Help => Ok(Outcome::Help),
+        ParseOutcome::Run(parsed) => {
+            println!(
+                "replay: unimplemented (seed={:#x}, trace_out={})",
+                parsed.seed,
+                parsed.trace_out.as_deref().unwrap_or("<none>")
+            );
+            Ok(Outcome::Ran)
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -75,21 +101,26 @@ struct ParsedArgs {
     trace_out: Option<String>,
 }
 
-fn parse_args(args: &[String]) -> Result<ParsedArgs, CliError> {
-    // Bare `--help` / `-h` short-circuits to a usage error so the help
-    // text gets printed and the process exits non-zero — matches the
-    // convention `clap` uses by default and keeps the stub honest
-    // about not being a real CLI yet.
-    if args.iter().any(|a| a == "-h" || a == "--help") {
-        return Err(CliError::Usage(String::from("replay: help requested")));
-    }
+#[derive(Debug, PartialEq, Eq)]
+enum ParseOutcome {
+    Help,
+    Run(ParsedArgs),
+}
 
+fn parse_args(args: &[String]) -> Result<ParseOutcome, CliError> {
     let mut seed: Option<u64> = None;
     let mut trace_out: Option<String> = None;
 
     let mut iter = args.iter();
     while let Some(arg) = iter.next() {
         match arg.as_str() {
+            // `--help` / `-h` is recognised only at the top level —
+            // after `--trace-out` consumes its value below, the next
+            // iteration of this loop sees the *following* argument,
+            // so a literal `--trace-out --help` still uses `--help`
+            // as the path. That is intentional: it preserves the
+            // "values are values, flags are flags" boundary.
+            "-h" | "--help" => return Ok(ParseOutcome::Help),
             "--seed" => {
                 let raw = iter.next().ok_or_else(|| {
                     CliError::Usage(String::from("replay: --seed requires a value"))
@@ -117,7 +148,7 @@ fn parse_args(args: &[String]) -> Result<ParsedArgs, CliError> {
 
     let seed = seed.ok_or_else(|| CliError::Usage(String::from("replay: --seed is required")))?;
 
-    Ok(ParsedArgs { seed, trace_out })
+    Ok(ParseOutcome::Run(ParsedArgs { seed, trace_out }))
 }
 
 fn parse_seed(raw: &str) -> Result<u64, CliError> {
@@ -148,34 +179,42 @@ mod tests {
         items.iter().map(|s| s.to_string()).collect()
     }
 
+    fn unwrap_run(outcome: ParseOutcome) -> ParsedArgs {
+        match outcome {
+            ParseOutcome::Run(p) => p,
+            ParseOutcome::Help => panic!("expected Run, got Help"),
+        }
+    }
+
     #[test]
     fn parses_decimal_seed() {
-        let parsed = parse_args(&args(&["--seed", "42"])).unwrap();
+        let parsed = unwrap_run(parse_args(&args(&["--seed", "42"])).unwrap());
         assert_eq!(parsed.seed, 42);
         assert_eq!(parsed.trace_out, None);
     }
 
     #[test]
     fn parses_hex_seed_with_underscores() {
-        let parsed = parse_args(&args(&["--seed", "0xDEAD_BEEF"])).unwrap();
+        let parsed = unwrap_run(parse_args(&args(&["--seed", "0xDEAD_BEEF"])).unwrap());
         assert_eq!(parsed.seed, 0xDEAD_BEEF);
     }
 
     #[test]
     fn parses_decimal_seed_with_underscores() {
-        let parsed = parse_args(&args(&["--seed", "1_234_567"])).unwrap();
+        let parsed = unwrap_run(parse_args(&args(&["--seed", "1_234_567"])).unwrap());
         assert_eq!(parsed.seed, 1_234_567);
     }
 
     #[test]
     fn parses_uppercase_hex_prefix() {
-        let parsed = parse_args(&args(&["--seed", "0XAA"])).unwrap();
+        let parsed = unwrap_run(parse_args(&args(&["--seed", "0XAA"])).unwrap());
         assert_eq!(parsed.seed, 0xAA);
     }
 
     #[test]
     fn parses_trace_out() {
-        let parsed = parse_args(&args(&["--seed", "1", "--trace-out", "/tmp/t.json"])).unwrap();
+        let parsed =
+            unwrap_run(parse_args(&args(&["--seed", "1", "--trace-out", "/tmp/t.json"])).unwrap());
         assert_eq!(parsed.seed, 1);
         assert_eq!(parsed.trace_out.as_deref(), Some("/tmp/t.json"));
     }
@@ -219,9 +258,19 @@ mod tests {
     }
 
     #[test]
-    fn help_flag_short_circuits() {
-        let err = parse_args(&args(&["-h"])).unwrap_err();
-        let CliError::Usage(msg) = err;
-        assert!(msg.contains("help requested"), "got: {msg}");
+    fn help_flag_returns_help_outcome() {
+        // `--help` and `-h` must succeed (clap convention, exit 0).
+        assert_eq!(parse_args(&args(&["-h"])).unwrap(), ParseOutcome::Help);
+        assert_eq!(parse_args(&args(&["--help"])).unwrap(), ParseOutcome::Help);
+    }
+
+    #[test]
+    fn help_does_not_swallow_trace_out_value() {
+        // Regression cover for the CodeRabbit review on PR #767:
+        // a literal `--help` after `--trace-out` should be consumed
+        // as the path value, not as a help request.
+        let parsed =
+            unwrap_run(parse_args(&args(&["--seed", "1", "--trace-out", "--help"])).unwrap());
+        assert_eq!(parsed.trace_out.as_deref(), Some("--help"));
     }
 }

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -1,0 +1,318 @@
+//! Host-side DST simulator skeleton (RFC 0006).
+//!
+//! This crate is the host-only driver that consumes the `sched-mock`
+//! seam landed in [RFC 0005](../../../docs/RFC/0005-scheduler-irq-seam.md)
+//! and converts today's flaky concurrency bugs into reproducible
+//! `cargo test -- --seed=0xDEADBEEF` failures.
+//!
+//! Issue #715 ships the **skeleton only**: the public type names, a
+//! diagnostic panic hook, and a `replay` binary stub. None of the types
+//! here have real bodies yet — every `Simulator::run`, `Trace` record,
+//! and `FaultPlan` interaction lands in follow-up issues:
+//!
+//! - #716 — run loop + `Simulator::with_seed(...).run(max_ticks)`.
+//! - #717 — `(Tick, Event)` trace recorder + JSON dump.
+//! - #718 — `sched_mock_trace!` macro + kernel-side emit points.
+//! - #722 — invariant + liveness checkers.
+//! - #723 — CI sweep (per-PR + nightly seed exploration).
+//!
+//! The deliberate emptiness here is the point: subsequent PRs land
+//! without colliding on workspace plumbing or panic-hook wiring, and
+//! the existing `host build (sched-mock)` CI job already exercises
+//! the host-target build path the simulator depends on.
+//!
+//! # Determinism contract
+//!
+//! Every public surface in this crate must keep the simulator
+//! byte-reproducible from `(seed, git commit, toolchain)` alone. That
+//! contract is enforced workspace-wide by `clippy.toml` forbidding
+//! `std::collections::HashMap` / `HashSet`, by the dated nightly pin
+//! in `rust-toolchain.toml`, and by the kernel-side nm-check that
+//! keeps `MockClock` / `MockTimerIrq` symbols out of release builds.
+//! New types added here should reach for `BTreeMap` / `BTreeSet`, or
+//! seeded `hashbrown::HashMap` with an explicit hasher — never
+//! `std`'s default-hashed maps.
+
+#![cfg_attr(not(test), deny(unsafe_code))]
+#![warn(missing_docs)]
+
+#[cfg(not(target_os = "none"))]
+mod imp {
+    use core::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::OnceLock;
+
+    /// A simulator seed.
+    ///
+    /// The seed is the API: every reproducible failure surfaced by the
+    /// simulator carries one of these in its panic message
+    /// (`VIBIX_SIM_SEED=0x...`). The same seed re-run against the same
+    /// `git commit` + pinned toolchain must produce a byte-identical
+    /// trace — see RFC 0006 §"Reproducibility Envelope".
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub struct Seed(pub u64);
+
+    impl Seed {
+        /// Returns the raw `u64` seed value.
+        #[inline]
+        pub const fn as_u64(self) -> u64 {
+            self.0
+        }
+    }
+
+    impl From<u64> for Seed {
+        #[inline]
+        fn from(v: u64) -> Self {
+            Self(v)
+        }
+    }
+
+    /// Static configuration for a simulator run.
+    ///
+    /// Fields beyond `seed` (max-tick budget, fault plan, invariant
+    /// set, trace dump path, ...) land in follow-up issues; this stub
+    /// only carries enough to thread the seed through.
+    #[derive(Clone, Debug)]
+    pub struct SimulatorConfig {
+        /// Master seed for the run.
+        pub seed: Seed,
+    }
+
+    impl SimulatorConfig {
+        /// Construct a config from a raw `u64` seed.
+        pub fn with_seed(seed: u64) -> Self {
+            Self { seed: Seed(seed) }
+        }
+    }
+
+    /// A `(Tick, Event)` trace stream emitted by a simulator run.
+    ///
+    /// The on-wire shape lands in #717; today this is an opaque empty
+    /// container so downstream issues can plumb `Simulator::run` ->
+    /// `Trace` without a name change later.
+    #[derive(Clone, Debug, Default)]
+    pub struct Trace {
+        // Intentionally private. Issue #717 fills this in with a
+        // `Vec<TraceRecord>` carrying serde-serializable `Event`
+        // variants — keeping the field private now means that
+        // `serde::Serialize` derive doesn't leak through public
+        // re-exports of `Trace` in the meantime.
+        _private: (),
+    }
+
+    impl Trace {
+        /// Construct an empty trace.
+        pub fn new() -> Self {
+            Self { _private: () }
+        }
+    }
+
+    /// Host-side deterministic simulator skeleton.
+    ///
+    /// The real run loop wires `MockClock` + `MockTimerIrq` into
+    /// [`vibix::task`] and steps the kernel one tick at a time; that
+    /// lands in #716. This stub exists so the panic hook and the
+    /// `replay` binary can refer to a real type today.
+    #[derive(Debug)]
+    pub struct Simulator {
+        cfg: SimulatorConfig,
+        /// The simulated tick count. The panic hook reads this through
+        /// the same atomic, so non-`Simulator` paths (e.g. a panicking
+        /// background thread) can still report the last-known tick.
+        current_tick: &'static AtomicU64,
+    }
+
+    impl Simulator {
+        /// Construct a simulator bound to `seed`, installing the
+        /// process-global panic hook (idempotent — last installer
+        /// wins, see [`install_panic_hook`]).
+        ///
+        /// The constructor is the documented hook-installation site
+        /// in RFC 0006 §"Failing-seed-to-repro path"; tests that need
+        /// the hook without an entire simulator should call
+        /// [`install_panic_hook`] directly.
+        pub fn with_seed(seed: u64) -> Self {
+            let cfg = SimulatorConfig::with_seed(seed);
+            let current_tick = current_tick_cell();
+            current_tick.store(0, Ordering::SeqCst);
+            install_panic_hook(Seed(seed));
+            Self { cfg, current_tick }
+        }
+
+        /// Returns the configuration the simulator was constructed with.
+        pub fn config(&self) -> &SimulatorConfig {
+            &self.cfg
+        }
+
+        /// Returns the seed bound to this simulator.
+        pub fn seed(&self) -> Seed {
+            self.cfg.seed
+        }
+
+        /// Returns the most recent observed tick.
+        ///
+        /// Today this is always `0` — the run loop in #716 is what
+        /// advances it. Exposed now so downstream code (replay
+        /// binary, panic hook) can refer to a stable accessor.
+        pub fn current_tick(&self) -> u64 {
+            self.current_tick.load(Ordering::SeqCst)
+        }
+    }
+
+    /// Process-global cell for the most recent simulator tick.
+    ///
+    /// The panic hook reads this directly so even a panic that fires
+    /// off-thread, after the owning `Simulator` has been moved, can
+    /// still surface `tick=<N>` in the message. Initialised lazily on
+    /// first call to `Simulator::with_seed` or `install_panic_hook`.
+    fn current_tick_cell() -> &'static AtomicU64 {
+        static CELL: OnceLock<AtomicU64> = OnceLock::new();
+        CELL.get_or_init(|| AtomicU64::new(0))
+    }
+
+    /// Process-global cell for the simulator seed observed by the
+    /// panic hook. Stored separately from `Simulator` so the hook can
+    /// run after a panicking thread has already unwound the owning
+    /// struct.
+    fn current_seed_cell() -> &'static AtomicU64 {
+        static CELL: OnceLock<AtomicU64> = OnceLock::new();
+        CELL.get_or_init(|| AtomicU64::new(0))
+    }
+
+    /// `true` once `install_panic_hook` has chained a previous hook.
+    /// Used to keep installation idempotent across multiple
+    /// `Simulator::with_seed` calls within the same process (e.g.
+    /// `cargo test` running several seeds back-to-back inside one
+    /// test binary).
+    fn hook_installed_cell() -> &'static std::sync::atomic::AtomicBool {
+        static CELL: OnceLock<std::sync::atomic::AtomicBool> = OnceLock::new();
+        CELL.get_or_init(|| std::sync::atomic::AtomicBool::new(false))
+    }
+
+    /// Install the simulator's panic hook.
+    ///
+    /// On panic, the hook prints
+    ///
+    /// ```text
+    /// SIMULATOR PANIC seed=<u64> tick=<u64>
+    /// ```
+    ///
+    /// to stderr (the `VIBIX_SIM_SEED=` annotation form lands in #717
+    /// once the trace path is plumbed; today the simpler diagnostic is
+    /// what issue #715 asks for) and then re-raises by chaining to the
+    /// previously-installed hook so the standard panic message and
+    /// backtrace still appear and the process still aborts under
+    /// `panic = "abort"`.
+    ///
+    /// Idempotent: repeated calls update the recorded seed but leave a
+    /// single hook installed. This matches RFC 0006's "last installer
+    /// wins" rule and keeps the hook stack from growing unboundedly
+    /// inside a `cargo test` run that constructs many `Simulator`
+    /// instances.
+    pub fn install_panic_hook(seed: Seed) {
+        // Always update the seed cell — tests that swap seeds expect
+        // the hook to surface the *current* seed, not the first one.
+        current_seed_cell().store(seed.as_u64(), Ordering::SeqCst);
+
+        // Only chain a hook once; subsequent calls are no-ops beyond
+        // updating the seed cell above.
+        if hook_installed_cell()
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return;
+        }
+
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            let seed = current_seed_cell().load(Ordering::SeqCst);
+            let tick = current_tick_cell().load(Ordering::SeqCst);
+            // Use `eprintln!` so the diagnostic shows up on the same
+            // stream as the standard panic message that the chained
+            // `prev` hook will print next; downstream tooling greps
+            // stderr for the `SIMULATOR PANIC` prefix.
+            eprintln!("SIMULATOR PANIC seed={seed} tick={tick}");
+            prev(info);
+        }));
+    }
+
+    /// **Test-only.** Set the recorded tick value directly.
+    ///
+    /// Used by the unit tests in this crate to verify the panic hook
+    /// surfaces the right `tick=<N>` annotation. Not exposed to
+    /// production code paths — the run loop in #716 owns tick
+    /// advancement via `Simulator::run`.
+    #[cfg(test)]
+    pub(crate) fn test_only_set_tick(tick: u64) {
+        current_tick_cell().store(tick, Ordering::SeqCst);
+    }
+}
+
+#[cfg(not(target_os = "none"))]
+pub use imp::{install_panic_hook, Seed, Simulator, SimulatorConfig, Trace};
+
+// On `target_os = "none"` (the bare-metal kernel image), the simulator
+// crate has no public surface — the `vibix` dependency is gated out
+// in Cargo.toml and there is no `std`. In practice the workspace
+// never builds this crate for that target, but keeping the module
+// empty here makes the gate explicit at the source level.
+#[cfg(target_os = "none")]
+mod imp {}
+
+#[cfg(all(test, not(target_os = "none")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seed_round_trips_through_simulator() {
+        let sim = Simulator::with_seed(0xDEAD_BEEF);
+        assert_eq!(sim.seed(), Seed(0xDEAD_BEEF));
+        assert_eq!(sim.config().seed.as_u64(), 0xDEAD_BEEF);
+    }
+
+    #[test]
+    fn current_tick_starts_at_zero() {
+        let sim = Simulator::with_seed(0);
+        assert_eq!(sim.current_tick(), 0);
+    }
+
+    #[test]
+    fn trace_default_is_empty() {
+        // Today `Trace` is empty by construction. This test exists so
+        // that the schema-bearing PR (#717) has to update an
+        // assertion when it adds real fields, surfacing the change in
+        // review.
+        let _t = Trace::new();
+        let _t2 = Trace::default();
+    }
+
+    #[test]
+    fn install_panic_hook_is_idempotent() {
+        // Multiple installs must not stack hooks. We can't observe
+        // the hook stack directly, but we can at least verify the
+        // function is callable repeatedly with different seeds
+        // without panicking or deadlocking.
+        install_panic_hook(Seed(1));
+        install_panic_hook(Seed(2));
+        install_panic_hook(Seed(3));
+    }
+
+    #[test]
+    fn panic_hook_records_latest_seed() {
+        // The hook always reports the *current* seed, not the first
+        // one installed. The hook chaining is exercised end-to-end
+        // by manual repro; this test pins the seed-cell behaviour.
+        install_panic_hook(Seed(0xAAAA));
+        install_panic_hook(Seed(0xBBBB));
+        // Construct a simulator after — `with_seed` updates the cell
+        // again, mirroring the real failing-seed-to-repro flow.
+        let sim = Simulator::with_seed(0xCCCC);
+        assert_eq!(sim.seed().as_u64(), 0xCCCC);
+    }
+
+    #[test]
+    fn test_hook_can_set_tick() {
+        let sim = Simulator::with_seed(7);
+        super::imp::test_only_set_tick(42);
+        assert_eq!(sim.current_tick(), 42);
+    }
+}

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -261,9 +261,30 @@ mod imp {}
 #[cfg(all(test, not(target_os = "none")))]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    /// Serialize tests that touch the process-global panic hook,
+    /// seed cell, and tick cell.
+    ///
+    /// Cargo runs tests in this binary on multiple threads by
+    /// default, but every test below mutates state shared by
+    /// `Simulator::with_seed`, `install_panic_hook`, and
+    /// `test_only_set_tick`. Without this guard, e.g.
+    /// `current_tick_starts_at_zero` and `test_hook_can_set_tick`
+    /// race on the tick cell and fail nondeterministically. The
+    /// guard ignores poisoning so a panic in one test does not
+    /// permanently lock out the rest of the suite.
+    fn serial_test_guard() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        match LOCK.get_or_init(|| Mutex::new(())).lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
 
     #[test]
     fn seed_round_trips_through_simulator() {
+        let _guard = serial_test_guard();
         let sim = Simulator::with_seed(0xDEAD_BEEF);
         assert_eq!(sim.seed(), Seed(0xDEAD_BEEF));
         assert_eq!(sim.config().seed.as_u64(), 0xDEAD_BEEF);
@@ -271,12 +292,17 @@ mod tests {
 
     #[test]
     fn current_tick_starts_at_zero() {
+        let _guard = serial_test_guard();
         let sim = Simulator::with_seed(0);
         assert_eq!(sim.current_tick(), 0);
     }
 
     #[test]
     fn trace_default_is_empty() {
+        // No global state touched, but the suite is small enough
+        // that taking the guard unconditionally keeps reasoning
+        // simple as future tests are added.
+        let _guard = serial_test_guard();
         // Today `Trace` is empty by construction. This test exists so
         // that the schema-bearing PR (#717) has to update an
         // assertion when it adds real fields, surfacing the change in
@@ -287,6 +313,7 @@ mod tests {
 
     #[test]
     fn install_panic_hook_is_idempotent() {
+        let _guard = serial_test_guard();
         // Multiple installs must not stack hooks. We can't observe
         // the hook stack directly, but we can at least verify the
         // function is callable repeatedly with different seeds
@@ -298,6 +325,7 @@ mod tests {
 
     #[test]
     fn panic_hook_records_latest_seed() {
+        let _guard = serial_test_guard();
         // The hook always reports the *current* seed, not the first
         // one installed. The hook chaining is exercised end-to-end
         // by manual repro; this test pins the seed-cell behaviour.
@@ -311,6 +339,7 @@ mod tests {
 
     #[test]
     fn test_hook_can_set_tick() {
+        let _guard = serial_test_guard();
         let sim = Simulator::with_seed(7);
         super::imp::test_only_set_tick(42);
         assert_eq!(sim.current_tick(), 42);


### PR DESCRIPTION
Closes #715.

## Summary

Adds the host-only `simulator/` crate from RFC 0006 (PR #712) as the workspace anchor for DST Phase 2. Empty-by-design: every follow-up (#716 run loop, #717 trace, #718 macro, #722 invariants, #723 CI sweep) lands on this scaffolding without re-litigating workspace plumbing or panic-hook wiring.

* New workspace member `simulator/` depends on `vibix` with `features = ["sched-mock"]`, gated on `cfg(not(target_os = "none"))` so the bare-metal kernel-image build can never pull it in.
* `simulator/src/lib.rs` exposes the public stubs RFC 0006 commits to: `Simulator`, `SimulatorConfig`, `Seed`, `Trace`.
* `Simulator::with_seed(u64)` installs an idempotent process-global panic hook that prints `SIMULATOR PANIC seed=<u64> tick=<u64>` to stderr, then chains to the previously-installed hook so the standard panic message and backtrace still appear. The richer `VIBIX_SIM_SEED=…` form lands in #717 once `Trace` carries a real path.
* `simulator/src/bin/replay.rs` is the committed CLI shape (`--seed <u64> [--trace-out <path>]`); accepts decimal, `0x`-hex, and underscored seed forms, prints `unimplemented`, exits 0. CLI errors exit 2 so future tooling can distinguish caller mistakes from simulator failures (exit 1, reserved for #716).

## Notes for reviewers

* The kernel crate name is `vibix` (matching the `host build (sched-mock)` job from #714, which already builds `cargo build -p vibix --lib --target x86_64-unknown-linux-gnu --features sched-mock`). The simulator's Cargo dep names `vibix` accordingly.
* Workspace `clippy.toml` already forbids `std::collections::HashMap`/`HashSet`, and `rust-toolchain.toml` pins `nightly-2026-04-16` — both inherited from #714, no changes needed.
* `#![warn(missing_docs)]` on the lib so future PRs can't add un-documented public fields silently.

## Test plan

- [x] `cargo build -p simulator` succeeds on host.
- [x] `cargo test -p simulator --no-run` succeeds (issue acceptance criterion).
- [x] `cargo test -p simulator` — 17 tests pass (6 lib + 11 replay CLI).
- [x] `cargo run -p simulator --bin replay -- --seed 0xDEAD_BEEF --trace-out /tmp/foo.json` exits 0 and prints `replay: unimplemented (seed=0xdeadbeef, trace_out=/tmp/foo.json)`.
- [x] `cargo build -p vibix --lib --target x86_64-unknown-linux-gnu --features sched-mock` still succeeds (predecessor #714's CI job).
- [x] `cargo xtask build` — kernel image still builds for `x86_64-unknown-none`; simulator crate is invisible to the bare-metal target.
- [x] `cargo fmt --all -- --check` clean.