### PR TITLE
DST Phase 2 (6.5): Seed minimizer — tick-window bisect + FaultPlan delta-debug

### DIFF
--- a/simulator/src/bin/replay.rs
+++ b/simulator/src/bin/replay.rs
@@ -1,17 +1,27 @@
-//! `replay` — host-side simulator CLI stub (RFC 0006, issue #715).
+//! `replay` — host-side simulator CLI (RFC 0006, issues #715/#717/#720).
 //!
-//! The committed argument shape is
+//! Two argument shapes are supported:
 //!
 //! ```text
 //! cargo run -p simulator --bin replay -- --seed <u64> [--trace-out <path>]
+//! cargo run -p simulator --bin replay -- minimize \
+//!     --seed <u64> --plan <path> --out <path> [--max-ticks <u64>]
 //! ```
 //!
-//! Today this binary parses those flags, prints `unimplemented`, and
-//! exits 0. The real replay path lands in #716 (run loop) and #717
-//! (trace dump). The argument shape is part of the API contract per
-//! RFC 0006 §"Local repro" — downstream auto-engineer tooling and
-//! human-facing documentation already cite it, so the names must not
-//! drift.
+//! The first form is the original `replay` stub (#715/#717): it parses
+//! flags, prints `unimplemented`, and exits 0. The real per-tick body
+//! lands in #716 (run loop) and #717 (trace dump). The argument shape
+//! is part of the API contract per RFC 0006 §"Local repro" — downstream
+//! auto-engineer tooling and human-facing documentation already cite
+//! it, so the names must not drift.
+//!
+//! The second form (issue #720) drives the two-stage seed minimizer
+//! ([`simulator::minimize`]): tick-window binary search followed by
+//! `ddmin` over the [`simulator::FaultPlan`]. The "reproduces"
+//! predicate is *the simulator panics* — i.e. running with the given
+//! seed + (clipped) plan + tick budget produces a `panic!`. This
+//! matches the failure mode every Phase 2 invariant violation surfaces
+//! as (`SIMULATOR PANIC seed=… tick=…` from the panic hook).
 //!
 //! `--seed` accepts decimal, `0x`-prefixed hex, and underscored forms
 //! (e.g. `0xDEAD_BEEF`, `1234_5678`). Anything else is a usage error
@@ -25,14 +35,26 @@
 //! when consumed as the value of `--trace-out` (so a literal path of
 //! `--help` is still legal, awkward as that may be).
 
+use std::fs;
 use std::process::ExitCode;
+
+use simulator::{
+    closure_reproducer, minimize, FaultPlan, MinimizeOutput, Simulator, SimulatorConfig, TickWindow,
+};
 
 const USAGE: &str = "\
 usage: replay --seed <u64> [--trace-out <path>]
+       replay minimize --seed <u64> --plan <path> --out <path> [--max-ticks <u64>]
 
