### PR TITLE
sys: implement fsync(2) / fdatasync(2) syscalls (#748)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -501,3 +501,7 @@ required-features = ["ext2"]
 [[test]]
 name = "block_cache_stress"
 harness = false
+
+[[test]]
+name = "syscall_fsync"
+harness = false

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -606,6 +606,16 @@ pub unsafe extern "C" fn syscall_dispatch(
             }
         }
 
+        // fsync(fd) — flush page cache + per-mount BlockCache::sync_fs;
+        // surface sticky EIO via the per-OpenFile errseq snapshot. RFC
+        // 0007 §Ordering vs fsync/fdatasync.
+        FSYNC => super::syscalls::vfs::sys_fsync_impl(a0 as u32, false),
+
+        // fdatasync(fd) — same data flush as fsync, may skip the
+        // inode-table flush per Linux semantics. See sys_fsync_impl
+        // for the data_only-vs-fsync split.
+        FDATASYNC => super::syscalls::vfs::sys_fsync_impl(a0 as u32, true),
+
         // dup2(oldfd, newfd)
         DUP2 => {
             let oldfd = a0 as i32;
@@ -1760,6 +1770,8 @@ pub mod syscall_nr {
     pub const DUP2: u64 = 33;
     pub const DUP3: u64 = 292;
     pub const FCNTL: u64 = 72;
+    pub const FSYNC: u64 = 74;
+    pub const FDATASYNC: u64 = 75;
     pub const FSTAT: u64 = 5;
     pub const STAT: u64 = 4;
     pub const LSTAT: u64 = 6;
@@ -1840,6 +1852,8 @@ mod tests {
         assert_eq!(syscall_nr::DUP2, 33, "SYS_dup2 must be 33");
         assert_eq!(syscall_nr::DUP3, 292, "SYS_dup3 must be 292");
         assert_eq!(syscall_nr::FCNTL, 72, "SYS_fcntl must be 72");
+        assert_eq!(syscall_nr::FSYNC, 74, "SYS_fsync must be 74");
+        assert_eq!(syscall_nr::FDATASYNC, 75, "SYS_fdatasync must be 75");
         assert_eq!(syscall_nr::LSEEK, 8, "SYS_lseek must be 8");
 
         // Memory management

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -608,13 +608,16 @@ pub unsafe extern "C" fn syscall_dispatch(
 
         // fsync(fd) — flush page cache + per-mount BlockCache::sync_fs;
         // surface sticky EIO via the per-OpenFile errseq snapshot. RFC
-        // 0007 §Ordering vs fsync/fdatasync.
-        FSYNC => super::syscalls::vfs::sys_fsync_impl(a0 as u32, false),
+        // 0007 §Ordering vs fsync/fdatasync. The raw `a0` (u64) is
+        // passed through; the impl validates the high 32 bits to
+        // reject e.g. `fsync(0x1_0000_0003)` rather than silently
+        // truncating to fd=3.
+        FSYNC => super::syscalls::vfs::sys_fsync_impl(a0, false),
 
         // fdatasync(fd) — same data flush as fsync, may skip the
         // inode-table flush per Linux semantics. See sys_fsync_impl
         // for the data_only-vs-fsync split.
-        FDATASYNC => super::syscalls::vfs::sys_fsync_impl(a0 as u32, true),
+        FDATASYNC => super::syscalls::vfs::sys_fsync_impl(a0, true),
 
         // dup2(oldfd, newfd)
         DUP2 => {

--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -1430,7 +1430,15 @@ fn do_chown(inode: &Arc<Inode>, uid: u32, gid: u32, cred: &Credential) -> i64 {
 ///   call only surfaces *new* errors.
 /// - Any errno propagated from `FileOps::fsync` or
 ///   `SuperOps::sync_fs`.
-pub fn sys_fsync_impl(fd: u32, data_only: bool) -> i64 {
+pub fn sys_fsync_impl(fd_raw: u64, data_only: bool) -> i64 {
+    // Reject userspace fds whose high 32 bits are set rather than
+    // silently truncating to a low-32-bit fd. `fsync(0x1_0000_0003)`
+    // must not collapse to `fsync(3)`; mirroring Linux's `EBADF`
+    // behaviour for out-of-range fd arguments.
+    if fd_raw > u32::MAX as u64 {
+        return EBADF;
+    }
+    let fd = fd_raw as u32;
     let tbl = crate::task::current_fd_table();
     let backend = match tbl.lock().get(fd) {
         Ok(b) => b,

--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -1400,6 +1400,56 @@ fn do_chown(inode: &Arc<Inode>, uid: u32, gid: u32, cred: &Credential) -> i64 {
     }
 }
 
+/// `fsync(fd)` / `fdatasync(fd)` syscall body. Routed from the dispatch
+/// table at `arch::x86_64::syscall::syscall_dispatch` (numbers 74 and 75
+/// respectively) and kept in `vfs.rs` because the work is purely
+/// VFS-layer plumbing: route the fd to its `OpenFile`, then call
+/// [`OpenFile::do_fsync`] which performs the RFC 0007 two-stage flush
+/// (page cache writeback then `BlockCache::sync_fs`) and the errseq
+/// EIO comparison.
+///
+/// `data_only=true` is `fdatasync(2)`; `data_only=false` is `fsync(2)`.
+/// The full RFC contract (including the `fdatasync` skip-inode-table
+/// rule) lives in [`OpenFile::do_fsync`] and the SuperOps `sync_fs`
+/// trait body. This wrapper only owns the syscall ABI: validate the
+/// fd, fetch the backend, downcast through `as_vfs`, and translate
+/// the `Result<(), i64>` to a syscall return value (negated errno on
+/// error, zero on success).
+///
+/// Errno table (matches Linux `fsync(2)`):
+///
+/// - `EBADF` — `fd` is not an open descriptor in this task's table.
+/// - `EINVAL` — `fd` refers to a non-VFS backend (e.g. `SerialBackend`
+///   for stdin/stdout/stderr before the userspace init has reopened
+///   them through devfs). Linux returns `EINVAL` for `fsync` on a
+///   special file that doesn't support synchronisation; we mirror
+///   that.
+/// - `EIO` — sticky writeback error; the inode's page-cache
+///   `wb_err` counter advanced since this `OpenFile`'s last
+///   snapshot. Once consumed, the snapshot is caught up so the next
+///   call only surfaces *new* errors.
+/// - Any errno propagated from `FileOps::fsync` or
+///   `SuperOps::sync_fs`.
+pub fn sys_fsync_impl(fd: u32, data_only: bool) -> i64 {
+    let tbl = crate::task::current_fd_table();
+    let backend = match tbl.lock().get(fd) {
+        Ok(b) => b,
+        Err(e) => return e,
+    };
+    let vfs = match backend.as_vfs() {
+        Some(v) => v,
+        // Non-VFS backends (e.g. the legacy SerialBackend hooked up
+        // for early-boot stdin/stdout) have nothing to sync. Linux
+        // returns `EINVAL` for `fsync(2)` on file descriptors that
+        // don't support synchronisation.
+        None => return EINVAL,
+    };
+    match vfs.open_file.do_fsync(data_only) {
+        Ok(()) => 0,
+        Err(e) => e,
+    }
+}
+
 /// Resolve the inode behind an fd for the fchmod/fchown family. Returns
 /// `EBADF` on an out-of-range fd, or on any backend that doesn't expose
 /// a VFS inode (e.g. a pure `SerialBackend`) since there is nothing to

--- a/kernel/src/fs/vfs/inode.rs
+++ b/kernel/src/fs/vfs/inode.rs
@@ -77,6 +77,23 @@ pub struct Inode {
 }
 
 impl Inode {
+    /// Read the inode's page-cache `wb_err` errseq counter.
+    ///
+    /// Forward-compat seam for RFC 0007: once issue #745 lands an
+    /// `Option<Arc<PageCache>>` `mapping` field on `Inode`, this
+    /// becomes `self.mapping.as_ref().map(|m| m.wb_err()).unwrap_or(0)`.
+    /// Until then, no inode has a mapping and the counter is
+    /// universally zero — `fsync(2)` therefore never surfaces a
+    /// sticky `EIO`, which is correct because there is no writeback
+    /// daemon yet to bump the counter (#755).
+    ///
+    /// Defining the accessor now means the syscall layer can already
+    /// consume the errseq value via `OpenFile::wb_err_snapshot`
+    /// without rewriting any plumbing when the mapping field lands.
+    pub fn wb_err(&self) -> u32 {
+        0
+    }
+
     pub fn new(
         ino: u64,
         sb: Weak<SuperBlock>,

--- a/kernel/src/fs/vfs/open_file.rs
+++ b/kernel/src/fs/vfs/open_file.rs
@@ -96,9 +96,26 @@ impl OpenFile {
         // pending writeback error could be re-reported repeatedly,
         // or worse, a flush-hook error could mask a sticky EIO that
         // a *subsequent* `fsync` would then see as fresh.
+        // CAS-based catch-up: under interleaved concurrent fsync, two
+        // overlapping calls could otherwise race so an older sampled
+        // wb_err overwrites a newer snapshot, re-surfacing already-
+        // consumed EIO on later calls. The compare_exchange loop
+        // ensures we only ever advance the snapshot toward the
+        // freshest observed counter and never regress it.
         let consume_wb_err = || {
             let current = self.inode.wb_err();
-            self.wb_err_snapshot.store(current, Ordering::Release);
+            let mut seen = self.wb_err_snapshot.load(Ordering::Acquire);
+            while seen != current {
+                match self.wb_err_snapshot.compare_exchange_weak(
+                    seen,
+                    current,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                ) {
+                    Ok(_) => break,
+                    Err(observed) => seen = observed,
+                }
+            }
         };
 
         // 1. Driver hook. Concrete filesystems may override
@@ -143,9 +160,20 @@ impl OpenFile {
         //    consume_wb_err) so the comparison reflects the freshest
         //    counter after the flush hooks ran.
         let current = self.inode.wb_err();
-        let snapshot = self.wb_err_snapshot.load(Ordering::Acquire);
-        if current != snapshot {
-            self.wb_err_snapshot.store(current, Ordering::Release);
+        let mut snapshot = self.wb_err_snapshot.load(Ordering::Acquire);
+        let advanced = snapshot != current;
+        while snapshot != current {
+            match self.wb_err_snapshot.compare_exchange_weak(
+                snapshot,
+                current,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => break,
+                Err(observed) => snapshot = observed,
+            }
+        }
+        if advanced {
             return Err(crate::fs::EIO);
         }
         Ok(())

--- a/kernel/src/fs/vfs/open_file.rs
+++ b/kernel/src/fs/vfs/open_file.rs
@@ -37,6 +37,21 @@ pub struct OpenFile {
     pub flags: AtomicU32,
     pub ops: Arc<dyn FileOps>,
     pub sb: Arc<SuperBlock>,
+    /// errseq snapshot of the inode's page-cache `wb_err` counter,
+    /// captured at `open(2)` and re-read by every `fsync(2)` /
+    /// `fdatasync(2)` on this `OpenFile`. RFC 0007 §`wb_err` errseq
+    /// counter: a sticky `EIO` is surfaced when the cache's counter
+    /// has advanced since this snapshot, after which the snapshot is
+    /// caught up so subsequent `fsync` calls observe a clean state
+    /// (the standard errseq "consume once per witness" semantics).
+    ///
+    /// Today the `Inode::mapping` field is not yet wired (issue
+    /// #745), so [`Inode::wb_err`] returns 0 universally and this
+    /// snapshot is always 0. The seam is in place so that when #745
+    /// lands, snapshotting the inode's mapping at `open` and
+    /// comparing against it on `fsync` becomes a one-line change to
+    /// [`Inode::wb_err`] without touching syscall plumbing.
+    pub wb_err_snapshot: AtomicU32,
 }
 
 impl OpenFile {
@@ -57,6 +72,61 @@ impl OpenFile {
     /// userspace (its guard scope ends) and there is no further
     /// in-flight work on this SB for this open. The SB stays pinned
     /// by `dentry_pin_count` for the file's lifetime instead.
+    /// Implementation of `fsync(2)` / `fdatasync(2)` for this open
+    /// file. RFC 0007 §Ordering vs fsync/fdatasync defines the
+    /// two-stage flush: page cache first, then the per-mount buffer
+    /// cache via `SuperOps::sync_fs`. The `data_only` flag selects
+    /// `fdatasync` (today the metadata flush is conservatively kept
+    /// as a superset; splitting requires a `sync_fs(data_only)` seam
+    /// which is tracked as a follow-up).
+    ///
+    /// On success, the caller's per-`OpenFile` `wb_err_snapshot` is
+    /// caught up to the inode's current `wb_err` value before
+    /// returning so the next `fsync` only surfaces failures that
+    /// happen *after* this call (errseq "consume once per witness").
+    /// On `EIO` from a stale `wb_err`, the snapshot is *also* caught
+    /// up — Linux semantics: `fsync` reports the error exactly once
+    /// per file description.
+    pub fn do_fsync(&self, data_only: bool) -> Result<(), i64> {
+        // 1. Driver hook. Concrete filesystems may override
+        //    FileOps::fsync to flush their inode metadata or to
+        //    invoke an inode-private writeback path; the default
+        //    body is `Ok(())`. Filler errors here propagate first so
+        //    the buffer-cache fence below isn't issued against a
+        //    cache that the driver knows is in an inconsistent
+        //    state.
+        self.ops.fsync(self, data_only)?;
+
+        // 2. Per-mount BlockCache::sync_fs (or whatever the FS
+        //    layered on top of it). For an in-memory filesystem
+        //    (ramfs, tarfs, devfs) the default `SuperOps::sync_fs`
+        //    body is `Ok(())`; for a block-backed FS the driver
+        //    forwards to its `BlockCache::sync_fs(device_id)`.
+        //
+        //    For `data_only=true` (fdatasync), the RFC calls for
+        //    skipping the inode-table flush. We do not currently
+        //    have a `sync_fs(data_only)` variant on `SuperOps`;
+        //    flushing the full sb is a conservative POSIX-compatible
+        //    superset (fdatasync is permitted to flush more than
+        //    necessary). Splitting is tracked as a follow-up; see
+        //    the issue auto-engineer files for the seam shape.
+        self.sb.ops.sync_fs(&self.sb)?;
+
+        // 3. errseq EIO surfacing. Compare the per-file-description
+        //    snapshot against the inode's current wb_err counter; if
+        //    the counter advanced since `open` (or since the last
+        //    fsync that consumed an error), some writeback in the
+        //    interval failed. Catch the snapshot up so the next
+        //    fsync only sees *new* errors.
+        let current = self.inode.wb_err();
+        let snapshot = self.wb_err_snapshot.load(Ordering::Acquire);
+        if current != snapshot {
+            self.wb_err_snapshot.store(current, Ordering::Release);
+            return Err(crate::fs::EIO);
+        }
+        Ok(())
+    }
+
     pub fn new(
         dentry: Arc<Dentry>,
         inode: Arc<Inode>,
@@ -89,6 +159,13 @@ impl OpenFile {
             // list.
             finalize_pending_detach(&sb);
         }
+        // Snapshot the inode's page-cache wb_err counter at open
+        // time. This is what `fsync(2)` will compare against later to
+        // surface a sticky EIO; if the counter advanced between open
+        // and fsync, some intervening writeback failed and the next
+        // fsync caller is the one that learns about it (RFC 0007
+        // §`wb_err` errseq counter).
+        let wb_err_at_open = inode.wb_err();
         let of = Arc::new(Self {
             dentry,
             inode,
@@ -96,6 +173,7 @@ impl OpenFile {
             flags: AtomicU32::new(flags),
             ops,
             sb,
+            wb_err_snapshot: AtomicU32::new(wb_err_at_open),
         });
         // Fire the driver `open` hook now that the `OpenFile` is fully
         // constructed and the SB pin has been migrated to
@@ -214,5 +292,110 @@ mod tests {
         drop(of);
         assert_eq!(sb.sb_active.load(Ordering::SeqCst), 0);
         assert_eq!(sb.dentry_pin_count.load(Ordering::SeqCst), 0);
+    }
+
+    fn build_open_file(sb: Arc<SuperBlock>) -> Arc<OpenFile> {
+        let inode = Arc::new(Inode::new(
+            1,
+            Arc::downgrade(&sb),
+            Arc::new(StubInode),
+            Arc::new(StubFile),
+            InodeKind::Reg,
+            InodeMeta::default(),
+        ));
+        let dentry = Dentry::new_root(inode.clone());
+        let file_ops: Arc<dyn FileOps> = Arc::new(StubFile);
+        let guard = SbActiveGuard::try_acquire(&sb).expect("guard");
+        OpenFile::new(dentry, inode, file_ops, sb, 0, guard)
+    }
+
+    #[test]
+    fn do_fsync_default_impl_returns_ok() {
+        // RFC 0007: with the default `FileOps::fsync` (Ok) and the
+        // default `SuperOps::sync_fs` (Ok), and an inode whose
+        // `wb_err()` is universally zero (Inode::mapping not yet
+        // wired — issue #745), `do_fsync` is a clean Ok(()) path.
+        let sb = Arc::new(SuperBlock::new(
+            FsId(3),
+            Arc::new(StubSuper),
+            "stub",
+            512,
+            SbFlags::default(),
+        ));
+        let of = build_open_file(sb);
+        assert_eq!(of.do_fsync(false), Ok(()));
+        assert_eq!(of.do_fsync(true), Ok(()));
+    }
+
+    #[test]
+    fn do_fsync_repeated_calls_remain_clean() {
+        // Stable wb_err snapshot ⇒ no false-positive EIO.
+        let sb = Arc::new(SuperBlock::new(
+            FsId(4),
+            Arc::new(StubSuper),
+            "stub",
+            512,
+            SbFlags::default(),
+        ));
+        let of = build_open_file(sb);
+        for _ in 0..10 {
+            assert_eq!(of.do_fsync(false), Ok(()));
+            assert_eq!(of.do_fsync(true), Ok(()));
+        }
+    }
+
+    #[test]
+    fn wb_err_snapshot_initialised_from_inode() {
+        // Forward-compat seam: `OpenFile::new` snapshots
+        // `inode.wb_err()` at construction. Today that helper always
+        // returns 0; the assertion pins the wiring so a future #745
+        // can update `Inode::wb_err` and immediately observe a
+        // non-zero snapshot here without having to re-thread anything
+        // through OpenFile.
+        let sb = Arc::new(SuperBlock::new(
+            FsId(5),
+            Arc::new(StubSuper),
+            "stub",
+            512,
+            SbFlags::default(),
+        ));
+        let of = build_open_file(sb);
+        assert_eq!(of.wb_err_snapshot.load(Ordering::Acquire), 0);
+    }
+
+    /// Stub SuperOps whose `sync_fs` simulates a writeback error and
+    /// can simulate a `wb_err` advance via a per-instance counter on
+    /// the inode. We can't yet reach into a real `PageCache`
+    /// (Inode::mapping is #745), so this exercises the syscall-side
+    /// errseq logic by overriding `Inode::wb_err` indirectly through
+    /// a wrapper SuperOps. Today's `Inode::wb_err()` is hardcoded to
+    /// 0, so this test is a placeholder pinning the seam — it will
+    /// be filled out by the test added when the mapping field lands.
+    #[test]
+    fn fsync_propagates_sb_sync_fs_error() {
+        struct FailingSuper;
+        impl SuperOps for FailingSuper {
+            fn root_inode(&self) -> Arc<Inode> {
+                unreachable!()
+            }
+            fn statfs(&self) -> Result<StatFs, i64> {
+                Ok(StatFs::default())
+            }
+            fn sync_fs(&self, _sb: &SuperBlock) -> Result<(), i64> {
+                Err(crate::fs::EIO)
+            }
+            fn unmount(&self) {}
+        }
+        let sb = Arc::new(SuperBlock::new(
+            FsId(6),
+            Arc::new(FailingSuper),
+            "stub",
+            512,
+            SbFlags::default(),
+        ));
+        let of = build_open_file(sb);
+        assert_eq!(of.do_fsync(false), Err(crate::fs::EIO));
+        // Same path for fdatasync.
+        assert_eq!(of.do_fsync(true), Err(crate::fs::EIO));
     }
 }

--- a/kernel/src/fs/vfs/open_file.rs
+++ b/kernel/src/fs/vfs/open_file.rs
@@ -88,14 +88,32 @@ impl OpenFile {
     /// up — Linux semantics: `fsync` reports the error exactly once
     /// per file description.
     pub fn do_fsync(&self, data_only: bool) -> Result<(), i64> {
+        // Helper: catch the per-OpenFile errseq snapshot up to the
+        // inode's current wb_err counter. errseq semantics ("consume
+        // once per witness") require this to fire on *every* exit
+        // from `do_fsync` — Ok-success, Err from a flush hook, or
+        // Err from the snapshot comparison — otherwise a single
+        // pending writeback error could be re-reported repeatedly,
+        // or worse, a flush-hook error could mask a sticky EIO that
+        // a *subsequent* `fsync` would then see as fresh.
+        let consume_wb_err = || {
+            let current = self.inode.wb_err();
+            self.wb_err_snapshot.store(current, Ordering::Release);
+        };
+
         // 1. Driver hook. Concrete filesystems may override
         //    FileOps::fsync to flush their inode metadata or to
         //    invoke an inode-private writeback path; the default
         //    body is `Ok(())`. Filler errors here propagate first so
         //    the buffer-cache fence below isn't issued against a
         //    cache that the driver knows is in an inconsistent
-        //    state.
-        self.ops.fsync(self, data_only)?;
+        //    state. The snapshot is caught up before propagation so
+        //    a sticky EIO accumulated by an earlier writeback isn't
+        //    re-reported the next time the caller invokes fsync.
+        if let Err(e) = self.ops.fsync(self, data_only) {
+            consume_wb_err();
+            return Err(e);
+        }
 
         // 2. Per-mount BlockCache::sync_fs (or whatever the FS
         //    layered on top of it). For an in-memory filesystem
@@ -110,14 +128,20 @@ impl OpenFile {
         //    superset (fdatasync is permitted to flush more than
         //    necessary). Splitting is tracked as a follow-up; see
         //    the issue auto-engineer files for the seam shape.
-        self.sb.ops.sync_fs(&self.sb)?;
+        if let Err(e) = self.sb.ops.sync_fs(&self.sb) {
+            consume_wb_err();
+            return Err(e);
+        }
 
         // 3. errseq EIO surfacing. Compare the per-file-description
         //    snapshot against the inode's current wb_err counter; if
         //    the counter advanced since `open` (or since the last
         //    fsync that consumed an error), some writeback in the
         //    interval failed. Catch the snapshot up so the next
-        //    fsync only sees *new* errors.
+        //    fsync only sees *new* errors. Note we deliberately read
+        //    `wb_err()` again here (rather than reusing a value from
+        //    consume_wb_err) so the comparison reflects the freshest
+        //    counter after the flush hooks ran.
         let current = self.inode.wb_err();
         let snapshot = self.wb_err_snapshot.load(Ordering::Acquire);
         if current != snapshot {

--- a/kernel/tests/syscall_fsync.rs
+++ b/kernel/tests/syscall_fsync.rs
@@ -1,0 +1,225 @@
+//! Integration test for issue #748: `fsync(2)` / `fdatasync(2)`
+//! syscalls.
+//!
+//! Exercises the `SYS_FSYNC` (74) and `SYS_FDATASYNC` (75) dispatch
+//! arms end-to-end:
+//!
+//! - `fsync` / `fdatasync` on a valid VFS fd succeeds (default
+//!   `FileOps::fsync` is `Ok(())`, default `SuperOps::sync_fs` is
+//!   `Ok(())`, no inode mapping is wired so `wb_err` is zero).
+//! - `fsync` / `fdatasync` on a closed/invalid fd returns `EBADF`.
+//! - The `OpenFile`'s per-file errseq snapshot starts at zero (no
+//!   inode mapping yet — issue #745) and never spuriously surfaces
+//!   `EIO`. This pins the seam in place so when #745 lands the
+//!   errseq logic has a regression test.
+//! - `fsync` and `fdatasync` are *separate* dispatch arms; the
+//!   distinction is preserved at the ABI even though the underlying
+//!   sb-side flush is currently a superset (split tracked as a
+//!   follow-up; see issue auto-engineer files).
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use core::ptr;
+
+use vibix::arch::x86_64::syscall::syscall_dispatch;
+use vibix::fs::EBADF;
+use vibix::mem::vmatree::{Share, Vma};
+use vibix::mem::vmobject::AnonObject;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+use x86_64::structures::paging::PageTableFlags;
+
+const SYS_OPEN: u64 = 2;
+const SYS_CLOSE: u64 = 3;
+const SYS_FSYNC: u64 = 74;
+const SYS_FDATASYNC: u64 = 75;
+
+const O_RDONLY: u32 = 0o0;
+const O_RDWR: u32 = 0o2;
+
+const HOSTNAME_PATH: &[u8] = b"/etc/hostname\0";
+
+const USER_PAGE_VA: usize = 0x0000_2001_0000_0000;
+const USER_PAGE_LEN: usize = 4 * 4096;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    vibix::task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "fsync_on_valid_fd_returns_zero",
+            &(fsync_on_valid_fd_returns_zero as fn()),
+        ),
+        (
+            "fdatasync_on_valid_fd_returns_zero",
+            &(fdatasync_on_valid_fd_returns_zero as fn()),
+        ),
+        (
+            "fsync_repeated_calls_stay_clean",
+            &(fsync_repeated_calls_stay_clean as fn()),
+        ),
+        ("fsync_bad_fd_ebadf", &(fsync_bad_fd_ebadf as fn())),
+        ("fdatasync_bad_fd_ebadf", &(fdatasync_bad_fd_ebadf as fn())),
+        (
+            "fsync_after_close_ebadf",
+            &(fsync_after_close_ebadf as fn()),
+        ),
+    ];
+    for (name, t) in tests {
+        serial_println!("syscall_fsync: {}", name);
+        t.run();
+    }
+}
+
+fn install_user_staging_vma() {
+    static INSTALLED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+    if INSTALLED.swap(true, core::sync::atomic::Ordering::SeqCst) {
+        return;
+    }
+    let prot_pte =
+        (PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE).bits();
+    vibix::task::install_vma_on_current(Vma::new(
+        USER_PAGE_VA,
+        USER_PAGE_VA + USER_PAGE_LEN,
+        0x3,
+        prot_pte,
+        Share::Private,
+        AnonObject::new(Some(USER_PAGE_LEN / 4096)),
+        0,
+    ));
+    unsafe {
+        ptr::write_volatile(USER_PAGE_VA as *mut u8, 0);
+    }
+}
+
+fn stage(bytes: &[u8]) -> u64 {
+    install_user_staging_vma();
+    assert!(bytes.len() < USER_PAGE_LEN);
+    unsafe {
+        let dst = USER_PAGE_VA as *mut u8;
+        for (i, b) in bytes.iter().enumerate() {
+            ptr::write_volatile(dst.add(i), *b);
+        }
+    }
+    USER_PAGE_VA as u64
+}
+
+fn open_with_flags(path: &[u8], flags: u32) -> i64 {
+    let uva = stage(path);
+    unsafe {
+        syscall_dispatch(
+            core::ptr::null_mut(),
+            SYS_OPEN,
+            uva,
+            flags as u64,
+            0,
+            0,
+            0,
+            0,
+        )
+    }
+}
+
+fn close(fd: i64) -> i64 {
+    unsafe { syscall_dispatch(core::ptr::null_mut(), SYS_CLOSE, fd as u64, 0, 0, 0, 0, 0) }
+}
+
+fn fsync(fd: i64) -> i64 {
+    unsafe { syscall_dispatch(core::ptr::null_mut(), SYS_FSYNC, fd as u64, 0, 0, 0, 0, 0) }
+}
+
+fn fdatasync(fd: i64) -> i64 {
+    unsafe {
+        syscall_dispatch(
+            core::ptr::null_mut(),
+            SYS_FDATASYNC,
+            fd as u64,
+            0,
+            0,
+            0,
+            0,
+            0,
+        )
+    }
+}
+
+fn fsync_on_valid_fd_returns_zero() {
+    let fd = open_with_flags(HOSTNAME_PATH, O_RDONLY);
+    assert!(fd >= 0, "open hostname: {}", fd);
+    let r = fsync(fd);
+    assert_eq!(r, 0, "fsync on valid VFS fd must succeed, got {}", r);
+    close(fd);
+}
+
+fn fdatasync_on_valid_fd_returns_zero() {
+    let fd = open_with_flags(HOSTNAME_PATH, O_RDWR);
+    if fd < 0 {
+        // Some FSes refuse RDWR on /etc/hostname; fall back to RDONLY
+        // so the test still exercises the dispatch arm.
+        let fd2 = open_with_flags(HOSTNAME_PATH, O_RDONLY);
+        assert!(fd2 >= 0, "open hostname rdonly: {}", fd2);
+        let r = fdatasync(fd2);
+        assert_eq!(r, 0, "fdatasync on valid VFS fd must succeed, got {}", r);
+        close(fd2);
+        return;
+    }
+    let r = fdatasync(fd);
+    assert_eq!(r, 0, "fdatasync on valid VFS fd must succeed, got {}", r);
+    close(fd);
+}
+
+fn fsync_repeated_calls_stay_clean() {
+    // RFC 0007 §wb_err errseq counter: with no writeback daemon (no
+    // mapping wired, no #755), the inode's wb_err counter never
+    // advances, so repeated fsync calls must each return zero —
+    // never a stale-snapshot EIO.
+    let fd = open_with_flags(HOSTNAME_PATH, O_RDONLY);
+    assert!(fd >= 0, "open hostname: {}", fd);
+    for i in 0..4 {
+        let r = fsync(fd);
+        assert_eq!(r, 0, "fsync iteration {} must stay clean, got {}", i, r);
+    }
+    for i in 0..4 {
+        let r = fdatasync(fd);
+        assert_eq!(r, 0, "fdatasync iteration {} must stay clean, got {}", i, r);
+    }
+    close(fd);
+}
+
+fn fsync_bad_fd_ebadf() {
+    let r = fsync(9999);
+    assert_eq!(r, EBADF, "fsync on bad fd must return EBADF, got {}", r);
+}
+
+fn fdatasync_bad_fd_ebadf() {
+    let r = fdatasync(9999);
+    assert_eq!(r, EBADF, "fdatasync on bad fd must return EBADF, got {}", r);
+}
+
+fn fsync_after_close_ebadf() {
+    let fd = open_with_flags(HOSTNAME_PATH, O_RDONLY);
+    assert!(fd >= 0, "open hostname: {}", fd);
+    let r = close(fd);
+    assert_eq!(r, 0, "close: {}", r);
+    let r = fsync(fd);
+    assert_eq!(r, EBADF, "fsync on closed fd must return EBADF, got {}", r);
+}


### PR DESCRIPTION
Closes #748

## Summary

- Adds `SYS_FSYNC` (74) and `SYS_FDATASYNC` (75) dispatch arms wired through to a new `OpenFile::do_fsync(data_only)` helper that performs the RFC 0007 §Ordering vs fsync/fdatasync two-stage flush: `FileOps::fsync` driver hook, then `SuperOps::sync_fs` to fence on the per-mount `BlockCache`.
- Adds `OpenFile::wb_err_snapshot: AtomicU32`, captured at `open(2)` and re-read on every `fsync` to surface a sticky `EIO` via the errseq pattern (RFC 0007 §`wb_err`). On consume, the snapshot is caught up so only *new* errors are surfaced (Linux semantics).
- Adds `Inode::wb_err()` as a forward-compat seam returning 0 today; once #745 wires `Inode::mapping`, this becomes a one-liner reading the page-cache's `wb_err` and the syscall plumbing requires no further change.

## Notes / scope

- The split between `fsync` and `fdatasync` at the SB layer (skip the inode-table flush for `fdatasync`) is **not** implemented here — `SuperOps::sync_fs` does not yet have a `data_only` variant. Calling the full `sync_fs` for both is a POSIX-compatible superset (fdatasync is permitted to flush more than necessary). A follow-up issue tracks adding the `sync_fs(data_only)` seam alongside #755.
- The page-cache writeback step in `do_fsync` is currently a no-op because no inode has a `mapping` yet (#745). When #745 lands, the writeback walk is added inside `do_fsync` before the `sync_fs` call (or via #755's daemon stub).

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo xtask build`
- [x] `cargo xtask test` — host unit + QEMU integration; new `syscall_fsync` integration test exercises the dispatch arms end-to-end (happy path, repeated-clean, bad-fd EBADF, after-close EBADF).
- [x] `cargo xtask smoke`
- [ ] CI gates: fmt+build, host unit, integration QEMU, smoke, pjdfstest, ext2 rootfs determinism, RFC 0004 vfs_creds, CodeRabbit