### PR TITLE
DST Phase 2 (5): sched_mock_trace! macro + scheduler introspection helpers

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -154,6 +154,17 @@ extern "x86-interrupt" fn page_fault(mut frame: InterruptStackFrame, code: PageF
     // entering the `VmObject::fault` slow path.
     let addr_u64 = x86_64::registers::control::Cr2::read_raw();
 
+    // RFC 0006 / #718: page-fault entry emit point. Captured *before*
+    // any handler logic so a panic inside the resolver still leaves a
+    // `Fault { PageFault, rip, cr2 }` record in the trace for the
+    // simulator to bisect against. The macro is a no-op on production
+    // builds (verified by `cargo xtask nm-check`).
+    crate::sched_mock_trace!(crate::task::trace::SchedMockEvent::Fault {
+        kind: crate::task::trace::SchedMockFaultKind::PageFault,
+        rip: frame.instruction_pointer.as_u64(),
+        cr2: addr_u64,
+    });
+
     // Defer `log_first_ring3_fault` to the terminal paths below. A
     // first-touch CoW write fault on a forked user-stack page is a
     // routine, fully-resolved event and must not trip the diagnostic

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -363,8 +363,24 @@ pub unsafe extern "C" fn syscall_dispatch(
         let delta = now.saturating_sub(pre);
         crate::serial_println!("irq-post-ring3: ticks={} pre={} delta={}", now, pre, delta);
     }
+    // RFC 0006 / #718: syscall entry emit point. The macro is a no-op
+    // off-feature; under `feature = "sched-mock"` it pushes a record
+    // into the per-thread trace sink so the simulator can correlate
+    // syscall traffic with scheduler transitions. Only the first four
+    // arg registers are recorded — RFC 0006 §"Event emit points"
+    // notes that four covers every syscall the v1 invariant set
+    // models, and truncating keeps the trace JSON small.
+    crate::sched_mock_trace!(crate::task::trace::SchedMockEvent::SyscallEntry {
+        nr,
+        args: [a0, a1, a2, a3],
+    });
+    // `_syscall_nr` is captured for the exit-side trace emit below.
+    // Bare-metal builds discard the macro argument entirely, so the
+    // binding is unused there — the leading underscore silences the
+    // lint without dropping the host-build use.
+    let _syscall_nr = nr;
     use syscall_nr::*;
-    match nr {
+    let _syscall_result = match nr {
         // read(fd, buf, len) — non-blocking; returns -EAGAIN if no data.
         READ => {
             let fd = a0 as u32;
@@ -1140,7 +1156,14 @@ pub unsafe extern "C" fn syscall_dispatch(
         SETGROUPS => super::syscalls::creds::sys_setgroups(a0 as i32, a1),
 
         _ => -38i64, // ENOSYS
-    }
+    };
+    // RFC 0006 / #718: syscall exit emit point. Records the same
+    // syscall number as the entry side; the v1 invariant set does not
+    // need the return value (and capturing it would force everyone
+    // returning out of the match early to thread it through). When a
+    // future invariant requires the rax value, broaden the variant.
+    crate::sched_mock_trace!(crate::task::trace::SchedMockEvent::SyscallExit { nr: _syscall_nr });
+    _syscall_result
 }
 
 /// Atomic execve body: stage the new image into a fresh `AddressSpace`

--- a/kernel/src/task/env.rs
+++ b/kernel/src/task/env.rs
@@ -402,12 +402,24 @@ impl Clock for MockClock {
         for (_deadline, ids) in expired {
             out.extend(ids);
         }
+        // Note: no `TaskWoken` emit here. The simulator's run loop
+        // emits `WakeupFired { id }` for every drained id at the
+        // seam call site (`Simulator::step`). Emitting `TaskWoken`
+        // additionally would double-record the same transition.
         out
     }
 
     fn enqueue_wakeup(&self, deadline: Tick, id: TaskId) {
         let mut g = self.inner.lock();
         g.wakeups.entry(deadline.0).or_default().push(id);
+        drop(g);
+        // RFC 0006 / #718: emit a `WakeupEnqueued` event so the
+        // simulator can correlate `sleep_ms` arming with the eventual
+        // drain. The macro is a no-op when `sched-mock` is off.
+        crate::sched_mock_trace!(crate::task::trace::SchedMockEvent::WakeupEnqueued {
+            deadline: deadline.0,
+            id,
+        });
     }
 }
 

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -33,6 +33,7 @@
 //! [`wake`] below.
 
 pub mod env;
+pub mod trace;
 
 // Scheduler-core submodules. These pull in `arch`, `sync`, `x86_64`,
 // and `crate::time` features that don't compile on the host, so they

--- a/kernel/src/task/sched_core.rs
+++ b/kernel/src/task/sched_core.rs
@@ -9,6 +9,13 @@
 use super::env;
 use super::priority;
 use super::softirq;
+// `SchedMockBlockReason` / `SchedMockEvent` are referenced only
+// inside `sched_mock_trace!` argument expressions; on bare-metal
+// the macro discards its argument before name resolution, so the
+// imports go unused. Allow that — the types are still in scope for
+// the host build path that exercises these emit points.
+#[allow(unused_imports)]
+use super::trace::{SchedMockBlockReason, SchedMockEvent, SchedMockFaultKind};
 
 use alloc::boxed::Box;
 use alloc::collections::VecDeque;
@@ -241,6 +248,13 @@ pub fn fork_current_task(
     );
     sched.push_ready(child_box);
     maybe_preempt_current_for_priority(&mut sched, new_prio);
+    // RFC 0006 / #718: record the fork transition. Parent id read
+    // through the snapshot we already took above; on a successful
+    // fork the child's id is what `Task::new_forked` minted.
+    crate::sched_mock_trace!(SchedMockEvent::TaskForked {
+        parent: sched.current.as_ref().map(|t| t.id).unwrap_or(usize::MAX),
+        child: child_id,
+    });
     crate::fork_trace!(
         "fork-trace: [fork_current_task exit] returning child_id={}",
         child_id
@@ -1006,11 +1020,22 @@ pub fn exit() -> ! {
             panic!("task::exit: no ready task to switch to");
         };
         let prev = sched.current.take().expect("task::exit before task::init");
+        // RFC 0006 / #718: record that the previously-running task is
+        // exiting *before* we drop its reference. No-op on production
+        // builds; under `feature = "sched-mock"` the simulator
+        // observes one `TaskExit { id }` per task::exit call.
+        crate::sched_mock_trace!(SchedMockEvent::TaskExit { id: prev.id });
         next.state = TaskState::Running;
         let next_rsp = next.rsp;
         let next_cr3 = next.cr3.start_address().as_u64();
         sched.current = Some(next);
         sched.current.as_mut().unwrap().slice_remaining_ms = DEFAULT_SLICE_MS;
+        // Emit `TaskScheduled` for the incoming task at the same point
+        // `preempt_tick` does — exit is a non-yielding context switch
+        // and feeds the same dispatch event stream.
+        crate::sched_mock_trace!(SchedMockEvent::TaskScheduled {
+            id: sched.current.as_ref().unwrap().id,
+        });
         // Arm SYSCALL/TSS for the incoming task's own per-task kernel
         // stack. Done while still holding SCHED so the Task reference
         // outlives the write.
@@ -1222,6 +1247,12 @@ pub fn preempt_tick() {
     let prev_prio = prev.priority;
     sched.current = Some(next);
     sched.current.as_mut().unwrap().slice_remaining_ms = DEFAULT_SLICE_MS;
+    // RFC 0006 / #718: emit a `TaskScheduled` event for the incoming
+    // task. No-op on production builds; under `feature = "sched-mock"`
+    // the host-side simulator drains these from the per-thread sink.
+    crate::sched_mock_trace!(SchedMockEvent::TaskScheduled {
+        id: sched.current.as_ref().unwrap().id,
+    });
     // Arm SYSCALL/TSS for the incoming task's own per-task kernel
     // stack. Done while still holding SCHED so the Task reference is
     // valid; the helper only performs atomic / live-TSS writes and
@@ -1341,8 +1372,20 @@ pub fn block_current() {
         let prev_id = prev.id;
         let next_rsp = next.rsp;
         let next_cr3 = next.cr3.start_address().as_u64();
+        // RFC 0006 / #718: emit `TaskBlocked` for the parking task and
+        // `TaskScheduled` for its successor. The block reason here is
+        // `Wait` because `block_current` is the WaitQueue / blocking-
+        // primitive park path; tick-deadline parks go through
+        // `sleep_ms` and emit `Sleep` separately before reaching here.
+        crate::sched_mock_trace!(SchedMockEvent::TaskBlocked {
+            id: prev_id,
+            reason: SchedMockBlockReason::Wait,
+        });
         sched.current = Some(next);
         sched.current.as_mut().unwrap().slice_remaining_ms = DEFAULT_SLICE_MS;
+        crate::sched_mock_trace!(SchedMockEvent::TaskScheduled {
+            id: sched.current.as_ref().unwrap().id,
+        });
         // Arm SYSCALL/TSS for the incoming task's own per-task kernel
         // stack under the SCHED lock; see `set_active_syscall_stack`
         // for why this consolidation exists (#505).
@@ -1409,6 +1452,13 @@ fn wake_in_sched(sched: &mut Scheduler, id: usize) {
         let prio = task.priority;
         sched.push_ready(task);
         maybe_preempt_current_for_priority(sched, prio);
+        // RFC 0006 / #718: emit `TaskWoken` only on the parked→ready
+        // transition (the happy-path case). The "wake_pending fast
+        // path" below mutates an atomic flag without changing the
+        // task's run state, so it is not an observable wake from the
+        // simulator's perspective — `block_current` will surface that
+        // race when it consumes the flag.
+        crate::sched_mock_trace!(SchedMockEvent::TaskWoken { id });
         return;
     }
 
@@ -1452,5 +1502,17 @@ pub fn sleep_ms(ms: u64) {
     let deadline = clock.now().saturating_add(ticks_to_wait);
     let id = current_id();
     clock.enqueue_wakeup(deadline, id);
+    // RFC 0006 / #718: tick-deadline park has its own block reason so
+    // invariant predicates can distinguish "asleep on a timer" from
+    // "asleep on a wait-queue". Emit `TaskBlocked { Sleep }` *before*
+    // calling `block_current`, which itself emits `TaskBlocked { Wait }`
+    // — both records land in the trace, in that order, so a downstream
+    // consumer can tell the wait-queue park from the sleep that
+    // brought it there. The wake-before-park race short-circuit
+    // inside `block_current` skips that second emit.
+    crate::sched_mock_trace!(SchedMockEvent::TaskBlocked {
+        id,
+        reason: SchedMockBlockReason::Sleep,
+    });
     block_current();
 }

--- a/kernel/src/task/trace.rs
+++ b/kernel/src/task/trace.rs
@@ -1,0 +1,482 @@
+//! Kernel-side scheduler-mock trace seam (RFC 0006 / issue #718).
+//!
+//! Defines [`sched_mock_trace!`], the compile-out emit-point macro that
+//! kernel paths use to feed the host-side DST simulator's
+//! `(Tick, Event)` stream. The macro has two states:
+//!
+//! - **Off-feature / bare-metal** (the production kernel image): expands
+//!   to `()`. The argument expression is **not** evaluated, so a
+//!   `sched_mock_trace!(SchedMockEvent::Syscall { nr, args })` call site
+//!   contributes zero instructions, zero data, and zero symbols to the
+//!   release ELF. The nm-check guard (`cargo xtask nm-check`, originally
+//!   landed in #669) verifies this statically by asserting no
+//!   `sched_mock_*` symbols leak past the cfg gate.
+//!
+//! - **Host build with `--features sched-mock`** (the simulator's
+//!   build): pushes the [`SchedMockEvent`] value into a thread-local
+//!   [`Vec`] sink whose contents the test / simulator code drains via
+//!   [`take_trace`]. The thread-local is per-`cargo test` worker and
+//!   per-simulator instance so parallel seeds do not race on a shared
+//!   buffer (mirroring the [`crate::task::env`] thread-local that
+//!   installs the `MockClock`/`MockTimerIrq` seam).
+//!
+//! The kernel deliberately defines its own [`SchedMockEvent`] enum
+//! rather than reaching into the `simulator` crate's `Event`: the
+//! dependency arrow is `simulator → kernel`, never the other way. The
+//! simulator (or downstream invariant code) maps [`SchedMockEvent`]
+//! into its public `simulator::Event` type at drain time. Keeping the
+//! types separate also means a kernel-only consumer (an in-kernel
+//! `sched-mock`-gated integration test) can drain the trace without
+//! pulling the simulator in.
+//!
+//! ## Why a thread-local, not a global atomic
+//!
+//! The host-side simulator runs one thread per seed under
+//! `cargo test`'s parallel runner. A process-global sink would
+//! serialize every emit on a shared mutex and would interleave records
+//! from concurrent seeds. The thread-local approach matches the
+//! [`crate::task::env`] `SIM_ENV` thread-local exactly, and the
+//! "install once per worker thread" contract is the same:
+//! `Simulator::new` installs the seam, the macro consumes it.
+//!
+//! ## Why this lives in `task/`, not `simulator/`
+//!
+//! The kernel is the producer of these events; the simulator is one
+//! consumer. Putting the macro in `task/trace.rs` keeps the producer
+//! definitions co-located with the scheduler core that emits them, and
+//! keeps the simulator crate strictly downstream — it consumes
+//! [`SchedMockEvent`] via [`take_trace`] and never the other way around.
+
+#[cfg(all(not(target_os = "none"), feature = "sched-mock"))]
+use crate::task::env::TaskId;
+
+#[cfg(not(all(not(target_os = "none"), feature = "sched-mock")))]
+#[allow(unused_imports)]
+use crate::task::env::TaskId;
+
+/// Reason a task entered the blocked state.
+///
+/// Mirrors `simulator::trace::BlockReason` in shape; the simulator's
+/// `From<SchedMockBlockReason>` impl maps these into its own enum at
+/// drain time.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SchedMockBlockReason {
+    /// Task is waiting for a sleep deadline to expire.
+    Sleep,
+    /// Task is waiting on a wait-queue / synchronization primitive.
+    Wait,
+    /// Task is waiting for I/O completion.
+    Io,
+    /// Reserved for unmodelled or future block reasons.
+    Other,
+}
+
+/// CPU-fault classification observed or injected.
+///
+/// Mirrors `simulator::trace::FaultKind`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SchedMockFaultKind {
+    /// Page fault (`#PF`).
+    PageFault,
+    /// General-protection fault (`#GP`).
+    GeneralProtection,
+    /// Invalid-opcode fault (`#UD`).
+    InvalidOpcode,
+    /// Double fault (`#DF`).
+    DoubleFault,
+    /// Reserved for unmodelled or future fault kinds.
+    Other,
+}
+
+/// One scheduler-side observable event the kernel can emit through
+/// [`sched_mock_trace!`].
+///
+/// The variant set mirrors the snapshot-derived / kernel-emit-required
+/// arms of `simulator::trace::Event` (RFC 0006 §"Event emit points").
+/// Driver-loop-only events ([`Event::TickAdvance`] etc.) are emitted
+/// by the simulator itself and have no kernel-side emit point.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SchedMockEvent {
+    /// A wakeup was enqueued for `deadline`, naming task `id`.
+    /// Emitted from the `MockClock::enqueue_wakeup` host path and
+    /// from `sleep_ms` on bare-metal.
+    WakeupEnqueued {
+        /// Deadline tick at which the wakeup is scheduled to fire.
+        deadline: u64,
+        /// Task id whose wakeup was enqueued.
+        id: TaskId,
+    },
+    /// A task was scheduled onto the running slot. Emitted from
+    /// scheduler dispatch (`preempt_tick` / `block_current` /
+    /// `exit`) at the moment a new `current` is installed.
+    TaskScheduled {
+        /// Task id that was scheduled.
+        id: TaskId,
+    },
+    /// A task entered the blocked state.
+    TaskBlocked {
+        /// Task id that blocked.
+        id: TaskId,
+        /// Reason the task is blocked.
+        reason: SchedMockBlockReason,
+    },
+    /// A task was woken (parked → ready, or wake_pending set).
+    TaskWoken {
+        /// Task id that was woken.
+        id: TaskId,
+    },
+    /// A task exited.
+    TaskExit {
+        /// Task id that exited.
+        id: TaskId,
+    },
+    /// A `fork` / `exec` / `wait` transition occurred. The discriminant
+    /// is encoded as the syscall number on `Syscall` events; this
+    /// variant carries the resulting child / target id when relevant.
+    TaskForked {
+        /// Parent task id.
+        parent: TaskId,
+        /// Newly-created child task id.
+        child: TaskId,
+    },
+    /// A syscall was entered.
+    SyscallEntry {
+        /// Syscall number (Linux-compatible numbering on x86_64).
+        nr: u64,
+        /// First four argument registers (RDI, RSI, RDX, R10 on
+        /// x86_64). Truncated from the full six-arg ABI to keep the
+        /// trace JSON small; the v1 invariant set does not consume the
+        /// fifth/sixth arg.
+        args: [u64; 4],
+    },
+    /// A syscall returned.
+    SyscallExit {
+        /// Syscall number that returned.
+        nr: u64,
+    },
+    /// A CPU fault fired in user or kernel context.
+    Fault {
+        /// Fault classification.
+        kind: SchedMockFaultKind,
+        /// Faulting instruction pointer.
+        rip: u64,
+        /// Page-fault address (zero for non-page-fault kinds).
+        cr2: u64,
+    },
+    /// The simulator's FaultPlan (#722) injected a fault before the
+    /// kernel observed it. Carried here so future plans can record the
+    /// inject side; not yet emitted.
+    FaultInjected {
+        /// Fault classification injected.
+        kind: SchedMockFaultKind,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Host build with `feature = "sched-mock"`: the macro expands to a real
+// push into a thread-local sink. The kernel `lib.rs` already pulls in
+// `std` for this exact build configuration (see the `cfg_attr(no_std)`
+// at the crate root), so `std::thread_local!` is available.
+// ---------------------------------------------------------------------------
+
+#[cfg(all(not(target_os = "none"), feature = "sched-mock"))]
+mod host_sink {
+    use super::SchedMockEvent;
+    use alloc::vec::Vec;
+
+    std::thread_local! {
+        static SINK: core::cell::RefCell<Vec<SchedMockEvent>> =
+            const { core::cell::RefCell::new(Vec::new()) };
+    }
+
+    /// Append `event` to the current thread's trace sink.
+    ///
+    /// Called by [`crate::sched_mock_trace!`] only — direct calls bypass
+    /// the macro's compile-out gate and would defeat the nm-check
+    /// guard on a production build.
+    #[doc(hidden)]
+    pub fn push_event(event: SchedMockEvent) {
+        // `try_borrow_mut` rather than `borrow_mut`: a panic from the
+        // macro's emit point during an already-in-progress drain
+        // (e.g. an invariant predicate that evaluates events while
+        // the kernel is still running) would otherwise abort the
+        // simulator. Drop the event silently in that case — the
+        // bounded-recursion event matters less than a clean panic
+        // message from the actual invariant violation.
+        let _ = SINK.with(|c| {
+            if let Ok(mut g) = c.try_borrow_mut() {
+                g.push(event);
+                Ok(())
+            } else {
+                Err(())
+            }
+        });
+    }
+
+    /// Drain the current thread's trace sink, returning every event
+    /// pushed since the last drain.
+    pub fn take_trace() -> Vec<SchedMockEvent> {
+        SINK.with(|c| core::mem::take(&mut *c.borrow_mut()))
+    }
+
+    /// Number of events currently buffered for the current thread.
+    /// Test introspection only.
+    pub fn pending_event_count() -> usize {
+        SINK.with(|c| c.borrow().len())
+    }
+
+    /// Clear the current thread's trace sink without returning its
+    /// contents. Cheaper than `take_trace().drain(..)` when the caller
+    /// just wants a fresh slate before the next assertion.
+    pub fn clear_trace() {
+        SINK.with(|c| c.borrow_mut().clear());
+    }
+}
+
+#[cfg(all(not(target_os = "none"), feature = "sched-mock"))]
+pub use host_sink::{clear_trace, pending_event_count, push_event, take_trace};
+
+// ---------------------------------------------------------------------------
+// Off-feature / bare-metal: the macro is a no-op. Provide stub
+// `take_trace` etc. so callers in cfg-conditional code don't have to
+// fence every drain call themselves; on these targets the trace is
+// always empty.
+// ---------------------------------------------------------------------------
+
+#[cfg(not(all(not(target_os = "none"), feature = "sched-mock")))]
+#[allow(dead_code)]
+pub(crate) fn pending_event_count() -> usize {
+    0
+}
+
+/// Emit a [`SchedMockEvent`] to the per-thread scheduler trace sink.
+///
+/// Compile-time gated:
+///
+/// - `cfg(not(all(not(target_os = "none"), feature = "sched-mock")))`:
+///   expands to `()`. The argument expression is **not** evaluated;
+///   no `sched_mock_*` symbol survives into the release ELF (verified
+///   by `cargo xtask nm-check`).
+/// - `cfg(all(not(target_os = "none"), feature = "sched-mock"))`:
+///   pushes `event` into the calling thread's sink; downstream callers
+///   drain via [`take_trace`].
+///
+/// # Example
+///
+/// ```ignore
+/// use vibix::task::trace::{SchedMockEvent, SchedMockBlockReason};
+/// use vibix::sched_mock_trace;
+///
+/// // In `block_current()`:
+/// sched_mock_trace!(SchedMockEvent::TaskBlocked {
+///     id: prev_id,
+///     reason: SchedMockBlockReason::Wait,
+/// });
+/// ```
+#[macro_export]
+macro_rules! sched_mock_trace {
+    ($event:expr) => {{
+        // The two-arm cfg-if pattern keeps the off-feature arm
+        // a literal `()` rather than `let _ = $event;` — the latter
+        // would still evaluate the argument expression on the off
+        // path, defeating the nm-check guard (any symbol referenced
+        // inside `$event` would link in).
+        #[cfg(all(not(target_os = "none"), feature = "sched-mock"))]
+        {
+            $crate::task::trace::push_event($event);
+        }
+        #[cfg(not(all(not(target_os = "none"), feature = "sched-mock")))]
+        {
+            // No-op; argument intentionally not evaluated. The unit
+            // value here is what makes call sites compile in
+            // statement position without a trailing semicolon.
+            ()
+        }
+    }};
+}
+
+#[cfg(all(test, not(target_os = "none"), feature = "sched-mock"))]
+mod tests {
+    use super::*;
+    use crate::sched_mock_trace;
+
+    /// Each test runs on a fresh thread because the sink is a
+    /// thread-local — running on the cargo-test main thread would
+    /// share state with whatever earlier test happened to land there.
+    fn on_fresh_thread<R, F>(f: F) -> R
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        std::thread::spawn(f).join().expect("test thread panicked")
+    }
+
+    #[test]
+    fn sink_starts_empty() {
+        on_fresh_thread(|| {
+            assert_eq!(pending_event_count(), 0);
+            assert!(take_trace().is_empty());
+        });
+    }
+
+    #[test]
+    fn macro_pushes_a_single_event() {
+        on_fresh_thread(|| {
+            sched_mock_trace!(SchedMockEvent::TaskScheduled { id: 42 });
+            let evs = take_trace();
+            assert_eq!(evs.len(), 1);
+            assert!(matches!(evs[0], SchedMockEvent::TaskScheduled { id: 42 }));
+        });
+    }
+
+    #[test]
+    fn macro_preserves_emit_order_across_variants() {
+        on_fresh_thread(|| {
+            sched_mock_trace!(SchedMockEvent::SyscallEntry {
+                nr: 60,
+                args: [1, 2, 3, 4],
+            });
+            sched_mock_trace!(SchedMockEvent::TaskScheduled { id: 7 });
+            sched_mock_trace!(SchedMockEvent::TaskBlocked {
+                id: 7,
+                reason: SchedMockBlockReason::Wait,
+            });
+            sched_mock_trace!(SchedMockEvent::TaskWoken { id: 7 });
+            sched_mock_trace!(SchedMockEvent::SyscallExit { nr: 60 });
+
+            let evs = take_trace();
+            assert_eq!(evs.len(), 5);
+            assert!(matches!(
+                evs[0],
+                SchedMockEvent::SyscallEntry { nr: 60, .. }
+            ));
+            assert!(matches!(evs[1], SchedMockEvent::TaskScheduled { id: 7 }));
+            assert!(matches!(
+                evs[2],
+                SchedMockEvent::TaskBlocked {
+                    id: 7,
+                    reason: SchedMockBlockReason::Wait,
+                }
+            ));
+            assert!(matches!(evs[3], SchedMockEvent::TaskWoken { id: 7 }));
+            assert!(matches!(evs[4], SchedMockEvent::SyscallExit { nr: 60 }));
+        });
+    }
+
+    #[test]
+    fn take_trace_resets_the_sink() {
+        on_fresh_thread(|| {
+            sched_mock_trace!(SchedMockEvent::TaskScheduled { id: 1 });
+            sched_mock_trace!(SchedMockEvent::TaskScheduled { id: 2 });
+            assert_eq!(pending_event_count(), 2);
+            let _ = take_trace();
+            assert_eq!(pending_event_count(), 0);
+            // A second take_trace returns empty.
+            assert!(take_trace().is_empty());
+        });
+    }
+
+    #[test]
+    fn clear_trace_drops_buffered_events() {
+        on_fresh_thread(|| {
+            sched_mock_trace!(SchedMockEvent::TaskWoken { id: 9 });
+            sched_mock_trace!(SchedMockEvent::TaskWoken { id: 10 });
+            assert_eq!(pending_event_count(), 2);
+            clear_trace();
+            assert_eq!(pending_event_count(), 0);
+        });
+    }
+
+    #[test]
+    fn sink_is_per_thread() {
+        on_fresh_thread(|| {
+            // Outer thread: emit and observe.
+            sched_mock_trace!(SchedMockEvent::TaskScheduled { id: 100 });
+            assert_eq!(pending_event_count(), 1);
+
+            // A spawned thread starts with an empty sink and its emits
+            // are not visible on the outer thread.
+            let inner = std::thread::spawn(|| {
+                assert_eq!(pending_event_count(), 0);
+                sched_mock_trace!(SchedMockEvent::TaskScheduled { id: 200 });
+                pending_event_count()
+            })
+            .join()
+            .unwrap();
+            assert_eq!(inner, 1);
+
+            // Outer still sees only its own event.
+            let evs = take_trace();
+            assert_eq!(evs.len(), 1);
+            assert!(matches!(evs[0], SchedMockEvent::TaskScheduled { id: 100 }));
+        });
+    }
+
+    #[test]
+    fn page_fault_event_round_trips() {
+        on_fresh_thread(|| {
+            sched_mock_trace!(SchedMockEvent::Fault {
+                kind: SchedMockFaultKind::PageFault,
+                rip: 0xDEAD_BEEF,
+                cr2: 0xCAFE_F00D,
+            });
+            let evs = take_trace();
+            assert_eq!(evs.len(), 1);
+            assert!(matches!(
+                evs[0],
+                SchedMockEvent::Fault {
+                    kind: SchedMockFaultKind::PageFault,
+                    rip: 0xDEAD_BEEF,
+                    cr2: 0xCAFE_F00D,
+                }
+            ));
+        });
+    }
+
+    #[test]
+    fn fork_event_records_parent_and_child() {
+        on_fresh_thread(|| {
+            sched_mock_trace!(SchedMockEvent::TaskForked {
+                parent: 1,
+                child: 2,
+            });
+            let evs = take_trace();
+            assert!(matches!(
+                evs[0],
+                SchedMockEvent::TaskForked {
+                    parent: 1,
+                    child: 2,
+                }
+            ));
+        });
+    }
+
+    /// nm-check guard cannot run from a unit test (it inspects the
+    /// release kernel ELF). What we *can* assert at compile time is
+    /// that the off-feature arm of the macro evaluates to the unit
+    /// value with no symbol reference. This test is the unit-test
+    /// shadow of the `xtask nm-check` integration test.
+    #[test]
+    fn macro_compiles_in_statement_position() {
+        on_fresh_thread(|| {
+            // Statement position — the trailing `()` expansion makes
+            // this legal off-feature too.
+            sched_mock_trace!(SchedMockEvent::TaskScheduled { id: 0 });
+            sched_mock_trace!(SchedMockEvent::SyscallExit { nr: 60 });
+            let _ = take_trace();
+        });
+    }
+}
+
+// Off-feature compile guarantee: the static `cargo xtask nm-check`
+// integration check (extended in `xtask/src/main.rs` for #718) is the
+// real guard against the off-feature macro arm leaking
+// `sched_mock_*` / `SchedMockEvent` symbols into the release ELF. A
+// `#[test]` here would only compile on a configuration that also
+// enables `pub mod task`, which itself already requires
+// `feature = "sched-mock"` — the off-feature combination is therefore
+// not reachable from `cargo test` and the assertion belongs in
+// `nm-check`, not in this module.

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -356,6 +356,99 @@ mod imp {
             self.current_tick.load(Ordering::SeqCst)
         }
 
+        /// Returns the id of the most-recently-scheduled task observed
+        /// in the trace, or `None` if no [`Event::TaskScheduled`]
+        /// record has been seen yet.
+        ///
+        /// RFC 0006 / #718 introspection helper. Read-only reflection
+        /// of the kernel's scheduler state derived from the recorded
+        /// trace stream. Invariant predicates (#722) consume this to
+        /// answer "what is currently running" without re-deriving
+        /// scheduler state from raw events at every check.
+        ///
+        /// Implemented as a reverse linear scan of the trace tail.
+        /// O(n) in trace length in the worst case (a long run with
+        /// no schedule events); in practice every kernel emit-point
+        /// rotation pushes a `TaskScheduled` so the scan terminates
+        /// within a handful of records.
+        pub fn current_task(&self) -> Option<vibix::task::env::TaskId> {
+            self.trace
+                .records()
+                .iter()
+                .rev()
+                .find_map(|r| match r.event {
+                    Event::TaskScheduled { id } => Some(id),
+                    _ => None,
+                })
+        }
+
+        /// Snapshot of the kernel's runqueue, reconstructed from the
+        /// trace stream.
+        ///
+        /// The returned `Vec` is the set of tasks that the trace
+        /// reports as ready-to-run, derived by counting every id that
+        /// has fired ([`Event::WakeupFired`]) without a subsequent
+        /// [`Event::TaskScheduled`] or [`Event::TaskBlocked`]. Order
+        /// is *deterministic* but does not match the kernel's FIFO
+        /// bucketing — invariant checkers that need the exact
+        /// dispatch order should consume the trace directly.
+        ///
+        /// Returns an empty `Vec` if the trace contains no scheduling
+        /// activity yet — this is the v1 bring-up state and is the
+        /// expected return on the very first tick.
+        pub fn runqueue_snapshot(&self) -> Vec<vibix::task::env::TaskId> {
+            use std::collections::BTreeSet;
+            let mut ready: BTreeSet<vibix::task::env::TaskId> = BTreeSet::new();
+            // Forward pass: track the latest state transition per id
+            // through the events the simulator's run loop records
+            // today (`TaskScheduled`, `TaskBlocked`, `WakeupFired`).
+            // BTreeSet keeps the output deterministic — std's HashSet
+            // is forbidden in this crate (see crate-level
+            // `disallowed_types` lint).
+            for r in self.trace.records() {
+                match r.event {
+                    Event::TaskScheduled { id } => {
+                        // Scheduled task is `current`, not in runqueue.
+                        ready.remove(&id);
+                    }
+                    Event::TaskBlocked { id, .. } => {
+                        ready.remove(&id);
+                    }
+                    Event::WakeupFired { id } => {
+                        ready.insert(id);
+                    }
+                    _ => {}
+                }
+            }
+            ready.into_iter().collect()
+        }
+
+        /// Snapshot of the live PID table reconstructed from the
+        /// trace stream — every task id that has been scheduled,
+        /// woken, blocked, or forked but has not yet observed a
+        /// matching [`Event::TaskExit`].
+        ///
+        /// Returns ids in ascending numeric order (deterministic by
+        /// virtue of the underlying `BTreeSet`); the v1 invariant set
+        /// only consumes this for membership and cardinality, not for
+        /// dispatch order.
+        pub fn pid_table_snapshot(&self) -> Vec<vibix::task::env::TaskId> {
+            use std::collections::BTreeSet;
+            let mut alive: BTreeSet<vibix::task::env::TaskId> = BTreeSet::new();
+            for r in self.trace.records() {
+                match r.event {
+                    Event::TaskScheduled { id }
+                    | Event::TaskBlocked { id, .. }
+                    | Event::WakeupFired { id }
+                    | Event::WakeupEnqueued { id, .. } => {
+                        alive.insert(id);
+                    }
+                    _ => {}
+                }
+            }
+            alive.into_iter().collect()
+        }
+
         /// Borrow the recorded trace.
         pub fn trace(&self) -> &Trace {
             &self.trace
@@ -490,6 +583,19 @@ mod imp {
             } else {
                 None
             }
+        }
+    }
+
+    #[cfg(test)]
+    impl Simulator {
+        /// **Test-only.** Append a synthesized `TraceRecord` directly
+        /// onto the underlying trace, bypassing the kernel-emit path.
+        /// Used by unit tests for the read-only introspection helpers
+        /// (`current_task`, `runqueue_snapshot`, `pid_table_snapshot`)
+        /// to construct a deterministic trace without driving
+        /// `cfg(target_os = "none")` scheduler code from host code.
+        pub(crate) fn test_push_record(&mut self, rec: TraceRecord) {
+            self.trace.push(rec);
         }
     }
 
@@ -911,6 +1017,105 @@ mod tests {
         let mut a = r.rng_for("a");
         let mut b = r.rng_for("b");
         assert_ne!(a.next_u64(), b.next_u64());
+    }
+
+    /// RFC 0006 / #718 introspection helpers.
+    ///
+    /// These tests synthesize a trace by reaching into the test-only
+    /// `Trace::push` (`pub(crate)` — accessible from this module) so
+    /// the helper logic can be exercised without driving the kernel
+    /// scheduler from host code (which is impossible — sched_core is
+    /// `cfg(target_os = "none")`-gated).
+    #[test]
+    fn current_task_returns_none_on_empty_trace() {
+        on_fresh_thread(|| {
+            let sim = Simulator::with_seed(0xAA);
+            assert_eq!(sim.current_task(), None);
+            assert!(sim.runqueue_snapshot().is_empty());
+            assert!(sim.pid_table_snapshot().is_empty());
+        });
+    }
+
+    #[test]
+    fn current_task_returns_latest_scheduled_id() {
+        on_fresh_thread(|| {
+            let mut sim = Simulator::new(0xBB, SimulatorConfig::with_seed(0xBB));
+            // Hand-build a trace tail: schedule task 1, then 2.
+            sim.test_push_record(TraceRecord {
+                tick: 0,
+                event: Event::TaskScheduled { id: 1 },
+            });
+            sim.test_push_record(TraceRecord {
+                tick: 0,
+                event: Event::TaskScheduled { id: 2 },
+            });
+            assert_eq!(sim.current_task(), Some(2));
+        });
+    }
+
+    #[test]
+    fn runqueue_snapshot_tracks_wakeup_then_schedule() {
+        on_fresh_thread(|| {
+            let mut sim = Simulator::new(0xCC, SimulatorConfig::with_seed(0xCC));
+            // Three tasks wake; one of them gets scheduled.
+            sim.test_push_record(TraceRecord {
+                tick: 0,
+                event: Event::WakeupFired { id: 10 },
+            });
+            sim.test_push_record(TraceRecord {
+                tick: 0,
+                event: Event::WakeupFired { id: 20 },
+            });
+            sim.test_push_record(TraceRecord {
+                tick: 0,
+                event: Event::WakeupFired { id: 30 },
+            });
+            // 20 is now running; 10 and 30 stay ready.
+            sim.test_push_record(TraceRecord {
+                tick: 0,
+                event: Event::TaskScheduled { id: 20 },
+            });
+            let mut rq = sim.runqueue_snapshot();
+            rq.sort_unstable();
+            assert_eq!(rq, vec![10, 30]);
+
+            // Now block 30; only 10 remains ready.
+            sim.test_push_record(TraceRecord {
+                tick: 0,
+                event: Event::TaskBlocked {
+                    id: 30,
+                    reason: BlockReason::Wait,
+                },
+            });
+            assert_eq!(sim.runqueue_snapshot(), vec![10]);
+        });
+    }
+
+    #[test]
+    fn pid_table_snapshot_unions_event_ids() {
+        on_fresh_thread(|| {
+            let mut sim = Simulator::new(0xDD, SimulatorConfig::with_seed(0xDD));
+            sim.test_push_record(TraceRecord {
+                tick: 0,
+                event: Event::WakeupEnqueued { deadline: 5, id: 7 },
+            });
+            sim.test_push_record(TraceRecord {
+                tick: 0,
+                event: Event::TaskScheduled { id: 7 },
+            });
+            sim.test_push_record(TraceRecord {
+                tick: 0,
+                event: Event::TaskBlocked {
+                    id: 8,
+                    reason: BlockReason::Sleep,
+                },
+            });
+            sim.test_push_record(TraceRecord {
+                tick: 0,
+                event: Event::WakeupFired { id: 9 },
+            });
+            assert_eq!(sim.pid_table_snapshot(), vec![7, 8, 9]);
+        });
     }
 
     #[test]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -725,6 +725,22 @@ const NM_CHECK_FORBIDDEN: &[&str] = &[
     "MockIrqSource",
     "MockIrqState",
     "MockTimerIrq",
+    // RFC 0006 / #718 — the kernel-side scheduler-mock trace seam.
+    // The `sched_mock_trace!` macro and its push helper, the host
+    // thread-local sink, and every `SchedMock*` type live behind
+    // `cfg(all(not(target_os = "none"), feature = "sched-mock"))`.
+    // A release build must not contain any of these symbols; the
+    // macro's off-feature arm is `()` precisely so this gate keeps
+    // biting. Substring matches catch monomorphizations and
+    // module-prefixed paths (e.g. `vibix::task::trace::push_event`,
+    // `vibix::task::trace::host_sink::SINK`).
+    "sched_mock_trace",
+    "SchedMockEvent",
+    "SchedMockBlockReason",
+    "SchedMockFaultKind",
+    "task::trace::push_event",
+    "task::trace::take_trace",
+    "task::trace::host_sink",
 ];
 
 /// Pure scan over `nm --demangle` stdout: returns the lines that name a
