### PR TITLE
vfs: extend Inode with mapping + aops slots (RFC 0007 #745)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -77,6 +77,17 @@ vfs_creds = []
 # driver (`ext2_mount`, future waves) flip this on with
 # `--features ext2`.
 ext2 = []
+# RFC 0007 page-cache migration window. When on, `Inode` carries a
+# `mapping: BlockingRwLock<Option<Arc<PageCache>>>` slot that backing
+# filesystems lazily install on first mmap or first read-via-cache (RFC
+# 0007 §Inode-binding rule). Off by default for the migration window so
+# the field's memory and lock costs land on a deliberate flip rather
+# than implicitly. The follow-on wave-2 sites (`sys_mmap`, per-FS
+# `FileOps::mmap` impls) will gate their reads on the same flag; until
+# they land, the field is constructible but unused, and the
+# `Inode::page_cache_or_create` install-once helper is the only call
+# site.
+page_cache = []
 
 [[test]]
 name = "basic_boot"

--- a/kernel/src/fs/vfs/inode.rs
+++ b/kernel/src/fs/vfs/inode.rs
@@ -9,6 +9,11 @@ use alloc::sync::{Arc, Weak};
 
 use crate::sync::{BlockingMutex, BlockingRwLock};
 
+#[cfg(feature = "page_cache")]
+use crate::mem::aops::AddressSpaceOps;
+#[cfg(feature = "page_cache")]
+use crate::mem::page_cache::PageCache;
+
 use super::ops::{FileOps, InodeOps};
 use super::super_block::SuperBlock;
 use super::Timespec;
@@ -74,6 +79,40 @@ pub struct Inode {
     pub meta: BlockingRwLock<InodeMeta>,
     pub state: BlockingMutex<InodeState>,
     pub kind: InodeKind,
+    /// Per-inode page cache slot (RFC 0007 §Inode-binding rule).
+    ///
+    /// Populated lazily on first mmap or first read-via-cache by
+    /// [`Inode::page_cache_or_create`]. Once installed, the
+    /// `Arc<PageCache>` never changes — the slot is "install-once" for
+    /// the inode's lifetime, which is what closes the execve-rename
+    /// TOCTOU on `FileObject.cache`: a `FileObject` snapshots this Arc
+    /// at open and never re-resolves it, so a rename underneath cannot
+    /// silently swap the underlying cache.
+    ///
+    /// Gated by `feature = "page_cache"` for the migration window
+    /// (RFC 0007 §`PageCache`). The field is the only on-Inode owner;
+    /// when the inode is dropped, the cache's strong ref drops with
+    /// it. The writeback daemon owns weak refs, so the daemon never
+    /// pins an inode past its last user-visible reference.
+    #[cfg(feature = "page_cache")]
+    pub mapping: BlockingRwLock<Option<Arc<PageCache>>>,
+    /// Per-FS address-space hook captured at inode publication.
+    ///
+    /// Backing filesystems that participate in the page cache install
+    /// their `AddressSpaceOps` via [`Inode::set_aops`] before the inode
+    /// is reachable from userspace. Filesystems that do not yet
+    /// participate (e.g. `devfs`, synthetic stubs) leave it `None`;
+    /// for those inodes, [`Inode::page_cache_or_create`] returns
+    /// `None` and the caller falls back to its non-cache I/O path.
+    ///
+    /// Once set, the Arc is **never replaced** — this is the
+    /// `inode-binding rule` (RFC 0007). The field is wrapped in
+    /// `BlockingMutex` solely to make `set_aops` install-once-safe;
+    /// reads after install go through the inner `Option` clone with
+    /// no locking concern (the discriminant is set once and the Arc
+    /// pointee is stable for the inode's lifetime).
+    #[cfg(feature = "page_cache")]
+    pub aops: BlockingMutex<Option<Arc<dyn AddressSpaceOps>>>,
 }
 
 impl Inode {
@@ -94,7 +133,86 @@ impl Inode {
             meta: BlockingRwLock::new(meta),
             state: BlockingMutex::new(InodeState::default()),
             kind,
+            #[cfg(feature = "page_cache")]
+            mapping: BlockingRwLock::new(None),
+            #[cfg(feature = "page_cache")]
+            aops: BlockingMutex::new(None),
         }
+    }
+
+    /// Install the per-FS [`AddressSpaceOps`] hook **once**, before
+    /// the inode becomes reachable from userspace. Subsequent calls
+    /// are silently ignored — the inode-binding rule (RFC 0007
+    /// §Inode-binding rule) forbids rebinding a published inode's
+    /// address-space hook.
+    ///
+    /// Returns `true` if the install happened, `false` if the slot
+    /// was already populated. Callers in tests and FS publication
+    /// paths can ignore the bool; the only reason to inspect it is
+    /// to assert install-once during debug builds.
+    #[cfg(feature = "page_cache")]
+    pub fn set_aops(&self, ops: Arc<dyn AddressSpaceOps>) -> bool {
+        let mut slot = self.aops.lock();
+        if slot.is_some() {
+            return false;
+        }
+        *slot = Some(ops);
+        true
+    }
+
+    /// Return the inode's page cache, constructing it on first call.
+    ///
+    /// Implements the install-once discipline of RFC 0007
+    /// §Inode-binding rule: every caller observes the *same*
+    /// `Arc<PageCache>` for the rest of the inode's life. Concurrent
+    /// first-callers race on the write lock; the loser drops its
+    /// freshly-built `PageCache` and returns the winner's.
+    ///
+    /// Returns `None` if the inode has no [`AddressSpaceOps`]
+    /// installed via [`Inode::set_aops`] — for such inodes the page
+    /// cache is not applicable and the caller (typically the wave-2
+    /// `sys_mmap` / `FileOps::mmap` consumers, #746 / #753) must fall
+    /// back to a non-cache path.
+    ///
+    /// Implementation:
+    ///
+    /// 1. Optimistic read-lock fast path: if `mapping` is already
+    ///    `Some`, clone the `Arc` and return.
+    /// 2. Otherwise re-check under the write lock (another task may
+    ///    have installed it between dropping the read lock and taking
+    ///    the write lock); if still `None`, build a fresh `PageCache`
+    ///    seeded with the current `i_size` snapshot, the inode's
+    ///    `(fs_id, ino)` identity, and a clone of the per-inode
+    ///    `Arc<dyn AddressSpaceOps>`. Install it and return the
+    ///    clone.
+    ///
+    /// The cache is bound to the inode's identity at construction
+    /// time and is never rebound. If the inode's superblock has
+    /// already been torn down (`sb.upgrade()` returns `None`) we use
+    /// `fs_id = 0` for the bound identity — the inode is on its way
+    /// out via `gc_queue` and the cache will not outlive this Arc.
+    ///
+    /// Lock order: takes [`Self::mapping`] (level matches the page
+    /// cache's level-4 mutex) and, on the install path, briefly takes
+    /// [`Self::aops`] inside it to clone the ops Arc. Both locks are
+    /// released before any caller-driven I/O.
+    #[cfg(feature = "page_cache")]
+    pub fn page_cache_or_create(&self) -> Option<Arc<PageCache>> {
+        use crate::mem::page_cache::InodeId;
+
+        if let Some(pc) = self.mapping.read().as_ref() {
+            return Some(Arc::clone(pc));
+        }
+        let ops = self.aops.lock().as_ref().map(Arc::clone)?;
+        let mut slot = self.mapping.write();
+        if let Some(pc) = slot.as_ref() {
+            return Some(Arc::clone(pc));
+        }
+        let fs_id = self.sb.upgrade().map(|sb| sb.fs_id.0).unwrap_or(0);
+        let i_size = self.meta.read().size;
+        let pc = Arc::new(PageCache::new(InodeId::new(fs_id, self.ino), i_size, ops));
+        *slot = Some(Arc::clone(&pc));
+        Some(pc)
     }
 }
 
