### PR TITLE
simulator: full Event enum + JSON dump + Trace::diff (#717)

### DIFF
--- a/simulator/docs/trace-schema.md
+++ b/simulator/docs/trace-schema.md
@@ -212,7 +212,7 @@ The parser in `simulator::trace::Trace::from_json` enforces:
 
 For every trace `T`:
 
-```
+```rust
 let json = T.to_json_string();
 let T2 = Trace::from_json(&json).unwrap();
 assert_eq!(T.records(), T2.records());

--- a/simulator/docs/trace-schema.md
+++ b/simulator/docs/trace-schema.md
@@ -1,0 +1,237 @@
+# Simulator trace JSON schema
+
+This document is the stable contract for the JSON output of
+`simulator::Trace::to_json` (RFC 0006, issue #717). Downstream
+consumers — the future `replay` binary, CI artefact viewers,
+property-test harnesses written against frozen failing seeds, and the
+`auto-engineer` review tooling — parse against this schema. **Adding,
+removing, or renaming any variant or field below is a `schema_version`
+bump**, and a bump is a breaking change for those consumers.
+
+## Top-level shape
+
+```json
+{
+  "schema_version": 1,
+  "records": [
+    { "tick": 0, "event": { "type": "tick_advance", "from": 0, "to": 1 } }
+  ]
+}
+```
+
+- `schema_version` is the integer version of this schema. The current
+  version is **1**. The parser refuses to deserialize an object whose
+  `schema_version` does not match the version it was compiled against.
+- `records` is a JSON array of `(tick, event)` pairs in emission order.
+  Emission order is the order the simulator's run loop produced them
+  on the recording thread. Reorder is not legal.
+
+## Record shape
+
+Every record is a JSON object with exactly two fields, in this order:
+
+| field   | type     | meaning                                                |
+| ------- | -------- | ------------------------------------------------------ |
+| `tick`  | `u64`    | Value of `MockClock::now()` when the event was emitted |
+| `event` | `object` | The event itself (variant tag in `type`)               |
+
+Field ordering inside every object is fixed (`tick` then `event`); the
+encoder emits no whitespace beyond a single space after each `:` and
+`,`. This is what makes the round-trip property
+*record → JSON → parse → re-record → byte-identical JSON* hold.
+
+## Event variants
+
+All events use a discriminator-tag layout — a `type` field whose
+string value selects the variant — and a fixed field order matching
+the corresponding Rust enum variant declaration order in
+`simulator::trace::Event`.
+
+### `tick_advance`
+
+The mock clock advanced by one tick. Emitted before any wakeups for
+the destination tick are drained, so a reader can correlate the new
+`now` value with the wakeup list that follows.
+
+```json
+{ "type": "tick_advance", "from": 0, "to": 1 }
+```
+
+| field  | type  | meaning                          |
+| ------ | ----- | -------------------------------- |
+| `from` | `u64` | Tick value before the advance.   |
+| `to`   | `u64` | Tick value after the advance.    |
+
+### `timer_injected`
+
+A virtual timer IRQ was injected by the simulator. Distinct from
+`fault_injected` — that variant covers FaultPlan-driven IRQs and
+faults landed by future #722 work.
+
+```json
+{ "type": "timer_injected" }
+```
+
+No payload fields.
+
+### `timer_irq_acked`
+
+The simulator acked the just-injected timer IRQ via the
+`TimerIrq::ack_timer` seam method.
+
+```json
+{ "type": "timer_irq_acked" }
+```
+
+No payload fields.
+
+### `wakeup_enqueued`
+
+A wakeup was enqueued for `deadline`, naming task `id`. **Snapshot-
+derived in v1**: the simulator does not synthesize `enqueue_wakeup`
+calls, so this variant is currently never emitted by the live run
+loop. Defined here so consumers parsing a trace from a future kernel
+build (after #718's `sched_mock_trace!` macro lands the enqueue emit
+point) can already speak the schema.
+
+```json
+{ "type": "wakeup_enqueued", "deadline": 12, "id": 7 }
+```
+
+| field      | type  | meaning                                            |
+| ---------- | ----- | -------------------------------------------------- |
+| `deadline` | `u64` | Tick at which the wakeup is scheduled to fire.     |
+| `id`       | `u64` | Task id whose wakeup was enqueued.                 |
+
+### `wakeup_fired`
+
+A task became runnable because its deadline expired and the seam
+returned its id from `drain_expired`. One event per drained id, in
+the order the seam returned them.
+
+```json
+{ "type": "wakeup_fired", "id": 7 }
+```
+
+| field | type  | meaning                          |
+| ----- | ----- | -------------------------------- |
+| `id`  | `u64` | Task id whose deadline fired.    |
+
+### `task_scheduled`
+
+A task was scheduled onto a CPU (one event per dispatch). Populated
+by #718's emit point on the scheduler dispatch path; not yet emitted
+by the live run loop.
+
+```json
+{ "type": "task_scheduled", "id": 7 }
+```
+
+| field | type  | meaning                          |
+| ----- | ----- | -------------------------------- |
+| `id`  | `u64` | Task id that was scheduled.      |
+
+### `task_blocked`
+
+A task entered the blocked state. Populated by #718's emit point on
+`sleep_ms` / `wait_event` / I/O block paths; not yet emitted by the
+live run loop.
+
+```json
+{ "type": "task_blocked", "id": 7, "reason": "sleep" }
+```
+
+| field    | type     | meaning                                       |
+| -------- | -------- | --------------------------------------------- |
+| `id`     | `u64`    | Task id that blocked.                         |
+| `reason` | `string` | One of `sleep`, `wait`, `io`, `other`.        |
+
+### `syscall`
+
+A syscall was entered. Populated by #718's emit point at the syscall
+handler entry. `args` carries up to four register-passed argument
+words — the SysV AMD64 syscall ABI uses six, but four covers every
+syscall modeled by the v1 invariant set; truncating here keeps the
+JSON small without losing information for the v1 flake catalogue.
+
+```json
+{ "type": "syscall", "nr": 60, "args": [1, 2, 3, 4] }
+```
+
+| field  | type        | meaning                                                  |
+| ------ | ----------- | -------------------------------------------------------- |
+| `nr`   | `u64`       | Syscall number (Linux-compatible numbering on x86_64).   |
+| `args` | `[u64; 4]`  | First four argument registers, exactly four entries.     |
+
+### `fault`
+
+A CPU exception fired in user or kernel context. Populated by #718's
+exception-trampoline emit point. `cr2` is only meaningful for
+`page_fault`; carry zero for the others.
+
+```json
+{ "type": "fault", "kind": "page_fault", "rip": 4198400, "cr2": 32 }
+```
+
+| field  | type     | meaning                                                              |
+| ------ | -------- | -------------------------------------------------------------------- |
+| `kind` | `string` | One of `page_fault`, `general_protection`, `invalid_opcode`, `double_fault`, `other`. |
+| `rip`  | `u64`    | Faulting instruction pointer.                                        |
+| `cr2`  | `u64`    | Page-fault address (zero for non-page-fault kinds).                  |
+
+### `fault_injected`
+
+The simulator's FaultPlan injected a fault before the kernel observed
+it. Distinct from `fault` so invariant checkers can correlate "we
+asked for a fault" with "the kernel saw a fault." Populated by #722's
+FaultPlan landing.
+
+```json
+{ "type": "fault_injected", "kind": "page_fault" }
+```
+
+| field  | type     | meaning                                              |
+| ------ | -------- | ---------------------------------------------------- |
+| `kind` | `string` | Same enum as `fault.kind`.                           |
+
+## Parser strictness
+
+The parser in `simulator::trace::Trace::from_json` enforces:
+
+1. Exact `schema_version` match. Mismatch → `Err`.
+2. Closed enum sets for `task_blocked.reason`, `fault.kind`, and
+   `fault_injected.kind`. Unknown strings → `Err`.
+3. Closed `event.type` set. Unknown event types → `Err`.
+4. No string escapes (no `\n`, `\u0041`, etc.). The encoder never
+   emits them; accepting them in the parser would mean two distinct
+   strings could decode to the same `BlockReason` / `FaultKind`,
+   breaking the byte-equality property of the round-trip test.
+5. No trailing bytes after the closing `}`.
+
+## Round-trip property
+
+For every trace `T`:
+
+```
+let json = T.to_json_string();
+let T2 = Trace::from_json(&json).unwrap();
+assert_eq!(T.records(), T2.records());
+assert_eq!(json, T2.to_json_string());
+```
+
+The simulator's CI gates on this property over a 200-tick smoke run
+that exercises every variant currently emitted by the run loop, plus a
+unit-test trace that exercises every variant in the schema. Variants
+that are not yet emitted (`wakeup_enqueued`, `task_scheduled`,
+`task_blocked`, `syscall`, `fault`, `fault_injected`) ride the
+unit-test path until #718 / #722 wires them into the live run loop.
+
+## Capacity bound
+
+A trace constructed with `Trace::with_capacity_limit(N)` evicts its
+oldest record once it holds `N` records, and emits a one-shot stderr
+warning the first time eviction fires. The on-wire JSON does not
+record the eviction event — a parsed trace is always unbounded, by
+design: the use case for `from_json` is round-trip equivalence and the
+future `replay` binary, neither of which want eviction firing on
+parse.

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -75,15 +75,19 @@
 #![deny(clippy::disallowed_types)]
 
 #[cfg(not(target_os = "none"))]
+pub mod trace;
+
+#[cfg(not(target_os = "none"))]
 mod imp {
     use core::sync::atomic::{AtomicU64, Ordering};
     use std::sync::OnceLock;
-    use std::vec::Vec;
 
     use rand_chacha::ChaCha8Rng;
     use rand_core::SeedableRng;
 
-    use vibix::task::env::{install_sim_env, Clock, MockClock, MockTimerIrq, TaskId};
+    use vibix::task::env::{install_sim_env, Clock, MockClock, MockTimerIrq};
+
+    pub use crate::trace::{BlockReason, Event, FaultKind, Trace, TraceRecord, SCHEMA_VERSION};
 
     /// A simulator seed.
     ///
@@ -150,99 +154,6 @@ mod imp {
     impl Default for SimulatorConfig {
         fn default() -> Self {
             Self::with_seed(0)
-        }
-    }
-
-    /// One observable transition recorded by the simulator.
-    ///
-    /// Today the schema is the minimal set the run loop emits:
-    /// `ClockAdvanced` / `TimerInjected` / `TaskWoken` / `TimerAcked`.
-    /// Issue #717 (`(Tick, Event)` recorder + JSON dump) extends this
-    /// with the full RFC 0006 §"State-machine model interface" event
-    /// set; keeping the variants small and additive here means the
-    /// determinism-equality assertions in the smoke test do not have
-    /// to be revisited every time the schema grows a field.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-    pub enum Event {
-        /// The mock clock advanced from `from` to `to`. Emitted before
-        /// any wakeups for the destination tick are drained so a
-        /// reader can correlate the new `now` value with the wakeup
-        /// list that follows.
-        ClockAdvanced {
-            /// Tick value before the advance.
-            from: u64,
-            /// Tick value after the advance.
-            to: u64,
-        },
-        /// A virtual timer IRQ was injected by the simulator.
-        TimerInjected,
-        /// The simulator acked the just-injected IRQ via the
-        /// [`TimerIrq::ack_timer`] seam method.
-        TimerAcked,
-        /// A task became runnable because its sleep deadline was at or
-        /// before the new tick.
-        ///
-        /// On host the simulator does not own a real ready bank; it
-        /// records the woken id so the trace and downstream invariant
-        /// checkers (#722) can correlate enqueues with wakeups.
-        TaskWoken {
-            /// Task id whose deadline expired.
-            id: TaskId,
-        },
-    }
-
-    /// One `(tick, event)` row in the trace stream.
-    ///
-    /// `tick` is the value of [`MockClock::now`] *at the time the
-    /// event was emitted*, not when it was scheduled. For
-    /// `ClockAdvanced` the recorded tick is `to`; for
-    /// `TimerInjected`/`TimerAcked`/`TaskWoken` it is `now()` after the
-    /// owning `step` call has advanced the clock.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-    pub struct TraceRecord {
-        /// Tick at which this record was emitted.
-        pub tick: u64,
-        /// The transition itself.
-        pub event: Event,
-    }
-
-    /// A `(Tick, Event)` trace stream emitted by a simulator run.
-    ///
-    /// Today the on-wire shape is the in-memory `Vec<TraceRecord>`
-    /// inside the simulator; #717 wires up `serde::Serialize` and
-    /// JSON-out. We expose only borrowed read accessors so future
-    /// changes to the storage shape (e.g. arena-backed records, or a
-    /// streaming writer) do not break callers.
-    #[derive(Clone, Debug, Default)]
-    pub struct Trace {
-        records: Vec<TraceRecord>,
-    }
-
-    impl Trace {
-        /// Construct an empty trace.
-        pub fn new() -> Self {
-            Self::default()
-        }
-
-        /// Number of records in the trace.
-        pub fn len(&self) -> usize {
-            self.records.len()
-        }
-
-        /// `true` if the trace has no records.
-        pub fn is_empty(&self) -> bool {
-            self.records.is_empty()
-        }
-
-        /// Borrow the records as a slice. Iteration order is the
-        /// emission order, which is also the deterministic order
-        /// imposed by the run loop.
-        pub fn records(&self) -> &[TraceRecord] {
-            &self.records
-        }
-
-        fn push(&mut self, rec: TraceRecord) {
-            self.records.push(rec);
         }
     }
 
@@ -509,7 +420,7 @@ mod imp {
 
             self.trace.push(TraceRecord {
                 tick: now_after,
-                event: Event::ClockAdvanced {
+                event: Event::TickAdvance {
                     from: now_before,
                     to: now_after,
                 },
@@ -530,14 +441,14 @@ mod imp {
             for id in clock.drain_expired(now) {
                 self.trace.push(TraceRecord {
                     tick: now_after,
-                    event: Event::TaskWoken { id },
+                    event: Event::WakeupFired { id },
                 });
             }
 
             irq.ack_timer();
             self.trace.push(TraceRecord {
                 tick: now_after,
-                event: Event::TimerAcked,
+                event: Event::TimerIrqAcked,
             });
         }
 
@@ -675,7 +586,8 @@ mod imp {
 
 #[cfg(not(target_os = "none"))]
 pub use imp::{
-    install_panic_hook, Event, Seed, SimRng, Simulator, SimulatorConfig, Trace, TraceRecord,
+    install_panic_hook, BlockReason, Event, FaultKind, Seed, SimRng, Simulator, SimulatorConfig,
+    Trace, TraceRecord, SCHEMA_VERSION,
 };
 
 // On `target_os = "none"` (the bare-metal kernel image), the simulator
@@ -756,10 +668,10 @@ mod tests {
             assert_eq!(recs.len(), 3);
             assert!(matches!(
                 recs[0].event,
-                Event::ClockAdvanced { from: 0, to: 1 }
+                Event::TickAdvance { from: 0, to: 1 }
             ));
             assert!(matches!(recs[1].event, Event::TimerInjected));
-            assert!(matches!(recs[2].event, Event::TimerAcked));
+            assert!(matches!(recs[2].event, Event::TimerIrqAcked));
             // Every record's tick is the post-advance value.
             for r in recs {
                 assert_eq!(r.tick, 1);
@@ -796,7 +708,7 @@ mod tests {
                 .records()
                 .iter()
                 .filter_map(|r| match r.event {
-                    Event::TaskWoken { id } => Some((r.tick, id)),
+                    Event::WakeupFired { id } => Some((r.tick, id)),
                     _ => None,
                 })
                 .collect();
@@ -904,17 +816,64 @@ mod tests {
         // times, and the 1000-tick run drove the canonical seam shape.
         let wakes_1: usize = a
             .iter()
-            .filter(|r| matches!(r.event, Event::TaskWoken { id: 1 }))
+            .filter(|r| matches!(r.event, Event::WakeupFired { id: 1 }))
             .count();
         let wakes_2: usize = a
             .iter()
-            .filter(|r| matches!(r.event, Event::TaskWoken { id: 2 }))
+            .filter(|r| matches!(r.event, Event::WakeupFired { id: 2 }))
             .count();
         // Task 1 fires at ticks 7, 14, 21, ... up to 994 → 142 wakes.
         // Task 2 fires at ticks 11, 22, 33, ... up to 990 → 90 wakes.
         // Exact counts are part of the determinism contract here.
         assert_eq!(wakes_1, 1000 / 7);
         assert_eq!(wakes_2, 1000 / 11);
+    }
+
+    /// RFC 0006 / issue #717 acceptance: a recorded trace round-trips
+    /// through the stable JSON schema without drift.
+    ///
+    /// Property: `record → JSON → parse → re-record → identical trace`.
+    /// Using the same #716 cooperating-tasks workload as the
+    /// determinism smoke test so the round-trip is tested against a
+    /// non-trivial trace (~1000 records, every variant the run loop
+    /// emits today, including `WakeupFired` for both task ids).
+    #[test]
+    fn smoke_recorded_trace_round_trips_through_json() {
+        on_fresh_thread(|| {
+            let mut sim = Simulator::new(0xC0FF_EE42, SimulatorConfig::with_seed(0xC0FF_EE42));
+            let (clock, _irq) = vibix::task::env::env();
+            let start = clock.now();
+            clock.enqueue_wakeup(start.saturating_add(7), 1);
+            clock.enqueue_wakeup(start.saturating_add(11), 2);
+
+            for _ in 0..200 {
+                sim.step();
+                let now = clock.now();
+                if now.raw() % 7 == 0 {
+                    clock.enqueue_wakeup(now.saturating_add(7), 1);
+                }
+                if now.raw() % 11 == 0 {
+                    clock.enqueue_wakeup(now.saturating_add(11), 2);
+                }
+            }
+
+            let json1 = sim.trace().to_json_string();
+            let parsed = Trace::from_json(&json1).expect("parse round-trip");
+            assert_eq!(
+                sim.trace().records(),
+                parsed.records(),
+                "parsed trace differs from original"
+            );
+            assert_eq!(sim.trace().diff(&parsed), None);
+
+            // Re-serialize the parsed trace and demand byte-identical
+            // JSON. This is the strict round-trip property — any field
+            // ordering drift in the encoder would fail here even if
+            // `records()` happened to compare equal via the
+            // `PartialEq` derive.
+            let json2 = parsed.to_json_string();
+            assert_eq!(json1, json2, "JSON drifted across record→json→parse→record");
+        });
     }
 
     #[test]

--- a/simulator/src/trace.rs
+++ b/simulator/src/trace.rs
@@ -1,0 +1,951 @@
+//! `(Tick, Event)` trace stream — the simulator's primary observable.
+//!
+//! RFC 0006 §"State-machine model interface" calls the `(Tick, Event)`
+//! stream out as the *external* surface every Phase 2 consumer
+//! (`proptest`, `#390`'s stress runner, the `replay` binary, a human
+//! grepping a CI-attached JSON trace) sees. Issue #717 lands the full
+//! [`Event`] enum, the in-memory [`Trace`] container, and the stable
+//! JSON schema (`schema_version = 1`) callers serialize against.
+//!
+//! ## Why a hand-rolled JSON encoder, not `serde_json`
+//!
+//! The simulator crate intentionally pulls *zero* transitive deps that
+//! could reach `getrandom` / OS entropy (RFC 0006 §"Determinism
+//! envelope") — see the `default-features = false` notes on
+//! `rand_chacha` / `rand_core` in `simulator/Cargo.toml`. `serde_json`
+//! itself is determinism-clean, but `serde`'s derive macros routinely
+//! pick up `proc-macro2` / `quote` / `syn` and a default-features churn
+//! during minor bumps that would force this crate onto a moving
+//! transitive-dep target. The trace schema has eight enum variants and
+//! at most three numeric fields per variant — the encoder fits in
+//! ~120 lines, the parser in ~250, and both stay free of any dep that
+//! could later sprout an entropy reader.
+//!
+//! The wire format is a strict subset of RFC 8259 JSON: ASCII-only
+//! field names, integers up to `u64::MAX`, no floats, no arrays of
+//! mixed type, no nested objects beyond `{ tick, event }`. Field
+//! ordering inside every object is fixed and matches the
+//! [`Event`] declaration order so byte-equality is preserved across
+//! `record → JSON → parse → re-record`.
+//!
+//! ## Capacity bound
+//!
+//! Long-running invariant sweeps can drive the trace to millions of
+//! records. RAM is bounded by the [`Trace::with_capacity_limit`]
+//! constructor: once the limit is reached the oldest record is
+//! evicted and a one-shot `eprintln!` warning fires. The default
+//! constructor leaves the trace unbounded — callers that care about
+//! RAM opt in deliberately.
+
+use std::string::{String, ToString};
+
+use vibix::task::env::TaskId;
+
+/// Stable JSON schema version.
+///
+/// Bump when adding, removing, or renaming an [`Event`] variant or
+/// field. Adding a new variant *and* preserving the existing variants'
+/// wire shape is still a bump, because a downstream parser written
+/// against schema_version=1 would now reject the new variant.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Reason a task entered the blocked state.
+///
+/// Wire form: bare ASCII string (e.g. `"sleep"`). The set is
+/// closed — adding a variant is a [`SCHEMA_VERSION`] bump.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum BlockReason {
+    /// Task is waiting for a sleep deadline to expire.
+    Sleep,
+    /// Task is waiting on a wait-queue / synchronization primitive.
+    Wait,
+    /// Task is waiting for I/O completion.
+    Io,
+    /// Reserved for unmodelled or future block reasons.
+    Other,
+}
+
+impl BlockReason {
+    fn as_wire(self) -> &'static str {
+        match self {
+            BlockReason::Sleep => "sleep",
+            BlockReason::Wait => "wait",
+            BlockReason::Io => "io",
+            BlockReason::Other => "other",
+        }
+    }
+
+    fn from_wire(s: &str) -> Option<Self> {
+        match s {
+            "sleep" => Some(BlockReason::Sleep),
+            "wait" => Some(BlockReason::Wait),
+            "io" => Some(BlockReason::Io),
+            "other" => Some(BlockReason::Other),
+            _ => None,
+        }
+    }
+}
+
+/// Kind of fault observed or injected.
+///
+/// Wire form: bare ASCII string. Closed set; adding a variant is a
+/// [`SCHEMA_VERSION`] bump.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FaultKind {
+    /// Page fault (`#PF`).
+    PageFault,
+    /// General-protection fault (`#GP`).
+    GeneralProtection,
+    /// Invalid-opcode fault (`#UD`).
+    InvalidOpcode,
+    /// Double fault (`#DF`).
+    DoubleFault,
+    /// Reserved for unmodelled or future fault kinds.
+    Other,
+}
+
+impl FaultKind {
+    fn as_wire(self) -> &'static str {
+        match self {
+            FaultKind::PageFault => "page_fault",
+            FaultKind::GeneralProtection => "general_protection",
+            FaultKind::InvalidOpcode => "invalid_opcode",
+            FaultKind::DoubleFault => "double_fault",
+            FaultKind::Other => "other",
+        }
+    }
+
+    fn from_wire(s: &str) -> Option<Self> {
+        match s {
+            "page_fault" => Some(FaultKind::PageFault),
+            "general_protection" => Some(FaultKind::GeneralProtection),
+            "invalid_opcode" => Some(FaultKind::InvalidOpcode),
+            "double_fault" => Some(FaultKind::DoubleFault),
+            "other" => Some(FaultKind::Other),
+            _ => None,
+        }
+    }
+}
+
+/// One observable transition recorded by the simulator.
+///
+/// The variant set is the full RFC 0006 §"State-machine model
+/// interface" enum, named per issue #717. Variants split into two
+/// classes by emit point (RFC 0006 §"Event emit points"):
+///
+/// **Driver-loop emitted** (populated today by [`crate::Simulator::step`]):
+/// - [`Event::TickAdvance`] — clock advanced one tick.
+/// - [`Event::TimerIrqAcked`] — virtual timer IRQ ack'd.
+/// - [`Event::WakeupFired`] — a deadline drained; one event per
+///   `(deadline, id)` returned by the seam.
+///
+/// **Snapshot-derived / kernel-emit-required** (defined here, not yet
+/// populated; populated by #718's `sched_mock_trace!` macro and by
+/// future invariant-checker snapshots):
+/// - [`Event::WakeupEnqueued`], [`Event::TaskScheduled`],
+///   [`Event::TaskBlocked`], [`Event::Syscall`], [`Event::Fault`],
+///   [`Event::FaultInjected`].
+///
+/// `#[non_exhaustive]` per RFC 0006 §"Open questions resolution"
+/// (UserSpace-A1): downstream consumers must `match _ =>` so adding a
+/// variant is a non-breaking change at the type level; the JSON
+/// schema_version still bumps.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Event {
+    /// The mock clock advanced from `from` to `to`. Emitted before any
+    /// wakeups for the destination tick are drained so a reader can
+    /// correlate the new `now` value with the wakeup list that
+    /// follows.
+    TickAdvance {
+        /// Tick value before the advance.
+        from: u64,
+        /// Tick value after the advance.
+        to: u64,
+    },
+    /// A virtual timer IRQ was injected by the simulator. Distinct
+    /// from [`Event::FaultInjected`] (which covers FaultPlan-driven
+    /// IRQs and faults landed by future #722 work).
+    TimerInjected,
+    /// The simulator acked the just-injected IRQ via the
+    /// [`vibix::task::env::TimerIrq::ack_timer`] seam method.
+    TimerIrqAcked,
+    /// A wakeup was enqueued for `deadline`, naming task `id`.
+    ///
+    /// Snapshot-derived in v1 (the simulator does not synthesize
+    /// `enqueue_wakeup` calls), populated when #718's
+    /// `sched_mock_trace!` macro lands on the kernel-side enqueue
+    /// path.
+    #[allow(dead_code)]
+    WakeupEnqueued {
+        /// Tick at which the wakeup is scheduled to fire.
+        deadline: u64,
+        /// Task id whose wakeup was enqueued.
+        id: TaskId,
+    },
+    /// A task became runnable because its deadline expired and the
+    /// seam returned its id from `drain_expired`.
+    WakeupFired {
+        /// Task id whose deadline fired.
+        id: TaskId,
+    },
+    /// A task was scheduled onto a CPU (one event per dispatch).
+    ///
+    /// Populated by #718's emit point on the scheduler dispatch path.
+    #[allow(dead_code)]
+    TaskScheduled {
+        /// Task id that was scheduled.
+        id: TaskId,
+    },
+    /// A task entered the blocked state.
+    ///
+    /// Populated by #718's emit point on `sleep_ms` /
+    /// `wait_event` / I/O block paths.
+    #[allow(dead_code)]
+    TaskBlocked {
+        /// Task id that blocked.
+        id: TaskId,
+        /// Reason the task is blocked.
+        reason: BlockReason,
+    },
+    /// A syscall was entered.
+    ///
+    /// Populated by #718's emit point at the syscall handler entry.
+    /// `args` carries up to four register-passed argument words (the
+    /// SysV AMD64 syscall ABI uses six, but four covers every syscall
+    /// modeled by the v1 invariant set; truncating here keeps the
+    /// trace JSON small without losing information for the v1 flake
+    /// catalogue).
+    #[allow(dead_code)]
+    Syscall {
+        /// Syscall number (Linux-compatible numbering on x86_64).
+        nr: u64,
+        /// First four argument registers.
+        args: [u64; 4],
+    },
+    /// A CPU exception fired in user or kernel context.
+    ///
+    /// Populated by #718's exception-trampoline emit point. `cr2` is
+    /// only meaningful for [`FaultKind::PageFault`]; carry zero for
+    /// the others.
+    #[allow(dead_code)]
+    Fault {
+        /// Fault classification.
+        kind: FaultKind,
+        /// Faulting instruction pointer.
+        rip: u64,
+        /// Page-fault address (zero for non-page-fault kinds).
+        cr2: u64,
+    },
+    /// The simulator's FaultPlan injected a fault before the kernel
+    /// observed it. Distinct from [`Event::Fault`] so invariant
+    /// checkers can correlate "we asked for a fault" with "the kernel
+    /// saw a fault." Populated by #722's FaultPlan landing.
+    #[allow(dead_code)]
+    FaultInjected {
+        /// Fault classification injected.
+        kind: FaultKind,
+    },
+}
+
+/// One `(tick, event)` row in the trace stream.
+///
+/// `tick` is the value of `MockClock::now()` *at the time the event
+/// was emitted*. For [`Event::TickAdvance`] the recorded tick is `to`;
+/// for [`Event::TimerInjected`] / [`Event::TimerIrqAcked`] /
+/// [`Event::WakeupFired`] it is `now()` after the owning `step` call
+/// has advanced the clock.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TraceRecord {
+    /// Tick at which this record was emitted.
+    pub tick: u64,
+    /// The transition itself.
+    pub event: Event,
+}
+
+/// A `(Tick, Event)` trace stream emitted by a simulator run.
+///
+/// Storage is a `Vec<TraceRecord>`; iteration order is the emission
+/// order, which is also the deterministic order imposed by the run
+/// loop. Capacity is unbounded by default — opt into eviction via
+/// [`Trace::with_capacity_limit`].
+#[derive(Clone, Debug, Default)]
+pub struct Trace {
+    records: Vec<TraceRecord>,
+    /// `Some(N)` means evict-from-head once `records.len() == N`.
+    /// `None` is unbounded.
+    capacity_limit: Option<usize>,
+    /// One-shot eviction-warning latch. Prevents `eprintln!` spam when
+    /// every push past the cap evicts; the human reader only needs to
+    /// know once per trace that the cap was hit.
+    eviction_warned: bool,
+}
+
+impl Trace {
+    /// Construct an empty unbounded trace.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Construct an empty trace that evicts the oldest record once it
+    /// holds `limit` records. `limit == 0` panics — a zero-cap trace
+    /// is never useful and almost certainly a logic bug at the call
+    /// site.
+    pub fn with_capacity_limit(limit: usize) -> Self {
+        assert!(
+            limit > 0,
+            "Trace::with_capacity_limit: limit must be > 0 (got 0)"
+        );
+        Self {
+            records: Vec::new(),
+            capacity_limit: Some(limit),
+            eviction_warned: false,
+        }
+    }
+
+    /// Number of records in the trace.
+    pub fn len(&self) -> usize {
+        self.records.len()
+    }
+
+    /// `true` if the trace has no records.
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+
+    /// Borrow the records as a slice.
+    pub fn records(&self) -> &[TraceRecord] {
+        &self.records
+    }
+
+    /// Append `rec`. Honours [`Trace::with_capacity_limit`] by
+    /// evicting from the head once the cap is reached.
+    pub(crate) fn push(&mut self, rec: TraceRecord) {
+        if let Some(cap) = self.capacity_limit {
+            if self.records.len() >= cap {
+                // Evict the oldest record. `Vec::remove(0)` is O(n) but
+                // a capacity-bounded trace is opt-in and the warning
+                // below tells the operator to use a larger cap.
+                self.records.remove(0);
+                if !self.eviction_warned {
+                    self.eviction_warned = true;
+                    if !suppress_eviction_warn() {
+                        eprintln!(
+                            "simulator::Trace: capacity limit ({cap}) reached; \
+                             evicting oldest records. The earliest portion of the \
+                             trace is now lost; raise the cap if the head matters."
+                        );
+                    }
+                }
+            }
+        }
+        self.records.push(rec);
+    }
+
+    /// Returns the index of the first record at which `self` and
+    /// `other` differ, or `None` if the two traces are identical.
+    ///
+    /// Used by the round-trip / replay-equivalence assertions: if
+    /// `record → JSON → parse → re-record` ever drifts, `diff` returns
+    /// the exact index to focus debugging on.
+    ///
+    /// Records past the shorter trace's length count as a difference
+    /// at the shorter length.
+    pub fn diff(&self, other: &Trace) -> Option<usize> {
+        let n = self.records.len().min(other.records.len());
+        for i in 0..n {
+            if self.records[i] != other.records[i] {
+                return Some(i);
+            }
+        }
+        if self.records.len() != other.records.len() {
+            Some(n)
+        } else {
+            None
+        }
+    }
+
+    /// Serialize the trace as JSON to `writer`.
+    ///
+    /// The output is a single JSON object with a stable shape:
+    ///
+    /// ```json
+    /// {
+    ///   "schema_version": 1,
+    ///   "records": [
+    ///     {"tick": 1, "event": {"type": "tick_advance", "from": 0, "to": 1}},
+    ///     {"tick": 1, "event": {"type": "timer_injected"}},
+    ///     ...
+    ///   ]
+    /// }
+    /// ```
+    ///
+    /// Field ordering inside every object is fixed (so two equal
+    /// traces produce byte-identical JSON), no whitespace beyond the
+    /// single space after each `:` / `,` is emitted, and only the
+    /// integer / string subset of JSON is used (no floats, no `null`).
+    pub fn to_json(&self, writer: &mut dyn core::fmt::Write) -> core::fmt::Result {
+        write!(
+            writer,
+            "{{\"schema_version\": {SCHEMA_VERSION}, \"records\": ["
+        )?;
+        for (i, rec) in self.records.iter().enumerate() {
+            if i > 0 {
+                writer.write_str(", ")?;
+            }
+            write!(writer, "{{\"tick\": {}, \"event\": ", rec.tick)?;
+            write_event_json(writer, &rec.event)?;
+            writer.write_char('}')?;
+        }
+        writer.write_str("]}")
+    }
+
+    /// Convenience wrapper around [`Trace::to_json`] returning a
+    /// `String`.
+    pub fn to_json_string(&self) -> String {
+        let mut s = String::new();
+        // `String` implements `core::fmt::Write` infallibly.
+        self.to_json(&mut s).expect("String write cannot fail");
+        s
+    }
+
+    /// Parse a JSON string produced by [`Trace::to_json`] back into a
+    /// [`Trace`]. Returns `Err` with a human-readable message on any
+    /// schema or syntax violation.
+    ///
+    /// The capacity limit is *not* preserved across the round-trip:
+    /// parsed traces are unbounded. The use case for `from_json` is
+    /// the round-trip property test and the future `replay` binary,
+    /// neither of which want eviction firing on parse.
+    pub fn from_json(input: &str) -> Result<Self, String> {
+        parse_trace(input)
+    }
+}
+
+// ---------------------------------------------------------------------
+// JSON encoder
+// ---------------------------------------------------------------------
+
+fn write_event_json(w: &mut dyn core::fmt::Write, event: &Event) -> core::fmt::Result {
+    match event {
+        Event::TickAdvance { from, to } => write!(
+            w,
+            "{{\"type\": \"tick_advance\", \"from\": {from}, \"to\": {to}}}"
+        ),
+        Event::TimerInjected => w.write_str("{\"type\": \"timer_injected\"}"),
+        Event::TimerIrqAcked => w.write_str("{\"type\": \"timer_irq_acked\"}"),
+        Event::WakeupEnqueued { deadline, id } => write!(
+            w,
+            "{{\"type\": \"wakeup_enqueued\", \"deadline\": {deadline}, \"id\": {id}}}"
+        ),
+        Event::WakeupFired { id } => {
+            write!(w, "{{\"type\": \"wakeup_fired\", \"id\": {id}}}")
+        }
+        Event::TaskScheduled { id } => {
+            write!(w, "{{\"type\": \"task_scheduled\", \"id\": {id}}}")
+        }
+        Event::TaskBlocked { id, reason } => write!(
+            w,
+            "{{\"type\": \"task_blocked\", \"id\": {id}, \"reason\": \"{}\"}}",
+            reason.as_wire()
+        ),
+        Event::Syscall { nr, args } => write!(
+            w,
+            "{{\"type\": \"syscall\", \"nr\": {nr}, \"args\": [{}, {}, {}, {}]}}",
+            args[0], args[1], args[2], args[3]
+        ),
+        Event::Fault { kind, rip, cr2 } => write!(
+            w,
+            "{{\"type\": \"fault\", \"kind\": \"{}\", \"rip\": {rip}, \"cr2\": {cr2}}}",
+            kind.as_wire()
+        ),
+        Event::FaultInjected { kind } => write!(
+            w,
+            "{{\"type\": \"fault_injected\", \"kind\": \"{}\"}}",
+            kind.as_wire()
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------
+// JSON parser
+//
+// Hand-rolled recursive-descent over the strict subset of JSON the
+// encoder above emits. Errors carry a byte offset so a malformed
+// trace dumped from CI is greppable.
+// ---------------------------------------------------------------------
+
+struct Parser<'a> {
+    input: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Parser<'a> {
+    fn new(input: &'a str) -> Self {
+        Self {
+            input: input.as_bytes(),
+            pos: 0,
+        }
+    }
+
+    fn err(&self, msg: &str) -> String {
+        format!("trace JSON parse error at byte {}: {}", self.pos, msg)
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.input.get(self.pos).copied()
+    }
+
+    fn bump(&mut self) -> Option<u8> {
+        let b = self.peek()?;
+        self.pos += 1;
+        Some(b)
+    }
+
+    fn skip_ws(&mut self) {
+        while let Some(b) = self.peek() {
+            if b == b' ' || b == b'\t' || b == b'\n' || b == b'\r' {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn expect(&mut self, b: u8) -> Result<(), String> {
+        self.skip_ws();
+        match self.bump() {
+            Some(c) if c == b => Ok(()),
+            Some(c) => Err(self.err(&format!("expected '{}', got '{}'", b as char, c as char))),
+            None => Err(self.err(&format!("expected '{}', got EOF", b as char))),
+        }
+    }
+
+    fn parse_string(&mut self) -> Result<String, String> {
+        self.skip_ws();
+        self.expect(b'"')?;
+        let start = self.pos;
+        while let Some(b) = self.peek() {
+            if b == b'"' {
+                let s = core::str::from_utf8(&self.input[start..self.pos])
+                    .map_err(|_| self.err("non-UTF-8 byte in string"))?
+                    .to_string();
+                self.pos += 1;
+                return Ok(s);
+            }
+            if b == b'\\' {
+                return Err(self.err("escapes not supported in trace JSON strings"));
+            }
+            self.pos += 1;
+        }
+        Err(self.err("unterminated string"))
+    }
+
+    fn parse_u64(&mut self) -> Result<u64, String> {
+        self.skip_ws();
+        let start = self.pos;
+        while let Some(b) = self.peek() {
+            if b.is_ascii_digit() {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+        if start == self.pos {
+            return Err(self.err("expected integer"));
+        }
+        let s = core::str::from_utf8(&self.input[start..self.pos])
+            .map_err(|_| self.err("non-UTF-8 byte in integer"))?;
+        s.parse::<u64>()
+            .map_err(|_| self.err(&format!("integer out of range or invalid: {s}")))
+    }
+
+    fn expect_field_name(&mut self, name: &str) -> Result<(), String> {
+        let got = self.parse_string()?;
+        if got != name {
+            return Err(self.err(&format!("expected field \"{name}\", got \"{got}\"")));
+        }
+        self.expect(b':')
+    }
+}
+
+fn parse_trace(input: &str) -> Result<Trace, String> {
+    let mut p = Parser::new(input);
+    p.expect(b'{')?;
+    p.expect_field_name("schema_version")?;
+    let v = p.parse_u64()?;
+    if v != u64::from(SCHEMA_VERSION) {
+        return Err(format!(
+            "trace JSON schema_version mismatch: expected {SCHEMA_VERSION}, got {v}"
+        ));
+    }
+    p.expect(b',')?;
+    p.expect_field_name("records")?;
+    p.expect(b'[')?;
+
+    let mut records = Vec::new();
+    p.skip_ws();
+    if p.peek() != Some(b']') {
+        loop {
+            records.push(parse_record(&mut p)?);
+            p.skip_ws();
+            match p.peek() {
+                Some(b',') => {
+                    p.pos += 1;
+                }
+                Some(b']') => break,
+                Some(c) => return Err(p.err(&format!("expected ',' or ']', got '{}'", c as char))),
+                None => return Err(p.err("unexpected EOF in records array")),
+            }
+        }
+    }
+    p.expect(b']')?;
+    p.expect(b'}')?;
+    p.skip_ws();
+    if p.pos != p.input.len() {
+        return Err(p.err("trailing bytes after JSON object"));
+    }
+    Ok(Trace {
+        records,
+        capacity_limit: None,
+        eviction_warned: false,
+    })
+}
+
+fn parse_record(p: &mut Parser<'_>) -> Result<TraceRecord, String> {
+    p.expect(b'{')?;
+    p.expect_field_name("tick")?;
+    let tick = p.parse_u64()?;
+    p.expect(b',')?;
+    p.expect_field_name("event")?;
+    let event = parse_event(p)?;
+    p.expect(b'}')?;
+    Ok(TraceRecord { tick, event })
+}
+
+fn parse_event(p: &mut Parser<'_>) -> Result<Event, String> {
+    p.expect(b'{')?;
+    p.expect_field_name("type")?;
+    let ty = p.parse_string()?;
+    let event = match ty.as_str() {
+        "tick_advance" => {
+            p.expect(b',')?;
+            p.expect_field_name("from")?;
+            let from = p.parse_u64()?;
+            p.expect(b',')?;
+            p.expect_field_name("to")?;
+            let to = p.parse_u64()?;
+            Event::TickAdvance { from, to }
+        }
+        "timer_injected" => Event::TimerInjected,
+        "timer_irq_acked" => Event::TimerIrqAcked,
+        "wakeup_enqueued" => {
+            p.expect(b',')?;
+            p.expect_field_name("deadline")?;
+            let deadline = p.parse_u64()?;
+            p.expect(b',')?;
+            p.expect_field_name("id")?;
+            let id = p.parse_u64()? as TaskId;
+            Event::WakeupEnqueued { deadline, id }
+        }
+        "wakeup_fired" => {
+            p.expect(b',')?;
+            p.expect_field_name("id")?;
+            let id = p.parse_u64()? as TaskId;
+            Event::WakeupFired { id }
+        }
+        "task_scheduled" => {
+            p.expect(b',')?;
+            p.expect_field_name("id")?;
+            let id = p.parse_u64()? as TaskId;
+            Event::TaskScheduled { id }
+        }
+        "task_blocked" => {
+            p.expect(b',')?;
+            p.expect_field_name("id")?;
+            let id = p.parse_u64()? as TaskId;
+            p.expect(b',')?;
+            p.expect_field_name("reason")?;
+            let r = p.parse_string()?;
+            let reason = BlockReason::from_wire(&r)
+                .ok_or_else(|| p.err(&format!("unknown block reason: {r}")))?;
+            Event::TaskBlocked { id, reason }
+        }
+        "syscall" => {
+            p.expect(b',')?;
+            p.expect_field_name("nr")?;
+            let nr = p.parse_u64()?;
+            p.expect(b',')?;
+            p.expect_field_name("args")?;
+            p.expect(b'[')?;
+            let a0 = p.parse_u64()?;
+            p.expect(b',')?;
+            let a1 = p.parse_u64()?;
+            p.expect(b',')?;
+            let a2 = p.parse_u64()?;
+            p.expect(b',')?;
+            let a3 = p.parse_u64()?;
+            p.expect(b']')?;
+            Event::Syscall {
+                nr,
+                args: [a0, a1, a2, a3],
+            }
+        }
+        "fault" => {
+            p.expect(b',')?;
+            p.expect_field_name("kind")?;
+            let k = p.parse_string()?;
+            let kind = FaultKind::from_wire(&k)
+                .ok_or_else(|| p.err(&format!("unknown fault kind: {k}")))?;
+            p.expect(b',')?;
+            p.expect_field_name("rip")?;
+            let rip = p.parse_u64()?;
+            p.expect(b',')?;
+            p.expect_field_name("cr2")?;
+            let cr2 = p.parse_u64()?;
+            Event::Fault { kind, rip, cr2 }
+        }
+        "fault_injected" => {
+            p.expect(b',')?;
+            p.expect_field_name("kind")?;
+            let k = p.parse_string()?;
+            let kind = FaultKind::from_wire(&k)
+                .ok_or_else(|| p.err(&format!("unknown fault kind: {k}")))?;
+            Event::FaultInjected { kind }
+        }
+        other => return Err(p.err(&format!("unknown event type: {other}"))),
+    };
+    p.expect(b'}')?;
+    Ok(event)
+}
+
+// ---------------------------------------------------------------------
+// One-shot eviction-warning suppressor for tests. The capacity-bounded
+// `eprintln!` in `Trace::push` is informational; the per-Trace
+// `eviction_warned` latch keeps it from spamming. We additionally
+// short-circuit it under `cfg(test)` via this `AtomicBool` so the
+// trace-bound unit test below does not pollute `cargo test`'s stderr
+// with an expected warning.
+// ---------------------------------------------------------------------
+
+#[cfg(test)]
+static SUPPRESS_EVICTION_WARN: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+#[cfg(test)]
+pub(crate) fn _set_suppress_eviction_warn(v: bool) {
+    SUPPRESS_EVICTION_WARN.store(v, std::sync::atomic::Ordering::SeqCst);
+}
+
+#[cfg(test)]
+fn suppress_eviction_warn() -> bool {
+    SUPPRESS_EVICTION_WARN.load(std::sync::atomic::Ordering::SeqCst)
+}
+
+#[cfg(not(test))]
+fn suppress_eviction_warn() -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_trace() -> Trace {
+        let mut t = Trace::new();
+        t.push(TraceRecord {
+            tick: 1,
+            event: Event::TickAdvance { from: 0, to: 1 },
+        });
+        t.push(TraceRecord {
+            tick: 1,
+            event: Event::TimerInjected,
+        });
+        t.push(TraceRecord {
+            tick: 1,
+            event: Event::WakeupFired { id: 42 },
+        });
+        t.push(TraceRecord {
+            tick: 1,
+            event: Event::TimerIrqAcked,
+        });
+        // Snapshot/macro-emitted variants — exercised here so the
+        // round-trip property covers them despite no production emit
+        // points existing yet.
+        t.push(TraceRecord {
+            tick: 2,
+            event: Event::WakeupEnqueued { deadline: 5, id: 7 },
+        });
+        t.push(TraceRecord {
+            tick: 2,
+            event: Event::TaskScheduled { id: 7 },
+        });
+        t.push(TraceRecord {
+            tick: 3,
+            event: Event::TaskBlocked {
+                id: 7,
+                reason: BlockReason::Sleep,
+            },
+        });
+        t.push(TraceRecord {
+            tick: 4,
+            event: Event::Syscall {
+                nr: 60,
+                args: [1, 2, 3, 4],
+            },
+        });
+        t.push(TraceRecord {
+            tick: 5,
+            event: Event::Fault {
+                kind: FaultKind::PageFault,
+                rip: 0xDEAD_BEEF,
+                cr2: 0xCAFE_F00D,
+            },
+        });
+        t.push(TraceRecord {
+            tick: 5,
+            event: Event::FaultInjected {
+                kind: FaultKind::GeneralProtection,
+            },
+        });
+        t
+    }
+
+    #[test]
+    fn empty_trace_serializes_to_canonical_json() {
+        let t = Trace::new();
+        let s = t.to_json_string();
+        assert_eq!(s, "{\"schema_version\": 1, \"records\": []}");
+    }
+
+    #[test]
+    fn known_event_serializes_with_fixed_field_order() {
+        let mut t = Trace::new();
+        t.push(TraceRecord {
+            tick: 7,
+            event: Event::TickAdvance { from: 6, to: 7 },
+        });
+        let s = t.to_json_string();
+        assert_eq!(
+            s,
+            "{\"schema_version\": 1, \"records\": [{\"tick\": 7, \"event\": \
+             {\"type\": \"tick_advance\", \"from\": 6, \"to\": 7}}]}"
+        );
+    }
+
+    #[test]
+    fn round_trip_preserves_every_variant() {
+        let original = sample_trace();
+        let json = original.to_json_string();
+        let parsed = Trace::from_json(&json).expect("parse round-trip");
+        assert_eq!(parsed.records(), original.records());
+        // re-record (re-serialize) produces byte-identical JSON
+        let json2 = parsed.to_json_string();
+        assert_eq!(json, json2, "JSON drifted across record→json→parse→record");
+        // and diff agrees
+        assert_eq!(original.diff(&parsed), None);
+    }
+
+    #[test]
+    fn diff_returns_first_divergent_index() {
+        let a = sample_trace();
+        let mut b = sample_trace();
+        // Mutate record 3.
+        b.records[3] = TraceRecord {
+            tick: 1,
+            event: Event::WakeupFired { id: 999 },
+        };
+        assert_eq!(a.diff(&b), Some(3));
+    }
+
+    #[test]
+    fn diff_returns_none_for_equal_traces() {
+        assert_eq!(sample_trace().diff(&sample_trace()), None);
+    }
+
+    #[test]
+    fn diff_reports_length_difference_when_one_is_a_prefix() {
+        let a = sample_trace();
+        let mut b = sample_trace();
+        b.records.pop();
+        // `a` is longer by one; first divergence is at the shorter
+        // length.
+        assert_eq!(a.diff(&b), Some(b.records.len()));
+        assert_eq!(b.diff(&a), Some(b.records.len()));
+    }
+
+    #[test]
+    fn capacity_limit_evicts_oldest() {
+        // Suppress the one-shot eprintln so test output stays clean.
+        _set_suppress_eviction_warn(true);
+        let mut t = Trace::with_capacity_limit(3);
+        for i in 0..5 {
+            t.push(TraceRecord {
+                tick: i,
+                event: Event::TimerInjected,
+            });
+        }
+        assert_eq!(t.len(), 3);
+        // Oldest two ticks (0, 1) are gone; ticks 2,3,4 remain.
+        let ticks: Vec<u64> = t.records().iter().map(|r| r.tick).collect();
+        assert_eq!(ticks, vec![2, 3, 4]);
+        _set_suppress_eviction_warn(false);
+    }
+
+    #[test]
+    #[should_panic(expected = "limit must be > 0")]
+    fn capacity_limit_zero_panics() {
+        let _ = Trace::with_capacity_limit(0);
+    }
+
+    #[test]
+    fn parse_rejects_wrong_schema_version() {
+        let bad = "{\"schema_version\": 99, \"records\": []}";
+        let err = Trace::from_json(bad).unwrap_err();
+        assert!(
+            err.contains("schema_version mismatch"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_unknown_event_type() {
+        let bad =
+            "{\"schema_version\": 1, \"records\": [{\"tick\": 0, \"event\": {\"type\": \"bogus\"}}]}";
+        let err = Trace::from_json(bad).unwrap_err();
+        assert!(
+            err.contains("unknown event type"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_unknown_block_reason() {
+        let bad = "{\"schema_version\": 1, \"records\": [{\"tick\": 0, \"event\": \
+                   {\"type\": \"task_blocked\", \"id\": 1, \"reason\": \"bogus\"}}]}";
+        let err = Trace::from_json(bad).unwrap_err();
+        assert!(
+            err.contains("unknown block reason"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_trailing_bytes() {
+        let bad = "{\"schema_version\": 1, \"records\": []}garbage";
+        let err = Trace::from_json(bad).unwrap_err();
+        assert!(err.contains("trailing bytes"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn parse_rejects_string_escapes() {
+        // Escapes are explicitly out of scope of the simulator's JSON
+        // subset; the parser must reject them rather than silently
+        // mis-interpret. (No emitted event contains a backslash.)
+        let bad = r#"{"schema_version": 1, "records": [{"tick": 0, "event": {"type": "task_blocked", "id": 1, "reason": "sl\u0065ep"}}]}"#;
+        let err = Trace::from_json(bad).unwrap_err();
+        assert!(err.contains("escapes"), "unexpected error: {err}");
+    }
+}


### PR DESCRIPTION
Closes #717.

DST Phase 2 (4): land the full RFC 0006 §"State-machine model interface" event surface and the stable JSON schema downstream consumers (replay binary, CI artefact viewers, future proptest harness) parse against.

## Summary

- **Event enum** rewritten to the RFC-spec names. Existing variants from #716 renamed (semantics preserved):
  - `ClockAdvanced` → `TickAdvance`
  - `TimerAcked` → `TimerIrqAcked`
  - `TaskWoken` → `WakeupFired`
- **New variants** defined here, emit points land in follow-ups: `WakeupEnqueued`, `TaskScheduled`, `TaskBlocked`, `Syscall`, `Fault`, `FaultInjected`. Marked `#[allow(dead_code)]` until #718 / #722 wires their emit points.
- `Event` is `#[non_exhaustive]` so future variant additions are non-breaking at the type level (RFC 0006 UserSpace-A1 resolution); the JSON `schema_version` still bumps.
- `Trace::to_json` / `to_json_string` — stable schema, fixed field order so two equal traces produce byte-identical JSON. `schema_version = 1`.
- `Trace::from_json` — hand-rolled strict parser. **No `serde_json`** to keep the simulator's zero-OS-entropy transitive-dep envelope (RFC 0006 §"Determinism envelope").
- `Trace::diff(&other) -> Option<usize>` — first divergent index, for replay-equivalence assertions.
- `Trace::with_capacity_limit(N)` — bounded recorder with head-eviction and one-shot stderr warning.
- New doc: `simulator/docs/trace-schema.md` — canonical schema reference.

## Test plan

- [x] `cargo test -p simulator --target x86_64-unknown-linux-gnu` — 29 lib tests + 14 replay-bin tests pass.
  - `trace::tests::round_trip_preserves_every_variant` — every variant in the schema (including the not-yet-emitted ones) round-trips.
  - `trace::tests::diff_*` — first divergent index, equal traces, length-difference cases.
  - `trace::tests::capacity_limit_evicts_oldest` — bounded trace eviction.
  - `trace::tests::parse_rejects_*` — schema_version mismatch, unknown event type, unknown block reason, trailing bytes, string escapes.
  - `tests::smoke_recorded_trace_round_trips_through_json` — 200-tick simulator run with two cooperating tasks; record → JSON → parse → re-serialize is byte-identical.
  - `tests::smoke_1000_ticks_with_two_tasks_is_deterministic` — pre-existing #716 determinism smoke continues to pass with the renamed variants.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy -p simulator --target x86_64-unknown-linux-gnu --all-targets` clean (`#![deny(clippy::disallowed_types)]` enforced; no `HashMap`/`HashSet` introduced).
- [x] `cargo xtask build` — kernel image still builds (simulator is `cfg(not(target_os = "none"))`-gated, but verifying the gate didn't regress).

## Out of scope

- Emit points for `WakeupEnqueued`/`TaskScheduled`/`TaskBlocked`/`Syscall`/`Fault` are #718's `sched_mock_trace!` macro work.
- `FaultInjected` is #722's FaultPlan landing.
- The `replay` binary still prints `unimplemented` on `--trace-out`; wiring it to actually run a fixed-length sim and dump the JSON is a follow-up — the library API is the merge gate for #717.