### PR TITLE
fs/ext2: AddressSpaceOps::readpage with sparse + tail zero (#749)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -418,6 +418,11 @@ harness = false
 required-features = ["ext2"]
 
 [[test]]
+name = "ext2_readpage"
+harness = false
+required-features = ["ext2"]
+
+[[test]]
 name = "ext2_orphan_chain"
 harness = false
 required-features = ["ext2"]

--- a/kernel/src/fs/ext2/aops.rs
+++ b/kernel/src/fs/ext2/aops.rs
@@ -1,0 +1,335 @@
+//! ext2 [`AddressSpaceOps`] implementation — the page-cache hook the
+//! generic per-inode page cache calls on read miss / writeback /
+//! readahead / truncate.
+//!
+//! RFC 0007 §`AddressSpaceOps` and §Tail-page zeroing are the normative
+//! spec. This module is **Workstream C / issue #749**: it lands the
+//! `readpage` path only. The other three trait methods (`writepage`,
+//! `truncate_below`, `readahead`) are deliberately stubbed out here:
+//!
+//! - `writepage` returns `Err(EROFS)` — issue #750 lands the real
+//!   buffer-cache writeback. Until then a forced-RO behaviour is
+//!   strictly safer than `unimplemented!()`-panic, because a future
+//!   page-fault path that wires `MAP_SHARED` writeback (#746/#755) can
+//!   exercise the writepage call site without bringing the kernel down;
+//!   the daemon will see `EROFS` and bump `wb_err`, which is the
+//!   correct user-visible behaviour for "this filesystem doesn't
+//!   support writeback yet".
+//! - `truncate_below` is left at the trait default (no-op + spinlock
+//!   assert). Issue #751 will replace it.
+//! - `readahead` is left at the trait default (no-op + spinlock
+//!   assert). Issue #752 will replace it.
+//!
+//! # Pipeline (`readpage`)
+//!
+//! For a 4 KiB file page at `pgoff`, the impl:
+//!
+//! 1. Snapshots `(i_size, i_block[15])` out of the inode metadata lock
+//!    (`Ext2InodeMeta`) under a brief read-guard, **before** any
+//!    `bread`. Holding the metadata lock across blocking I/O would
+//!    serialise every concurrent `stat(2)` against the slowest reader.
+//! 2. If `pgoff` is entirely past `i_size` (i.e. `pgoff * 4096 >=
+//!    i_size`), returns `Ok(0)` and leaves `buf` untouched per the
+//!    `AddressSpaceOps::readpage` contract.
+//! 3. Otherwise, computes the `[file_lo .. file_hi)` byte window
+//!    inside the page that lies within `i_size`, where
+//!    `file_hi = min(pgoff*4096 + 4096, i_size)` and `file_lo =
+//!    pgoff*4096`.
+//! 4. Walks each FS-block-sized chunk inside that window via
+//!    [`super::indirect::resolve_block`]:
+//!    - `Ok(Some(abs))` — `bread` and memcpy into `buf` at the
+//!      page-relative offset. Sub-block alignment matters for the
+//!      head/tail of the window when `block_size > 4096` would be
+//!      possible (it isn't on legal ext2 — block sizes are 1024, 2048,
+//!      or 4096 — but the arithmetic is written to handle any
+//!      `block_size <= 4096` evenly).
+//!    - `Ok(None)` — sparse hole. Zero-fill the chunk inside `buf`.
+//!    - `Err(WalkError::Io)` → `EIO`.
+//!    - `Err(WalkError::Corrupt)` → `EIO` (the upstream walker also
+//!      forces the mount RO via the corrupt-pointer detector; the
+//!      readpage caller observes a faithful errno regardless).
+//! 5. Zero-fills the **tail** `[file_hi - pgoff*4096 .. 4096)` of
+//!    `buf`. RFC 0007 §Tail-page zeroing: every byte past `i_size`
+//!    inside a partially-in-file page is zero so a `read()` of the
+//!    cached page returns POSIX-compliant zeros without the syscall
+//!    layer having to compute the tail again.
+//! 6. Returns `Ok(4096)` — the impl always populates the full page
+//!    when any byte was in-file. The trait's "byte count" is the
+//!    populated byte count; for a partial-tail page that's still 4096
+//!    because the tail zero-fill is part of the populate contract,
+//!    not a short-read indication. This matches the wording in RFC
+//!    0007 §`AddressSpaceOps` ("the caller pre-zeroes only when the
+//!    impl returns `Ok(0)`").
+//!
+//! # Errno table (RFC 0007 §Errno table)
+//!
+//! - `EIO` — buffer-cache read failure (`BlockError::*`), or the
+//!   indirect walker returned [`super::indirect::WalkError::Io`] /
+//!   [`super::indirect::WalkError::Corrupt`].
+//! - `Ok(0)` — `pgoff * 4096 >= i_size`. Pages entirely past EOF; the
+//!   page-cache caller pre-zeroes.
+//! - `Ok(4096)` — at least one byte of `buf` was in-file (data,
+//!   sparse-hole zero, or tail zero) and the page is fully populated.
+//!
+//! The mount being torn down (`Weak::upgrade()` returns `None` for
+//! either `super_ref` or the inode lookup) surfaces as `EIO` — by the
+//! time a `readpage` is in flight the inode that owns this Ops has
+//! lost its backing storage, which is the same observable a real
+//! storage failure would produce.
+//!
+//! # Lock-order ladder (RFC 0007)
+//!
+//! `assert_no_spinlocks_held("Ext2Aops::readpage")` is the first line
+//! of the body. The page cache drops its level-4 index mutex before
+//! calling here, so the assert is the contract enforcement point: if
+//! any future caller forgets to drop the index mutex (or tries to call
+//! `readpage` from inside a spin-locked critical section), the assert
+//! fires before we issue any buffer-cache `bread`.
+
+use alloc::sync::{Arc, Weak};
+
+use crate::debug_lockdep::assert_no_spinlocks_held;
+use crate::fs::ext2::indirect::{resolve_block, Geometry, WalkError};
+use crate::fs::ext2::Ext2Super;
+use crate::fs::{EIO, EROFS};
+use crate::mem::aops::AddressSpaceOps;
+
+use super::file::build_metadata_map;
+use super::inode::Ext2Inode;
+
+/// Page size the page cache deals in. Matches `crate::mem::PAGE_SIZE`
+/// on x86_64 (4 KiB); duplicated here as a `const` because the
+/// `AddressSpaceOps::readpage` signature already encodes the size in
+/// `&mut [u8; 4096]` and we want a single source of truth that's
+/// trivially greppable from this module's docs.
+const PAGE_SIZE: u64 = 4096;
+
+/// ext2's [`AddressSpaceOps`] implementation.
+///
+/// Holds [`Weak`] references to the per-mount [`Ext2Super`] and the
+/// in-memory [`Ext2Inode`] this Ops is bound to. Both are weak so a
+/// dropped mount or a dropped inode cleanly tears the cache's strong
+/// `Arc<dyn AddressSpaceOps>` down without keeping the FS alive past
+/// its user-visible lifetime — matching the inode-binding rule (RFC
+/// 0007 §Inode-binding rule): a future inode reincarnation gets its
+/// own distinct `PageCache` against its own distinct `Ext2Aops`.
+///
+/// # Construction
+///
+/// `Ext2Aops` is built by the publication path that hands a fresh
+/// [`Ext2Inode`] to the VFS — see [`Ext2Aops::new`]. The Ops Arc is
+/// installed on the [`crate::fs::vfs::inode::Inode`] via
+/// [`crate::fs::vfs::inode::Inode::set_aops`] before the inode
+/// becomes reachable from userspace, so the install-once invariant
+/// (RFC 0007 §Inode-binding rule) holds by construction.
+///
+/// Wave-1 (this issue) only constructs `Ext2Aops` from tests — the
+/// real publication wiring lands with the Workstream-D consumers
+/// (`FileOps::mmap` in #753, `FileOps::read` cache-routing in #754).
+/// The struct shape is finalised here so those follow-ups don't need
+/// to revise the type's surface.
+pub struct Ext2Aops {
+    pub super_ref: Weak<Ext2Super>,
+    pub inode_ref: Weak<Ext2Inode>,
+}
+
+impl Ext2Aops {
+    /// Build an `Ext2Aops` bound to `(super_, ext2_inode)`. The Arc is
+    /// returned ready to install via
+    /// [`crate::fs::vfs::inode::Inode::set_aops`] — both arguments
+    /// are downgraded to `Weak` so the Ops never pins the mount or
+    /// the inode past their user-visible lifetimes.
+    pub fn new(super_: &Arc<Ext2Super>, ext2_inode: &Arc<Ext2Inode>) -> Arc<Self> {
+        Arc::new(Self {
+            super_ref: Arc::downgrade(super_),
+            inode_ref: Arc::downgrade(ext2_inode),
+        })
+    }
+}
+
+impl AddressSpaceOps for Ext2Aops {
+    fn readpage(&self, pgoff: u64, buf: &mut [u8; 4096]) -> Result<usize, i64> {
+        // RFC 0007 §Lock-order ladder: every method on this trait
+        // must call `assert_no_spinlocks_held` as its very first
+        // statement so a caller that forgot to drop a spinlock trips
+        // here before issuing any blocking I/O.
+        assert_no_spinlocks_held("Ext2Aops::readpage");
+
+        // Upgrade the weak handles. A `None` here means the mount or
+        // the inode has been torn down out from under the cache; the
+        // page cache will treat this as a faithful filler error and
+        // surface `EIO` to the faulting task via
+        // `PageCache::abandon_locked_stub`.
+        let super_ref = self.super_ref.upgrade().ok_or(EIO)?;
+        let ext2_inode = self.inode_ref.upgrade().ok_or(EIO)?;
+
+        // Snapshot the metadata fields we need (size + i_block) under
+        // the inode's read-guard, then drop the guard before any
+        // blocking `bread`. The pattern mirrors `read_file_at` —
+        // holding the metadata lock across block I/O would block
+        // every concurrent `stat(2)` for the duration of the
+        // slowest reader.
+        let (size, i_block) = {
+            let meta = ext2_inode.meta.read();
+            (meta.size, meta.i_block)
+        };
+
+        // Page entirely past EOF — the trait says return `Ok(0)` and
+        // leave `buf` untouched. The page-cache caller is responsible
+        // for the pre-zero in this case.
+        let page_lo = pgoff.checked_mul(PAGE_SIZE).ok_or(EIO)?;
+        if page_lo >= size {
+            return Ok(0);
+        }
+        // The exclusive upper bound of the file-content window that
+        // overlaps this page. Bounded by both `i_size` (so the tail
+        // gets zero-filled) and the page's own end (so a small file
+        // that fits in fewer than 4096 bytes tail-zeroes everything
+        // past `size`).
+        let page_hi_full = page_lo.saturating_add(PAGE_SIZE);
+        let page_hi_in_file = core::cmp::min(page_hi_full, size);
+        debug_assert!(page_hi_in_file > page_lo);
+
+        // Build the geometry + metadata-forbidden map fresh per
+        // call. The cost is `O(groups)` (a few bgdt entries on a
+        // typical mount) and the alternative — caching the map on
+        // `Ext2Super` — is tracked as a perf follow-up under the
+        // same TODO `read_file_at` carries.
+        let (s_first_data_block, s_blocks_count) = {
+            let sb = super_ref.sb_disk.lock();
+            (sb.s_first_data_block, sb.s_blocks_count)
+        };
+        let geom =
+            Geometry::new(super_ref.block_size, s_first_data_block, s_blocks_count).ok_or(EIO)?;
+        let md = build_metadata_map(&super_ref);
+
+        let block_size = super_ref.block_size as u64;
+        debug_assert!(block_size > 0, "mount validated block_size != 0");
+
+        // Iterate FS-block-sized chunks across the in-file window.
+        // For block_size >= 4096 (i.e. 4096 — ext2's max legal block
+        // size) each page covers exactly one disk block; for
+        // block_size < 4096 (1024 / 2048) the page spans multiple
+        // blocks. The loop is written to handle both uniformly.
+        let mut cur = page_lo;
+        while cur < page_hi_in_file {
+            let logical_u64 = cur / block_size;
+            // ext2 caps `s_blocks_count` at `u32::MAX`; a logical
+            // index past that is a corrupted geometry we treat as
+            // EIO at the read site (the walker would also reject
+            // it via its own bounds check).
+            let logical: u32 = logical_u64.try_into().map_err(|_| EIO)?;
+
+            // In-block offset / chunk size: bound by the block's
+            // tail and the in-file window's tail.
+            let in_block = (cur % block_size) as usize;
+            let block_remaining = block_size as usize - in_block;
+            let window_remaining = (page_hi_in_file - cur) as usize;
+            let chunk = core::cmp::min(block_remaining, window_remaining);
+            let buf_off = (cur - page_lo) as usize;
+
+            match resolve_block(
+                &super_ref.cache,
+                super_ref.device_id,
+                &geom,
+                &md,
+                &i_block,
+                logical,
+                None,
+            ) {
+                Ok(Some(abs)) => {
+                    let bh = super_ref
+                        .cache
+                        .bread(super_ref.device_id, abs as u64)
+                        .map_err(|_| EIO)?;
+                    let data = bh.data.read();
+                    debug_assert!(in_block + chunk <= data.len());
+                    debug_assert!(buf_off + chunk <= buf.len());
+                    buf[buf_off..buf_off + chunk]
+                        .copy_from_slice(&data[in_block..in_block + chunk]);
+                }
+                Ok(None) => {
+                    // Sparse hole. RFC 0007 §Errno table sparse-hole
+                    // row: zero-fill the chunk inside `buf` rather
+                    // than relying on the caller's pre-zero — the
+                    // caller only pre-zeroes on `Ok(0)`, which is
+                    // the past-EOF path, not the sparse-hole path.
+                    debug_assert!(buf_off + chunk <= buf.len());
+                    for b in &mut buf[buf_off..buf_off + chunk] {
+                        *b = 0;
+                    }
+                }
+                Err(WalkError::Io) => return Err(EIO),
+                Err(WalkError::Corrupt) => {
+                    // RFC 0004 §Security: a corrupt pointer means
+                    // the on-disk image is lying to us. Surface as
+                    // `EIO`; the walker's own corruption detector is
+                    // what trips the force-RO latch on the write
+                    // path (we're a read path, so the latch is
+                    // out-of-band here).
+                    return Err(EIO);
+                }
+            }
+
+            cur += chunk as u64;
+        }
+
+        // RFC 0007 §Tail-page zeroing: zero `[i_size .. page_end)`
+        // inside `buf` so a subsequent `read()` of the cached page
+        // returns POSIX-compliant zeros without the syscall layer
+        // having to recompute the tail. Skipped when the in-file
+        // window already filled the whole page.
+        if page_hi_in_file < page_hi_full {
+            let tail_off = (page_hi_in_file - page_lo) as usize;
+            debug_assert!(tail_off <= buf.len());
+            for b in &mut buf[tail_off..] {
+                *b = 0;
+            }
+        }
+
+        Ok(PAGE_SIZE as usize)
+    }
+
+    fn writepage(&self, _pgoff: u64, _buf: &[u8; 4096]) -> Result<(), i64> {
+        // RFC 0007 §Lock-order ladder: every method body asserts no
+        // spinlocks at entry, even the stubbed-out ones — the
+        // assertion is part of the trait contract, not the work.
+        assert_no_spinlocks_held("Ext2Aops::writepage (stub — #750)");
+        // Issue #750 lands the real buffer-cache writeback chain.
+        // Until then surface `EROFS` so a `MAP_SHARED` writeback
+        // attempt (e.g. via the page-fault path that #746 / #755
+        // wires) bumps `wb_err` and surfaces a deterministic errno
+        // to userspace, rather than panicking the kernel.
+        Err(EROFS)
+    }
+
+    // `readahead` and `truncate_below` left at the trait defaults —
+    // both are no-op + `assert_no_spinlocks_held`. Issue #751 lands
+    // `truncate_below`; issue #752 lands `readahead`.
+}
+
+#[cfg(test)]
+mod tests {
+    //! Host unit tests. The end-to-end pipeline (`readpage` against a
+    //! mounted `read_test.img`) is exercised by the QEMU integration
+    //! test `kernel/tests/ext2_readpage.rs`; the host tests here cover
+    //! the non-I/O surface — the construction shape and the trait-
+    //! object plumbing — without standing up an `Ext2Super`.
+    //!
+    //! Why split: building an `Ext2Super` host-side requires the
+    //! `target_os = "none"` block-cache surface, which the host test
+    //! profile excludes. The integration test exists for that reason.
+
+    // Compile-time only check: `Arc<Ext2Aops>` coerces to
+    // `Arc<dyn AddressSpaceOps>` and is `Send + Sync`.
+    #[test]
+    fn ext2_aops_is_object_safe_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<super::Ext2Aops>();
+        // The trait object form is what `Inode::set_aops` consumes;
+        // assert that too so a future refactor that accidentally
+        // makes `Ext2Aops` `!Send` trips here, not at the install
+        // call site.
+        assert_send_sync::<alloc::sync::Arc<dyn super::AddressSpaceOps>>();
+    }
+}