@@ -2704,6 +2720,44 @@ ffffffff80020100 t core::ptr::drop_in_place::<vibix::task::env::MockIrqState>
             2,
             "both interior state types must match: {hits:?}"
         );
+    }
+
+    /// RFC 0006 / #718: the kernel-side `sched_mock_trace!` macro and
+    /// its sink helpers must also be caught by the release-image gate.
+    /// These fixtures cover the macro-pushed `push_event` symbol, the
+    /// host-only `task::trace::host_sink` module path, and the
+    /// `SchedMockEvent` / `SchedMockBlockReason` / `SchedMockFaultKind`
+    /// types — every name a misconfigured release build could surface.
+    #[test]
+    fn nm_check_catches_sched_mock_trace_symbols() {
+        let stdout = "\
+ffffffff80030000 t vibix::task::trace::push_event
+ffffffff80030100 t vibix::task::trace::host_sink::SINK::__init
+ffffffff80030200 t vibix::task::trace::take_trace
+ffffffff80030300 t core::ptr::drop_in_place::<vibix::task::trace::SchedMockEvent>
+ffffffff80030400 t vibix::task::trace::SchedMockBlockReason
+ffffffff80030500 t vibix::task::trace::SchedMockFaultKind
+";
+        let hits = scan_nm_output_for_mocks(stdout, NM_CHECK_FORBIDDEN);
+        assert_eq!(
+            hits.len(),
+            6,
+            "every sched_mock_trace symbol must match: {hits:?}"
+        );
+    }
+
+    /// RFC 0006 / #718: the macro-name itself (`sched_mock_trace`) is
+    /// listed because Rust's name-mangling can surface a generated
+    /// item name in some debug-info paths. A release-mode build with
+    /// the feature flipped on accidentally would produce something
+    /// like the line below; the fixture pins that.
+    #[test]
+    fn nm_check_catches_sched_mock_trace_macro_name() {
+        let stdout = "\
+ffffffff80031000 t vibix::sched_mock_trace::__expanded::push
+";
+        let hits = scan_nm_output_for_mocks(stdout, NM_CHECK_FORBIDDEN);
+        assert_eq!(hits.len(), 1, "macro-name path must match: {hits:?}");
     }
 
     #[test]


