### PR TITLE
arch/x86_64: STI/CLI bracket the page-fault slow path (#735)

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -142,6 +142,16 @@ extern "x86-interrupt" fn page_fault(mut frame: InterruptStackFrame, code: PageF
     if crate::cpu::has(crate::cpu::Feature::Smap) {
         unsafe { core::arch::asm!("clac", options(nomem, nostack)) };
     }
+    // RFC 0007 §Page-fault IRQ discipline, step 1: sample CR2 into a
+    // kernel-stack local **before** any path that could re-enable
+    // interrupts. A nested fault that fires after `sti` will overwrite
+    // CR2 in hardware; once we have `addr_u64` on our stack the value is
+    // safe across re-entry. The error `code` parameter is already a
+    // hardware-pushed local, so it survives the same way. The pure-logic
+    // gates below (SMAP, RSVD, canonical, prot) all run with IRQs still
+    // disabled (interrupt gate) — they don't block — and the verdict
+    // they produce is the safe seam at which to reopen interrupts before
+    // entering the `VmObject::fault` slow path.
     let addr_u64 = x86_64::registers::control::Cr2::read_raw();
 
     // Defer `log_first_ring3_fault` to the terminal paths below. A
@@ -247,7 +257,29 @@ extern "x86-interrupt" fn page_fault(mut frame: InterruptStackFrame, code: PageF
             } else {
                 Access::Read
             };
-            match object.fault(offset, access) {
+            // RFC 0007 §Page-fault IRQ discipline steps 2–4: with the
+            // pure-logic verdict already produced under IF=0, reopen
+            // interrupts before entering the `VmObject::fault` slow
+            // path. `obj.fault` can take a `BlockingMutex` (every
+            // `FileObject::fault` does) and would deadlock against any
+            // task already holding the same mutex if we left IRQs
+            // disabled. Disable them again before the PTE install +
+            // TLB flush below so IRET returns to the faulter with a
+            // coherent IF=1 / IF=0 state per the saved RFLAGS.
+            //
+            // SAFETY: `sti` only sets IF in RFLAGS; the page-fault
+            // gate is an interrupt gate (the `x86_64` crate's
+            // `set_handler_fn` default), so IF was hardware-cleared on
+            // entry and the saved `frame.cpu_flags` retains the
+            // pre-fault value untouched.
+            unsafe { core::arch::asm!("sti", options(nomem, nostack, preserves_flags)) };
+            let fault_res = object.fault(offset, access);
+            // SAFETY: `cli` only clears IF. We re-disable before the
+            // PTE install below so the page-table mutator sees a
+            // coherent ring-0/IF=0 environment matching the rest of
+            // the kernel paging layer.
+            unsafe { core::arch::asm!("cli", options(nomem, nostack, preserves_flags)) };
+            match fault_res {
                 Ok(phys) => {
                     let frame = PhysFrame::from_start_address(PhysAddr::new(phys))
                         .expect("#PF: VmObject returned unaligned phys");
@@ -276,7 +308,17 @@ extern "x86-interrupt" fn page_fault(mut frame: InterruptStackFrame, code: PageF
             // frame the PTE currently points at — the right source in
             // every generation of a nested fork, and robust to the
             // child VMA having an empty `clone_private()` cache.
-            match crate::mem::paging::cow_copy_and_remap(active, page, pte_flags) {
+            //
+            // RFC 0007 §Page-fault IRQ discipline: `cow_copy_and_remap`
+            // allocates a fresh frame and memcpys 4 KiB — both can
+            // contend on the frame allocator's `BlockingMutex`. STI
+            // before, CLI after, same as the demand-fault path above.
+            //
+            // SAFETY: see the demand-fault arm.
+            unsafe { core::arch::asm!("sti", options(nomem, nostack, preserves_flags)) };
+            let cow_res = crate::mem::paging::cow_copy_and_remap(active, page, pte_flags);
+            unsafe { core::arch::asm!("cli", options(nomem, nostack, preserves_flags)) };
+            match cow_res {
                 Ok(_) => return,
                 Err(e) => serial_println!(
                     "#PF CoW copy-and-remap failed addr={:#x}: {:?}",
@@ -305,7 +347,16 @@ extern "x86-interrupt" fn page_fault(mut frame: InterruptStackFrame, code: PageF
             .expect("#PF growsdown: new_vma_start not page-aligned");
         let active = x86_64::registers::control::Cr3::read().0;
         let pte_flags = PageTableFlags::from_bits_truncate(prot_pte);
-        match object.fault(offset, Access::Write) {
+        // RFC 0007 §Page-fault IRQ discipline: same STI/CLI bracket as
+        // the demand-fault arm above — `obj.fault` here is the
+        // growsdown stack page's filler and may block on the frame
+        // allocator's `BlockingMutex`.
+        //
+        // SAFETY: see the demand-fault arm.
+        unsafe { core::arch::asm!("sti", options(nomem, nostack, preserves_flags)) };
+        let fault_res = object.fault(offset, Access::Write);
+        unsafe { core::arch::asm!("cli", options(nomem, nostack, preserves_flags)) };
+        match fault_res {
             Ok(phys) => {
                 let frame = PhysFrame::from_start_address(PhysAddr::new(phys))
                     .expect("#PF growsdown: VmObject returned unaligned phys");

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -272,13 +272,13 @@ extern "x86-interrupt" fn page_fault(mut frame: InterruptStackFrame, code: PageF
             // `set_handler_fn` default), so IF was hardware-cleared on
             // entry and the saved `frame.cpu_flags` retains the
             // pre-fault value untouched.
-            unsafe { core::arch::asm!("sti", options(nomem, nostack, preserves_flags)) };
+            unsafe { core::arch::asm!("sti", options(nomem, nostack)) };
             let fault_res = object.fault(offset, access);
             // SAFETY: `cli` only clears IF. We re-disable before the
             // PTE install below so the page-table mutator sees a
             // coherent ring-0/IF=0 environment matching the rest of
             // the kernel paging layer.
-            unsafe { core::arch::asm!("cli", options(nomem, nostack, preserves_flags)) };
+            unsafe { core::arch::asm!("cli", options(nomem, nostack)) };
             match fault_res {
                 Ok(phys) => {
                     let frame = PhysFrame::from_start_address(PhysAddr::new(phys))
@@ -315,9 +315,9 @@ extern "x86-interrupt" fn page_fault(mut frame: InterruptStackFrame, code: PageF
             // before, CLI after, same as the demand-fault path above.
             //
             // SAFETY: see the demand-fault arm.
-            unsafe { core::arch::asm!("sti", options(nomem, nostack, preserves_flags)) };
+            unsafe { core::arch::asm!("sti", options(nomem, nostack)) };
             let cow_res = crate::mem::paging::cow_copy_and_remap(active, page, pte_flags);
-            unsafe { core::arch::asm!("cli", options(nomem, nostack, preserves_flags)) };
+            unsafe { core::arch::asm!("cli", options(nomem, nostack)) };
             match cow_res {
                 Ok(_) => return,
                 Err(e) => serial_println!(
@@ -353,9 +353,9 @@ extern "x86-interrupt" fn page_fault(mut frame: InterruptStackFrame, code: PageF
         // allocator's `BlockingMutex`.
         //
         // SAFETY: see the demand-fault arm.
-        unsafe { core::arch::asm!("sti", options(nomem, nostack, preserves_flags)) };
+        unsafe { core::arch::asm!("sti", options(nomem, nostack)) };
         let fault_res = object.fault(offset, Access::Write);
-        unsafe { core::arch::asm!("cli", options(nomem, nostack, preserves_flags)) };
+        unsafe { core::arch::asm!("cli", options(nomem, nostack)) };
         match fault_res {
             Ok(phys) => {
                 let frame = PhysFrame::from_start_address(PhysAddr::new(phys))

--- a/kernel/src/mem/pf.rs
+++ b/kernel/src/mem/pf.rs
@@ -19,6 +19,34 @@
 //! follow-ups (#159 and #160) because they need task/addrspace state
 //! that isn't reachable from pure logic.
 //!
+//! ### IRQ discipline (RFC 0007 §Page-fault IRQ discipline)
+//!
+//! The page-fault gate is an **interrupt** gate (the `x86_64` crate's
+//! `set_handler_fn` default), so IF is hardware-cleared on entry. The
+//! handler in `idt::page_fault` keeps that ordering load-bearing:
+//!
+//! * CR2 is sampled into a kernel-stack local **before** any code path
+//!   that could `sti`. A nested fault after `sti` would clobber the
+//!   hardware CR2; the local survives because the kernel stack is
+//!   distinct from the faulter's frame state.
+//! * Steps 1, 3, 4, 6 above (the gates this module owns) are pure
+//!   logic and run with IRQs still disabled. The verdict they produce
+//!   is the *safe seam* at which to reopen interrupts.
+//! * Immediately before any `VmObject::fault` / `cow_copy_and_remap`
+//!   call (step 7's slow path), the handler issues `sti` so the
+//!   slow path may freely take a `BlockingMutex` and park. Without
+//!   this, the first `BlockingMutex::lock` against contention would
+//!   deadlock the CPU — there is no preemption to land the wake.
+//! * `cli` fires again immediately on return from the slow path,
+//!   before the PTE install + TLB flush + IRET. The page-table
+//!   mutator and the IRETQ frame restoration both expect IF=0 inside
+//!   the handler proper.
+//!
+//! Pre-`sti` work (the gates) and post-`cli` work (the PTE install)
+//! never block; the only window where the handler is preemptible is
+//! the bracketed slow path, which is exactly the window the RFC's
+//! design demands.
+//!
 //! Security note on the panic paths: both `panic_smap_violation` and
 //! `panic_rsvd_corruption` must **log the faulting VA only**, never the
 //! PTE word or the frame's physaddr. A reserved-bit fault often means


### PR DESCRIPTION
## Summary

Closes #735. Reworks the `arch::x86_64::idt::page_fault` handler so the slow path runs with IRQs enabled, per RFC 0007 §Page-fault IRQ discipline. This is the first sequenced step of Workstream A — every other wave-1 issue (file-backed `mmap`, page cache, etc.) takes a `BlockingMutex` somewhere in its `FileObject::fault` slow path and would deadlock the first time it's contended without this change.

- CR2 is sampled into a kernel-stack local **before** any path that could `sti`. A nested fault after `sti` would clobber the hardware CR2; the local survives.
- The pure-logic gates (SMAP, RSVD, canonical, `prot_user`) continue to run with IRQs disabled — they don't block.
- Each slow-path call (`VmObject::fault` / `cow_copy_and_remap`, in both the in-VMA arm and the growsdown arm) is bracketed `sti` → call → `cli` so it runs preemptible. `cli` fires before the PTE install + TLB flush so the page-table mutator sees IF=0 like the rest of the paging layer.
- Page-fault gate stays an *interrupt* gate (the `x86_64` crate's `set_handler_fn` default) — STI placement is fully under our control.
- `mem::pf` module doc-comment now documents the IRQ ordering alongside the existing gate-order checklist.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo xtask build` clean (one pre-existing `dead_code` warning on `task::Task::is_guard_hit`)
- [x] `cargo xtask test` green — host unit tests, in-kernel QEMU integration tests including `demand_paging`, `cow_vma`, `fork_cow`, `page_fault` (which collectively exercise both bracketed arms)
- [x] `cargo xtask smoke` green — all 42 markers present
- [ ] CI: fmt+build, host unit tests, integration tests QEMU, smoke, pjdfstest, ext2 rootfs determinism, RFC 0004 vfs_creds gate, CodeRabbit review