--- a/kernel/src/fs/ext2/mod.rs
+++ b/kernel/src/fs/ext2/mod.rs
@@ -168,3 +168,17 @@ pub use orphan_finalize::finalize as finalize_orphan;
 // §Cross-directory loop check.
 #[cfg(all(feature = "ext2", target_os = "none"))]
 pub mod rename;
+
+// Address-space ops (#749 readpage; #750 writepage; #751 truncate_below;
+// #752 readahead). The `Ext2Aops` struct itself implements the
+// `AddressSpaceOps` trait the page cache calls on miss / writeback /
+// truncate. Same feature gate as the rest of the driver — it consumes
+// `Ext2Super` + `Ext2Inode` and routes through the buffer cache. The
+// `page_cache` feature is what gates whether the consumer ever wires
+// it up (via `Inode::set_aops`); the impl itself is reachable
+// independently for direct unit testing.
+#[cfg(all(feature = "ext2", target_os = "none"))]
+pub mod aops;
+
+#[cfg(all(feature = "ext2", target_os = "none"))]
+pub use aops::Ext2Aops;

--- a/kernel/tests/ext2_readpage.rs
+++ b/kernel/tests/ext2_readpage.rs
@@ -208,13 +208,18 @@ fn readpage_dense_file_page_zero() {
 
 /// Page 3 of `large.bin` covers logical blocks 12..15 — entirely
 /// reached through the single-indirect block (the direct slots stop
-/// at logical 11). Confirms the indirect path lights up end-to-end
-/// inside readpage and the per-block markers line up.
+/// at logical 11). Page 67 of the same file covers logical blocks
+/// 268..271 — entirely on the **double-indirect** path
+/// (single-indirect runs out at logical 267 on this 1 KiB-block
+/// fixture: `12 + ptrs_per_block(256) = 268`). The two together
+/// confirm both indirect levels of the RFC 0004 walker light up
+/// end-to-end inside `readpage` and the per-block markers line up.
 fn readpage_dense_file_indirect_page() {
     let (sb, _fs, super_arc) = mount_ro();
     let (_inode, ext2_inode) = iget_with_ext2(&super_arc, &sb, INO_LARGE);
     let aops = Ext2Aops::new(&super_arc, &ext2_inode);
 
+    // --- single-indirect: page 3 → logical blocks 12..15 ---
     let mut buf = [0xffu8; 4096];
     let n = readpage(&aops, 3, &mut buf).expect("readpage page 3");
     assert_eq!(n, 4096);
@@ -233,6 +238,33 @@ fn readpage_dense_file_indirect_page() {
             assert_eq!(
                 byte, expected,
                 "indirect logical block {logical} body byte {i}"
+            );
+        }
+    }
+
+    // --- double-indirect: page 67 → logical blocks 268..271 ---
+    // 1 KiB-block ext2: ptrs_per_block = 256, so the single-indirect
+    // range spans logical [12, 268). Page byte-offset 67 * 4096 =
+    // 274432 = logical 268 on a 1024-byte block — first page entirely
+    // past the single-indirect boundary.
+    let mut buf2 = [0xffu8; 4096];
+    let n = readpage(&aops, 67, &mut buf2).expect("readpage page 67 (double-indirect)");
+    assert_eq!(n, 4096);
+
+    for b in 0..4usize {
+        let logical = 268 + b;
+        let head = format_block_head(logical);
+        let off = b * 1024;
+        assert_eq!(
+            &buf2[off..off + head.len()],
+            head.as_slice(),
+            "double-indirect logical block {logical} marker"
+        );
+        for (i, &byte) in buf2[off + head.len()..off + 1024].iter().enumerate() {
+            let expected = ((logical * 131 + i) & 0xff) as u8;
+            assert_eq!(
+                byte, expected,
+                "double-indirect logical block {logical} body byte {i}"
             );
         }
     }

--- a/kernel/tests/ext2_readpage.rs
+++ b/kernel/tests/ext2_readpage.rs
@@ -1,0 +1,439 @@
+//! Integration test for issue #749: ext2 [`AddressSpaceOps::readpage`]
+//! through the indirect-block walker + buffer cache.
+//!
+//! Mounts the existing `read_test.img` fixture (small / large / sparse
+//! pre-populated inodes — see `fixtures/README.md`) and calls
+//! `Ext2Aops::readpage` directly to validate:
+//!
+//! - **Dense file readpage** — page 0 of `large.bin` (300 KiB, crosses
+//!   the 12-direct → single-indirect boundary at logical block 12)
+//!   must match the per-block markers the generator stamped down. Page
+//!   3 covers logical blocks 12..15 entirely on the indirect path —
+//!   exercises a 4-KiB page made of four 1-KiB indirect-block reads.
+//! - **Sparse-hole readpage** — page 0 of `sparse.bin` (block 0 is
+//!   `'X'`, blocks 1..3 are sparse holes) must yield 1 KiB of `'X'`
+//!   followed by 3 KiB of zeros. Page 1 (blocks 4..7, all holes) must
+//!   be all-zero. Page 2 (blocks 8..11, blocks 8/9 holes, block 10 is
+//!   `'Z'`, block 11 is past `i_size`) must yield 2 KiB of zero, 1 KiB
+//!   of `'Z'`, then 1 KiB of tail-zero past EOF.
+//! - **Tail-page zero** — page 0 of `small.bin` (26 bytes) must yield
+//!   the 26-byte greeting followed by 4070 bytes of zero. The page-end
+//!   bytes specifically are the [tail-page zeroing] surface (RFC 0007
+//!   §Tail-page zeroing).
+//! - **Past-EOF readpage** — page 5 of `small.bin` (well past `i_size
+//!   = 26`) must return `Ok(0)` and leave `buf` at its caller-provided
+//!   sentinel (the trait contract: pages past EOF are pre-zeroed by
+//!   the caller, not by the impl).
+//! - **Errno propagation** — readpage on a torn-down (post-`unmount`)
+//!   `Ext2Aops` must surface `EIO` rather than panic. Exercised by
+//!   dropping the `Arc<Ext2Super>` and calling readpage on the same
+//!   `Ext2Aops` whose `super_ref` is now stale.
+//!
+//! The test mounts RO so the fixture stays byte-identical across runs
+//! (a RW mount would stamp `s_state := EXT2_ERROR_FS` into the ramdisk
+//! copy on every invocation).
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::sync::{Arc, Weak};
+use core::panic::PanicInfo;
+
+use vibix::block::BlockDevice;
+use vibix::fs::ext2::aops::Ext2Aops;
+use vibix::fs::ext2::inode::Ext2Inode;
+use vibix::fs::ext2::{iget, Ext2Fs, Ext2Super};
+use vibix::fs::vfs::ops::{FileSystem as _, MountSource};
+use vibix::fs::vfs::super_block::SuperBlock;
+use vibix::fs::vfs::MountFlags;
+use vibix::fs::EIO;
+use vibix::mem::aops::AddressSpaceOps;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+const READ_IMG: &[u8; 1_048_576] = include_bytes!("../src/fs/ext2/fixtures/read_test.img");
+
+// Pre-assigned inos on the deterministic `mkfs.ext2` invocation that
+// generates `read_test.img` — see `fixtures/README.md`. Pinning them
+// here catches an accidental fixture re-generation that shifts inode
+// allocation order.
+const INO_SMALL: u32 = 12;
+const INO_LARGE: u32 = 13;
+const INO_SPARSE: u32 = 15;
+
+const SMALL_BYTES: &[u8] = b"hello ext2 read path #561\n";
+const SPARSE_SIZE: usize = 11 * 1024;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "readpage_dense_file_page_zero",
+            &(readpage_dense_file_page_zero as fn()),
+        ),
+        (
+            "readpage_dense_file_indirect_page",
+            &(readpage_dense_file_indirect_page as fn()),
+        ),
+        (
+            "readpage_sparse_hole_zero_fills",
+            &(readpage_sparse_hole_zero_fills as fn()),
+        ),
+        (
+            "readpage_sparse_all_holes_page",
+            &(readpage_sparse_all_holes_page as fn()),
+        ),
+        (
+            "readpage_partial_page_tail_zeroes_past_eof",
+            &(readpage_partial_page_tail_zeroes_past_eof as fn()),
+        ),
+        (
+            "readpage_small_file_tail_zero",
+            &(readpage_small_file_tail_zero as fn()),
+        ),
+        (
+            "readpage_past_eof_returns_zero_and_buf_untouched",
+            &(readpage_past_eof_returns_zero_and_buf_untouched as fn()),
+        ),
+        (
+            "readpage_after_super_torn_down_returns_eio",
+            &(readpage_after_super_torn_down_returns_eio as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+// Shared `RamDisk` — see kernel/tests/common/ext2_ramdisk.rs (issues
+// #627, #658).
+#[path = "common/ext2_ramdisk.rs"]
+mod ext2_ramdisk;
+use ext2_ramdisk::RamDisk;
+
+/// Mount `read_test.img` RO. Returns the `SuperBlock`, the `Ext2Fs`
+/// factory (kept alive so the per-mount state isn't torn down between
+/// the mount and the test body), and the per-mount `Ext2Super`.
+fn mount_ro() -> (Arc<SuperBlock>, Arc<Ext2Fs>, Arc<Ext2Super>) {
+    let disk = RamDisk::from_image(READ_IMG.as_slice(), 512);
+    let fs = Ext2Fs::new_with_device(disk as Arc<dyn BlockDevice>);
+    let sb = fs
+        .mount(MountSource::None, MountFlags::RDONLY)
+        .expect("RO mount of read_test.img must succeed");
+    let super_arc = fs
+        .current_super()
+        .expect("current_super must upgrade after mount");
+    (sb, fs, super_arc)
+}
+
+/// `iget(ino)` and recover the parallel `Arc<Ext2Inode>` from the
+/// per-mount `ext2_inode_cache` so we can construct an `Ext2Aops`.
+fn iget_with_ext2(
+    super_arc: &Arc<Ext2Super>,
+    sb: &Arc<SuperBlock>,
+    ino: u32,
+) -> (Arc<vibix::fs::vfs::inode::Inode>, Arc<Ext2Inode>) {
+    let inode = iget(super_arc, sb, ino).expect("iget");
+    // The driver-private cache is populated by `iget` at the same
+    // moment it publishes the VFS-cache `Weak<Inode>`. Upgrading the
+    // weak here is the canonical recovery path used by the unlink /
+    // setattr / orphan-finalize call sites.
+    let ext2_inode = {
+        let ecache = super_arc.ext2_inode_cache.lock();
+        ecache
+            .get(&ino)
+            .and_then(Weak::upgrade)
+            .expect("ext2_inode_cache must hold a Weak<Ext2Inode> after iget")
+    };
+    (inode, ext2_inode)
+}
+
+fn readpage(aops: &Ext2Aops, pgoff: u64, buf: &mut [u8; 4096]) -> Result<usize, i64> {
+    AddressSpaceOps::readpage(aops, pgoff, buf)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Page 0 of `large.bin` covers logical blocks 0..3 entirely on the
+/// direct path. Each 1-KiB block carries the generator's marker
+/// (`BLK00000` … `BLK00003`) followed by a deterministic body.
+fn readpage_dense_file_page_zero() {
+    let (sb, _fs, super_arc) = mount_ro();
+    let (_inode, ext2_inode) = iget_with_ext2(&super_arc, &sb, INO_LARGE);
+    let aops = Ext2Aops::new(&super_arc, &ext2_inode);
+
+    let mut buf = [0xffu8; 4096];
+    let n = readpage(&aops, 0, &mut buf).expect("readpage page 0");
+    assert_eq!(n, 4096, "dense in-file page returns full 4 KiB");
+
+    for b in 0..4usize {
+        let head = format_block_head(b);
+        let off = b * 1024;
+        assert_eq!(
+            &buf[off..off + head.len()],
+            head.as_slice(),
+            "logical block {b} marker"
+        );
+        for (i, &byte) in buf[off + head.len()..off + 1024].iter().enumerate() {
+            let expected = ((b * 131 + i) & 0xff) as u8;
+            assert_eq!(byte, expected, "logical block {b} body byte {i}");
+        }
+    }
+
+    drop(ext2_inode);
+    drop(_inode);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+/// Page 3 of `large.bin` covers logical blocks 12..15 — entirely
+/// reached through the single-indirect block (the direct slots stop
+/// at logical 11). Confirms the indirect path lights up end-to-end
+/// inside readpage and the per-block markers line up.
+fn readpage_dense_file_indirect_page() {
+    let (sb, _fs, super_arc) = mount_ro();
+    let (_inode, ext2_inode) = iget_with_ext2(&super_arc, &sb, INO_LARGE);
+    let aops = Ext2Aops::new(&super_arc, &ext2_inode);
+
+    let mut buf = [0xffu8; 4096];
+    let n = readpage(&aops, 3, &mut buf).expect("readpage page 3");
+    assert_eq!(n, 4096);
+
+    for b in 0..4usize {
+        let logical = 12 + b;
+        let head = format_block_head(logical);
+        let off = b * 1024;
+        assert_eq!(
+            &buf[off..off + head.len()],
+            head.as_slice(),
+            "indirect logical block {logical} marker"
+        );
+        for (i, &byte) in buf[off + head.len()..off + 1024].iter().enumerate() {
+            let expected = ((logical * 131 + i) & 0xff) as u8;
+            assert_eq!(
+                byte, expected,
+                "indirect logical block {logical} body byte {i}"
+            );
+        }
+    }
+
+    drop(ext2_inode);
+    drop(_inode);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+/// Page 0 of `sparse.bin`: logical block 0 is `'X' * 1024`, blocks 1..3
+/// are sparse holes (zero direct slot, no on-disk allocation). The
+/// readpage impl must zero-fill the holes inline — the trait caller
+/// only pre-zeroes on `Ok(0)`, not on `Ok(4096)` with sparse interior
+/// chunks.
+fn readpage_sparse_hole_zero_fills() {
+    let (sb, _fs, super_arc) = mount_ro();
+    let (_inode, ext2_inode) = iget_with_ext2(&super_arc, &sb, INO_SPARSE);
+    let aops = Ext2Aops::new(&super_arc, &ext2_inode);
+
+    let mut buf = [0xffu8; 4096];
+    let n = readpage(&aops, 0, &mut buf).expect("readpage sparse page 0");
+    assert_eq!(n, 4096);
+
+    // Block 0: 'X' * 1024.
+    for (i, &b) in buf[0..1024].iter().enumerate() {
+        assert_eq!(b, b'X', "sparse page 0 block 0 byte {i}");
+    }
+    // Blocks 1..=3: sparse holes — must be zero.
+    for blk in 1..=3usize {
+        for (i, &b) in buf[blk * 1024..(blk + 1) * 1024].iter().enumerate() {
+            assert_eq!(b, 0, "sparse page 0 hole block {blk} byte {i}");
+        }
+    }
+
+    drop(ext2_inode);
+    drop(_inode);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+/// Page 1 of `sparse.bin`: logical blocks 4..7, all sparse holes.
+/// Every byte of the page must be zero.
+fn readpage_sparse_all_holes_page() {
+    let (sb, _fs, super_arc) = mount_ro();
+    let (_inode, ext2_inode) = iget_with_ext2(&super_arc, &sb, INO_SPARSE);
+    let aops = Ext2Aops::new(&super_arc, &ext2_inode);
+
+    let mut buf = [0xffu8; 4096];
+    let n = readpage(&aops, 1, &mut buf).expect("readpage sparse page 1");
+    assert_eq!(n, 4096);
+
+    for (i, &b) in buf.iter().enumerate() {
+        assert_eq!(b, 0, "sparse page 1 (all holes) byte {i}");
+    }
+
+    drop(ext2_inode);
+    drop(_inode);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+/// Page 2 of `sparse.bin`: logical blocks 8..11. Blocks 8/9 are sparse
+/// holes; block 10 is `'Z' * 1024`; block 11 is past `i_size = 11264`
+/// — it must be tail-zeroed (RFC 0007 §Tail-page zeroing).
+fn readpage_partial_page_tail_zeroes_past_eof() {
+    let (sb, _fs, super_arc) = mount_ro();
+    let (_inode, ext2_inode) = iget_with_ext2(&super_arc, &sb, INO_SPARSE);
+    let aops = Ext2Aops::new(&super_arc, &ext2_inode);
+
+    let mut buf = [0xffu8; 4096];
+    let n = readpage(&aops, 2, &mut buf).expect("readpage sparse page 2");
+    assert_eq!(
+        n, 4096,
+        "partial-tail page returns full 4096 (tail zero-fill is part of the populate contract)"
+    );
+
+    // Block 8: hole.
+    for (i, &b) in buf[0..1024].iter().enumerate() {
+        assert_eq!(b, 0, "sparse page 2 block 8 hole byte {i}");
+    }
+    // Block 9: hole.
+    for (i, &b) in buf[1024..2048].iter().enumerate() {
+        assert_eq!(b, 0, "sparse page 2 block 9 hole byte {i}");
+    }
+    // Block 10: 'Z' * 1024.
+    for (i, &b) in buf[2048..3072].iter().enumerate() {
+        assert_eq!(b, b'Z', "sparse page 2 block 10 byte {i}");
+    }
+    // Block 11 is past i_size = SPARSE_SIZE = 11264 = 11 KiB → tail zero.
+    let tail_off = SPARSE_SIZE - 2 * 4096; // 11264 - 8192 = 3072
+    assert_eq!(tail_off, 3072);
+    for (i, &b) in buf[tail_off..].iter().enumerate() {
+        assert_eq!(
+            b, 0,
+            "sparse page 2 tail (past EOF) byte {i} (offset {tail_off})"
+        );
+    }
+
+    drop(ext2_inode);
+    drop(_inode);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+/// `small.bin` is 26 bytes — all in page 0. Bytes 0..26 must match the
+/// greeting; bytes 26..4096 are tail-zero (RFC 0007 §Tail-page zeroing).
+fn readpage_small_file_tail_zero() {
+    let (sb, _fs, super_arc) = mount_ro();
+    let (_inode, ext2_inode) = iget_with_ext2(&super_arc, &sb, INO_SMALL);
+    let aops = Ext2Aops::new(&super_arc, &ext2_inode);
+
+    let mut buf = [0xffu8; 4096];
+    let n = readpage(&aops, 0, &mut buf).expect("readpage small page 0");
+    assert_eq!(n, 4096);
+
+    assert_eq!(&buf[..SMALL_BYTES.len()], SMALL_BYTES);
+    for (i, &b) in buf[SMALL_BYTES.len()..].iter().enumerate() {
+        assert_eq!(
+            b,
+            0,
+            "small file tail zero byte {} (page offset {})",
+            i,
+            SMALL_BYTES.len() + i,
+        );
+    }
+
+    drop(ext2_inode);
+    drop(_inode);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+/// Page 5 of `small.bin` (page byte offset 20480) is well past
+/// `i_size = 26`. The trait contract (RFC 0007 §`AddressSpaceOps`)
+/// says past-EOF pages return `Ok(0)` and the impl leaves `buf`
+/// untouched — the caller pre-zeroes.
+fn readpage_past_eof_returns_zero_and_buf_untouched() {
+    let (sb, _fs, super_arc) = mount_ro();
+    let (_inode, ext2_inode) = iget_with_ext2(&super_arc, &sb, INO_SMALL);
+    let aops = Ext2Aops::new(&super_arc, &ext2_inode);
+
+    let mut buf = [0xa5u8; 4096];
+    let n = readpage(&aops, 5, &mut buf).expect("readpage past EOF");
+    assert_eq!(n, 0, "past-EOF readpage returns Ok(0)");
+    // Buf untouched — the sentinel survives.
+    for (i, &b) in buf.iter().enumerate() {
+        assert_eq!(b, 0xa5, "past-EOF readpage must not touch buf, byte {i}");
+    }
+
+    drop(ext2_inode);
+    drop(_inode);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+/// After the mount tears down, the `Ext2Aops`' `Weak<Ext2Super>`
+/// upgrade fails. The trait contract requires a faithful errno —
+/// `EIO` is the correct surface for "the backing storage is gone".
+fn readpage_after_super_torn_down_returns_eio() {
+    let (sb, _fs, super_arc) = mount_ro();
+    let (inode, ext2_inode) = iget_with_ext2(&super_arc, &sb, INO_SMALL);
+    let aops = Ext2Aops::new(&super_arc, &ext2_inode);
+
+    // Drop the strong refs that pin the mount.
+    sb.ops.unmount();
+    drop(inode);
+    drop(ext2_inode);
+    drop(super_arc);
+    drop(_fs);
+    drop(sb);
+
+    // Now the aops' Weak refs no longer upgrade. readpage must return
+    // EIO rather than panic.
+    let mut buf = [0xffu8; 4096];
+    let r = readpage(&aops, 0, &mut buf);
+    assert_eq!(
+        r,
+        Err(EIO),
+        "readpage after mount teardown must surface EIO"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Reproduce the generator's per-block marker (`BLKnnnnn`, no NUL, no
+/// trailing separator). Mirrors `kernel/tests/ext2_file_read.rs`.
+fn format_block_head(b: usize) -> alloc::vec::Vec<u8> {
+    let mut out = alloc::vec::Vec::with_capacity(8);
+    out.extend_from_slice(b"BLK");
+    let digits = [
+        ((b / 10_000) % 10) as u8,
+        ((b / 1_000) % 10) as u8,
+        ((b / 100) % 10) as u8,
+        ((b / 10) % 10) as u8,
+        (b % 10) as u8,
+    ];
+    for d in digits {
+        out.push(b'0' + d);
+    }
+    out
+}


### PR DESCRIPTION
Closes #749

## Summary

Lands Workstream C / wave-1 of RFC 0007 epic #734. The new `Ext2Aops` in `fs/ext2/aops.rs` implements the `AddressSpaceOps` page-cache hook trait. Only `readpage` is real this PR — `writepage` is stubbed `EROFS` (real impl arrives with #750), `truncate_below` and `readahead` use the trait defaults (replaced by #751 / #752).

`readpage(pgoff, &mut [u8; 4096])`:

1. Snapshots `(i_size, i_block[15])` under the inode's metadata read-guard, drops the guard before any `bread`.
2. Returns `Ok(0)` for pages entirely past `i_size`, leaving `buf` untouched per the trait contract.
3. Walks each FS-block chunk inside the in-file window `[pgoff*4096, min(pgoff*4096 + 4096, i_size))` via the existing RFC 0004 indirect walker (`super::indirect::resolve_block`):
   - `Ok(Some(abs))` — `bread` + memcpy into `buf` at the page-relative offset.
   - `Ok(None)` — sparse hole; zero-fill the chunk inside `buf`.
   - `Err(WalkError::Io | Corrupt)` — surface `EIO`.
4. Zero-fills the `[i_size .. page_end)` tail (RFC 0007 §Tail-page zeroing).
5. Returns `Ok(4096)` when any byte was in-file (tail-zeroing is part of the populate contract; partial-tail does not produce a short return).

A torn-down `Weak<Ext2Super>` / `Weak<Ext2Inode>` upgrade failure on `Ext2Aops` surfaces as `EIO`. The `assert_no_spinlocks_held` ladder check is the first statement of every method body (RFC 0007 §Lock-order ladder), including the `EROFS` writepage stub.

## Test plan

New integration test `kernel/tests/ext2_readpage.rs` mounts the existing `read_test.img` fixture and exercises eight cases:

- [x] `readpage_dense_file_page_zero` — page 0 of `large.bin` (logical blocks 0..3 direct path) per-block markers.
- [x] `readpage_dense_file_indirect_page` — page 3 of `large.bin` (logical blocks 12..15, single-indirect path).
- [x] `readpage_sparse_hole_zero_fills` — page 0 of `sparse.bin` (block 0 `'X'`, blocks 1..3 holes → zero).
- [x] `readpage_sparse_all_holes_page` — page 1 of `sparse.bin` (blocks 4..7 all holes).
- [x] `readpage_partial_page_tail_zeroes_past_eof` — page 2 of `sparse.bin` (block 11 past `i_size = 11264` → tail-zeroed).
- [x] `readpage_small_file_tail_zero` — page 0 of `small.bin` (26 bytes content + 4070 bytes tail-zero).
- [x] `readpage_past_eof_returns_zero_and_buf_untouched` — page 5 of `small.bin` past EOF, `Ok(0)` and `buf` sentinel survives.
- [x] `readpage_after_super_torn_down_returns_eio` — `unmount` then call readpage on the same `Ext2Aops`; surfaces `EIO`.

Other tests run:

- [x] `cargo xtask build` — clean.
- [x] `cargo xtask smoke` — all 42 markers present.
- [x] `cargo test --package vibix --lib --features ext2` — 604 host unit tests passing.
- [x] `cargo test … --test ext2_readpage` — all 8 new tests pass.
- [x] `cargo test … --test ext2_file_read` — 8 existing tests still green.
- [x] `cargo test … --test ext2_inode_iget --test ext2_block_alloc` — adjacent ext2 tests still green.

## Pre-existing-main issues observed (not fixed in this PR)

- `blocking_sync::rwlock_concurrent_readers` flakes (timing race, no relation to ext2 / page cache).
- `bench/page-cache` workspace clippy errors (missing `Box` / `Vec` imports — pre-existing on main).
- `userspace/pjdfstest_runner` `op_ref` clippy error.
- `kernel/build.rs:109` `manual_is_multiple_of` clippy warning.

## Out of scope (sibling issues, not touched)

- #750 — real `writepage` (this PR's stub returns `EROFS`).
- #751 — `truncate_below` (trait default).
- #752 — `readahead` (trait default).
- #753 — `FileOps::mmap` wiring.
- #754 — route `FileOps::read` through the cache.