### PR TITLE
DST Phase 2 (6): FaultPlan — seeded fault injection

### DIFF
--- a/simulator/src/fault_plan.rs
+++ b/simulator/src/fault_plan.rs
@@ -1,0 +1,935 @@
+//! Seeded fault-injection plan (RFC 0006 §"Failure-injection scope").
+//!
+//! Issue #719 lands the v1 fault-injection surface: an ordered
+//! `Vec<(Tick, FaultEvent)>` that the simulator consumes during
+//! [`crate::Simulator::step`]. Each due [`FaultEvent`] dispatches a
+//! deterministic perturbation against the seam mocks and emits a
+//! [`crate::Event::FaultInjected`] record into the trace so invariant
+//! checkers can correlate "we asked for a fault" with the kernel's
+//! observable response.
+//!
+//! ## v1 surface
+//!
+//! [`FaultEvent`] carries exactly three variants in v1:
+//!
+//! - [`FaultEvent::SpuriousTimerIrq`] — call
+//!   [`vibix::task::env::TimerIrq::inject_timer`] one extra time at
+//!   `tick`. Models LAPIC/PIT lost-edge retries (RFC 0006
+//!   §"Failure-injection scope": "Spurious timer IRQs").
+//! - [`FaultEvent::TimerDrift { ticks }`] — advance the mock clock by
+//!   `ticks` extra ticks at `tick`. Models delayed timer IRQs (RFC
+//!   §"Timer drift").
+//! - [`FaultEvent::WakeupReorder { within_tick }`] — the next
+//!   `WakeupFired` batch at the current tick is rotated by
+//!   `within_tick` positions before being emitted. Models "did the
+//!   parent's `wait` see the child's `exit` first?" (RFC §"Wakeup
+//!   re-ordering inside a tick" — the lever flagged for the #501
+//!   fork/exec/wait flake).
+//!
+//! ## What v1 *cannot* generate
+//!
+//! Hardware-fault variants (`InjectPageFault`, `InjectGeneralProtection`,
+//! `InjectDoubleFault`) are deliberately absent. RFC 0006 defers them
+//! to Phase 2.1 (issues #728/#729/#730/#731) — synthesizing a #PF /
+//! #GP / #DF on the host requires kernel-side trampoline work that
+//! does not exist yet. To make this an *enforced* deferral rather than
+//! a "we'll add it later" promise, the [`FaultEvent`] enum's variant
+//! set is the entire generated surface, and a `compile_fail` doctest
+//! pins the constraint at the type level. Any future patch that adds
+//! a `FaultEvent::InjectPageFault` variant will fail the doctest until
+//! the v1 surface is officially expanded — a decision that requires
+//! re-opening RFC 0006 §"Failure-injection scope".
+//!
+//! ```compile_fail
+//! # use simulator::FaultEvent;
+//! // RFC 0006 v1 forbids host-side hardware-fault injection. Adding a
+//! // page-fault variant must be a deliberate RFC change; this line
+//! // must therefore fail to compile against any v1 simulator.
+//! let _ = FaultEvent::InjectPageFault;
+//! ```
+//!
+//! ```compile_fail
+//! # use simulator::FaultEvent;
+//! let _ = FaultEvent::InjectGeneralProtection;
+//! ```
+//!
+//! ```compile_fail
+//! # use simulator::FaultEvent;
+//! let _ = FaultEvent::InjectDoubleFault;
+//! ```
+//!
+//! ## JSON round-trip
+//!
+//! [`FaultPlan::to_json`] / [`FaultPlan::from_json`] produce a stable
+//! schema (`fault_plan_schema_version = 1`) with the same
+//! field-ordering discipline as [`crate::trace`]. The replay binary
+//! and the proptest shrinker both consume the JSON form: a flake
+//! recorded under one seed survives `record → JSON → parse → re-replay`
+//! without bit drift.
+
+use std::string::{String, ToString};
+use std::vec::Vec;
+
+use rand_chacha::ChaCha8Rng;
+use rand_core::Rng;
+
+/// Stable JSON schema version for [`FaultPlan`] serialization.
+///
+/// Bump when adding, removing, or renaming a [`FaultEvent`] variant or
+/// field. v1 is the surface RFC 0006 §"Failure-injection scope" pins;
+/// every subsequent change is an RFC review.
+pub const FAULT_PLAN_SCHEMA_VERSION: u32 = 1;
+
+/// One injectable fault.
+///
+/// The variant set is the v1 fault-injection surface from RFC 0006:
+/// timer jitter, spurious IRQs, and within-tick wakeup re-ordering.
+/// Hardware faults (`#PF` / `#GP` / `#DF`) are deferred to Phase 2.1
+/// per RFC §"Failure-injection scope" and are *not* representable in
+/// this enum — callers that try to construct a `InjectPageFault`
+/// variant get a compile error (see the crate-level doctests in
+/// [this module](crate::fault_plan)).
+///
+/// `#[non_exhaustive]` so adding a v2 fault is a non-breaking source
+/// change at the type level; the JSON `fault_plan_schema_version`
+/// still bumps.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FaultEvent {
+    /// Inject one extra timer IRQ at the scheduled tick. Models a
+    /// LAPIC/PIT lost-edge retry where the same edge fires the ISR
+    /// twice within one logical tick.
+    SpuriousTimerIrq,
+    /// Advance the mock clock by `ticks` extra ticks at the scheduled
+    /// tick. Models a delayed timer IRQ where the kernel's notion of
+    /// `now` jumps forward by more than one between two consecutive
+    /// `preempt_tick` calls.
+    ///
+    /// `ticks == 0` is permitted but a no-op against the clock; it is
+    /// still recorded in the trace for replay parity.
+    TimerDrift {
+        /// Number of additional ticks to advance the clock by, on top
+        /// of the canonical one-tick advance the run loop performs.
+        ticks: u64,
+    },
+    /// Rotate the *next* drained wakeup batch by `within_tick`
+    /// positions before the simulator emits the corresponding
+    /// [`crate::Event::WakeupFired`] records. Models a `BTreeMap`
+    /// drain order that disagrees with the kernel's expected
+    /// dispatch order — the most direct lever on fork/exec/wait
+    /// races (#501).
+    ///
+    /// If the drain batch has fewer than two entries the rotation is
+    /// a no-op against the trace but still recorded as an injected
+    /// fault for replay parity.
+    WakeupReorder {
+        /// Number of positions to rotate the wakeup batch by. The
+        /// simulator computes `within_tick % batch.len()` so any
+        /// `u64` is a valid value (the wire form is stable across
+        /// batch-size changes).
+        within_tick: u64,
+    },
+}
+
+impl FaultEvent {
+    /// Wire-form classification used by [`crate::Event::FaultInjected`]'s
+    /// existing `kind: FaultKind` field.
+    ///
+    /// v1 does not own a dedicated `FaultKind` variant per fault event
+    /// (the trace's `FaultKind` enum was designed before #719 against
+    /// the hardware-fault catalogue: `page_fault`, `general_protection`,
+    /// etc.). Mapping every v1 [`FaultEvent`] to
+    /// [`crate::FaultKind::Other`] keeps the schema stable while
+    /// still letting callers correlate the `FaultInjected` record
+    /// with the next plan entry; the [`crate::trace::Event`] stream
+    /// remains the canonical evidence and downstream invariant
+    /// checkers consume the [`FaultEvent`] directly via
+    /// [`FaultPlan::events`].
+    pub fn fault_kind(self) -> crate::FaultKind {
+        match self {
+            FaultEvent::SpuriousTimerIrq
+            | FaultEvent::TimerDrift { .. }
+            | FaultEvent::WakeupReorder { .. } => crate::FaultKind::Other,
+        }
+    }
+
+    /// Stable wire string used in the JSON serialization. Closed set;
+    /// adding a [`FaultEvent`] variant is a [`FAULT_PLAN_SCHEMA_VERSION`]
+    /// bump.
+    fn type_tag(self) -> &'static str {
+        match self {
+            FaultEvent::SpuriousTimerIrq => "spurious_timer_irq",
+            FaultEvent::TimerDrift { .. } => "timer_drift",
+            FaultEvent::WakeupReorder { .. } => "wakeup_reorder",
+        }
+    }
+}
+
+/// Ordered `(tick, FaultEvent)` schedule consumed during a simulator
+/// run.
+///
+/// **Ordering contract.** Entries are kept sorted by `tick` (ascending,
+/// stable for ties). The simulator's `step()` consumes every entry whose
+/// `tick` matches the current post-advance tick value, in vector order;
+/// two entries that share a `tick` dispatch in the order they were
+/// inserted. This stability is load-bearing for replay: a recorded plan
+/// that fires `SpuriousTimerIrq` *then* `TimerDrift` at the same tick
+/// must fire in that order on every replay.
+///
+/// **Mutability.** A `FaultPlan` is constructed via [`FaultPlan::new`]
+/// or [`FaultPlanBuilder`] and is normally immutable for the duration
+/// of a simulator run. The [`FaultPlan::push`] method exists for the
+/// proptest-state-machine integration: each `InjectFault` transition
+/// appends one entry to the simulator's currently-installed plan via
+/// [`crate::Simulator::push_fault_event`].
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct FaultPlan {
+    /// `(tick, event)` entries, sorted by `tick` ascending; ties
+    /// preserved in insertion order.
+    entries: Vec<(u64, FaultEvent)>,
+}
+
+impl FaultPlan {
+    /// Construct an empty fault plan. Useful as the default for runs
+    /// that don't need any injection.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Construct a fault plan from a pre-built entry list. The list is
+    /// sorted by `tick` (stable on ties) before being stored — so
+    /// callers that produce entries in non-monotonic order still get
+    /// the documented dispatch contract.
+    pub fn from_entries<I>(entries: I) -> Self
+    where
+        I: IntoIterator<Item = (u64, FaultEvent)>,
+    {
+        let mut v: Vec<(u64, FaultEvent)> = entries.into_iter().collect();
+        // Stable sort preserves insertion order within equal-tick
+        // groups, which is the dispatch contract.
+        v.sort_by_key(|(t, _)| *t);
+        Self { entries: v }
+    }
+
+    /// Number of `(tick, event)` entries.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// `true` if the plan has no entries.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Borrow the plan's entries as a slice, ordered by `tick`
+    /// ascending.
+    pub fn entries(&self) -> &[(u64, FaultEvent)] {
+        &self.entries
+    }
+
+    /// Iterate the [`FaultEvent`] values in plan order. Convenience
+    /// for tests that don't care about the tick column.
+    pub fn events(&self) -> impl Iterator<Item = FaultEvent> + '_ {
+        self.entries.iter().map(|(_, e)| *e)
+    }
+
+    /// Append a new entry, preserving the sort-by-tick (stable on
+    /// ties) invariant. Used by the proptest-state-machine
+    /// integration's `InjectFault` transition.
+    pub fn push(&mut self, tick: u64, event: FaultEvent) {
+        // Find the first index whose tick is *strictly greater* than
+        // ours, then insert before it. This preserves stable ordering
+        // within an equal-tick group: the new entry sorts after every
+        // existing entry at the same tick.
+        let pos = self
+            .entries
+            .iter()
+            .position(|(t, _)| *t > tick)
+            .unwrap_or(self.entries.len());
+        self.entries.insert(pos, (tick, event));
+    }
+
+    /// Remove and return every `(tick, event)` whose tick equals
+    /// `current_tick`. The simulator calls this once per `step` to
+    /// drain the entries due at the just-advanced tick.
+    ///
+    /// Returns events in their stored order — the v1 dispatch
+    /// contract.
+    pub fn drain_due(&mut self, current_tick: u64) -> Vec<FaultEvent> {
+        // Two-pointer split: collect every leading entry whose tick is
+        // <= current_tick (entries strictly *less* than the current
+        // tick belong to a tick we already passed without firing them
+        // — that is a logic bug in the run loop and we surface it by
+        // dispatching the late entries here rather than silently
+        // dropping; replay-equivalence is preserved either way).
+        let mut due = Vec::new();
+        let mut keep = Vec::with_capacity(self.entries.len());
+        for (t, e) in self.entries.drain(..) {
+            if t <= current_tick {
+                due.push(e);
+            } else {
+                keep.push((t, e));
+            }
+        }
+        self.entries = keep;
+        due
+    }
+
+    /// Serialize the plan as canonical JSON (matching the [`crate::trace`]
+    /// encoder discipline: fixed field ordering, integer-only, no
+    /// floats / nulls / arrays of mixed type).
+    pub fn to_json(&self, w: &mut dyn core::fmt::Write) -> core::fmt::Result {
+        write!(
+            w,
+            "{{\"fault_plan_schema_version\": {FAULT_PLAN_SCHEMA_VERSION}, \"entries\": ["
+        )?;
+        for (i, (tick, ev)) in self.entries.iter().enumerate() {
+            if i > 0 {
+                w.write_str(", ")?;
+            }
+            write!(w, "{{\"tick\": {tick}, \"event\": ")?;
+            write_event(w, ev)?;
+            w.write_char('}')?;
+        }
+        w.write_str("]}")
+    }
+
+    /// Convenience: serialize to a `String`.
+    pub fn to_json_string(&self) -> String {
+        let mut s = String::new();
+        self.to_json(&mut s).expect("String write cannot fail");
+        s
+    }
+
+    /// Parse a JSON string produced by [`FaultPlan::to_json`].
+    pub fn from_json(input: &str) -> Result<Self, String> {
+        parse_plan(input)
+    }
+}
+
+fn write_event(w: &mut dyn core::fmt::Write, ev: &FaultEvent) -> core::fmt::Result {
+    match *ev {
+        FaultEvent::SpuriousTimerIrq => {
+            write!(w, "{{\"type\": \"{}\"}}", ev.type_tag())
+        }
+        FaultEvent::TimerDrift { ticks } => {
+            write!(w, "{{\"type\": \"{}\", \"ticks\": {ticks}}}", ev.type_tag())
+        }
+        FaultEvent::WakeupReorder { within_tick } => write!(
+            w,
+            "{{\"type\": \"{}\", \"within_tick\": {within_tick}}}",
+            ev.type_tag()
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------
+// JSON parser — same hand-rolled recursive-descent shape as
+// `trace.rs`. Kept independent of `trace.rs`'s `Parser` to avoid
+// re-exporting `pub(crate)` machinery across modules; the duplication
+// is < 60 lines and keeps the determinism envelope (no serde) clear.
+// ---------------------------------------------------------------------
+
+struct PlanParser<'a> {
+    input: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> PlanParser<'a> {
+    fn new(input: &'a str) -> Self {
+        Self {
+            input: input.as_bytes(),
+            pos: 0,
+        }
+    }
+
+    fn err(&self, msg: &str) -> String {
+        format!("fault plan JSON parse error at byte {}: {}", self.pos, msg)
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.input.get(self.pos).copied()
+    }
+
+    fn bump(&mut self) -> Option<u8> {
+        let b = self.peek()?;
+        self.pos += 1;
+        Some(b)
+    }
+
+    fn skip_ws(&mut self) {
+        while let Some(b) = self.peek() {
+            if matches!(b, b' ' | b'\t' | b'\n' | b'\r') {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn expect(&mut self, b: u8) -> Result<(), String> {
+        self.skip_ws();
+        match self.bump() {
+            Some(c) if c == b => Ok(()),
+            Some(c) => Err(self.err(&format!("expected '{}', got '{}'", b as char, c as char))),
+            None => Err(self.err(&format!("expected '{}', got EOF", b as char))),
+        }
+    }
+
+    fn parse_string(&mut self) -> Result<String, String> {
+        self.skip_ws();
+        self.expect(b'"')?;
+        let start = self.pos;
+        while let Some(b) = self.peek() {
+            if b == b'"' {
+                let s = core::str::from_utf8(&self.input[start..self.pos])
+                    .map_err(|_| self.err("non-UTF-8 byte in string"))?
+                    .to_string();
+                self.pos += 1;
+                return Ok(s);
+            }
+            if b == b'\\' {
+                return Err(self.err("escapes not supported in fault plan JSON strings"));
+            }
+            self.pos += 1;
+        }
+        Err(self.err("unterminated string"))
+    }
+
+    fn parse_u64(&mut self) -> Result<u64, String> {
+        self.skip_ws();
+        let start = self.pos;
+        while let Some(b) = self.peek() {
+            if b.is_ascii_digit() {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+        if start == self.pos {
+            return Err(self.err("expected integer"));
+        }
+        let s = core::str::from_utf8(&self.input[start..self.pos])
+            .map_err(|_| self.err("non-UTF-8 byte in integer"))?;
+        s.parse::<u64>()
+            .map_err(|_| self.err(&format!("integer out of range or invalid: {s}")))
+    }
+
+    fn expect_field(&mut self, name: &str) -> Result<(), String> {
+        let got = self.parse_string()?;
+        if got != name {
+            return Err(self.err(&format!("expected field \"{name}\", got \"{got}\"")));
+        }
+        self.expect(b':')
+    }
+}
+
+fn parse_plan(input: &str) -> Result<FaultPlan, String> {
+    let mut p = PlanParser::new(input);
+    p.expect(b'{')?;
+    p.expect_field("fault_plan_schema_version")?;
+    let v = p.parse_u64()?;
+    if v != u64::from(FAULT_PLAN_SCHEMA_VERSION) {
+        return Err(format!(
+            "fault plan JSON schema_version mismatch: expected {FAULT_PLAN_SCHEMA_VERSION}, got {v}"
+        ));
+    }
+    p.expect(b',')?;
+    p.expect_field("entries")?;
+    p.expect(b'[')?;
+
+    let mut entries: Vec<(u64, FaultEvent)> = Vec::new();
+    p.skip_ws();
+    if p.peek() != Some(b']') {
+        loop {
+            entries.push(parse_entry(&mut p)?);
+            p.skip_ws();
+            match p.peek() {
+                Some(b',') => {
+                    p.pos += 1;
+                }
+                Some(b']') => break,
+                Some(c) => return Err(p.err(&format!("expected ',' or ']', got '{}'", c as char))),
+                None => return Err(p.err("unexpected EOF in entries array")),
+            }
+        }
+    }
+    p.expect(b']')?;
+    p.expect(b'}')?;
+    p.skip_ws();
+    if p.pos != p.input.len() {
+        return Err(p.err("trailing bytes after JSON object"));
+    }
+    // The on-wire form already preserves order; no re-sort needed
+    // here — that would be lossy if a future schema bump permits
+    // unsorted input.
+    Ok(FaultPlan { entries })
+}
+
+fn parse_entry(p: &mut PlanParser<'_>) -> Result<(u64, FaultEvent), String> {
+    p.expect(b'{')?;
+    p.expect_field("tick")?;
+    let tick = p.parse_u64()?;
+    p.expect(b',')?;
+    p.expect_field("event")?;
+    let event = parse_event(p)?;
+    p.expect(b'}')?;
+    Ok((tick, event))
+}
+
+fn parse_event(p: &mut PlanParser<'_>) -> Result<FaultEvent, String> {
+    p.expect(b'{')?;
+    p.expect_field("type")?;
+    let ty = p.parse_string()?;
+    let event = match ty.as_str() {
+        "spurious_timer_irq" => FaultEvent::SpuriousTimerIrq,
+        "timer_drift" => {
+            p.expect(b',')?;
+            p.expect_field("ticks")?;
+            let ticks = p.parse_u64()?;
+            FaultEvent::TimerDrift { ticks }
+        }
+        "wakeup_reorder" => {
+            p.expect(b',')?;
+            p.expect_field("within_tick")?;
+            let within_tick = p.parse_u64()?;
+            FaultEvent::WakeupReorder { within_tick }
+        }
+        other => {
+            return Err(p.err(&format!(
+                "unknown fault event type: {other}; \
+                 RFC 0006 v1 surface is spurious_timer_irq / timer_drift / wakeup_reorder"
+            )));
+        }
+    };
+    p.expect(b'}')?;
+    Ok(event)
+}
+
+// ---------------------------------------------------------------------
+// Builder
+// ---------------------------------------------------------------------
+
+/// Builder for randomized [`FaultPlan`]s seeded from a [`crate::SimRng`]
+/// `rng_for("faults")` sub-stream.
+///
+/// The builder exists separately from `FaultPlan::new` so the
+/// "construct a hand-rolled plan" path (used by replay tests) and the
+/// "construct a randomized plan from a master seed" path (used by the
+/// proptest harness) stay textually distinct — replay tests must
+/// never accidentally consume an RNG byte that perturbs a future
+/// random plan.
+///
+/// Tunables are conservative: tests want a moderate number of faults
+/// per run, not a flood. The exact knobs ([`FaultPlanBuilder::density`],
+/// [`FaultPlanBuilder::max_tick`], [`FaultPlanBuilder::variants`]) are
+/// public so a flake reproduction can dial them up to widen the
+/// search.
+#[derive(Debug)]
+pub struct FaultPlanBuilder<'a> {
+    rng: &'a mut ChaCha8Rng,
+    density: f64,
+    max_tick: u64,
+    variants: VariantMask,
+}
+
+/// Bitmask selecting which [`FaultEvent`] variants the builder may
+/// emit. v1 has three; tests that want to isolate one variant (e.g.
+/// "show me a divergence caused only by `WakeupReorder`") flip the
+/// others off.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct VariantMask {
+    /// Allow [`FaultEvent::SpuriousTimerIrq`].
+    pub spurious_timer_irq: bool,
+    /// Allow [`FaultEvent::TimerDrift`].
+    pub timer_drift: bool,
+    /// Allow [`FaultEvent::WakeupReorder`].
+    pub wakeup_reorder: bool,
+}
+
+impl VariantMask {
+    /// All v1 variants enabled. The default the builder ships with.
+    pub const fn all() -> Self {
+        Self {
+            spurious_timer_irq: true,
+            timer_drift: true,
+            wakeup_reorder: true,
+        }
+    }
+
+    /// No variants enabled. Combined with [`FaultPlanBuilder::density`]
+    /// this produces the empty plan; useful as a control in
+    /// trace-divergence tests.
+    pub const fn none() -> Self {
+        Self {
+            spurious_timer_irq: false,
+            timer_drift: false,
+            wakeup_reorder: false,
+        }
+    }
+
+    /// Only [`FaultEvent::SpuriousTimerIrq`].
+    pub const fn only_spurious() -> Self {
+        Self {
+            spurious_timer_irq: true,
+            timer_drift: false,
+            wakeup_reorder: false,
+        }
+    }
+
+    /// Only [`FaultEvent::TimerDrift`].
+    pub const fn only_drift() -> Self {
+        Self {
+            spurious_timer_irq: false,
+            timer_drift: true,
+            wakeup_reorder: false,
+        }
+    }
+
+    /// Only [`FaultEvent::WakeupReorder`].
+    pub const fn only_reorder() -> Self {
+        Self {
+            spurious_timer_irq: false,
+            timer_drift: false,
+            wakeup_reorder: true,
+        }
+    }
+
+    /// Number of variants enabled. Used by the builder to pick a
+    /// uniformly-distributed variant when more than one is allowed.
+    fn count(self) -> u32 {
+        u32::from(self.spurious_timer_irq)
+            + u32::from(self.timer_drift)
+            + u32::from(self.wakeup_reorder)
+    }
+}
+
+impl<'a> FaultPlanBuilder<'a> {
+    /// Construct a builder backed by `rng`. The caller is expected to
+    /// have already named the sub-stream — typically by calling
+    /// [`crate::SimRng::rng_for`] with `"faults"` and passing the
+    /// returned `ChaCha8Rng` here.
+    ///
+    /// Default tunables: `density = 0.05` (≈5% of ticks carry a
+    /// fault), `max_tick = 1024`, all v1 variants enabled.
+    pub fn new(rng: &'a mut ChaCha8Rng) -> Self {
+        Self {
+            rng,
+            density: 0.05,
+            max_tick: 1024,
+            variants: VariantMask::all(),
+        }
+    }
+
+    /// Set the per-tick fault density (probability that a given tick
+    /// carries a fault). Clamped to `[0.0, 1.0]`.
+    pub fn density(mut self, density: f64) -> Self {
+        self.density = density.clamp(0.0, 1.0);
+        self
+    }
+
+    /// Set the inclusive upper bound on the ticks the builder may
+    /// schedule a fault at. Defaults to 1024.
+    pub fn max_tick(mut self, max_tick: u64) -> Self {
+        self.max_tick = max_tick;
+        self
+    }
+
+    /// Set the [`VariantMask`].
+    pub fn variants(mut self, variants: VariantMask) -> Self {
+        self.variants = variants;
+        self
+    }
+
+    /// Consume the builder and produce a [`FaultPlan`].
+    ///
+    /// The RNG byte stream consumed is `O(max_tick)` — one
+    /// `next_u64()` per candidate tick to decide "fault here?" plus a
+    /// handful per chosen tick to pick the variant and parameters.
+    /// Because the builder consumes from a *named* sub-stream
+    /// (`rng_for("faults")`), adding or removing a different sub-stream
+    /// elsewhere does not perturb the bytes the builder sees; the
+    /// determinism contract from RFC 0006 §RNG is preserved.
+    pub fn build(self) -> FaultPlan {
+        let count = self.variants.count();
+        if count == 0 || self.density == 0.0 {
+            return FaultPlan::new();
+        }
+
+        let density_u64 = (self.density * (u64::MAX as f64)) as u64;
+        let mut entries: Vec<(u64, FaultEvent)> = Vec::new();
+
+        // Sample one random `u64` per candidate tick. We fold it into
+        // a Bernoulli trial against `density_u64`; on success we draw
+        // additional bytes for the variant + parameters. This shape
+        // means changing `density` from 0.05 to 0.10 doubles the
+        // expected fault count without re-shuffling the *positions*
+        // already drawn — the underlying ChaCha8 stream byte index
+        // stays one-to-one with the tick index.
+        let rng = self.rng;
+        for tick in 0..=self.max_tick {
+            let trial = rng.next_u64();
+            if trial >= density_u64 {
+                continue;
+            }
+            // Pick a variant uniformly among the enabled ones.
+            let variant_pick = rng.next_u64() % u64::from(count);
+            let event = pick_variant(self.variants, variant_pick, rng);
+            entries.push((tick, event));
+        }
+        FaultPlan::from_entries(entries)
+    }
+}
+
+/// Map an enabled-variant index to the corresponding [`FaultEvent`],
+/// drawing parameter bytes from `rng` as needed.
+fn pick_variant(mask: VariantMask, idx: u64, rng: &mut ChaCha8Rng) -> FaultEvent {
+    let mut remaining = idx;
+    for (enabled, factory) in [
+        (
+            mask.spurious_timer_irq,
+            (|_: &mut ChaCha8Rng| FaultEvent::SpuriousTimerIrq)
+                as fn(&mut ChaCha8Rng) -> FaultEvent,
+        ),
+        (
+            mask.timer_drift,
+            (|r: &mut ChaCha8Rng| FaultEvent::TimerDrift {
+                // 1..=4 ticks of drift — small enough to not trivially
+                // wedge the run, large enough to flush most ordering
+                // hazards.
+                ticks: 1 + (r.next_u64() % 4),
+            }) as fn(&mut ChaCha8Rng) -> FaultEvent,
+        ),
+        (
+            mask.wakeup_reorder,
+            (|r: &mut ChaCha8Rng| FaultEvent::WakeupReorder {
+                within_tick: r.next_u64() % 8,
+            }) as fn(&mut ChaCha8Rng) -> FaultEvent,
+        ),
+    ] {
+        if !enabled {
+            continue;
+        }
+        if remaining == 0 {
+            return factory(rng);
+        }
+        remaining -= 1;
+    }
+    // Unreachable in practice (idx < mask.count() by construction);
+    // guard with a deterministic fallback rather than panic so the
+    // determinism envelope stays clean.
+    FaultEvent::SpuriousTimerIrq
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::SimRng;
+
+    #[test]
+    fn empty_plan_serializes_canonically() {
+        let p = FaultPlan::new();
+        assert_eq!(
+            p.to_json_string(),
+            "{\"fault_plan_schema_version\": 1, \"entries\": []}"
+        );
+    }
+
+    #[test]
+    fn round_trip_through_json_preserves_every_variant() {
+        let plan = FaultPlan::from_entries(vec![
+            (0, FaultEvent::SpuriousTimerIrq),
+            (3, FaultEvent::TimerDrift { ticks: 2 }),
+            (3, FaultEvent::WakeupReorder { within_tick: 1 }),
+            (7, FaultEvent::TimerDrift { ticks: 0 }),
+        ]);
+        let json = plan.to_json_string();
+        let parsed = FaultPlan::from_json(&json).expect("parse");
+        assert_eq!(parsed, plan);
+        // Re-serialize and demand byte-identical JSON.
+        assert_eq!(parsed.to_json_string(), json);
+    }
+
+    #[test]
+    fn parse_rejects_unknown_event_type() {
+        let bad = "{\"fault_plan_schema_version\": 1, \"entries\": [\
+                   {\"tick\": 0, \"event\": {\"type\": \"page_fault\"}}]}";
+        let err = FaultPlan::from_json(bad).unwrap_err();
+        assert!(
+            err.contains("unknown fault event type"),
+            "unexpected error: {err}"
+        );
+        // The error message must mention the v1 surface so a developer
+        // who tries `page_fault` knows it's deferred to Phase 2.1.
+        assert!(
+            err.contains("spurious_timer_irq"),
+            "error should hint at v1 variants: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_wrong_schema_version() {
+        let bad = "{\"fault_plan_schema_version\": 99, \"entries\": []}";
+        let err = FaultPlan::from_json(bad).unwrap_err();
+        assert!(err.contains("schema_version mismatch"), "{err}");
+    }
+
+    #[test]
+    fn from_entries_sorts_by_tick_stably() {
+        let plan = FaultPlan::from_entries(vec![
+            (5, FaultEvent::SpuriousTimerIrq),
+            (1, FaultEvent::TimerDrift { ticks: 1 }),
+            (5, FaultEvent::TimerDrift { ticks: 2 }),
+            (1, FaultEvent::WakeupReorder { within_tick: 3 }),
+        ]);
+        let ticks: Vec<u64> = plan.entries().iter().map(|(t, _)| *t).collect();
+        assert_eq!(ticks, vec![1, 1, 5, 5]);
+        // Stable: TimerDrift{1} came before WakeupReorder{3} at tick 1.
+        assert_eq!(
+            plan.entries()[0].1,
+            FaultEvent::TimerDrift { ticks: 1 },
+            "stable sort preserved"
+        );
+        assert_eq!(
+            plan.entries()[1].1,
+            FaultEvent::WakeupReorder { within_tick: 3 }
+        );
+    }
+
+    #[test]
+    fn push_preserves_sort_stably() {
+        let mut p = FaultPlan::new();
+        p.push(5, FaultEvent::SpuriousTimerIrq);
+        p.push(1, FaultEvent::TimerDrift { ticks: 1 });
+        p.push(5, FaultEvent::TimerDrift { ticks: 2 });
+        let ticks: Vec<u64> = p.entries().iter().map(|(t, _)| *t).collect();
+        assert_eq!(ticks, vec![1, 5, 5]);
+        // Tick-5 entries are in insertion order: SpuriousTimerIrq first.
+        assert_eq!(p.entries()[1].1, FaultEvent::SpuriousTimerIrq);
+        assert_eq!(p.entries()[2].1, FaultEvent::TimerDrift { ticks: 2 });
+    }
+
+    #[test]
+    fn drain_due_takes_only_matching_tick() {
+        let mut p = FaultPlan::from_entries(vec![
+            (1, FaultEvent::SpuriousTimerIrq),
+            (3, FaultEvent::TimerDrift { ticks: 1 }),
+            (3, FaultEvent::WakeupReorder { within_tick: 0 }),
+            (5, FaultEvent::SpuriousTimerIrq),
+        ]);
+        // Tick 0: nothing due.
+        assert!(p.drain_due(0).is_empty());
+        assert_eq!(p.len(), 4);
+        // Tick 1: drains the first entry.
+        assert_eq!(p.drain_due(1), vec![FaultEvent::SpuriousTimerIrq]);
+        assert_eq!(p.len(), 3);
+        // Tick 3: drains both tick-3 entries in order.
+        assert_eq!(
+            p.drain_due(3),
+            vec![
+                FaultEvent::TimerDrift { ticks: 1 },
+                FaultEvent::WakeupReorder { within_tick: 0 },
+            ]
+        );
+        assert_eq!(p.len(), 1);
+        // Tick 6: drains the late tick-5 entry (cannot leave stale
+        // entries behind — replay equivalence preserved).
+        assert_eq!(p.drain_due(6), vec![FaultEvent::SpuriousTimerIrq]);
+        assert!(p.is_empty());
+    }
+
+    #[test]
+    fn builder_is_deterministic_across_master_seeds() {
+        // Same master seed → same fault plan, byte-for-byte.
+        let r1 = SimRng::new(0xCAFE_F00D);
+        let mut s1 = r1.rng_for("faults");
+        let p1 = FaultPlanBuilder::new(&mut s1).max_tick(256).build();
+
+        let r2 = SimRng::new(0xCAFE_F00D);
+        let mut s2 = r2.rng_for("faults");
+        let p2 = FaultPlanBuilder::new(&mut s2).max_tick(256).build();
+
+        assert_eq!(p1, p2);
+        // The plan must contain at least one fault — `density = 0.05`
+        // over 257 candidate ticks gives an expected count of ~13;
+        // a zero-fault outcome would mean either the RNG is broken
+        // or the density math regressed.
+        assert!(
+            !p1.is_empty(),
+            "expected at least one fault under default density"
+        );
+    }
+
+    #[test]
+    fn builder_named_substream_does_not_share_bytes_with_other_streams() {
+        // Adding a `rng_for("scheduler")` consumer must not perturb
+        // the bytes `rng_for("faults")` emits — the property RFC
+        // 0006 §RNG pins as load-bearing for shrinking.
+        let r = SimRng::new(0x1111);
+
+        let mut faults_a = r.rng_for("faults");
+        let plan_a = FaultPlanBuilder::new(&mut faults_a).max_tick(64).build();
+
+        // Burn bytes on a different sub-stream.
+        let mut sched = r.rng_for("scheduler");
+        for _ in 0..100 {
+            let _ = sched.next_u64();
+        }
+
+        let mut faults_b = r.rng_for("faults");
+        let plan_b = FaultPlanBuilder::new(&mut faults_b).max_tick(64).build();
+
+        assert_eq!(plan_a, plan_b);
+    }
+
+    #[test]
+    fn builder_variant_mask_filters() {
+        let r = SimRng::new(0x2222);
+        let mut s = r.rng_for("faults");
+        let plan = FaultPlanBuilder::new(&mut s)
+            .max_tick(512)
+            .density(0.1)
+            .variants(VariantMask::only_reorder())
+            .build();
+        for ev in plan.events() {
+            assert!(matches!(ev, FaultEvent::WakeupReorder { .. }));
+        }
+    }
+
+    #[test]
+    fn builder_zero_density_yields_empty_plan() {
+        let r = SimRng::new(0x3333);
+        let mut s = r.rng_for("faults");
+        let plan = FaultPlanBuilder::new(&mut s).density(0.0).build();
+        assert!(plan.is_empty());
+    }
+
+    #[test]
+    fn builder_empty_mask_yields_empty_plan() {
+        let r = SimRng::new(0x4444);
+        let mut s = r.rng_for("faults");
+        let plan = FaultPlanBuilder::new(&mut s)
+            .variants(VariantMask::none())
+            .build();
+        assert!(plan.is_empty());
+    }
+
+    #[test]
+    fn fault_kind_maps_v1_variants_to_other() {
+        // RFC 0006 v1 fault kinds aren't represented in the trace's
+        // FaultKind enum (which was designed against hardware faults);
+        // every v1 variant therefore maps to FaultKind::Other.
+        assert_eq!(
+            FaultEvent::SpuriousTimerIrq.fault_kind(),
+            crate::FaultKind::Other
+        );
+        assert_eq!(
+            FaultEvent::TimerDrift { ticks: 1 }.fault_kind(),
+            crate::FaultKind::Other
+        );
+        assert_eq!(
+            FaultEvent::WakeupReorder { within_tick: 0 }.fault_kind(),
+            crate::FaultKind::Other
+        );
+    }
+}

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -75,6 +75,9 @@
 #![deny(clippy::disallowed_types)]
 
 #[cfg(not(target_os = "none"))]
+pub mod fault_plan;
+
+#[cfg(not(target_os = "none"))]
 pub mod invariants;
 
 // `proptest_model` is `cfg(test)`-gated at the file level — it pulls
@@ -99,6 +102,9 @@ mod imp {
 
     use vibix::task::env::{install_sim_env, Clock, MockClock, MockTimerIrq};
 
+    pub use crate::fault_plan::{
+        FaultEvent, FaultPlan, FaultPlanBuilder, VariantMask, FAULT_PLAN_SCHEMA_VERSION,
+    };
     pub use crate::invariants::{
         AllRunnableEventuallyRun, BlockedToRunnableNeedsWakeup, ForkHasMatchingExitOrWait,
         InvariantSet, LivenessInvariant, MonotonicPids, NoStrandedWakeups, SafetyInvariant,
@@ -160,6 +166,17 @@ mod imp {
         /// `SimulatorConfig` from defaults and want a different
         /// invariant surface mutate this field after construction.
         pub invariants: InvariantSet,
+        /// Seeded fault-injection plan (RFC 0006 §"Failure-injection
+        /// scope", issue #719). The simulator drains every entry whose
+        /// `tick` matches the current post-advance tick on each
+        /// [`Simulator::step`] and dispatches the corresponding
+        /// perturbation against the seam mocks.
+        ///
+        /// Default is the empty plan — runs that don't opt into fault
+        /// injection see byte-identical traces to the pre-#719
+        /// behaviour. Tests that want injection construct a builder
+        /// off `SimRng::rng_for("faults")` and assign the result here.
+        pub fault_plan: FaultPlan,
     }
 
     impl SimulatorConfig {
@@ -171,6 +188,7 @@ mod imp {
                 seed: Seed(seed),
                 max_ticks: 1_000_000,
                 invariants: InvariantSet::v1(),
+                fault_plan: FaultPlan::new(),
             }
         }
     }
@@ -309,6 +327,11 @@ mod imp {
         /// atomic so the panic hook can report `tick=<N>` even after
         /// the owning `Simulator` has unwound.
         current_tick: &'static AtomicU64,
+        /// `Some(n)` after a `WakeupReorder { within_tick: n }` fault
+        /// has been dispatched and before the corresponding wakeup
+        /// drain has consumed it. Cleared every step regardless of
+        /// whether the drain produced a non-empty batch.
+        pending_reorder: Option<u64>,
     }
 
     impl Simulator {
@@ -349,6 +372,7 @@ mod imp {
                 rng: SimRng::new(seed),
                 trace: Trace::new(),
                 current_tick,
+                pending_reorder: None,
             }
         }
 
@@ -491,6 +515,25 @@ mod imp {
             &mut self.rng
         }
 
+        /// Borrow the simulator's currently-installed [`FaultPlan`].
+        ///
+        /// Reading this during a run shows the *unconsumed* tail —
+        /// every entry whose `tick` is strictly greater than the last
+        /// call to [`Simulator::step`]. Callers that want the original
+        /// recorded plan capture a clone before constructing the
+        /// simulator.
+        pub fn fault_plan(&self) -> &FaultPlan {
+            &self.cfg.fault_plan
+        }
+
+        /// Append a [`FaultEvent`] at `tick` to the simulator's
+        /// installed [`FaultPlan`]. Used by the proptest-state-machine
+        /// integration's `InjectFault` transition (issue #722) so the
+        /// shrunk transition sequence directly drives fault dispatch.
+        pub fn push_fault_event(&mut self, tick: u64, event: FaultEvent) {
+            self.cfg.fault_plan.push(tick, event);
+        }
+
         /// Borrow the installed `MockClock`. Test introspection only —
         /// production code should reach the clock through `task::env()`
         /// like the kernel does.
@@ -563,7 +606,7 @@ mod imp {
         fn step_inner(&mut self) -> Result<(), Violation> {
             let now_before = self.clock.now().raw();
             self.clock.tick();
-            let now_after = self.clock.now().raw();
+            let mut now_after = self.clock.now().raw();
             self.current_tick.store(now_after, Ordering::SeqCst);
 
             self.trace.push(TraceRecord {
@@ -573,6 +616,81 @@ mod imp {
                     to: now_after,
                 },
             });
+
+            // RFC 0006 §"Failure-injection scope" / issue #719:
+            // dispatch every fault-plan entry due at the just-advanced
+            // tick *before* the canonical timer-IRQ injection. The
+            // ordering matters because `TimerDrift` must extend the
+            // tick interval visible to the upcoming `drain_expired`
+            // call (a wakeup armed for `now_after + 2` becomes due at
+            // this tick if the drift is `>= 2`); `WakeupReorder` must
+            // arm the rotation before the drain consumes it; and
+            // `SpuriousTimerIrq` is a pre-canonical extra inject so the
+            // post-drift IRQ count visible to the kernel is the sum
+            // (canonical + spurious).
+            let due = self.cfg.fault_plan.drain_due(now_after);
+            for fault in due {
+                match fault {
+                    FaultEvent::SpuriousTimerIrq => {
+                        // Push the FaultInjected record *before* the
+                        // extra inject so a reader of the trace can
+                        // tell which `TimerInjected` is the spurious
+                        // one (the next one). The trace shape after a
+                        // SpuriousTimerIrq fault at tick T is therefore
+                        // `TickAdvance, FaultInjected{Other},
+                        // TimerInjected (spurious), TimerInjected
+                        // (canonical), …`.
+                        self.trace.push(TraceRecord {
+                            tick: now_after,
+                            event: Event::FaultInjected {
+                                kind: fault.fault_kind(),
+                            },
+                        });
+                        self.irq.inject_timer();
+                        self.trace.push(TraceRecord {
+                            tick: now_after,
+                            event: Event::TimerInjected,
+                        });
+                    }
+                    FaultEvent::TimerDrift { ticks } => {
+                        self.trace.push(TraceRecord {
+                            tick: now_after,
+                            event: Event::FaultInjected {
+                                kind: fault.fault_kind(),
+                            },
+                        });
+                        if ticks > 0 {
+                            self.clock.advance(ticks);
+                            let drifted = self.clock.now().raw();
+                            self.trace.push(TraceRecord {
+                                tick: drifted,
+                                event: Event::TickAdvance {
+                                    from: now_after,
+                                    to: drifted,
+                                },
+                            });
+                            now_after = drifted;
+                            self.current_tick.store(now_after, Ordering::SeqCst);
+                        }
+                    }
+                    FaultEvent::WakeupReorder { within_tick } => {
+                        self.trace.push(TraceRecord {
+                            tick: now_after,
+                            event: Event::FaultInjected {
+                                kind: fault.fault_kind(),
+                            },
+                        });
+                        // Arm the rotation. If a previous reorder for
+                        // this tick was already pending it stacks
+                        // (sum of rotations modulo batch len at drain
+                        // time) — that keeps two `WakeupReorder`
+                        // entries at the same tick observably distinct
+                        // when the batch length is >= 3.
+                        let prev = self.pending_reorder.unwrap_or(0);
+                        self.pending_reorder = Some(prev.wrapping_add(within_tick));
+                    }
+                }
+            }
 
             self.irq.inject_timer();
             self.trace.push(TraceRecord {
@@ -586,7 +704,19 @@ mod imp {
             // simulator's trace.
             let (clock, irq) = vibix::task::env::env();
             let now = clock.now();
-            for id in clock.drain_expired(now) {
+            let mut drained = clock.drain_expired(now);
+            if let Some(rot) = self.pending_reorder.take() {
+                if drained.len() >= 2 {
+                    let n = drained.len();
+                    let r = (rot as usize) % n;
+                    drained.rotate_left(r);
+                }
+                // Even if the batch was too small to observably
+                // reorder, we already emitted the `FaultInjected`
+                // record so replay equivalence holds; the rotation
+                // state is consumed regardless.
+            }
+            for id in drained {
                 self.trace.push(TraceRecord {
                     tick: now_after,
                     event: Event::WakeupFired { id },
@@ -757,9 +887,10 @@ mod imp {
 #[cfg(not(target_os = "none"))]
 pub use imp::{
     install_panic_hook, AllRunnableEventuallyRun, BlockReason, BlockedToRunnableNeedsWakeup, Event,
-    FaultKind, ForkHasMatchingExitOrWait, InvariantSet, LivenessInvariant, MonotonicPids,
-    NoStrandedWakeups, SafetyInvariant, Seed, SimRng, Simulator, SimulatorConfig,
-    SingleRunningPerCpu, Trace, TraceRecord, Violation, SCHEMA_VERSION,
+    FaultEvent, FaultKind, FaultPlan, FaultPlanBuilder, ForkHasMatchingExitOrWait, InvariantSet,
+    LivenessInvariant, MonotonicPids, NoStrandedWakeups, SafetyInvariant, Seed, SimRng, Simulator,
+    SimulatorConfig, SingleRunningPerCpu, Trace, TraceRecord, VariantMask, Violation,
+    FAULT_PLAN_SCHEMA_VERSION, SCHEMA_VERSION,
 };
 
 // On `target_os = "none"` (the bare-metal kernel image), the simulator
@@ -1182,6 +1313,162 @@ mod tests {
             });
             assert_eq!(sim.pid_table_snapshot(), vec![7, 8, 9]);
         });
+    }
+
+    // -----------------------------------------------------------------
+    // RFC 0006 / issue #719: FaultPlan acceptance tests.
+    //
+    // The acceptance criteria for #719 are:
+    //   1. A plan recorded from a flaky run replays bit-identically.
+    //   2. Each v1 fault variant produces an observable trace
+    //      divergence vs. an unmoderated run on the same seed.
+    //
+    // The two-task workload below is the same shape the determinism
+    // smoke test uses, with a third task added so `WakeupReorder` can
+    // observably permute a multi-id batch (a single-id drain has
+    // nothing to rotate).
+    // -----------------------------------------------------------------
+
+    fn run_with_plan(seed: u64, plan: FaultPlan, ticks: u64) -> Vec<TraceRecord> {
+        let mut cfg = SimulatorConfig::with_seed(seed);
+        cfg.fault_plan = plan;
+        let mut sim = Simulator::new(seed, cfg);
+        let (clock, _irq) = vibix::task::env::env();
+        let start = clock.now();
+        // Three cooperating tasks with co-prime periods so the
+        // wakeup batches at certain ticks contain >= 2 ids — that's
+        // the precondition for `WakeupReorder` to observably permute
+        // the trace.
+        clock.enqueue_wakeup(start.saturating_add(2), 1);
+        clock.enqueue_wakeup(start.saturating_add(2), 2);
+        clock.enqueue_wakeup(start.saturating_add(3), 3);
+        for _ in 0..ticks {
+            sim.step();
+            let now = clock.now();
+            // Re-arm at every wake. Multiple ids share several ticks
+            // (e.g. tick 6: id 1 from period 2 *and* id 3 from period
+            // 3), guaranteeing batches the reorder fault can act on.
+            if now.raw() % 2 == 0 {
+                clock.enqueue_wakeup(now.saturating_add(2), 1);
+                clock.enqueue_wakeup(now.saturating_add(2), 2);
+            }
+            if now.raw() % 3 == 0 {
+                clock.enqueue_wakeup(now.saturating_add(3), 3);
+            }
+        }
+        sim.trace().records().to_vec()
+    }
+
+    /// Recorded plan replays bit-identically — the property that
+    /// makes seed-reproducible flake bug reports possible.
+    #[test]
+    fn fault_plan_recorded_run_replays_bit_identically() {
+        // Build a randomized plan from `rng_for("faults")`.
+        let plan = {
+            let r = SimRng::new(0xFEED_FACE);
+            let mut s = r.rng_for("faults");
+            crate::FaultPlanBuilder::new(&mut s)
+                .max_tick(64)
+                .density(0.10)
+                .build()
+        };
+        // Round-trip the plan through JSON before replay so the
+        // recorded form (the wire artifact a CI dump would carry) is
+        // what feeds the second run.
+        let plan_json = plan.to_json_string();
+        let plan_replay = crate::FaultPlan::from_json(&plan_json).expect("plan parse");
+        assert_eq!(plan, plan_replay);
+
+        let a = on_fresh_thread(move || run_with_plan(0xFEED_FACE, plan, 64));
+        let b = on_fresh_thread(move || run_with_plan(0xFEED_FACE, plan_replay, 64));
+        assert_eq!(
+            a,
+            b,
+            "recorded plan replay drifted (lengths {} vs {})",
+            a.len(),
+            b.len()
+        );
+        // The plan must have actually injected something — otherwise
+        // "replays identically" is trivial.
+        let injected = a
+            .iter()
+            .filter(|r| matches!(r.event, Event::FaultInjected { .. }))
+            .count();
+        assert!(
+            injected > 0,
+            "expected at least one FaultInjected event in the recorded run"
+        );
+    }
+
+    /// Each v1 fault variant produces an observable trace divergence
+    /// vs. an unmoderated run on the same seed. This is the
+    /// "fault has effect" half of the acceptance — without it, the
+    /// plan could be silently dropped and the determinism property
+    /// would still hold trivially.
+    #[test]
+    fn fault_plan_each_variant_diverges_from_unmoderated_run() {
+        let baseline = on_fresh_thread(|| run_with_plan(0xABCD, crate::FaultPlan::new(), 32));
+
+        // SpuriousTimerIrq at tick 4: emits an extra TimerInjected
+        // record + a FaultInjected record, neither of which appears
+        // in the baseline.
+        let plan_irq =
+            crate::FaultPlan::from_entries(vec![(4, crate::FaultEvent::SpuriousTimerIrq)]);
+        let with_irq = on_fresh_thread(move || run_with_plan(0xABCD, plan_irq, 32));
+        assert_ne!(
+            baseline, with_irq,
+            "SpuriousTimerIrq did not perturb the trace"
+        );
+
+        // TimerDrift at tick 4 by 2 extra ticks: shifts subsequent
+        // wakeup deadlines forward; the trace diverges at the drifted
+        // tick.
+        let plan_drift =
+            crate::FaultPlan::from_entries(vec![(4, crate::FaultEvent::TimerDrift { ticks: 2 })]);
+        let with_drift = on_fresh_thread(move || run_with_plan(0xABCD, plan_drift, 32));
+        assert_ne!(baseline, with_drift, "TimerDrift did not perturb the trace");
+
+        // WakeupReorder at tick 6 (where the workload guarantees a
+        // 3-element batch: ids 1, 2, 3 all due). Rotating by 1
+        // observably permutes the WakeupFired records.
+        let plan_reorder = crate::FaultPlan::from_entries(vec![(
+            6,
+            crate::FaultEvent::WakeupReorder { within_tick: 1 },
+        )]);
+        let with_reorder = on_fresh_thread(move || run_with_plan(0xABCD, plan_reorder, 32));
+        assert_ne!(
+            baseline, with_reorder,
+            "WakeupReorder did not perturb the trace"
+        );
+
+        // The three perturbed runs are also pairwise distinct: each
+        // variant exercises a different lever.
+        assert_ne!(with_irq, with_drift);
+        assert_ne!(with_irq, with_reorder);
+        assert_ne!(with_drift, with_reorder);
+    }
+
+    /// Empty plan must produce a byte-identical trace to a run that
+    /// never received a `fault_plan` field at all — the
+    /// "default-zero" property the existing run-loop tests implicitly
+    /// rely on.
+    #[test]
+    fn fault_plan_empty_is_indistinguishable_from_baseline() {
+        let unmodified = on_fresh_thread(|| {
+            // Baseline: simulator built via `with_seed`, which
+            // installs the default empty FaultPlan.
+            let mut sim = Simulator::with_seed(0xBEEF);
+            sim.run_for(16);
+            sim.trace().records().to_vec()
+        });
+        let with_explicit_empty = on_fresh_thread(|| {
+            let mut cfg = SimulatorConfig::with_seed(0xBEEF);
+            cfg.fault_plan = crate::FaultPlan::new();
+            let mut sim = Simulator::new(0xBEEF, cfg);
+            sim.run_for(16);
+            sim.trace().records().to_vec()
+        });
+        assert_eq!(unmodified, with_explicit_empty);
     }
 
     #[test]

--- a/simulator/src/proptest_model.rs
+++ b/simulator/src/proptest_model.rs
@@ -49,6 +49,7 @@ use proptest::strategy::ValueTree;
 use proptest::test_runner::{Config, TestRunner};
 use proptest_state_machine::ReferenceStateMachine;
 
+use crate::fault_plan::FaultEvent;
 use crate::invariants::Violation;
 use crate::trace::Trace;
 use crate::{Simulator, SimulatorConfig};
@@ -75,10 +76,14 @@ use vibix::task::env::TaskId;
 ///   it through so the proptest harness exercises a real seam path
 ///   even before #718 lands.
 /// - [`SchedulerTransition::Yield`] is `step()` once.
-/// - [`SchedulerTransition::InjectFault`] is a no-op until #719's
-///   `FaultPlan` lands. We keep it in the transition set so the day
-///   #719 merges the strategy already generates fault-injection
-///   sequences; the `apply_to_simulator` body grows then.
+/// - [`SchedulerTransition::InjectFault`] drives the v1 fault-
+///   injection surface landed by #719. Each transition appends one
+///   entry to the simulator's installed [`crate::FaultPlan`] at the
+///   tick immediately following the transition's apply point —
+///   `SpuriousTimerIrq`, `TimerDrift`, or `WakeupReorder` selected
+///   from the `kind: u8` range `0..3`. Hardware faults (`#PF` /
+///   `#GP` / `#DF`) are deferred to Phase 2.1 and are
+///   unrepresentable here.
 #[derive(Clone, Debug)]
 pub enum SchedulerTransition {
     /// Spawn a child task with the given id.
@@ -117,10 +122,16 @@ pub enum SchedulerTransition {
     },
     /// Cooperative yield: one `step()`.
     Yield,
-    /// Stubbed fault injection — no-op until #719's `FaultPlan` lands.
+    /// v1 fault injection (#719). The `kind` index selects one of
+    /// the three [`crate::FaultEvent`] variants; the
+    /// `apply_to_simulator` body translates the index to a concrete
+    /// `FaultEvent` and appends it to the simulator's [`crate::FaultPlan`]
+    /// at `current_tick + 1` so the next `step` dispatches it.
     InjectFault {
-        /// Fault kind index. Reserved for #719.
-        #[allow(dead_code)]
+        /// Fault kind index, range `0..3`:
+        /// `0 = SpuriousTimerIrq`, `1 = TimerDrift{ticks: 1}`,
+        /// `2 = WakeupReorder{within_tick: 1}`. Hardware-fault
+        /// indices (`#PF` / `#GP` / `#DF`) are unrepresentable.
         kind: u8,
     },
 }
@@ -188,10 +199,11 @@ impl ReferenceStateMachine for SchedulerStateMachine {
         };
         let next_id = state.next_id;
 
-        // Note: `InjectFault` is included in the strategy but stubbed
-        // in `apply_to_simulator` until #719 (FaultPlan) lands. We
-        // keep the strategy weight low so it does not crowd out the
-        // transitions that exercise real seam paths today.
+        // `InjectFault` is now wired to the live `FaultPlan` (#719).
+        // The strategy weight stays modest so a 16-step shrunk
+        // sequence is dominated by `Wake`/`Yield` (the seam paths
+        // every flake actually catches), with fault injection layered
+        // on top to surface ordering hazards.
         prop_oneof![
             // Fork: introduces a new id from the model's monotonic
             // counter. Cap arrivals so the strategy converges.
@@ -203,7 +215,7 @@ impl ReferenceStateMachine for SchedulerStateMachine {
             }),
             5 => (some_id, 1u64..16).prop_map(|(id, delta)| SchedulerTransition::Wake { id, delta }),
             5 => Just(SchedulerTransition::Yield),
-            1 => (0u8..4).prop_map(|kind| SchedulerTransition::InjectFault { kind }),
+            1 => (0u8..3).prop_map(|kind| SchedulerTransition::InjectFault { kind }),
         ]
         .boxed()
     }
@@ -232,7 +244,10 @@ impl ReferenceStateMachine for SchedulerStateMachine {
             }
             SchedulerTransition::Yield => {}
             SchedulerTransition::InjectFault { .. } => {
-                // Stubbed until #719.
+                // The reference model does not predict the
+                // simulator's fault-plan state — that is the
+                // simulator's owned object and the trace is the
+                // judge. We leave the model state untouched.
             }
         }
         state
@@ -293,11 +308,35 @@ fn apply_to_simulator(
             Ok(())
         }
         SchedulerTransition::Yield => sim.step_checked(),
-        SchedulerTransition::InjectFault { .. } => {
-            // Stubbed until #719's FaultPlan lands. Skipped from the
-            // simulator side; the proptest strategy still generates
-            // it so the day #719 merges the existing shrink
-            // sequences include fault-injection points.
+        SchedulerTransition::InjectFault { kind } => {
+            // Append a v1 fault-plan entry scheduled for the *next*
+            // tick (current_tick + 1) — the simulator's `step()`
+            // dispatches every entry whose tick equals the
+            // post-advance tick value, so a tick of `current_tick`
+            // would be late and dispatch as a "missed entry"
+            // sweep-up; using `+1` keeps the dispatch tight against
+            // the transition that scheduled it.
+            //
+            // Parameters are deliberately conservative (`ticks: 1`,
+            // `within_tick: 1`) — proptest's shrinker only sees the
+            // `kind: u8` index and trims the sequence; widening the
+            // parameter space here would expand the search space
+            // without giving the shrinker a way to minimize within
+            // it. Wider exploration lives in `FaultPlanBuilder`,
+            // which a randomized run can opt into via
+            // `cfg.fault_plan = FaultPlanBuilder::new(...).build()`.
+            let event = match kind {
+                0 => FaultEvent::SpuriousTimerIrq,
+                1 => FaultEvent::TimerDrift { ticks: 1 },
+                2 => FaultEvent::WakeupReorder { within_tick: 1 },
+                // The strategy clamps `kind` to `0..3`; treat any
+                // out-of-range value as a no-op rather than
+                // panicking — a panic here would obscure the actual
+                // proptest failure.
+                _ => return Ok(()),
+            };
+            let next_tick = sim.current_tick().saturating_add(1);
+            sim.push_fault_event(next_tick, event);
             Ok(())
         }
     }


### PR DESCRIPTION
Closes #719.

## Summary

Implements RFC 0006 §"Failure-injection scope" v1 for the host-side DST simulator. Introduces `FaultPlan` — an ordered `Vec<(Tick, FaultEvent)>` consumed during `Simulator::step` — together with a `FaultPlanBuilder` seeded off `SimRng::rng_for("faults")`, JSON round-trip, and live wiring into the proptest-state-machine integration's `InjectFault` transition.

`FaultEvent` carries the three v1 variants RFC 0006 commits to:
- `SpuriousTimerIrq` — extra `MockTimerIrq::inject_timer` (LAPIC lost-edge retry).
- `TimerDrift { ticks }` — extra `MockClock::advance` (delayed timer IRQ).
- `WakeupReorder { within_tick }` — rotate the next drained wakeup batch (the lever for #501-shaped fork/exec/wait races).

Hardware faults (`#PF` / `#GP` / `#DF`) are deferred to Phase 2.1 (#728 / #729 / #730 / #731). The deferral is enforced at the type level: there is no `InjectPageFault` / `InjectGeneralProtection` / `InjectDoubleFault` variant on `FaultEvent`, and three `compile_fail` doctests pin the absence so any later patch that re-adds them must explicitly re-open RFC 0006 §"Failure-injection scope".

Plans are JSON-round-trippable through a stable `fault_plan_schema_version = 1` shape, sharing `trace.rs`'s hand-rolled-encoder discipline (no serde, fixed field ordering, integer-only, no float / null) so the determinism envelope stays serde-clean.

`SimulatorConfig::fault_plan` defaults to the empty plan, so runs that don't opt into injection see byte-identical traces to pre-#719 behaviour. The proptest-state-machine integration's `InjectFault` arm (no-op stub from #722) now appends one entry per kind index to the live plan at `current_tick + 1`, scheduling dispatch on the next `step`.

## Acceptance

- **Recorded plan replays bit-identically.** `fault_plan_recorded_run_replays_bit_identically` builds a plan from `rng_for("faults")`, round-trips it through JSON, and replays both the original and the parsed plan on fresh threads under the same seed; the two traces compare equal record-for-record.
- **Each variant produces observable trace divergence.** `fault_plan_each_variant_diverges_from_unmoderated_run` runs a 3-task workload with each v1 variant injected at a single tick, asserts every perturbed run differs from the unmoderated baseline, and that the three variant-specific runs are pairwise distinct.
- **Empty plan is byte-identical to baseline.** `fault_plan_empty_is_indistinguishable_from_baseline` pins the default-zero contract.
- **Hardware-fault deferral enforced at the type level.** Three `compile_fail` doctests in `fault_plan.rs` reject `FaultEvent::InjectPageFault` / `InjectGeneralProtection` / `InjectDoubleFault`.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo build -p simulator` clean.
- [x] `cargo build --target x86_64-unknown-linux-gnu -p vibix --lib --features sched-mock` clean (CI host-build path).
- [x] `cargo clippy -p simulator --all-targets` clean.
- [x] `cargo test -p simulator` — 67 lib tests + 14 replay tests + 3 compile_fail doctests pass.
- [x] `cargo test -p simulator` repeated immediately — same pass count, no flakes (CI's two-pass determinism gate).
- [x] `cargo xtask test-unit` — kernel host unit tests still pass (576/576).
- [ ] Full CI: host-build, simulator determinism passes, lint, in-kernel integration tests under QEMU.