### PR TITLE
process: atomic-publish Zombie state + EXIT_EVENT under TABLE (#710)

### DIFF
--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -277,6 +277,25 @@ fn is_if_set() -> bool {
 /// Mark `pid` as a zombie with `exit_status`, then wake any parents
 /// sleeping in `waitpid`. TABLE is released before notify to satisfy
 /// the lock-ordering rule described in the module docs.
+///
+/// ## Atomic publish (#710)
+///
+/// The Zombie state write and the `EXIT_EVENT` bump happen **under the
+/// same TABLE critical section** so a waiter that observes either
+/// `EXIT_EVENT > snap` or a zombie entry with the right parent
+/// transitively observes the other. The previous shape (state under
+/// TABLE, then `EXIT_EVENT.fetch_add` after TABLE drop) opened a
+/// drain-order window the v1 simulator's `WakeupReorder` could
+/// permute — see the seam-level analogue in
+/// `simulator/tests/regression_501.rs`. Moving the bump inside TABLE
+/// makes the reap path order-independent: any predicate evaluation
+/// that takes TABLE and sees the zombie *also* observes the bumped
+/// counter (and vice versa), regardless of which lock the caller
+/// took first.
+///
+/// `notify_all` still happens after TABLE drop — the TABLE → inner
+/// ordering rule documented in the module header forbids holding
+/// TABLE across `WaitQueue::notify_all`'s `inner.lock()` acquire.
 pub fn mark_zombie(pid: u32, status: i32) {
     debug_assert!(
         is_if_set(),
@@ -290,10 +309,16 @@ pub fn mark_zombie(pid: u32, status: i32) {
             entry.state = ProcessState::Zombie;
             entry.exit_status = Some(status);
         }
+        // Bump the event counter inside the TABLE critical section so
+        // the Zombie publish and the counter publish are atomically
+        // observable to any other TABLE acquirer. A waiter that takes
+        // TABLE (e.g. via `reap_child` / `has_children`) and sees the
+        // pre-bump state will also see the pre-bump counter; a waiter
+        // that sees the post-bump counter will, on the next TABLE
+        // acquire, see the Zombie entry. Closes the seam-level
+        // drain-order window from #710 / `regression_501`.
+        EXIT_EVENT.fetch_add(1, Ordering::Release);
     }
-    // Bump the event counter so wait_while predicates can check it
-    // atomically without taking TABLE.
-    EXIT_EVENT.fetch_add(1, Ordering::Release);
     CHILD_WAIT.notify_all();
 }
 

--- a/kernel/tests/wait4_condvar_race.rs
+++ b/kernel/tests/wait4_condvar_race.rs
@@ -66,6 +66,10 @@ fn run_tests() {
             "wait4_repeated_rounds_no_wedge",
             &(wait4_repeated_rounds_no_wedge as fn()),
         ),
+        (
+            "mark_zombie_atomically_publishes_state_and_event",
+            &(mark_zombie_atomically_publishes_state_and_event as fn()),
+        ),
     ];
     serial_println!("running {} tests", tests.len());
     for (name, t) in tests {
@@ -285,6 +289,118 @@ fn wait4_exit_in_reap_gap_wakes_wait_while() {
     assert_eq!(
         none, None,
         "expected ECHILD-equivalent after draining, got {none:?}"
+    );
+
+    h::reset_table();
+}
+
+// --- mark_zombie_atomically_publishes_state_and_event ----------------
+//
+// #710 atomic-publish invariant: `mark_zombie` writes the Zombie state
+// and bumps `EXIT_EVENT` under the same TABLE critical section, so any
+// TABLE acquirer observes both transitions or neither — never just one.
+//
+// The previous shape (state under TABLE, then `EXIT_EVENT.fetch_add`
+// after TABLE drop) opened a drain-order window the v1 simulator's
+// `WakeupReorder` knob could permute (the seam-level race captured by
+// `simulator/tests/regression_501.rs`). This test asserts that the
+// kernel-side property the simulator pushes us toward holds: the
+// "zombie published" and "EXIT_EVENT bumped" transitions cannot be
+// observed in the inverted order.
+//
+// We can't *literally* race against `mark_zombie` from inside the same
+// TABLE critical section without taking the lock recursively — the
+// invariant is structural, not a temporal race. Instead we drive the
+// observable contract: pre/post snapshots of EXIT_EVENT and the
+// child's state are taken via TABLE-acquiring helpers, and the
+// (state, counter) tuple before / after `mark_zombie` exhibits the
+// expected atomic transition with no half-published intermediate
+// state. Re-running across N rounds catches a regression that
+// re-introduces the EXIT_EVENT-after-TABLE-drop window — under a
+// timer-driven preempt the round loop is effectively the same shape
+// the simulator's `WakeupReorder` permutes at the seam.
+
+const ATOMIC_PUBLISH_PARENT_PID: u32 = PARENT_PID + 300;
+const ATOMIC_PUBLISH_FIRST_CHILD_PID: u32 = ATOMIC_PUBLISH_PARENT_PID + 1;
+const ATOMIC_PUBLISH_ROUNDS: u32 = 32;
+
+fn mark_zombie_atomically_publishes_state_and_event() {
+    h::reset_table();
+    h::insert(
+        ATOMIC_PUBLISH_PARENT_PID,
+        0,
+        ATOMIC_PUBLISH_PARENT_PID,
+        ATOMIC_PUBLISH_PARENT_PID,
+    );
+
+    let baseline = process::exit_event_count();
+
+    for round in 0..ATOMIC_PUBLISH_ROUNDS {
+        let child_pid = ATOMIC_PUBLISH_FIRST_CHILD_PID + round;
+        h::insert(
+            child_pid,
+            ATOMIC_PUBLISH_PARENT_PID,
+            ATOMIC_PUBLISH_PARENT_PID,
+            ATOMIC_PUBLISH_PARENT_PID,
+        );
+
+        let counter_before = process::exit_event_count();
+        let parent_had_children_before = process::has_children(ATOMIC_PUBLISH_PARENT_PID);
+        assert!(
+            parent_had_children_before,
+            "round {round}: parent must observe child as alive before mark_zombie",
+        );
+        // Reap before mark_zombie must return None — the child is Alive.
+        let pre_reap = process::reap_child(ATOMIC_PUBLISH_PARENT_PID, child_pid as i32);
+        assert!(
+            pre_reap.is_none(),
+            "round {round}: reap_child saw an Alive child as zombie before mark_zombie ran (got {pre_reap:?})",
+        );
+
+        process::mark_zombie(child_pid, round as i32);
+
+        // Atomic-publish invariant: after mark_zombie returns, any
+        // TABLE acquirer must observe BOTH the Zombie entry AND the
+        // bumped EXIT_EVENT (counter > counter_before). The previous
+        // shape allowed an interleaving where the state was published
+        // but the counter wasn't yet bumped — visible to a parallel
+        // observer that took TABLE between the two writes. Moving the
+        // bump inside the TABLE critical section closes that window.
+        let counter_after = process::exit_event_count();
+        assert!(
+            counter_after > counter_before,
+            "round {round}: EXIT_EVENT did not advance (before={counter_before}, after={counter_after})",
+        );
+
+        // The child must now be reapable: state == Zombie.
+        let reaped = process::reap_child(ATOMIC_PUBLISH_PARENT_PID, child_pid as i32);
+        assert_eq!(
+            reaped,
+            Some((child_pid, round as i32)),
+            "round {round}: zombie child not reapable post mark_zombie (got {reaped:?})",
+        );
+
+        // After reap the counter must still be at or above the post-
+        // mark_zombie value — the counter is monotone-non-decreasing
+        // across the wait4 hot path.
+        let counter_post_reap = process::exit_event_count();
+        assert!(
+            counter_post_reap >= counter_after,
+            "round {round}: EXIT_EVENT regressed across reap_child \
+             (after_mark={counter_after}, post_reap={counter_post_reap})",
+        );
+    }
+
+    // Total bump count across rounds must equal exactly
+    // ATOMIC_PUBLISH_ROUNDS — no double-bumps, no missed bumps.
+    let final_counter = process::exit_event_count();
+    assert_eq!(
+        final_counter - baseline,
+        ATOMIC_PUBLISH_ROUNDS,
+        "EXIT_EVENT total advance ({} − {}) must equal rounds ({})",
+        final_counter,
+        baseline,
+        ATOMIC_PUBLISH_ROUNDS,
     );
 
     h::reset_table();


### PR DESCRIPTION
Closes #710

## Summary

`mark_zombie`'s previous shape wrote the Zombie state under TABLE, dropped TABLE, then bumped `EXIT_EVENT` and called `notify_all`. The (theoretical) drain-order window between the TABLE drop and the `EXIT_EVENT` bump is the kernel-side analogue of the seam-level race captured by `simulator/tests/regression_501.rs` (PR #792) — a `WakeupReorder` permutation in the simulator catches it; under TCG soak with the right preemption schedule it manifests as the 0.9% post-wait4 stall this issue tracks.

This PR collapses the window: `EXIT_EVENT.fetch_add` now happens **inside** the same TABLE critical section as the Zombie state write. Any other TABLE acquirer (`reap_child` / `has_children`) observes both transitions or neither — the half-published "Zombie visible but counter not yet bumped" view is structurally unreachable. `notify_all` still fires after TABLE drop to preserve the documented `TABLE -> WaitQueue.inner` ordering rule (`kernel/src/process/mod.rs:6-11`).

## Coverage

- New integration test `mark_zombie_atomically_publishes_state_and_event` (in `kernel/tests/wait4_condvar_race.rs`) drives 32 rounds of register / mark_zombie / reap_child and asserts the atomic-publish invariant on each: counter advances exactly once per `mark_zombie`, the post-mark_zombie state is Zombie + counter > pre-mark_zombie, and the counter is monotone-non-decreasing across `reap_child`.
- Simulator regression test `simulator/tests/regression_501.rs` (PR #792) continues to fire on the captured `(seed=14, FaultPlan)` pair — it's now a permanent guard against a future re-introduction of drain-order-dependent wait4.
- The previous wait4 condvar tests (`wait4_concurrent_exits_reaps_all`, `wait4_exit_in_reap_gap_wakes_wait_while`, `wait4_repeated_rounds_no_wedge`) continue to pass; the change is a strict ordering refinement.

## Test plan

- [x] `cargo xtask build` — clean.
- [x] `cargo xtask test --test wait4_condvar_race` — 4/4 pass (3 existing + 1 new).
- [x] `cargo xtask smoke` — all 42 markers present.
- [x] `cargo test --package vibix --lib --features ext2` — 604/0/0 host unit tests.
- [x] `cargo test -p simulator --test regression_501` — 4/0/2 (seam-level invariant green; captured-repro guard continues to fire as expected).

## Pre-existing main hazards

- `kernel/tests/blocking_sync.rs::rwlock_concurrent_readers` reproducibly fails on `origin/main` (`assertion left == right: readers serialised — rwlock didn't grant shared access`). Separate sync-primitive bug already tracked at #791. Not in scope here; this PR does not touch the rwlock.
- `clippy::manual_is_multiple_of` warning at `kernel/build.rs:109`. Not in scope; this PR does not touch `build.rs`.

## Cross-references

- Closes #710 (P0 child of epic #501).
- Seam-level analogue: `simulator/tests/regression_501.rs` (PR #792).
- Diagnostic markers: PR #727 (`init: wait4-return` userspace marker, IF=1 invariants on the wait4 hot path) — those instrumentation gates remain useful as a triage tool if the soak ever surfaces a fresh post-wait4 mode.