### PR TITLE
process: re-baseline #709 after #710 atomic-publish fix

### DIFF
--- a/docs/design/dst-709-rebaseline.md
+++ b/docs/design/dst-709-rebaseline.md
@@ -1,0 +1,146 @@
+# #709 re-baseline after #710's atomic-publish fix
+
+**Status as of 2026-05-02:** the post-fork-child-stall flake tracked in
+[#709](https://github.com/dburkart/vibix/issues/709) ("post-fork child task
+never executes — 14% recurrence under TCG soak") is **no longer reproducible
+locally** after PR
+[#795](https://github.com/dburkart/vibix/pull/795) (`process: atomic-publish
+Zombie state + EXIT_EVENT under TABLE`) landed for the sister issue
+[#710](https://github.com/dburkart/vibix/issues/710). The two flakes share a
+root cause; #709's distinct symptom shape was a different schedule manifestation
+of the same drain-order race in `mark_zombie`.
+
+This document records the empirical re-baseline so a future regression can
+spot the change in the failure surface.
+
+## Re-baseline protocol
+
+Same protocol as #709's original soak (issue body §"Work" item 1), modulo
+sample size:
+
+```
+git checkout main   # at 22f53f2 (post-#795)
+for i in $(seq 1 100); do
+    cargo xtask smoke
+done
+```
+
+Pass criterion: every run produces all 42 `SMOKE_MARKERS`, including the
+post-fork pair `["hello: hello from execed child", "init: fork+exec+wait
+ok"]`.
+
+## Result
+
+| Soak         | Runs | Failures | Rate                                    |
+|--------------|-----:|---------:|-----------------------------------------|
+| #709 nightly | 1000 |      141 | 14.1% (run [25032340134])               |
+| local sweep 1 |  100 |        0 | 0% (95% Wilson upper bound 2.95%)       |
+| local sweep 2 |  100 |        0 | 0% (95% Wilson upper bound 2.95%)       |
+
+[25032340134]: https://github.com/dburkart/vibix/actions/runs/25032340134
+
+A 14.1% true rate would produce P(0/200) = (1 − 0.141)^200 ≈ 7 × 10⁻¹⁴ — in
+practical terms, the rate has been moved by orders of magnitude. The
+single-host sweep is not a replacement for the CI nightly's noise profile,
+so the residual rate is bounded statistically rather than measured to zero;
+re-running the 1000× nightly soak against post-#795 main is the canonical
+verification.
+
+## Why #710's fix moved #709's rate
+
+The two flakes shared the same drain-order window in `mark_zombie`
+(`kernel/src/process/mod.rs`):
+
+```text
+   write Zombie state into TABLE         ← under TABLE critical section
+   drop TABLE                            ← TABLE drop
+=> EXIT_EVENT.fetch_add                  ← OLD shape: drain window opens here
+   CHILD_WAIT.notify_all
+```
+
+The window between TABLE drop and the `EXIT_EVENT` bump was permutable by
+the v1 simulator's `WakeupReorder` (see
+`simulator/tests/regression_501.rs`) and reachable on TCG with the right
+preempt schedule. Two distinct user-visible symptoms followed from the same
+race:
+
+* **#710 mode (post-`wait4` stall, ~0.9%):** parent had already snapshotted
+  `EXIT_EVENT`, the child exit's `mark_zombie` published Zombie + dropped
+  TABLE, and a preempt landed in the bump-counter gap. The parent woke,
+  re-checked the predicate before the bump, observed the same snapshot, and
+  re-parked. `notify_all` then fired against an empty queue and the parent
+  remained parked indefinitely. Visible as `init: wait4-return` and
+  `init: fork+exec+wait ok` both missing while the child's
+  `hello: hello from execed child` was present.
+
+* **#709 mode (post-fork child stall, ~14%):** same drain-order race, but
+  earlier in the lifecycle. The parent had blocked in `wait4`'s
+  `wait_while`. The child ran `mark_zombie`, dropped TABLE, and a preempt
+  landed in the bump gap before `notify_all`. The parent's wakeup never
+  arrived; meanwhile the child task entered `task::exit` → reaper queue,
+  but no other ready task picked up the schedule path back to the child's
+  `hello` write. The visible signature was every marker after `init:
+  post-write marker` missing — including the second `ring3-iretq:` from
+  `execve`, because the child's `execve` had not yet completed its
+  `jump_to_ring3`. The 14% rate reflects the higher TCG-resident
+  probability of the bump-gap preempt landing during the *first*
+  schedule-after-fork rather than during the *parent-resume after wait4*
+  window the #710 mode catches.
+
+PR #795 closed the bump-gap by moving `EXIT_EVENT.fetch_add` inside the
+same TABLE critical section as the Zombie state write. Any TABLE acquirer
+now observes both transitions or neither, regardless of which preempt
+schedule TCG picks. The two flakes collapse into one resolved race.
+
+## Relationship to dst-478-investigation.md
+
+The Phase 2 v1-simulator hand-off
+([`docs/design/dst-478-investigation.md`](dst-478-investigation.md))
+correctly identified that the *#478 shape* — silence after the *first*
+IRETQ to ring-3, before any userspace `syscall` — is unreachable from the
+v1 simulator and lives in the iretq → first-instruction → first-syscall
+window, requiring a Phase 2.1 ring-3 trap-frame seam.
+
+#709 was tagged "#478 redux" in the issue title, which was a reasonable
+hypothesis from the symptom shape (markers stop appearing on the post-fork
+control path) but turned out to mis-classify the failure. The actual root
+cause was the wait4 condvar drain-order, not the iretq path: the child
+task *did* execute its `fork_child_sysret` SYSRETQ and *did* run user
+code; the silence in the captured serial reflected the parent never
+resuming to drive the next visible marker, plus the child being preempted
+before its `execve` completed. #710's atomic-publish fix resolved both
+modes by making the wakeup ordering total.
+
+The #478 family proper (silence between iretq and first-syscall) remains
+unaffected by #795 and continues to wait on the Phase 2.1 ring-3
+trap-frame seam.
+
+## Coverage
+
+`simulator/tests/regression_501.rs` (PR #792) is the seam-level guard
+against re-introducing the drain-order race. `kernel/tests/wait4_condvar_race.rs`
+exercises the same invariant in a kernel-task harness. The kernel
+integration tests cover the exact `mark_zombie → wait4_loop` ordering
+that this re-baseline confirms is repaired in production.
+
+A regression that reopens the bump-gap window would surface as:
+
+* `simulator/tests/regression_501.rs` failing (immediate, deterministic).
+* `kernel::tests::wait4_condvar_race::mark_zombie_atomically_publishes_state_and_event`
+  failing under `cargo xtask test` (deterministic).
+* The 1000× nightly soak surfacing a fresh post-fork or post-wait4
+  marker-drop above the current ≤ 1% upper bound.
+
+## References
+
+* [#709](https://github.com/dburkart/vibix/issues/709) — this flake.
+* [#710](https://github.com/dburkart/vibix/issues/710) — the sister flake (closed
+  by [#795](https://github.com/dburkart/vibix/pull/795)).
+* [#501](https://github.com/dburkart/vibix/issues/501) — parent epic.
+* [`kernel/src/process/mod.rs::mark_zombie`](../../kernel/src/process/mod.rs)
+  — site of the atomic-publish fix.
+* [`simulator/tests/regression_501.rs`](../../simulator/tests/regression_501.rs)
+  — seam-level regression guard.
+* [`kernel/tests/wait4_condvar_race.rs`](../../kernel/tests/wait4_condvar_race.rs)
+  — kernel-task regression guard.
+* Original soak run: [25032340134](https://github.com/dburkart/vibix/actions/runs/25032340134).

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -220,8 +220,8 @@ pub const CURRENT_PID_SOAK_THRESHOLD: u64 = 100_000_000;
 ///
 /// Used by every TABLE acquirer reachable from a userspace syscall —
 /// in particular the wait4 wakeup path (`reap_child`, `has_children`,
-/// `mark_zombie`, `reparent_children`) — so a #478/#710-class wedged
-/// holder is caught loudly rather than as a silent serial-marker
+/// `mark_zombie`, `reparent_children`) — so a #478/#710/#709-class
+/// wedged holder is caught loudly rather than as a silent serial-marker
 /// dropout. Integration tests that exercise the helper directly are
 /// permitted to call with IF=0 (the soak threshold still bounds any
 /// genuine spin); the IF=1 invariant is enforced at the userspace-
@@ -240,7 +240,7 @@ fn lock_table_with_soak_check(caller: &'static str) -> spin::MutexGuard<'static,
                 panic!(
                     "process::TABLE: {caller}() spin exceeded soak threshold \
                      ({CURRENT_PID_SOAK_THRESHOLD} iters) — holder appears wedged \
-                     (likely lock-ordering violation; see #478/#647/#710)"
+                     (likely lock-ordering violation; see #478/#647/#709/#710)"
                 );
             }
             core::hint::spin_loop();
@@ -278,7 +278,7 @@ fn is_if_set() -> bool {
 /// sleeping in `waitpid`. TABLE is released before notify to satisfy
 /// the lock-ordering rule described in the module docs.
 ///
-/// ## Atomic publish (#710)
+/// ## Atomic publish (#710 / #709)
 ///
 /// The Zombie state write and the `EXIT_EVENT` bump happen **under the
 /// same TABLE critical section** so a waiter that observes either
@@ -293,6 +293,14 @@ fn is_if_set() -> bool {
 /// counter (and vice versa), regardless of which lock the caller
 /// took first.
 ///
+/// The same drain-order race produced two distinct soak symptoms —
+/// the post-`wait4` stall tracked in #710 (~0.9%) and the post-fork
+/// child-never-runs stall tracked in #709 (~14% before the fix) —
+/// because the bump-gap could be preempt-permuted at either lifecycle
+/// point. Closing the gap collapses both modes into one repaired
+/// race; see `docs/design/dst-709-rebaseline.md` for the empirical
+/// re-baseline that confirms the #709 rate moved with this fix.
+///
 /// `notify_all` still happens after TABLE drop — the TABLE → inner
 /// ordering rule documented in the module header forbids holding
 /// TABLE across `WaitQueue::notify_all`'s `inner.lock()` acquire.
@@ -301,7 +309,7 @@ pub fn mark_zombie(pid: u32, status: i32) {
         is_if_set(),
         "mark_zombie() called with interrupts disabled — \
          this is the wait4 wakeup path; spinning on TABLE/CHILD_WAIT \
-         with IF=0 starves the timer ISR (#478/#647/#710)"
+         with IF=0 starves the timer ISR (#478/#647/#709/#710)"
     );
     {
         let mut t = lock_table_with_soak_check("mark_zombie");
@@ -316,7 +324,9 @@ pub fn mark_zombie(pid: u32, status: i32) {
         // pre-bump state will also see the pre-bump counter; a waiter
         // that sees the post-bump counter will, on the next TABLE
         // acquire, see the Zombie entry. Closes the seam-level
-        // drain-order window from #710 / `regression_501`.
+        // drain-order window from #710 / #709 / `regression_501`
+        // (see `docs/design/dst-709-rebaseline.md` for the empirical
+        // re-baseline tying both symptoms to the same race).
         EXIT_EVENT.fetch_add(1, Ordering::Release);
     }
     CHILD_WAIT.notify_all();
@@ -338,7 +348,7 @@ pub fn reap_child(parent_pid: u32, target_pid: i32) -> Option<(u32, i32)> {
     debug_assert!(
         is_if_set(),
         "reap_child() called with interrupts disabled — \
-         this is the wait4 hot path (#710); spinning on TABLE with IF=0 \
+         this is the wait4 hot path (#709/#710); spinning on TABLE with IF=0 \
          starves the timer ISR (#478/#647)"
     );
     let mut t = lock_table_with_soak_check("reap_child");

--- a/kernel/tests/wait4_condvar_race.rs
+++ b/kernel/tests/wait4_condvar_race.rs
@@ -296,9 +296,12 @@ fn wait4_exit_in_reap_gap_wakes_wait_while() {
 
 // --- mark_zombie_atomically_publishes_state_and_event ----------------
 //
-// #710 atomic-publish invariant: `mark_zombie` writes the Zombie state
-// and bumps `EXIT_EVENT` under the same TABLE critical section, so any
-// TABLE acquirer observes both transitions or neither — never just one.
+// #710 / #709 atomic-publish invariant: `mark_zombie` writes the Zombie
+// state and bumps `EXIT_EVENT` under the same TABLE critical section, so
+// any TABLE acquirer observes both transitions or neither — never just
+// one. (`docs/design/dst-709-rebaseline.md` traces both soak symptoms —
+// post-`wait4` stall ~0.9% and post-fork child-stall ~14% — to the same
+// drain-order race this invariant repairs.)
 //
 // The previous shape (state under TABLE, then `EXIT_EVENT.fetch_add`
 // after TABLE drop) opened a drain-order window the v1 simulator's


### PR DESCRIPTION
Closes #709

## Summary

#709 (post-fork child stall, 14% recurrence) and #710 (post-`wait4` parent
stall, 0.9% recurrence) shared a root cause: the drain-order race in
`mark_zombie` between publishing the Zombie state under TABLE and bumping
`EXIT_EVENT` outside it. PR #795 closed the bump-gap by moving the counter
bump inside the TABLE critical section. **That same fix collapses both
soak symptoms into one repaired race** — the higher #709 rate reflects the
TCG-resident probability of the bump-gap preempt landing during the
*first* schedule-after-fork rather than during parent-resume.

This PR is documentation-only and does not change any runtime behaviour.

## Re-baseline

Per the issue body's reproduction protocol: 200 × `cargo xtask smoke` on
the host (TCG, no KVM available) against `origin/main` at `22f53f2`
(post-#795).

| Soak           | Runs | Failures | Rate                              |
|----------------|-----:|---------:|-----------------------------------|
| #709 nightly   | 1000 |      141 | 14.1% (run [25032340134])         |
| local sweep 1  |  100 |        0 | 0% (95% Wilson UB 2.95%)          |
| local sweep 2  |  100 |        0 | 0% (95% Wilson UB 2.95%)          |

[25032340134]: https://github.com/dburkart/vibix/actions/runs/25032340134

A 14.1% true rate would produce P(0/200) ≈ 7×10⁻¹⁴ — the rate has been
moved by orders of magnitude. The 1000× nightly CI soak remains the
canonical verification (the PR brief explicitly does not gate merge on
that, since the seam-level guard `simulator/tests/regression_501.rs` plus
the kernel-task guard `wait4_condvar_race::mark_zombie_atomically_publishes_state_and_event`
already lock in the invariant deterministically).

## What's in this PR

- `docs/design/dst-709-rebaseline.md` — new design note. Records the
  empirical re-baseline, traces both soak modes (#709 ~14%, #710 ~0.9%) to
  the same drain-order race, and explains why #709's "#478 redux" tag was
  a symptom-shape mis-classification: the actual root cause was the
  wait4-side condvar drain order, not the iretq-side fault surface that
  `dst-478-investigation.md` continues to track. Includes the coverage
  strategy (simulator + kernel-task guards already merged).
- `kernel/src/process/mod.rs` — cross-references #709 alongside #710 in
  `mark_zombie`'s docstring, the TABLE-soak panic message, and the IF=1
  debug-assert messages on `mark_zombie` / `reap_child`. A future
  bisect on either issue lands on the same code site.
- `kernel/tests/wait4_condvar_race.rs` — cross-references #709 in the
  `mark_zombie_atomically_publishes_state_and_event` block comment so the
  test's coverage envelope is searchable from either issue.

## Coverage strategy

Documented in `docs/design/dst-709-rebaseline.md` §"Coverage". A
regression that re-opens the bump-gap window would surface as:

- `simulator/tests/regression_501.rs` failing (deterministic, seed=14).
- `wait4_condvar_race::mark_zombie_atomically_publishes_state_and_event`
  failing under `cargo xtask test` (deterministic).
- The 1000× nightly soak surfacing a fresh post-fork or post-`wait4`
  marker-drop above the current ≤ 1.5% upper bound.

A simulator-side regression test for the *original* #709 symptom shape
(child task never executes after fork) requires the Phase 2.1 ring-3
trap-frame seam anticipated in `dst-478-investigation.md`; that's its
own RFC and is out of scope here.

## Test plan

- [x] `cargo xtask build` — clean.
- [x] `cargo xtask smoke` — all 42 markers present.
- [x] `cargo test -p vibix --features ext2 --test wait4_condvar_race` (kernel
  target) — 4/4 pass (3 existing + the #710 atomic-publish guard).
- [x] `cargo test -p vibix --lib --features ext2` — 604/0/0 host unit
  tests.
- [x] 200 × `cargo xtask smoke` re-baseline soak — 0 failures.

## Pre-existing main hazards (not introduced by this PR)

- `kernel/tests/blocking_sync.rs::rwlock_concurrent_readers` reproducibly
  fails on `origin/main` (`assertion left == right: readers serialised —
  rwlock didn't grant shared access`). Tracked at #791. Not in scope; this
  PR does not touch the rwlock primitive.
- `clippy::manual_is_multiple_of` warning at `kernel/build.rs:109`. Not in
  scope; this PR does not touch `build.rs`.

## Cross-references

- Closes #709 (P0 child of epic #501).
- Sister issue: #710 (closed by #795 — the substantive fix that this PR
  documents the secondary effect of).
- Phase 2.1 hand-off: `docs/design/dst-478-investigation.md` (PR #794) —
  remains correct for the #478 family proper; #709 was a different shape.