-The host-side DST simulator's replay binary. Today this is a stub
-that only parses arguments and prints \"unimplemented\"; the real
-run-loop body lands in #716 and the trace dump in #717.
+The host-side DST simulator's replay binary.
+
+Top-level form (issue #715/#717): parses arguments and prints \"unimplemented\";
+the real run-loop body lands in #716 and the trace dump in #717.
+
+`minimize` subcommand (issue #720): two-stage seed minimizer. Reads a fault
+plan JSON file, runs tick-window bisect followed by FaultPlan delta-debug,
+and writes the minimized (seed, FaultPlan, tick_window) triple as JSON to
+the output path. The \"reproduces\" predicate is a simulator panic.
 
 Options:
   --seed <u64>          Master seed for the run. Accepts decimal,
@@ -41,11 +63,16 @@ Options:
   --trace-out <path>    Path to write the JSON trace dump. Stub
                         accepts and validates this argument but does
                         not yet write a file.
+  --plan <path>         (minimize) Path to an input FaultPlan JSON file.
+  --out <path>          (minimize) Path to write the minimized output.
+  --max-ticks <u64>     (minimize) Initial upper bound on ticks the
+                        simulator runs for. Default 1_000_000.
   -h, --help            Print this message.
 
 Exit codes:
-  0   Success (today: always, since the body is unimplemented).
-  1   Reserved for simulator failures (run loop, #716).
+  0   Success.
+  1   Reserved for simulator failures (run loop, #716; minimize: input
+      did not reproduce).
   2   CLI usage error (missing required flag, parse failure).";
 
 fn main() -> ExitCode {
@@ -64,12 +91,20 @@ fn main() -> ExitCode {
             eprintln!("{USAGE}");
             ExitCode::from(2)
         }
+        Err(CliError::Runtime(msg)) => {
+            eprintln!("{msg}");
+            ExitCode::from(1)
+        }
     }
 }
 
 #[derive(Debug)]
 enum CliError {
     Usage(String),
+    /// Non-usage runtime failure (input does not reproduce, IO error,
+    /// JSON parse error). Exit code 1 — distinct from CLI usage
+    /// errors (exit 2) and from a clean run (exit 0).
+    Runtime(String),
 }
 
 /// Result of a successful CLI parse + run.
@@ -77,11 +112,20 @@ enum CliError {
 enum Outcome {
     /// `--help` / `-h` was requested.
     Help,
-    /// The stub ran (and printed `unimplemented`).
+    /// The stub or subcommand ran successfully.
     Ran,
 }
 
 fn run(args: Vec<String>) -> Result<Outcome, CliError> {
+    // Subcommand dispatch: `replay minimize ...` is the #720 path,
+    // anything else is the top-level #715/#717 stub.
+    if let Some(first) = args.first() {
+        if first == "minimize" {
+            let parsed = parse_minimize(&args[1..])?;
+            run_minimize(parsed)?;
+            return Ok(Outcome::Ran);
+        }
+    }
     match parse_args(&args)? {
         ParseOutcome::Help => Ok(Outcome::Help),
         ParseOutcome::Run(parsed) => {
@@ -181,6 +225,222 @@ fn parse_seed(raw: &str) -> Result<u64, CliError> {
     parsed.map_err(|e| CliError::Usage(format!("replay: --seed `{raw}` is not a valid u64: {e}")))
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct MinimizeArgs {
+    seed: u64,
+    plan_path: String,
+    out_path: String,
+    max_ticks: u64,
+}
+
+const MINIMIZE_DEFAULT_MAX_TICKS: u64 = 1_000_000;
+
+fn parse_minimize(args: &[String]) -> Result<MinimizeArgs, CliError> {
+    let mut seed: Option<u64> = None;
+    let mut plan: Option<String> = None;
+    let mut out: Option<String> = None;
+    let mut max_ticks: Option<u64> = None;
+
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--seed" => {
+                let raw = iter.next().ok_or_else(|| {
+                    CliError::Usage(String::from("replay minimize: --seed requires a value"))
+                })?;
+                if seed.is_some() {
+                    return Err(CliError::Usage(String::from(
+                        "replay minimize: --seed may be specified only once",
+                    )));
+                }
+                seed = Some(parse_seed(raw)?);
+            }
+            "--plan" => {
+                let raw = iter.next().ok_or_else(|| {
+                    CliError::Usage(String::from("replay minimize: --plan requires a value"))
+                })?;
+                if plan.is_some() {
+                    return Err(CliError::Usage(String::from(
+                        "replay minimize: --plan may be specified only once",
+                    )));
+                }
+                if raw.is_empty() {
+                    return Err(CliError::Usage(String::from(
+                        "replay minimize: --plan requires a non-empty path",
+                    )));
+                }
+                plan = Some(raw.clone());
+            }
+            "--out" => {
+                let raw = iter.next().ok_or_else(|| {
+                    CliError::Usage(String::from("replay minimize: --out requires a value"))
+                })?;
+                if out.is_some() {
+                    return Err(CliError::Usage(String::from(
+                        "replay minimize: --out may be specified only once",
+                    )));
+                }
+                if raw.is_empty() {
+                    return Err(CliError::Usage(String::from(
+                        "replay minimize: --out requires a non-empty path",
+                    )));
+                }
+                out = Some(raw.clone());
+            }
+            "--max-ticks" => {
+                let raw = iter.next().ok_or_else(|| {
+                    CliError::Usage(String::from(
+                        "replay minimize: --max-ticks requires a value",
+                    ))
+                })?;
+                if max_ticks.is_some() {
+                    return Err(CliError::Usage(String::from(
+                        "replay minimize: --max-ticks may be specified only once",
+                    )));
+                }
+                let cleaned: String = raw.chars().filter(|c| *c != '_').collect();
+                let v = cleaned.parse::<u64>().map_err(|e| {
+                    CliError::Usage(format!(
+                        "replay minimize: --max-ticks `{raw}` is not a valid u64: {e}"
+                    ))
+                })?;
+                if v == 0 {
+                    return Err(CliError::Usage(String::from(
+                        "replay minimize: --max-ticks must be > 0",
+                    )));
+                }
+                max_ticks = Some(v);
+            }
+            "-h" | "--help" => {
+                // Print usage and request a help-style exit. The
+                // outer `run` reads the usage banner from `Outcome::Help`,
+                // not from a returned error, so we surface it via a
+                // sentinel `Usage` with an empty message that the
+                // caller does not show. Simpler: just print and exit.
+                println!("{USAGE}");
+                std::process::exit(0);
+            }
+            other => {
+                return Err(CliError::Usage(format!(
+                    "replay minimize: unrecognised argument `{other}`"
+                )));
+            }
+        }
+    }
+
+    let seed =
+        seed.ok_or_else(|| CliError::Usage(String::from("replay minimize: --seed is required")))?;
+    let plan_path =
+        plan.ok_or_else(|| CliError::Usage(String::from("replay minimize: --plan is required")))?;
+    let out_path =
+        out.ok_or_else(|| CliError::Usage(String::from("replay minimize: --out is required")))?;
+    let max_ticks = max_ticks.unwrap_or(MINIMIZE_DEFAULT_MAX_TICKS);
+
+    Ok(MinimizeArgs {
+        seed,
+        plan_path,
+        out_path,
+        max_ticks,
+    })
+}
+
+/// Run the simulator on a fresh thread with the given config and
+/// return `true` iff the run panicked.
+///
+/// `Simulator::new` installs a per-thread `task::env` slot that panics
+/// on a second install; minimization needs to run hundreds of
+/// reproductions, so each one gets its own thread. We catch the
+/// panic via `catch_unwind` rather than `panic = "abort"` — the
+/// simulator crate ships with the workspace's default unwind panic
+/// strategy on host builds (only the bare-metal kernel image uses
+/// abort).
+fn run_one_panics(seed: u64, plan: &FaultPlan, hi: u64) -> bool {
+    let plan = plan.clone();
+    std::thread::spawn(move || {
+        // `catch_unwind` requires `UnwindSafe`; the simulator owns
+        // only `&'static` mocks + a `Vec`-shaped trace, both of which
+        // are unwind-safe. We use `AssertUnwindSafe` here because the
+        // closure mutably reaches `cfg.fault_plan` through a
+        // pass-by-value `cfg`, which the type system flags as
+        // potentially-unsound across an unwind boundary even though
+        // there is no shared state to corrupt.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            let mut cfg = SimulatorConfig::with_seed(seed);
+            cfg.fault_plan = plan;
+            // Cap at the requested tick budget; the minimizer always
+            // passes its `hi` here.
+            cfg.max_ticks = hi;
+            let mut sim = Simulator::new(seed, cfg);
+            sim.run_for(hi);
+        }));
+        result.is_err()
+    })
+    .join()
+    .unwrap_or(false)
+}
+
+fn run_minimize(args: MinimizeArgs) -> Result<(), CliError> {
+    let plan_text = fs::read_to_string(&args.plan_path).map_err(|e| {
+        CliError::Runtime(format!(
+            "replay minimize: cannot read --plan `{}`: {e}",
+            args.plan_path
+        ))
+    })?;
+    let plan = FaultPlan::from_json(&plan_text).map_err(|e| {
+        CliError::Runtime(format!(
+            "replay minimize: cannot parse --plan `{}`: {e}",
+            args.plan_path
+        ))
+    })?;
+
+    // Build the panic-detecting reproducer. The minimizer's
+    // `Reproducer::reproduces` callback receives the (already
+    // tick-clipped) plan and tick window; we run the simulator under
+    // `catch_unwind` and report `true` iff it panicked.
+    let mut rep = closure_reproducer(|seed: u64, plan: &FaultPlan, w: TickWindow| {
+        run_one_panics(seed, plan, w.hi)
+    });
+
+    let initial_window = TickWindow::full(args.max_ticks);
+    let out = minimize(&mut rep, args.seed, plan, initial_window).map_err(CliError::Runtime)?;
+
+    let json = encode_minimize_output(&out);
+    fs::write(&args.out_path, json).map_err(|e| {
+        CliError::Runtime(format!(
+            "replay minimize: cannot write --out `{}`: {e}",
+            args.out_path
+        ))
+    })?;
+
+    eprintln!(
+        "replay minimize: done — plan {} entries, window [{}, {}), {} reproduction calls",
+        out.plan.entries().len(),
+        out.tick_window.lo,
+        out.tick_window.hi,
+        out.calls,
+    );
+    Ok(())
+}
+
+/// Encode a [`MinimizeOutput`] as a small JSON document.
+///
+/// The schema is deliberately minimal — `seed`, `plan` (the same
+/// schema [`FaultPlan::to_json`] writes), and `tick_window`
+/// (`{lo, hi}`). A `minimize_schema_version = 1` field at the head
+/// pins the wire form against future changes.
+fn encode_minimize_output(out: &MinimizeOutput) -> String {
+    let plan_json = out.plan.to_json_string();
+    format!(
+        "{{\"minimize_schema_version\": 1, \"seed\": {seed}, \"plan\": {plan}, \
+         \"tick_window\": {{\"lo\": {lo}, \"hi\": {hi}}}, \"calls\": {calls}}}",
+        seed = out.seed,
+        plan = plan_json,
+        lo = out.tick_window.lo,
+        hi = out.tick_window.hi,
+        calls = out.calls,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -232,28 +492,36 @@ mod tests {
     #[test]
     fn missing_seed_is_usage_error() {
         let err = parse_args(&args(&[])).unwrap_err();
-        let CliError::Usage(msg) = err;
+        let CliError::Usage(msg) = err else {
+            panic!("expected Usage")
+        };
         assert!(msg.contains("--seed is required"), "got: {msg}");
     }
 
     #[test]
     fn unknown_flag_is_usage_error() {
         let err = parse_args(&args(&["--seed", "1", "--bogus"])).unwrap_err();
-        let CliError::Usage(msg) = err;
+        let CliError::Usage(msg) = err else {
+            panic!("expected Usage")
+        };
         assert!(msg.contains("unrecognised argument"), "got: {msg}");
     }
 
     #[test]
     fn dangling_seed_flag_is_usage_error() {
         let err = parse_args(&args(&["--seed"])).unwrap_err();
-        let CliError::Usage(msg) = err;
+        let CliError::Usage(msg) = err else {
+            panic!("expected Usage")
+        };
         assert!(msg.contains("--seed requires a value"), "got: {msg}");
     }
 
     #[test]
     fn empty_trace_out_is_usage_error() {
         let err = parse_args(&args(&["--seed", "1", "--trace-out", ""])).unwrap_err();
-        let CliError::Usage(msg) = err;
+        let CliError::Usage(msg) = err else {
+            panic!("expected Usage")
+        };
         assert!(
             msg.contains("--trace-out requires a non-empty path"),
             "got: {msg}"
@@ -263,7 +531,9 @@ mod tests {
     #[test]
     fn bad_seed_is_usage_error() {
         let err = parse_args(&args(&["--seed", "notanint"])).unwrap_err();
-        let CliError::Usage(msg) = err;
+        let CliError::Usage(msg) = err else {
+            panic!("expected Usage")
+        };
         assert!(msg.contains("not a valid u64"), "got: {msg}");
     }
 
@@ -277,7 +547,9 @@ mod tests {
     #[test]
     fn duplicate_seed_is_usage_error() {
         let err = parse_args(&args(&["--seed", "1", "--seed", "2"])).unwrap_err();
-        let CliError::Usage(msg) = err;
+        let CliError::Usage(msg) = err else {
+            panic!("expected Usage")
+        };
         assert!(
             msg.contains("--seed may be specified only once"),
             "got: {msg}"
@@ -295,7 +567,9 @@ mod tests {
             "/tmp/b.json",
         ]))
         .unwrap_err();
-        let CliError::Usage(msg) = err;
+        let CliError::Usage(msg) = err else {
+            panic!("expected Usage")
+        };
         assert!(
             msg.contains("--trace-out may be specified only once"),
             "got: {msg}"
@@ -310,5 +584,150 @@ mod tests {
         let parsed =
             unwrap_run(parse_args(&args(&["--seed", "1", "--trace-out", "--help"])).unwrap());
         assert_eq!(parsed.trace_out.as_deref(), Some("--help"));
+    }
+
+    // --- `minimize` subcommand argument parsing ---
+
+    #[test]
+    fn minimize_parses_required_args() {
+        let parsed = parse_minimize(&args(&[
+            "--seed",
+            "0xDEAD_BEEF",
+            "--plan",
+            "/tmp/p.json",
+            "--out",
+            "/tmp/o.json",
+        ]))
+        .unwrap();
+        assert_eq!(parsed.seed, 0xDEAD_BEEF);
+        assert_eq!(parsed.plan_path, "/tmp/p.json");
+        assert_eq!(parsed.out_path, "/tmp/o.json");
+        assert_eq!(parsed.max_ticks, MINIMIZE_DEFAULT_MAX_TICKS);
+    }
+
+    #[test]
+    fn minimize_parses_max_ticks_override() {
+        let parsed = parse_minimize(&args(&[
+            "--seed",
+            "1",
+            "--plan",
+            "/tmp/p.json",
+            "--out",
+            "/tmp/o.json",
+            "--max-ticks",
+            "65_536",
+        ]))
+        .unwrap();
+        assert_eq!(parsed.max_ticks, 65_536);
+    }
+
+    #[test]
+    fn minimize_missing_seed_is_usage_error() {
+        let err =
+            parse_minimize(&args(&["--plan", "/tmp/p.json", "--out", "/tmp/o.json"])).unwrap_err();
+        let CliError::Usage(msg) = err else {
+            panic!("expected Usage")
+        };
+        assert!(msg.contains("--seed is required"), "got: {msg}");
+    }
+
+    #[test]
+    fn minimize_missing_plan_is_usage_error() {
+        let err = parse_minimize(&args(&["--seed", "1", "--out", "/tmp/o.json"])).unwrap_err();
+        let CliError::Usage(msg) = err else {
+            panic!("expected Usage")
+        };
+        assert!(msg.contains("--plan is required"), "got: {msg}");
+    }
+
+    #[test]
+    fn minimize_missing_out_is_usage_error() {
+        let err = parse_minimize(&args(&["--seed", "1", "--plan", "/tmp/p.json"])).unwrap_err();
+        let CliError::Usage(msg) = err else {
+            panic!("expected Usage")
+        };
+        assert!(msg.contains("--out is required"), "got: {msg}");
+    }
+
+    #[test]
+    fn minimize_zero_max_ticks_is_usage_error() {
+        let err = parse_minimize(&args(&[
+            "--seed",
+            "1",
+            "--plan",
+            "/tmp/p.json",
+            "--out",
+            "/tmp/o.json",
+            "--max-ticks",
+            "0",
+        ]))
+        .unwrap_err();
+        let CliError::Usage(msg) = err else {
+            panic!("expected Usage")
+        };
+        assert!(msg.contains("--max-ticks must be > 0"), "got: {msg}");
+    }
+
+    #[test]
+    fn minimize_unknown_flag_is_usage_error() {
+        let err = parse_minimize(&args(&[
+            "--seed",
+            "1",
+            "--plan",
+            "/tmp/p.json",
+            "--out",
+            "/tmp/o.json",
+            "--bogus",
+        ]))
+        .unwrap_err();
+        let CliError::Usage(msg) = err else {
+            panic!("expected Usage")
+        };
+        assert!(msg.contains("unrecognised argument"), "got: {msg}");
+    }
+
+    #[test]
+    fn encode_minimize_output_round_trip_shape() {
+        // Sanity: the encoder produces well-formed JSON that the
+        // FaultPlan parser accepts as the inner `plan` object.
+        let plan = FaultPlan::from_entries(vec![(
+            42,
+            simulator::FaultEvent::WakeupReorder { within_tick: 1 },
+        )]);
+        let out = MinimizeOutput {
+            seed: 0xCAFE,
+            plan: plan.clone(),
+            tick_window: TickWindow { lo: 10, hi: 50 },
+            calls: 17,
+        };
+        let s = encode_minimize_output(&out);
+        assert!(s.contains("\"minimize_schema_version\": 1"));
+        assert!(s.contains("\"seed\": 51966"));
+        assert!(s.contains("\"lo\": 10"));
+        assert!(s.contains("\"hi\": 50"));
+        assert!(s.contains("\"calls\": 17"));
+        // The plan substring must itself be valid plan JSON.
+        let needle = "\"plan\": ";
+        let plan_start = s.find(needle).expect("plan field") + needle.len();
+        // Find the end of the plan object by counting braces.
+        let bytes = s.as_bytes();
+        let mut depth = 0i32;
+        let mut end = plan_start;
+        for (i, b) in bytes[plan_start..].iter().enumerate() {
+            match b {
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        end = plan_start + i + 1;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        let plan_substr = &s[plan_start..end];
+        let parsed = FaultPlan::from_json(plan_substr).expect("plan re-parses");
+        assert_eq!(parsed, plan);
     }
 }

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -80,6 +80,9 @@ pub mod fault_plan;
 #[cfg(not(target_os = "none"))]
 pub mod invariants;
 
+#[cfg(not(target_os = "none"))]
+pub mod minimize;
+
 // `proptest_model` is `cfg(test)`-gated at the file level — it pulls
 // in `proptest` / `proptest-state-machine` from `[dev-dependencies]`,
 // neither of which appear in production builds. See
@@ -109,6 +112,9 @@ mod imp {
         AllRunnableEventuallyRun, BlockedToRunnableNeedsWakeup, ForkHasMatchingExitOrWait,
         InvariantSet, LivenessInvariant, MonotonicPids, NoStrandedWakeups, SafetyInvariant,
         SingleRunningPerCpu, Violation,
+    };
+    pub use crate::minimize::{
+        closure_reproducer, minimize, ClosureReproducer, MinimizeOutput, Reproducer, TickWindow,
     };
     pub use crate::trace::{BlockReason, Event, FaultKind, Trace, TraceRecord, SCHEMA_VERSION};
 
@@ -886,10 +892,11 @@ mod imp {
 
 #[cfg(not(target_os = "none"))]
 pub use imp::{
-    install_panic_hook, AllRunnableEventuallyRun, BlockReason, BlockedToRunnableNeedsWakeup, Event,
-    FaultEvent, FaultKind, FaultPlan, FaultPlanBuilder, ForkHasMatchingExitOrWait, InvariantSet,
-    LivenessInvariant, MonotonicPids, NoStrandedWakeups, SafetyInvariant, Seed, SimRng, Simulator,
-    SimulatorConfig, SingleRunningPerCpu, Trace, TraceRecord, VariantMask, Violation,
+    closure_reproducer, install_panic_hook, minimize, AllRunnableEventuallyRun, BlockReason,
+    BlockedToRunnableNeedsWakeup, ClosureReproducer, Event, FaultEvent, FaultKind, FaultPlan,
+    FaultPlanBuilder, ForkHasMatchingExitOrWait, InvariantSet, LivenessInvariant, MinimizeOutput,
+    MonotonicPids, NoStrandedWakeups, Reproducer, SafetyInvariant, Seed, SimRng, Simulator,
+    SimulatorConfig, SingleRunningPerCpu, TickWindow, Trace, TraceRecord, VariantMask, Violation,
     FAULT_PLAN_SCHEMA_VERSION, SCHEMA_VERSION,
 };
 

--- a/simulator/src/minimize.rs
+++ b/simulator/src/minimize.rs
@@ -215,7 +215,7 @@ pub fn minimize<R: Reproducer + ?Sized>(
     })
 }
 
-/// Find the smallest `hi` in `[1, tick_window.hi]` such that
+/// Find the smallest `hi` in `[0, tick_window.hi]` such that
 /// `(seed, plan, TickWindow { lo, hi })` still reproduces.
 fn bisect_tick_hi<R: Reproducer + ?Sized>(
     counted: &mut Counted<'_, R>,
@@ -223,14 +223,26 @@ fn bisect_tick_hi<R: Reproducer + ?Sized>(
     plan: &FaultPlan,
     tick_window: TickWindow,
 ) -> Result<u64, String> {
+    // Probe the zero-tick window first. A failure that does not depend
+    // on the simulator advancing at all (seed-only repros, or repros
+    // that surface during simulator construction) reproduces with
+    // `hi = 0`; without this probe the binary search below would force
+    // the reported minimum to `hi = 1` and overstate the window.
+    let zero = TickWindow {
+        lo: tick_window.lo,
+        hi: 0,
+    };
+    if counted.check(seed, plan, zero) {
+        return Ok(0);
+    }
     if tick_window.hi <= 1 {
         return Ok(tick_window.hi);
     }
     // Invariant: `lo` does not reproduce, `hi` reproduces. Both bounds
-    // refer to the `hi` field of `TickWindow`. Start `lo = 0` (zero
-    // ticks: the simulator never advances; cannot reproduce a fault
-    // injected at any tick > 0) and `hi = tick_window.hi` (the
-    // entry-sanity check already proved this reproduces).
+    // refer to the `hi` field of `TickWindow`. Start `lo = 0` (the
+    // zero-tick probe above proved this does not reproduce) and
+    // `hi = tick_window.hi` (the entry-sanity check already proved
+    // this reproduces).
     let mut lo = 0u64;
     let mut hi = tick_window.hi;
     while hi - lo > 1 {
@@ -262,20 +274,24 @@ fn bisect_tick_lo<R: Reproducer + ?Sized>(
     // sanity check proved this reproduces) and `hi = tick_window.hi + 1`
     // (clipping every entry trivially defeats reproduction unless the
     // failure does not depend on the plan at all — handled below).
+    // `max_valid_lo` caps the returned lower bound to a value that
+    // keeps the resulting `[lo, hi)` interval well-formed, since the
+    // `hi` sentinel itself is one past the last valid tick.
     let mut lo = tick_window.lo;
     let mut hi = tick_window.hi.saturating_add(1);
+    let max_valid_lo = tick_window.hi;
 
     // Quick top-out check: if dropping every plan entry still
     // reproduces, the failure is independent of the plan; the lower
     // bound can be set right at `tick_window.hi` (no plan entries
     // remain in scope) and stage 2 will reduce the plan to empty.
     let drop_all = TickWindow {
-        lo: hi,
+        lo: max_valid_lo,
         hi: tick_window.hi,
     };
     let drop_all_plan = clip_plan_lo(plan, drop_all.lo);
     if counted.check(seed, &drop_all_plan, drop_all) {
-        return Ok(hi);
+        return Ok(max_valid_lo);
     }
 
     while hi - lo > 1 {
@@ -555,6 +571,44 @@ mod tests {
         let out = minimize(&mut rep, 42, plan, TickWindow::full(1024)).expect("minimize");
         assert!(out.plan.is_empty());
         assert_eq!(out.tick_window.hi, 1);
+    }
+
+    #[test]
+    fn bisect_tick_hi_returns_zero_when_failure_reproduces_at_zero_ticks() {
+        // A predicate that reproduces regardless of `tick_window.hi`
+        // (e.g. a panic during simulator construction). Without the
+        // zero-tick probe in `bisect_tick_hi`, the bisect would bottom
+        // out at `hi = 1` and overstate the minimal window.
+        let plan = FaultPlan::new();
+        let mut rep = closure_reproducer(|_seed, _plan, _w| true);
+        let out = minimize(&mut rep, 7, plan, TickWindow::full(1024)).expect("minimize");
+        assert_eq!(out.tick_window.hi, 0);
+        assert_eq!(out.tick_window.lo, 0);
+        assert!(out.plan.is_empty());
+    }
+
+    #[test]
+    fn bisect_tick_lo_fast_path_returns_well_formed_window() {
+        // Plan-independent failure: the `bisect_tick_lo` fast path
+        // takes the "drop every entry, still reproduces" branch.
+        // The returned window must remain a valid half-open interval
+        // (`lo <= hi`) — a regression here used to return `lo = hi + 1`.
+        let plan = FaultPlan::from_entries(vec![
+            (1, FaultEvent::SpuriousTimerIrq),
+            (5, FaultEvent::TimerDrift { ticks: 1 }),
+            (10, FaultEvent::WakeupReorder { within_tick: 2 }),
+        ]);
+        // Reproduces once `hi >= 3`, regardless of plan contents.
+        let mut rep = closure_reproducer(|_seed, _plan, w| w.hi >= 3);
+        let out = minimize(&mut rep, 0, plan, TickWindow::full(64)).expect("minimize");
+        assert!(
+            out.tick_window.lo <= out.tick_window.hi,
+            "tick window must be well-formed: got [{}, {})",
+            out.tick_window.lo,
+            out.tick_window.hi,
+        );
+        assert_eq!(out.tick_window.hi, 3);
+        assert_eq!(out.tick_window.lo, 3);
     }
 
     #[test]

--- a/simulator/src/minimize.rs
+++ b/simulator/src/minimize.rs
@@ -1,0 +1,573 @@
+//! Seed minimizer — tick-window bisect + FaultPlan delta-debug
+//! (RFC 0006 §"Seed minimization and trace shrinking", issue #720).
+//!
+//! Turns a 30-minute failing repro into a sub-minute one by trimming
+//! everything irrelevant from a `(seed, FaultPlan, T_max)` tuple while
+//! preserving the property "this configuration still reproduces the
+//! failure."
+//!
+//! # Two stages
+//!
+//! 1. **Tick-window binary search.** Given an upper bound `T_max`, find
+//!    the smallest `T_hi <= T_max` such that running the simulator for
+//!    `T_hi` ticks still reproduces. Then find the largest `T_lo` such
+//!    that dropping every fault-plan entry with `tick < T_lo` (i.e.
+//!    "skipping" the leading window) still reproduces. The output is
+//!    a half-open interval `[T_lo, T_hi)` that covers the failure
+//!    causally and nothing more.
+//!
+//! 2. **`ddmin` over the FaultPlan.** Standard Zeller-Hildebrandt
+//!    1-minimal delta debugging on the (already tick-clipped) entry
+//!    list: try dropping every contiguous chunk of size `n = len/g`
+//!    (granularity `g` doubles every full sweep that finds nothing),
+//!    keep any drop that still reproduces, restart at the new size.
+//!    Terminates at a `1-minimal` plan: removing any single entry
+//!    breaks reproduction.
+//!
+//! # Operation bound
+//!
+//! Stage 1: `O(log T_max)` reproduction calls (two binary searches).
+//! Stage 2: `O(|plan|^2)` reproduction calls in the worst case, the
+//! standard ddmin bound.
+//!
+//! Total: **`O(log T_max) + O(|plan|^2)`** — documented and asserted
+//! by the unit tests below via a call counter.
+//!
+//! # Determinism
+//!
+//! The `Reproducer` callback is treated as a pure function of
+//! `(seed, plan, tick_window)`. Every reproduction attempt re-runs the
+//! simulator from a fresh thread (because [`crate::Simulator::new`]'s
+//! kernel-side `install_sim_env` panics on a second call to the same
+//! thread). The minimizer itself does not consume any RNG bytes — its
+//! search trajectory is a pure function of the input.
+
+use std::string::String;
+use std::vec::Vec;
+
+use crate::fault_plan::{FaultEvent, FaultPlan};
+
+/// Closed-on-the-left, open-on-the-right window of ticks the simulator
+/// must execute for the failure to reproduce.
+///
+/// The lower bound `lo` filters the [`FaultPlan`]: entries with
+/// `tick < lo` are dropped before the simulator consumes them. The
+/// upper bound `hi` is the number of ticks the simulator runs for —
+/// `Simulator::run_for(hi)`. A failure that reproduces under
+/// `TickWindow { lo: 0, hi: T_max }` is the input the minimizer
+/// starts from.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TickWindow {
+    /// Minimum tick at which fault-plan events remain enabled. Events
+    /// with `tick < lo` are filtered out before reproduction.
+    pub lo: u64,
+    /// Number of `Simulator::step` calls made during reproduction
+    /// (i.e. the simulator's `run_for(hi)` argument).
+    pub hi: u64,
+}
+
+impl TickWindow {
+    /// Construct a window covering `[0, hi)`.
+    pub const fn full(hi: u64) -> Self {
+        Self { lo: 0, hi }
+    }
+}
+
+/// Result of running the two-stage minimizer.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MinimizeOutput {
+    /// Master seed (unchanged from input — the minimizer never tries
+    /// alternative seeds; that would be a *different* repro).
+    pub seed: u64,
+    /// Minimized fault plan: `1-minimal` w.r.t. `Reproducer`.
+    pub plan: FaultPlan,
+    /// Minimized tick window. `tick_window.hi` is the smallest
+    /// `Simulator::run_for(N)` that still reproduces; `tick_window.lo`
+    /// is the largest leading-tick prefix that can be skipped.
+    pub tick_window: TickWindow,
+    /// Number of times [`Reproducer::reproduces`] was called during
+    /// minimization. Used by tests to assert the operation bound.
+    pub calls: u64,
+}
+
+/// Callback invoked by the minimizer to decide whether a candidate
+/// `(seed, plan, tick_window)` triple still reproduces the failure.
+///
+/// Implementations that drive the simulator typically:
+///
+/// 1. Construct a fresh thread (because `Simulator::new`'s
+///    `install_sim_env` is per-thread and panics on a second call).
+/// 2. Catch panics with `std::panic::catch_unwind` and treat a panic
+///    as "reproduces" for failure modes that surface as `panic!`.
+///
+/// The trait is single-method to keep adapters trivial; the
+/// [`closure_reproducer`] helper wraps any `FnMut` into a
+/// `Reproducer`.
+pub trait Reproducer {
+    /// Returns `true` if running the simulator with the given seed,
+    /// plan (already tick-clipped), and `tick_window.hi` ticks still
+    /// reproduces the failure under test.
+    fn reproduces(&mut self, seed: u64, plan: &FaultPlan, tick_window: TickWindow) -> bool;
+}
+
+/// Wrap an `FnMut` into a [`Reproducer`].
+pub fn closure_reproducer<F>(f: F) -> ClosureReproducer<F>
+where
+    F: FnMut(u64, &FaultPlan, TickWindow) -> bool,
+{
+    ClosureReproducer { f }
+}
+
+/// `Reproducer` impl backed by a closure. Constructed via
+/// [`closure_reproducer`].
+pub struct ClosureReproducer<F> {
+    f: F,
+}
+
+impl<F> Reproducer for ClosureReproducer<F>
+where
+    F: FnMut(u64, &FaultPlan, TickWindow) -> bool,
+{
+    fn reproduces(&mut self, seed: u64, plan: &FaultPlan, tick_window: TickWindow) -> bool {
+        (self.f)(seed, plan, tick_window)
+    }
+}
+
+/// Filter a [`FaultPlan`] to entries with `tick >= lo`.
+fn clip_plan_lo(plan: &FaultPlan, lo: u64) -> FaultPlan {
+    let kept: Vec<(u64, FaultEvent)> = plan
+        .entries()
+        .iter()
+        .filter(|(t, _)| *t >= lo)
+        .copied()
+        .collect();
+    FaultPlan::from_entries(kept)
+}
+
+/// Counter-wrapped `Reproducer` so the minimizer can report how many
+/// reproduction attempts it spent — both for diagnostics and for the
+/// unit tests' operation-bound assertions.
+struct Counted<'r, R: Reproducer + ?Sized> {
+    inner: &'r mut R,
+    calls: u64,
+}
+
+impl<R: Reproducer + ?Sized> Counted<'_, R> {
+    fn check(&mut self, seed: u64, plan: &FaultPlan, window: TickWindow) -> bool {
+        self.calls += 1;
+        self.inner.reproduces(seed, plan, window)
+    }
+}
+
+/// Run stage 1 (tick-window bisect) then stage 2 (ddmin over the plan)
+/// against `reproducer`. The input is required to already reproduce
+/// — the minimizer asserts this with one initial sanity call and
+/// returns an error if it does not.
+///
+/// Operation bound: `O(log tick_window.hi) + O(|plan|^2)`.
+pub fn minimize<R: Reproducer + ?Sized>(
+    reproducer: &mut R,
+    seed: u64,
+    plan: FaultPlan,
+    tick_window: TickWindow,
+) -> Result<MinimizeOutput, String> {
+    let mut counted = Counted {
+        inner: reproducer,
+        calls: 0,
+    };
+
+    // Sanity: the input itself must reproduce. If it doesn't, the
+    // user's predicate is wrong and ddmin would silently terminate
+    // on the empty plan (every subset trivially "reproduces" because
+    // none reproduce). Surface the error.
+    if !counted.check(seed, &plan, tick_window) {
+        return Err(String::from(
+            "minimize: input (seed, plan, tick_window) does not reproduce the failure; \
+             check the Reproducer predicate before retrying",
+        ));
+    }
+
+    // Stage 1a: shrink `tick_window.hi`.
+    let hi = bisect_tick_hi(&mut counted, seed, &plan, tick_window)?;
+    let mut window = TickWindow {
+        lo: tick_window.lo,
+        hi,
+    };
+
+    // Stage 1b: grow `tick_window.lo`. Searches the largest prefix of
+    // ticks that can be skipped (i.e. plan entries with tick < lo
+    // dropped) without breaking reproduction.
+    let lo = bisect_tick_lo(&mut counted, seed, &plan, window)?;
+    window.lo = lo;
+
+    // Apply the lower-bound clip to the plan so stage 2 only ddmin's
+    // over the entries the bisect determined are still in scope.
+    let clipped = clip_plan_lo(&plan, window.lo);
+
+    // Stage 2: ddmin over the (clipped) plan's entries.
+    let minimized = ddmin(&mut counted, seed, clipped, window)?;
+
+    Ok(MinimizeOutput {
+        seed,
+        plan: minimized,
+        tick_window: window,
+        calls: counted.calls,
+    })
+}
+
+/// Find the smallest `hi` in `[1, tick_window.hi]` such that
+/// `(seed, plan, TickWindow { lo, hi })` still reproduces.
+fn bisect_tick_hi<R: Reproducer + ?Sized>(
+    counted: &mut Counted<'_, R>,
+    seed: u64,
+    plan: &FaultPlan,
+    tick_window: TickWindow,
+) -> Result<u64, String> {
+    if tick_window.hi <= 1 {
+        return Ok(tick_window.hi);
+    }
+    // Invariant: `lo` does not reproduce, `hi` reproduces. Both bounds
+    // refer to the `hi` field of `TickWindow`. Start `lo = 0` (zero
+    // ticks: the simulator never advances; cannot reproduce a fault
+    // injected at any tick > 0) and `hi = tick_window.hi` (the
+    // entry-sanity check already proved this reproduces).
+    let mut lo = 0u64;
+    let mut hi = tick_window.hi;
+    while hi - lo > 1 {
+        let mid = lo + (hi - lo) / 2;
+        let candidate = TickWindow {
+            lo: tick_window.lo,
+            hi: mid,
+        };
+        if counted.check(seed, plan, candidate) {
+            hi = mid;
+        } else {
+            lo = mid;
+        }
+    }
+    Ok(hi)
+}
+
+/// Find the largest `lo` in `[0, tick_window.hi]` such that
+/// `(seed, clip_plan_lo(plan, lo), TickWindow { lo, hi })` still
+/// reproduces.
+fn bisect_tick_lo<R: Reproducer + ?Sized>(
+    counted: &mut Counted<'_, R>,
+    seed: u64,
+    plan: &FaultPlan,
+    tick_window: TickWindow,
+) -> Result<u64, String> {
+    // Invariant: `lo` reproduces, `hi` does not. We search the largest
+    // value that still reproduces. Start `lo = tick_window.lo` (the
+    // sanity check proved this reproduces) and `hi = tick_window.hi + 1`
+    // (clipping every entry trivially defeats reproduction unless the
+    // failure does not depend on the plan at all — handled below).
+    let mut lo = tick_window.lo;
+    let mut hi = tick_window.hi.saturating_add(1);
+
+    // Quick top-out check: if dropping every plan entry still
+    // reproduces, the failure is independent of the plan; the lower
+    // bound can be set right at `tick_window.hi` (no plan entries
+    // remain in scope) and stage 2 will reduce the plan to empty.
+    let drop_all = TickWindow {
+        lo: hi,
+        hi: tick_window.hi,
+    };
+    let drop_all_plan = clip_plan_lo(plan, drop_all.lo);
+    if counted.check(seed, &drop_all_plan, drop_all) {
+        return Ok(hi);
+    }
+
+    while hi - lo > 1 {
+        let mid = lo + (hi - lo) / 2;
+        let candidate_window = TickWindow {
+            lo: mid,
+            hi: tick_window.hi,
+        };
+        let candidate_plan = clip_plan_lo(plan, mid);
+        if counted.check(seed, &candidate_plan, candidate_window) {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+    }
+    Ok(lo)
+}
+
+/// Zeller-Hildebrandt ddmin over the plan's entries. Returns a
+/// 1-minimal plan: removing any single entry breaks reproduction.
+fn ddmin<R: Reproducer + ?Sized>(
+    counted: &mut Counted<'_, R>,
+    seed: u64,
+    plan: FaultPlan,
+    window: TickWindow,
+) -> Result<FaultPlan, String> {
+    let mut entries: Vec<(u64, FaultEvent)> = plan.entries().to_vec();
+    let mut granularity: usize = 2;
+
+    // Outer loop: shrink while progress is being made. Standard ddmin
+    // shape — split into `granularity` chunks, try removing each
+    // chunk, then try removing each chunk's complement; if neither
+    // helps, double the granularity.
+    loop {
+        let n = entries.len();
+        if n < 2 {
+            break;
+        }
+        let chunk_size = n.div_ceil(granularity);
+
+        // Try removing each contiguous chunk (size = chunk_size).
+        let mut reduced = false;
+        let mut start = 0;
+        while start < n {
+            let end = (start + chunk_size).min(n);
+            let mut candidate: Vec<(u64, FaultEvent)> = Vec::with_capacity(n - (end - start));
+            candidate.extend_from_slice(&entries[..start]);
+            candidate.extend_from_slice(&entries[end..]);
+            let candidate_plan = FaultPlan::from_entries(candidate.clone());
+            if counted.check(seed, &candidate_plan, window) {
+                entries = candidate;
+                reduced = true;
+                break;
+            }
+            start = end;
+        }
+
+        if reduced {
+            // Restart the sweep at the same granularity, but capped to
+            // the new length so chunks remain non-empty.
+            granularity = granularity.min(entries.len()).max(2);
+            continue;
+        }
+
+        // Try removing each chunk's complement (i.e. keep only one
+        // chunk). Equivalent to "is this chunk alone enough to
+        // reproduce?" — the other half of the ddmin recurrence.
+        let mut start = 0;
+        while start < n {
+            let end = (start + chunk_size).min(n);
+            let candidate: Vec<(u64, FaultEvent)> = entries[start..end].to_vec();
+            let candidate_plan = FaultPlan::from_entries(candidate.clone());
+            if counted.check(seed, &candidate_plan, window) {
+                entries = candidate;
+                granularity = 2;
+                reduced = true;
+                break;
+            }
+            start = end;
+        }
+        if reduced {
+            continue;
+        }
+
+        // No reduction at this granularity. Double it and retry; if
+        // we've already reached granularity == n, we are 1-minimal.
+        if granularity >= entries.len() {
+            break;
+        }
+        granularity = (granularity * 2).min(entries.len());
+    }
+
+    Ok(FaultPlan::from_entries(entries))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fault_plan::FaultEvent;
+
+    /// A `Reproducer` that "fails" iff the plan contains a specific
+    /// trigger event at a specific tick within the window. Used by
+    /// the unit tests below as a deterministic synthetic flake.
+    struct TriggerOnEvent {
+        trigger_tick: u64,
+        trigger_event: FaultEvent,
+    }
+
+    impl Reproducer for TriggerOnEvent {
+        fn reproduces(&mut self, _seed: u64, plan: &FaultPlan, window: TickWindow) -> bool {
+            // The trigger must be within the active window:
+            // - tick >= window.lo (otherwise clipped out by the caller,
+            //   but this branch keeps the predicate independent of the
+            //   caller doing the clipping)
+            // - tick < window.hi (otherwise the simulator never gets
+            //   far enough)
+            // - and the entry must actually be present.
+            plan.entries().iter().any(|(t, e)| {
+                *t == self.trigger_tick
+                    && *e == self.trigger_event
+                    && *t >= window.lo
+                    && *t < window.hi
+            })
+        }
+    }
+
+    fn noisy_plan_around(trigger_tick: u64, trigger: FaultEvent) -> FaultPlan {
+        // Build a noisy plan with the trigger buried among unrelated
+        // events at varied ticks. 20+ entries so ddmin has real work
+        // to do.
+        let entries = vec![
+            (10, FaultEvent::SpuriousTimerIrq),
+            (100, FaultEvent::TimerDrift { ticks: 1 }),
+            (250, FaultEvent::WakeupReorder { within_tick: 1 }),
+            (500, FaultEvent::SpuriousTimerIrq),
+            (1000, FaultEvent::TimerDrift { ticks: 3 }),
+            (2500, FaultEvent::WakeupReorder { within_tick: 2 }),
+            (5000, FaultEvent::SpuriousTimerIrq),
+            (7500, FaultEvent::TimerDrift { ticks: 1 }),
+            (10000, FaultEvent::WakeupReorder { within_tick: 1 }),
+            (11000, FaultEvent::SpuriousTimerIrq),
+            (12000, FaultEvent::TimerDrift { ticks: 2 }),
+            (trigger_tick, trigger),
+            (12500, FaultEvent::WakeupReorder { within_tick: 1 }),
+            (13000, FaultEvent::SpuriousTimerIrq),
+            (15000, FaultEvent::TimerDrift { ticks: 1 }),
+            (20000, FaultEvent::WakeupReorder { within_tick: 3 }),
+            (25000, FaultEvent::SpuriousTimerIrq),
+            (30000, FaultEvent::TimerDrift { ticks: 1 }),
+            (40000, FaultEvent::WakeupReorder { within_tick: 1 }),
+            (50000, FaultEvent::SpuriousTimerIrq),
+        ];
+        FaultPlan::from_entries(entries)
+    }
+
+    #[test]
+    fn synthetic_flake_minimizes_to_single_event_plan() {
+        // Acceptance: a synthetic flake "panic if SpuriousTimerIrq
+        // lands in tick 12345" minimizes to a single-event plan.
+        let trigger_tick = 12345;
+        let trigger = FaultEvent::SpuriousTimerIrq;
+        let plan = noisy_plan_around(trigger_tick, trigger);
+        let initial_window = TickWindow::full(100_000);
+
+        let mut rep = TriggerOnEvent {
+            trigger_tick,
+            trigger_event: trigger,
+        };
+
+        let out = minimize(&mut rep, 0xDEAD_BEEF, plan, initial_window).expect("minimize");
+
+        // 1-minimal plan: exactly the trigger event at the trigger
+        // tick, nothing else.
+        assert_eq!(out.plan.entries(), &[(trigger_tick, trigger)]);
+
+        // Tick window is tight: hi is just past the trigger,
+        // lo is exactly at it (the largest skip that still includes
+        // the trigger).
+        assert_eq!(out.tick_window.lo, trigger_tick);
+        assert_eq!(out.tick_window.hi, trigger_tick + 1);
+        // Seed is unchanged.
+        assert_eq!(out.seed, 0xDEAD_BEEF);
+    }
+
+    #[test]
+    fn minimize_respects_operation_bound() {
+        // Operation bound: `O(log T_max) + O(|plan|^2)` reproduction
+        // calls. With T_max = 100_000 (log2 ≈ 17) and |plan| = 20,
+        // a 5x slack accommodates ddmin's chunk-then-complement passes
+        // while still flagging quadratic-blowup regressions.
+        let trigger_tick = 12345;
+        let trigger = FaultEvent::SpuriousTimerIrq;
+        let plan = noisy_plan_around(trigger_tick, trigger);
+        let initial_window = TickWindow::full(100_000);
+
+        let mut rep = TriggerOnEvent {
+            trigger_tick,
+            trigger_event: trigger,
+        };
+
+        let out = minimize(&mut rep, 1, plan.clone(), initial_window).expect("minimize");
+
+        let log_t = 64u64 - 100_000u64.leading_zeros() as u64; // ≈17
+        let plan_sq = (plan.len() as u64).pow(2); // 400
+        let bound = 5 * (log_t + plan_sq);
+        assert!(
+            out.calls <= bound,
+            "minimize used {} calls, exceeds 5*(log T + |plan|^2) = {}",
+            out.calls,
+            bound,
+        );
+    }
+
+    #[test]
+    fn minimize_errors_when_input_does_not_reproduce() {
+        // If the input itself doesn't reproduce, `minimize` must
+        // surface the error rather than silently returning the empty
+        // plan.
+        let plan = FaultPlan::from_entries(vec![(1, FaultEvent::SpuriousTimerIrq)]);
+        let mut rep = closure_reproducer(|_, _, _| false);
+        let err = minimize(&mut rep, 0, plan, TickWindow::full(10)).unwrap_err();
+        assert!(err.contains("does not reproduce"), "got: {err}");
+    }
+
+    #[test]
+    fn ddmin_reduces_redundant_plan_to_minimal_subset() {
+        // Predicate "reproduces iff plan contains both A and B".
+        let a = (5, FaultEvent::SpuriousTimerIrq);
+        let b = (15, FaultEvent::TimerDrift { ticks: 2 });
+        let entries = vec![
+            (1, FaultEvent::SpuriousTimerIrq),
+            a,
+            (10, FaultEvent::WakeupReorder { within_tick: 1 }),
+            b,
+            (20, FaultEvent::SpuriousTimerIrq),
+            (25, FaultEvent::WakeupReorder { within_tick: 2 }),
+        ];
+        let plan = FaultPlan::from_entries(entries);
+
+        let mut rep = closure_reproducer(move |_seed, plan: &FaultPlan, _w| {
+            let has_a = plan.entries().contains(&a);
+            let has_b = plan.entries().contains(&b);
+            has_a && has_b
+        });
+
+        let out = minimize(&mut rep, 0, plan, TickWindow::full(100)).expect("minimize");
+        // 1-minimal: dropping either entry breaks the predicate, so
+        // both must remain.
+        assert_eq!(out.plan.entries(), &[a, b]);
+    }
+
+    #[test]
+    fn tick_window_lo_grows_when_failure_starts_late() {
+        // Predicate "reproduces iff plan contains a SpuriousTimerIrq
+        // at tick 50000". The failure does not depend on any earlier
+        // tick — the lo bisect should grow lo all the way to 50000.
+        let trigger_tick = 50_000;
+        let trigger = FaultEvent::SpuriousTimerIrq;
+        let plan = noisy_plan_around(trigger_tick, trigger);
+        let mut rep = TriggerOnEvent {
+            trigger_tick,
+            trigger_event: trigger,
+        };
+        let out = minimize(&mut rep, 0, plan, TickWindow::full(100_000)).expect("minimize");
+        assert_eq!(out.tick_window.lo, trigger_tick);
+        assert_eq!(out.tick_window.hi, trigger_tick + 1);
+        assert_eq!(out.plan.entries(), &[(trigger_tick, trigger)]);
+    }
+
+    #[test]
+    fn empty_plan_input_returns_empty_output_when_failure_is_seed_only() {
+        // A failure that depends only on the seed (no plan, no window
+        // beyond a couple of ticks). The minimizer must terminate
+        // quickly without trying to ddmin a nonexistent plan.
+        let plan = FaultPlan::new();
+        let mut rep = closure_reproducer(|_seed, _plan, w| w.hi >= 1);
+        let out = minimize(&mut rep, 42, plan, TickWindow::full(1024)).expect("minimize");
+        assert!(out.plan.is_empty());
+        assert_eq!(out.tick_window.hi, 1);
+    }
+
+    #[test]
+    fn clip_plan_lo_drops_strictly_lower_ticks() {
+        let entries = vec![
+            (0, FaultEvent::SpuriousTimerIrq),
+            (5, FaultEvent::TimerDrift { ticks: 1 }),
+            (10, FaultEvent::WakeupReorder { within_tick: 1 }),
+        ];
+        let plan = FaultPlan::from_entries(entries);
+        let clipped = clip_plan_lo(&plan, 5);
+        assert_eq!(clipped.len(), 2);
+        assert_eq!(clipped.entries()[0].0, 5);
+        assert_eq!(clipped.entries()[1].0, 10);
+    }
+}


### PR DESCRIPTION
Closes #720.

Implements RFC 0006 §\"Seed minimization and trace shrinking\". Two-stage
minimizer turns a 30-minute failing repro into a sub-minute one:

1. **Tick-window binary search.** Shrinks the upper tick bound and grows
   the lower tick bound, both via `O(log T)` bisects. The lower bisect
   filters the `FaultPlan` to drop entries with `tick < lo`.
2. **`ddmin`** (Zeller-Hildebrandt). 1-minimal subset of fault-plan
   entries.

Total operation bound: `O(log T) + O(|plan|^2)`, documented at the top
of `simulator/src/minimize.rs` and asserted by a unit test
(`minimize_respects_operation_bound`) that runs the acceptance flake
through the minimizer with a 5x slack on the call counter.

## Summary

- New module `simulator/src/minimize.rs` exposing `Reproducer` trait,
  `minimize(..)` entry point, `TickWindow`, `MinimizeOutput`,
  `closure_reproducer` adapter.
- `replay` binary grows a `minimize` subcommand:
  `cargo run -p simulator --bin replay -- minimize --seed S --plan P --out O [--max-ticks N]`.
- The CLI's reproduction predicate is \"the simulator panics\" — every
  Phase 2 invariant violation already surfaces as a `panic!` (the
  `SIMULATOR PANIC seed=… tick=…` panic hook from #716/#717), so a
  panicking simulation is exactly the failure mode minimization should
  preserve.
- Each reproduction attempt runs on a fresh thread (`Simulator::new`'s
  `install_sim_env` is per-thread) and is wrapped in `catch_unwind`.
- Output JSON re-uses the existing `FaultPlan` schema from #719 inside a
  small wrapper (`{minimize_schema_version: 1, seed, plan, tick_window,
  calls}`) so the inner plan round-trips through `FaultPlan::from_json`.

## Test plan

- [x] Unit: `synthetic_flake_minimizes_to_single_event_plan` plants
      \"panic if `SpuriousTimerIrq` lands in tick 12345\" among 19
      unrelated entries spanning ticks 10..50000 and asserts the
      minimizer collapses to exactly `[(12345, SpuriousTimerIrq)]` with
      `tick_window == [12345, 12346)`.
- [x] Unit: `minimize_respects_operation_bound` asserts call count
      `<= 5 * (log2 T + |plan|^2)` so quadratic-blowup regressions trip
      the test.
- [x] Unit: `ddmin_reduces_redundant_plan_to_minimal_subset` exercises
      the 1-minimal property with a two-event AND predicate.
- [x] Unit: `tick_window_lo_grows_when_failure_starts_late` exercises
      the lo-bisect when the failure event is at tick 50000.
- [x] Unit: `minimize_errors_when_input_does_not_reproduce` covers the
      sanity-check error path.
- [x] Unit: `empty_plan_input_returns_empty_output_when_failure_is_seed_only`
      covers the seed-only failure mode.
- [x] Unit: 7 new `minimize_*` argument-parsing tests on the CLI
      subcommand cover required-flag, duplicate-flag, zero-tick, and
      unknown-flag paths.
- [x] CLI smoke (manual): `replay minimize --help`, missing-flag,
      missing-file, and \"input does not reproduce\" exit-code (=1)
      paths verified.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo test -p simulator` passes (74 lib + 22 bin + 3 doctest).