@@ -165,6 +283,80 @@ mod tests {
         assert_eq!(ino.ino, 42);
         assert_eq!(ino.meta.read().size, 100);
         assert!(!ino.state.lock().unlinked);
+    }
+
+    #[cfg(feature = "page_cache")]
+    fn fresh_inode() -> Arc<Inode> {
+        let sb = Arc::new(SuperBlock::new(
+            FsId(9),
+            Arc::new(StubSuper),
+            "stub",
+            512,
+            SbFlags::default(),
+        ));
+        Arc::new(Inode::new(
+            123,
+            Arc::downgrade(&sb),
+            Arc::new(StubInode),
+            Arc::new(StubFile),
+            InodeKind::Reg,
+            InodeMeta {
+                mode: 0o644,
+                nlink: 1,
+                size: 4096,
+                ..Default::default()
+            },
+        ))
+    }
+
+    #[cfg(feature = "page_cache")]
+    #[test]
+    fn page_cache_or_create_returns_none_without_aops() {
+        let inode = fresh_inode();
+        assert!(inode.page_cache_or_create().is_none());
+        assert!(inode.mapping.read().is_none());
+    }
+
+    #[cfg(feature = "page_cache")]
+    #[test]
+    fn page_cache_or_create_installs_once() {
+        let inode = fresh_inode();
+        inode.set_aops(crate::mem::aops::tests::fresh_ops());
+        let a = inode.page_cache_or_create().expect("aops installed");
+        let b = inode.page_cache_or_create().expect("aops installed");
+        // Same Arc both calls — not a fresh PageCache on second call.
+        assert!(Arc::ptr_eq(&a, &b));
+    }
+
+    #[cfg(feature = "page_cache")]
+    #[test]
+    fn page_cache_starts_empty() {
+        let inode = fresh_inode();
+        inode.set_aops(crate::mem::aops::tests::fresh_ops());
+        assert!(inode.mapping.read().is_none());
+        let _ = inode.page_cache_or_create();
+        assert!(inode.mapping.read().is_some());
+    }
+
+    #[cfg(feature = "page_cache")]
+    #[test]
+    fn page_cache_seeds_identity_and_size() {
+        use core::sync::atomic::Ordering;
+        let inode = fresh_inode();
+        inode.set_aops(crate::mem::aops::tests::fresh_ops());
+        let pc = inode.page_cache_or_create().expect("aops installed");
+        assert_eq!(pc.inode_id.fs_id, 9);
+        assert_eq!(pc.inode_id.ino, 123);
+        assert_eq!(pc.i_size.load(Ordering::Relaxed), 4096);
+    }
+
+    #[cfg(feature = "page_cache")]
+    #[test]
+    fn set_aops_is_install_once() {
+        let inode = fresh_inode();
+        assert!(inode.set_aops(crate::mem::aops::tests::fresh_ops()));
+        // Second install attempt is rejected — inode-binding rule.
+        assert!(!inode.set_aops(crate::mem::aops::tests::fresh_ops()));
     }
 
     #[test]