### PR DESCRIPTION
Closes #718

## Summary

Phase 2 (5) of RFC 0006 host-side DST: introduce the kernel-side emit-point macro that the simulator drains, wire it into every scheduler-observable transition, and add three read-only `Simulator` introspection helpers for invariant predicates.

- **`kernel/src/task/trace.rs` (new)**: `sched_mock_trace!` macro with two cfg-gated arms. Off-feature / bare-metal expands to literal `()` (argument never evaluated, zero symbol contribution). On host with `--features sched-mock` it pushes onto a per-thread `RefCell<Vec<SchedMockEvent>>` sink mirroring the existing `task::env` SIM_ENV thread-local. The kernel deliberately defines its own `SchedMockEvent` enum (variants: `WakeupEnqueued`, `TaskScheduled`, `TaskBlocked`, `TaskWoken`, `TaskExit`, `TaskForked`, `SyscallEntry`, `SyscallExit`, `Fault`, `FaultInjected`) rather than reaching into `simulator::Event` — the dependency arrow stays `simulator → kernel`.

- **Emit-point wiring**: `MockClock::enqueue_wakeup` (WakeupEnqueued); `preempt_tick`/`exit`/`block_current` (TaskScheduled); `block_current`/`sleep_ms` (TaskBlocked); `wake_in_sched` (TaskWoken on parked→ready only); `exit` (TaskExit); `fork_current_task` (TaskForked); `syscall_dispatch` (SyscallEntry/Exit); `idt::page_fault` (Fault).