### PR DESCRIPTION
Closes #745.

## Summary

Adds the two per-inode slots that the wave-2 page-cache consumers (`sys_mmap` #746 and `FileOps::mmap` impls #753) will read at fault time, plus the install-once helper that lazily materialises the cache on first access:

- `Inode::mapping: BlockingRwLock<Option<Arc<PageCache>>>` — per-inode page cache. Empty until the first read-via-cache / first mmap; once set, the `Arc<PageCache>` is stable for the inode's lifetime (RFC 0007 §Inode-binding rule, closing the execve-rename TOCTOU on `FileObject.cache`).
- `Inode::aops: BlockingMutex<Option<Arc<dyn AddressSpaceOps>>>` — per-FS address-space hook. Populated once via `set_aops()` before the inode becomes reachable from userspace; second install returns `false`.
- `Inode::page_cache_or_create() -> Option<Arc<PageCache>>` — optimistic-read / re-check-under-write fast-path; loser of an install race drops its fresh `PageCache` and returns the winner's. Returns `None` for inodes without an aops (devfs, synthetic stubs, future non-cached FS). Seeds the cache with the inode's `(fs_id, ino)` identity and current `i_size`.

Both fields, the helper, and `set_aops` are gated by `feature = "page_cache"` per RFC 0007 §`PageCache`. The feature is added to `kernel/Cargo.toml`; nothing on `main` consumes it yet — the wave-2 mmap sites will flip it on together once they land.

Out of scope (sibling issues): `sys_mmap` (#746), per-FS `FileOps::mmap` impls (#753), writeback daemon hookup (#740/#742). This PR only adds the inert slots + helper.

## Test plan

- [x] `cargo xtask build` (default features) — green
- [x] `cargo xtask build --features page_cache` — green
- [x] `cargo xtask smoke` — all 42 markers present
- [x] Host unit tests — 576 passed
- [x] New `#[cfg(feature = "page_cache")]` install-once tests cover: no-aops returns None, idempotent install with `Arc::ptr_eq`, fresh inode mapping is empty, identity+size seeding, `set_aops` rejects second install
- [x] `cargo fmt --all` — clean