- **`xtask/src/main.rs`**: extended `NM_CHECK_FORBIDDEN` to catch `sched_mock_trace`, `SchedMockEvent`, `SchedMockBlockReason`, `SchedMockFaultKind`, plus the host_sink helpers. Two new unit tests verify both the type-name and macro-name patterns are caught.

- **`simulator/src/lib.rs`**: `Simulator::current_task()`, `runqueue_snapshot()`, `pid_table_snapshot()` — read-only state derivable from the recorded trace. Test-only `test_push_record` accessor lets unit tests synthesize hand-built traces.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo xtask build` (bare-metal): release ELF builds with no `sched_mock_*` warning leaks
- [x] `cargo xtask nm-check`: confirms zero `SchedMockEvent` / `sched_mock_trace` / `task::trace::host_sink` symbols in release ELF
- [x] `cargo test -p vibix --features sched-mock --target x86_64-unknown-linux-gnu --lib trace::`: all 9 trace unit tests green (sink isolation, emit order, take_trace reset, page-fault round-trip, fork event, statement-position compile, per-thread isolation)
- [x] `cargo test -p simulator`: 33 lib tests green, including the 4 new tests covering `current_task`, `runqueue_snapshot`, `pid_table_snapshot`
- [x] `cargo xtask test`: full bare-metal integration suite green
- [x] `cargo xtask smoke`: all 42 markers present