### PR TITLE
mem: refcount-discipline + lockdep tests for page cache (#742)

### DIFF
--- a/kernel/src/debug_lockdep.rs
+++ b/kernel/src/debug_lockdep.rs
@@ -345,6 +345,178 @@ mod tests {
         assert_eq!(*m.lock(), 42);
     }
 
+    // --- RFC 0007 §Lock-order — AddressSpaceOps method-entry tripwire
+    //
+    // RFC 0007 mandates that **every** `AddressSpaceOps` method body
+    // calls `assert_no_spinlocks_held` as its first instruction. The
+    // tests below exercise that contract from the *caller* side: a
+    // host caller that holds a `SpinLock` across an `Arc<dyn
+    // AddressSpaceOps>` invocation must trip the assert and panic.
+    // This is the regression gate that catches a future drive-by edit
+    // to a trait-impl body that drops the assert.
+    //
+    // We cover the four trait methods (`readpage`, `writepage`,
+    // `readahead`, `truncate_below`) including the two with default
+    // bodies (the defaults are also required to call the assert). All
+    // tests serialise on the shared `TEST_LOCK` so the panicked
+    // `HELD_SPINLOCKS` mutation does not poison sibling tests.
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "MemoryBackedOps::readpage")]
+    fn readpage_trips_when_caller_holds_spinlock() {
+        use crate::mem::aops::AddressSpaceOps;
+        use alloc::sync::Arc;
+
+        let _t = test_guard();
+        let ops: Arc<dyn AddressSpaceOps> = crate::mem::aops::MemoryBackedOps::with_pages(2);
+        let m = SpinLock::new(0u8);
+        let _g = m.lock();
+        let mut buf = [0u8; 4096];
+        // Holding `_g` across this call MUST panic.
+        let _ = ops.readpage(0, &mut buf);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "MemoryBackedOps::writepage")]
+    fn writepage_trips_when_caller_holds_spinlock() {
+        use crate::mem::aops::AddressSpaceOps;
+        use alloc::sync::Arc;
+
+        let _t = test_guard();
+        let ops: Arc<dyn AddressSpaceOps> = crate::mem::aops::MemoryBackedOps::with_pages(2);
+        let m = SpinLock::new(0u8);
+        let _g = m.lock();
+        let buf = [0u8; 4096];
+        let _ = ops.writepage(0, &buf);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "MemoryBackedOps::readahead")]
+    fn readahead_trips_when_caller_holds_spinlock() {
+        use crate::mem::aops::AddressSpaceOps;
+        use alloc::sync::Arc;
+
+        let _t = test_guard();
+        let ops: Arc<dyn AddressSpaceOps> = crate::mem::aops::MemoryBackedOps::with_pages(2);
+        let m = SpinLock::new(0u8);
+        let _g = m.lock();
+        ops.readahead(0, 4);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "MemoryBackedOps::truncate_below")]
+    fn truncate_below_trips_when_caller_holds_spinlock() {
+        use crate::mem::aops::AddressSpaceOps;
+        use alloc::sync::Arc;
+
+        let _t = test_guard();
+        let ops: Arc<dyn AddressSpaceOps> = crate::mem::aops::MemoryBackedOps::with_pages(2);
+        let m = SpinLock::new(0u8);
+        let _g = m.lock();
+        ops.truncate_below(0);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "default no-op")]
+    fn default_readahead_trips_when_caller_holds_spinlock() {
+        // The trait's default-method bodies are also required to call
+        // the assert (RFC 0007 §Lock-order ladder; aops module doc).
+        // A driver that only implements `readpage`/`writepage` and
+        // inherits the default `readahead`/`truncate_below` must
+        // still trip on a held SpinLock. Use a fresh impl that does
+        // NOT override the defaults.
+        use crate::mem::aops::AddressSpaceOps;
+        use alloc::sync::Arc;
+
+        struct DefaultOnly;
+        impl AddressSpaceOps for DefaultOnly {
+            fn readpage(&self, _: u64, _: &mut [u8; 4096]) -> Result<usize, i64> {
+                Ok(0)
+            }
+            fn writepage(&self, _: u64, _: &[u8; 4096]) -> Result<(), i64> {
+                Ok(())
+            }
+        }
+
+        let _t = test_guard();
+        let ops: Arc<dyn AddressSpaceOps> = Arc::new(DefaultOnly);
+        let m = SpinLock::new(0u8);
+        let _g = m.lock();
+        ops.readahead(0, 1);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "default no-op")]
+    fn default_truncate_below_trips_when_caller_holds_spinlock() {
+        use crate::mem::aops::AddressSpaceOps;
+        use alloc::sync::Arc;
+
+        struct DefaultOnly;
+        impl AddressSpaceOps for DefaultOnly {
+            fn readpage(&self, _: u64, _: &mut [u8; 4096]) -> Result<usize, i64> {
+                Ok(0)
+            }
+            fn writepage(&self, _: u64, _: &[u8; 4096]) -> Result<(), i64> {
+                Ok(())
+            }
+        }
+
+        let _t = test_guard();
+        let ops: Arc<dyn AddressSpaceOps> = Arc::new(DefaultOnly);
+        let m = SpinLock::new(0u8);
+        let _g = m.lock();
+        ops.truncate_below(0);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn aops_methods_pass_when_no_spinlock_held() {
+        // Companion to the panic tests: if no SpinLock is held, the
+        // exact same dispatch must succeed. Catches a regression
+        // where a future trait-impl edit accidentally hard-fires the
+        // assert (e.g. by passing a non-zero counter).
+        use crate::mem::aops::AddressSpaceOps;
+        use alloc::sync::Arc;
+
+        let _t = test_guard();
+        let ops: Arc<dyn AddressSpaceOps> = crate::mem::aops::MemoryBackedOps::with_pages(2);
+        let mut buf = [0u8; 4096];
+        ops.readpage(0, &mut buf).unwrap();
+        ops.writepage(0, &buf).unwrap();
+        ops.readahead(0, 4);
+        ops.truncate_below(0);
+        // Counter back to zero post each call.
+        assert_eq!(held_spinlocks(), 0);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn assert_passes_after_lock_released() {
+        // RFC 0007 §Lock-order: the cache slow path drops
+        // `cache.inner` *before* invoking `ops.readpage`. Model that
+        // here as: take a lock, drop it, then call into ops. Must
+        // not panic.
+        use crate::mem::aops::AddressSpaceOps;
+        use alloc::sync::Arc;
+
+        let _t = test_guard();
+        let ops: Arc<dyn AddressSpaceOps> = crate::mem::aops::MemoryBackedOps::with_pages(2);
+        let m = SpinLock::new(0u8);
+        {
+            let _g = m.lock();
+            assert_eq!(held_spinlocks(), 1);
+        }
+        // Lock released; subsequent ops dispatch must succeed.
+        let mut buf = [0u8; 4096];
+        ops.readpage(0, &mut buf).unwrap();
+    }
+
     /// Release-build sanity: with `debug_assertions` off the
     /// counter is gone and the assertion is a no-op. We can only
     /// observe this indirectly — the inc/dec/held APIs all return

--- a/kernel/src/mem/file_object.rs
+++ b/kernel/src/mem/file_object.rs
@@ -993,7 +993,9 @@ mod tests {
 
         let obj = FileObject::new(cache.clone(), 0, 8, Share::Shared, 0o2);
         // Drive a fault — winner path runs `readpage`.
-        let phys = obj.fault(0, Access::Read).expect("first fault must resolve");
+        let phys = obj
+            .fault(0, Access::Read)
+            .expect("first fault must resolve");
         assert_ne!(phys, 0);
         assert!(
             probe

--- a/kernel/src/mem/file_object.rs
+++ b/kernel/src/mem/file_object.rs
@@ -894,4 +894,155 @@ mod tests {
         // and wins.
         assert!(cache.lookup(0).is_none());
     }
+
+    // --- RFC 0007 §Lock-order — slow-path split-lock discipline -----
+    //
+    // The page-fault slow path holds `cache.inner` only across the
+    // index-mutating helpers (`install_or_get`, `mark_page_dirty`,
+    // `lookup`). It is **never** held across `ops.readpage`. RFC 0007
+    // §Lock-order ladder: cache mutex (level 4) is acquired before
+    // and released before the buffer cache (level 6) the FS impl
+    // takes internally; holding it across the call would invert the
+    // ladder on first contention.
+    //
+    // The tests below drive a real `FileObject::fault` and verify
+    // that during `ops.readpage`:
+    //
+    //   1. The caller did not hold `cache.inner` (we try_lock from
+    //      inside `readpage` and assert success).
+    //   2. The lockdep counter reads zero (no spinlock held).
+    //
+    // Together these prove the split-lock discipline holds end-to-end
+    // through the slow path the cache primitives expose today.
+
+    /// Custom AddressSpaceOps that, on `readpage`, asserts the
+    /// caller's `cache.inner` is *not* currently held.
+    ///
+    /// The probe stores its own back-reference to the
+    /// `Arc<PageCache>` so the readpage body can `try_lock` the cache
+    /// mutex from inside the dispatch. If the slow path is holding
+    /// `cache.inner` across the call (RFC 0007 §Lock-order
+    /// violation) the try_lock returns `None` and the test observes
+    /// `observed_unlocked == false`.
+    struct LockOrderProbe {
+        cache: spin::Mutex<Option<Arc<PageCache>>>,
+        observed_unlocked: core::sync::atomic::AtomicBool,
+    }
+
+    impl LockOrderProbe {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                cache: spin::Mutex::new(None),
+                observed_unlocked: core::sync::atomic::AtomicBool::new(false),
+            })
+        }
+
+        fn install_cache(&self, cache: Arc<PageCache>) {
+            *self.cache.lock() = Some(cache);
+        }
+    }
+
+    impl crate::mem::aops::AddressSpaceOps for LockOrderProbe {
+        fn readpage(&self, _pgoff: u64, buf: &mut [u8; 4096]) -> Result<usize, i64> {
+            // Method-entry invariant: `assert_no_spinlocks_held` is
+            // RFC 0007 §Lock-order ladder's hard contract. If the
+            // slow path had retained any `SpinLock` guard across
+            // this dispatch, this call panics — and the host test
+            // sees a `should_panic`-style failure (libtest reports
+            // it as "panicked at: …"). We therefore exercise *both*
+            // the spinlock invariant (via the assert) and the
+            // BlockingMutex invariant (via the `try_lock` below) in
+            // the same body.
+            crate::debug_lockdep::assert_no_spinlocks_held("LockOrderProbe::readpage");
+
+            // Probe: try to acquire `cache.inner`. If the caller had
+            // retained the guard across this dispatch we would
+            // deadlock here on bare metal; on host the underlying
+            // `spin::Mutex::try_lock` returns `None` instead.
+            let cache_guard = self.cache.lock();
+            if let Some(c) = cache_guard.as_ref() {
+                let inner_guard = c.inner.try_lock();
+                if inner_guard.is_some() {
+                    self.observed_unlocked
+                        .store(true, core::sync::atomic::Ordering::Release);
+                }
+            }
+            // Default-fill the page so the cache publishes UPTODATE.
+            buf[0] = 0xa5;
+            Ok(4096)
+        }
+
+        fn writepage(&self, _pgoff: u64, _buf: &[u8; 4096]) -> Result<(), i64> {
+            crate::debug_lockdep::assert_no_spinlocks_held("LockOrderProbe::writepage");
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn slow_path_drops_cache_inner_before_readpage() {
+        // RFC 0007 §Lock-order ladder: the slow path enters
+        // `ops.readpage` with no level-4 cache lock held. We probe
+        // this from inside `readpage` itself.
+        let probe = LockOrderProbe::new();
+        let cache = Arc::new(PageCache::new(
+            fake_inode_id(),
+            8 * FRAME_SIZE,
+            probe.clone(),
+        ));
+        probe.install_cache(cache.clone());
+
+        let obj = FileObject::new(cache.clone(), 0, 8, Share::Shared, 0o2);
+        // Drive a fault — winner path runs `readpage`.
+        let phys = obj.fault(0, Access::Read).expect("first fault must resolve");
+        assert_ne!(phys, 0);
+        assert!(
+            probe
+                .observed_unlocked
+                .load(core::sync::atomic::Ordering::Acquire),
+            "readpage observed cache.inner as locked — RFC 0007 §Lock-order violation",
+        );
+    }
+
+    #[test]
+    fn fault_strong_count_returns_to_one_post_resolution() {
+        // RFC 0007 §Refcount discipline (fault hot path): the slow
+        // path clones the `Arc<CachePage>` to stack-local during the
+        // resolution, then drops it before returning. Eviction
+        // observes `Arc::strong_count == 1` on the cache index post
+        // resolution; if a leak in the fault path holds an extra
+        // clone, eviction would block forever.
+        let obj = fresh_object(Share::Shared);
+        let _ = obj.fault(0, Access::Read).unwrap();
+        // Borrow the index entry without bumping strong (mirrors the
+        // evictor's BTreeMap::get pattern).
+        let cache = obj.cache();
+        let strong_borrow = {
+            let inner = cache.inner.lock();
+            let p = inner.pages.get(&0).expect("indexed");
+            Arc::strong_count(p)
+        };
+        assert_eq!(
+            strong_borrow, 1,
+            "fault hot path leaked an Arc<CachePage> clone — eviction would block",
+        );
+    }
+
+    #[test]
+    fn fault_then_drop_addrspace_returns_strong_count_to_one() {
+        // Drop the FileObject after a successful fault. The cache
+        // index still owns the only Arc; strong_count stays at 1.
+        // Catches a regression where FileObject ends up holding
+        // `Arc<CachePage>` clones on success (it should not — the
+        // page is consumed for its `phys` field only).
+        let obj = fresh_object(Share::Shared);
+        let _ = obj.fault(0, Access::Read).unwrap();
+        let cache = obj.cache();
+        drop(obj);
+        let strong_borrow = {
+            let inner = cache.inner.lock();
+            let p = inner.pages.get(&0).expect("indexed");
+            Arc::strong_count(p)
+        };
+        assert_eq!(strong_borrow, 1);
+    }
 }

--- a/kernel/src/mem/page_cache.rs
+++ b/kernel/src/mem/page_cache.rs
@@ -1848,7 +1848,10 @@ mod tests {
             Arc::strong_count(p)
         };
         // outer `stub` + index = 2 (we still hold `stub`).
-        assert_eq!(strong_borrow, 2, "frame-refcount bumps must not affect strong");
+        assert_eq!(
+            strong_borrow, 2,
+            "frame-refcount bumps must not affect strong"
+        );
         assert_eq!(
             crate::mem::refcount::page_refcount_in(&slots, phys)
                 .load(core::sync::atomic::Ordering::Relaxed),
@@ -1873,7 +1876,10 @@ mod tests {
         // block forever (host stub uses spin::Mutex; `try_lock` is
         // the deadlock-safe probe).
         let guard = cache.inner.try_lock();
-        assert!(guard.is_some(), "cache.inner must be free post install_or_get");
+        assert!(
+            guard.is_some(),
+            "cache.inner must be free post install_or_get"
+        );
     }
 
     #[test]

--- a/kernel/src/mem/page_cache.rs
+++ b/kernel/src/mem/page_cache.rs
@@ -137,6 +137,17 @@ mod host_stub {
         pub fn lock(&self) -> spin::MutexGuard<'_, T> {
             self.0.lock()
         }
+
+        /// Non-blocking acquisition. Returns `None` if the lock is
+        /// currently held. Used by the host-only lock-order tests
+        /// (RFC 0007 §Lock-order ladder, split-lock discipline) to
+        /// probe whether a `cache.inner` guard has leaked across a
+        /// slow-path I/O wait — a `None` here would deadlock on
+        /// bare metal, so the host probe surfaces the violation as
+        /// a test failure instead.
+        pub fn try_lock(&self) -> Option<spin::MutexGuard<'_, T>> {
+            self.0.try_lock()
+        }
     }
 
     pub struct WaitQueue;
@@ -1517,5 +1528,407 @@ mod tests {
         assert_eq!(RaState::window_for_streak(31), RA_MAX_PAGES);
         // Saturating-shl path covers extreme inputs without panicking.
         assert_eq!(RaState::window_for_streak(u32::MAX), RA_MAX_PAGES);
+    }
+
+    // --- RFC 0007 §Refcount discipline — eviction-gate matrix --------
+    //
+    // These tests model the two independent counters the RFC mandates:
+    //
+    //   - `mem::refcount::get(phys)` — counts (1 cache-own) + (N
+    //     installed PTEs). Bumped on PTE install / decremented on PTE
+    //     teardown.
+    //   - `Arc::strong_count(&CachePage)` — counts (1 cache index) +
+    //     (N in-flight `Arc::clone`s held by faulters that have not
+    //     yet decided whether to install a PTE) + (writeback daemon's
+    //     snapshot, if any).
+    //
+    // Eviction (#740 — not yet merged) must check **both**:
+    //
+    //   - `Arc::strong_count(&CachePage) == 1` rules out an in-flight
+    //     fault that may yet bump `mem::refcount` (RFC 0007 §Refcount
+    //     discipline).
+    //   - `mem::refcount(phys) <= 1` rules out a still-installed PTE.
+    //
+    // The two predicates are non-overlapping by design — neither
+    // subsumes the other. These tests pin the predicates so a
+    // future eviction implementation cannot silently regress to a
+    // single-counter check.
+
+    /// Pure predicate the future eviction policy will gate on. Passes
+    /// only when **both** disciplines say the page is safe to drop:
+    /// the cache index is the sole `Arc<CachePage>` strong holder
+    /// **and** the per-frame refcount is at the cache's own slot
+    /// (nothing has installed a PTE).
+    ///
+    /// This is the same predicate `evict()` will run; pinning it here
+    /// as a pure function lets the test matrix below cover every
+    /// combination of (strong_count, frame_refcount) without dragging
+    /// in the not-yet-merged eviction control flow.
+    fn eviction_safe(stub: &Arc<CachePage>, frame_refcount: u16) -> bool {
+        Arc::strong_count(stub) == 1 && frame_refcount <= 1
+    }
+
+    /// Phys address used by the eviction-gate-matrix tests when they
+    /// drive the `mem::refcount::*_in` slot helpers. The page-cache
+    /// test harness's own `fake_phys()` deliberately picks values at
+    /// `MAX_PHYS_BYTES` so they cannot collide with a real allocator
+    /// hand-out — but that places them outside the refcount table.
+    /// These tests want both: a stable `CachePage` Arc *and* a
+    /// refcount slot keyed against the same notional frame. We use
+    /// `0x1000` (the first refcount slot) for the host-only refcount
+    /// table; the cache itself never dereferences `phys`.
+    const TEST_REFCOUNT_PHYS: u64 = 0x1000;
+
+    #[test]
+    fn eviction_gate_blocks_when_pte_installed() {
+        // PTE-installed-only: the cache index holds the sole Arc
+        // (strong_count == 1) but `mem::refcount` shows a PTE is
+        // mapped (== 2 = cache + 1 PTE). RFC 0007 §Refcount
+        // discipline: eviction blocks on the frame-refcount check
+        // even though no in-flight clone exists.
+        let cache = fresh_cache();
+        match cache.install_or_get(0, || make_stub(0)) {
+            InstallOutcome::InstalledNew(p) => p.publish_uptodate_and_unlock(),
+            InstallOutcome::AlreadyPresent(_) => unreachable!(),
+        };
+        // Outer Arc dropped at end of match — cache index is now the
+        // sole strong holder. The real evictor borrows from the
+        // BTreeMap (no Arc clone), so its observed `strong_count` is
+        // 1 in this state. Mirror that with a borrow under
+        // `cache.inner`.
+        let strong_borrow = {
+            let inner = cache.inner.lock();
+            let p = inner.pages.get(&0).expect("indexed");
+            Arc::strong_count(p)
+        };
+        assert_eq!(strong_borrow, 1, "borrow-only access does not bump strong");
+
+        // Frame refcount: 2 = cache(1) + PTE(1). Use the host-test
+        // refcount-slot helpers.
+        let slots: alloc::vec::Vec<core::sync::atomic::AtomicU16> = (0..4)
+            .map(|_| core::sync::atomic::AtomicU16::new(0))
+            .collect();
+        crate::mem::refcount::init_on_alloc_in(&slots, TEST_REFCOUNT_PHYS);
+        crate::mem::refcount::inc_refcount_in(&slots, TEST_REFCOUNT_PHYS); // PTE bump
+        let frame_rc = crate::mem::refcount::page_refcount_in(&slots, TEST_REFCOUNT_PHYS)
+            .load(core::sync::atomic::Ordering::Relaxed);
+        assert_eq!(frame_rc, 2, "frame refcount = cache + PTE");
+
+        // The strong-count axis says safe (1), the frame-refcount
+        // axis says blocked (2). Eviction must respect *both* — RFC
+        // 0007 §Refcount discipline: "neither subsumes the other."
+        assert!(
+            !(strong_borrow == 1 && frame_rc <= 1),
+            "evictor must refuse: PTE still mapped",
+        );
+    }
+
+    #[test]
+    fn eviction_gate_blocks_when_in_flight_clone_held() {
+        // In-flight fault has cloned the Arc out of the index but has
+        // not yet bumped `mem::refcount` (still mid-resolution). The
+        // frame refcount is the cache's own (== 1); the strong count
+        // is > 1. RFC 0007 §Refcount discipline: eviction blocks on
+        // the strong-count check even though the frame refcount is
+        // clear.
+        let cache = fresh_cache();
+        let stub = match cache.install_or_get(0, || make_stub(0)) {
+            InstallOutcome::InstalledNew(p) => p,
+            InstallOutcome::AlreadyPresent(_) => unreachable!(),
+        };
+        stub.publish_uptodate_and_unlock();
+
+        // `cache.lookup` returns a fresh `Arc::clone` — exactly what
+        // the slow-path fault hot path does (RFC 0007 §Refcount
+        // discipline, fault hot path code block).
+        let in_flight = cache.lookup(0).expect("indexed");
+        assert!(Arc::ptr_eq(&in_flight, &stub));
+
+        // Frame refcount: 1 = cache only (no PTE installed yet).
+        let frame_rc = 1u16;
+
+        // Strong count snapshot from inside the index borrow — same
+        // shape the evictor would observe.
+        let strong_borrow = {
+            let inner = cache.inner.lock();
+            let p = inner.pages.get(&0).expect("indexed");
+            Arc::strong_count(p)
+        };
+        // 3 = cache index + outer `stub` + `in_flight`.
+        assert_eq!(strong_borrow, 3);
+
+        assert!(
+            !eviction_safe(&in_flight, frame_rc),
+            "evictor must refuse: in-flight Arc clone outstanding",
+        );
+
+        // Drop the in-flight clone; eviction gate becomes per-strong
+        // satisfiable (still blocked here only because outer `stub`
+        // holds another clone).
+        drop(in_flight);
+        let strong_after_drop = {
+            let inner = cache.inner.lock();
+            let p = inner.pages.get(&0).expect("indexed");
+            Arc::strong_count(p)
+        };
+        assert_eq!(strong_after_drop, 2, "outer `stub` is the +1");
+    }
+
+    #[test]
+    fn eviction_gate_passes_when_only_cache_holds_arc_and_no_pte() {
+        // Cache-own only: the cache index is the sole Arc holder,
+        // `mem::refcount == 1` (cache's own slot, no PTE). Both
+        // predicates pass; the future evictor may proceed (frame
+        // becomes droppable, will eventually `frame::put`). This is
+        // the only combination on the matrix that is safe.
+        let cache = fresh_cache();
+        let stub = match cache.install_or_get(0, || make_stub(0)) {
+            InstallOutcome::InstalledNew(p) => p,
+            InstallOutcome::AlreadyPresent(_) => unreachable!(),
+        };
+        stub.publish_uptodate_and_unlock();
+        // Use a refcount-table-valid phys for the host helpers
+        // (`stub.phys` is a fake_phys() value at the MAX_PHYS_BYTES
+        // boundary chosen so it can never collide with a real
+        // allocator hand-out; the refcount slot table refuses it).
+        let phys = TEST_REFCOUNT_PHYS;
+        drop(stub);
+
+        let slots: alloc::vec::Vec<core::sync::atomic::AtomicU16> = (0..4)
+            .map(|_| core::sync::atomic::AtomicU16::new(0))
+            .collect();
+        // Cache's own ref is `init_on_alloc_in` (== 1) — no PTE bumps.
+        crate::mem::refcount::init_on_alloc_in(&slots, phys);
+        let frame_rc = crate::mem::refcount::page_refcount_in(&slots, phys)
+            .load(core::sync::atomic::Ordering::Relaxed);
+
+        let strong_borrow = {
+            let inner = cache.inner.lock();
+            let p = inner.pages.get(&0).expect("indexed");
+            Arc::strong_count(p)
+        };
+
+        assert_eq!(strong_borrow, 1, "cache index is the sole strong holder");
+        assert_eq!(frame_rc, 1, "frame refcount = cache only");
+
+        // Synthesise the borrow-style strong_count for the closure
+        // form (we cannot pass a borrowed Arc-not-clone to a generic
+        // helper, so we recombine the predicates inline here).
+        assert!(
+            strong_borrow == 1 && frame_rc <= 1,
+            "evictor may proceed: cache-own only",
+        );
+    }
+
+    #[test]
+    fn eviction_gate_blocks_when_both_pte_and_in_flight_clone() {
+        // Both axes: the dominant case — a fault has resolved into a
+        // PTE install (`mem::refcount > 1`) AND another concurrent
+        // fault is mid-resolution (`Arc::strong_count > 1`). Eviction
+        // blocks on either; here it blocks on both, so the predicate
+        // must return false regardless of which check the evictor
+        // runs first.
+        let cache = fresh_cache();
+        let stub = match cache.install_or_get(0, || make_stub(0)) {
+            InstallOutcome::InstalledNew(p) => p,
+            InstallOutcome::AlreadyPresent(_) => unreachable!(),
+        };
+        stub.publish_uptodate_and_unlock();
+        // Use a refcount-table-valid phys for the host helpers
+        // (`stub.phys` is a fake_phys() value at the MAX_PHYS_BYTES
+        // boundary chosen so it can never collide with a real
+        // allocator hand-out; the refcount slot table refuses it).
+        let phys = TEST_REFCOUNT_PHYS;
+
+        let slots: alloc::vec::Vec<core::sync::atomic::AtomicU16> = (0..4)
+            .map(|_| core::sync::atomic::AtomicU16::new(0))
+            .collect();
+        crate::mem::refcount::init_on_alloc_in(&slots, phys);
+        crate::mem::refcount::inc_refcount_in(&slots, phys); // PTE
+        let frame_rc = crate::mem::refcount::page_refcount_in(&slots, phys)
+            .load(core::sync::atomic::Ordering::Relaxed);
+
+        // Drop outer Arc to mirror the "PTE owns the bump, not us"
+        // shape, then re-clone for the in-flight observer.
+        drop(stub);
+        let in_flight = cache.lookup(0).unwrap();
+
+        assert!(!eviction_safe(&in_flight, frame_rc));
+    }
+
+    #[test]
+    fn eviction_gate_writeback_snapshot_blocks_eviction() {
+        // The writeback daemon's `snapshot_dirty()` clones the Arc
+        // out of the index (RFC 0007 §`PageCache` writeback snapshot
+        // pattern). While the snapshot is alive, eviction must
+        // block — the daemon may still call `writepage` against the
+        // page contents. This is the exact reason `snapshot_dirty`
+        // returns `Vec<(u64, Arc<CachePage>)>` rather than a
+        // borrowing iterator.
+        let cache = fresh_cache();
+        let stub = match cache.install_or_get(0, || make_stub(0)) {
+            InstallOutcome::InstalledNew(p) => p,
+            InstallOutcome::AlreadyPresent(_) => unreachable!(),
+        };
+        stub.publish_uptodate_and_unlock();
+        cache.mark_page_dirty(0);
+        drop(stub);
+
+        // Pretend the writeback daemon just snapshotted.
+        let snap = cache.snapshot_dirty();
+        assert_eq!(snap.len(), 1);
+
+        // Strong count from the cache's perspective is 2 (index +
+        // snapshot Arc). Eviction blocks even though we hold no
+        // in-flight fault clone.
+        let strong_borrow = {
+            let inner = cache.inner.lock();
+            let p = inner.pages.get(&0).expect("indexed");
+            Arc::strong_count(p)
+        };
+        assert_eq!(strong_borrow, 2, "snapshot is the +1");
+        assert!(
+            !eviction_safe(&snap[0].1, 1),
+            "evictor must refuse while writeback snapshot is alive",
+        );
+
+        // After the daemon completes and drops the snapshot, the
+        // strong count returns to 1 — eviction may proceed (for the
+        // strong-count axis; the frame-refcount axis is independent).
+        drop(snap);
+        let strong_after_snap = {
+            let inner = cache.inner.lock();
+            let p = inner.pages.get(&0).expect("indexed");
+            Arc::strong_count(p)
+        };
+        assert_eq!(strong_after_snap, 1);
+    }
+
+    #[test]
+    fn refcount_disciplines_are_independent() {
+        // RFC 0007 §Refcount discipline is explicit: the two counters
+        // are *non-overlapping*. Mutations to one must not affect the
+        // other. Verify by exercising the strong count without
+        // touching `mem::refcount`, and vice versa.
+        let cache = fresh_cache();
+        let stub = match cache.install_or_get(0, || make_stub(0)) {
+            InstallOutcome::InstalledNew(p) => p,
+            InstallOutcome::AlreadyPresent(_) => unreachable!(),
+        };
+        stub.publish_uptodate_and_unlock();
+        // Use a refcount-table-valid phys for the host helpers
+        // (`stub.phys` is a fake_phys() value at the MAX_PHYS_BYTES
+        // boundary chosen so it can never collide with a real
+        // allocator hand-out; the refcount slot table refuses it).
+        let phys = TEST_REFCOUNT_PHYS;
+
+        let slots: alloc::vec::Vec<core::sync::atomic::AtomicU16> = (0..4)
+            .map(|_| core::sync::atomic::AtomicU16::new(0))
+            .collect();
+        crate::mem::refcount::init_on_alloc_in(&slots, phys);
+
+        // Bump strong count via lookups; mem::refcount stays at 1.
+        let a = cache.lookup(0).unwrap();
+        let b = cache.lookup(0).unwrap();
+        let c = cache.lookup(0).unwrap();
+        assert_eq!(
+            crate::mem::refcount::page_refcount_in(&slots, phys)
+                .load(core::sync::atomic::Ordering::Relaxed),
+            1,
+            "strong-count bumps must not affect frame refcount",
+        );
+        drop((a, b, c));
+
+        // Bump mem::refcount via PTE simulation; strong count stays.
+        crate::mem::refcount::inc_refcount_in(&slots, phys);
+        crate::mem::refcount::inc_refcount_in(&slots, phys);
+        let strong_borrow = {
+            let inner = cache.inner.lock();
+            let p = inner.pages.get(&0).expect("indexed");
+            Arc::strong_count(p)
+        };
+        // outer `stub` + index = 2 (we still hold `stub`).
+        assert_eq!(strong_borrow, 2, "frame-refcount bumps must not affect strong");
+        assert_eq!(
+            crate::mem::refcount::page_refcount_in(&slots, phys)
+                .load(core::sync::atomic::Ordering::Relaxed),
+            3,
+        );
+    }
+
+    // --- RFC 0007 §Lock-order ladder — split-lock discipline ----------
+
+    #[test]
+    fn install_or_get_drops_inner_before_returning_outcome() {
+        // Split-lock discipline (RFC 0007 §Split-lock discipline):
+        // `install_or_get` takes `cache.inner` only across the
+        // index check + insert. Once it returns, the mutex is free
+        // for any other slow-path observer. We model that by
+        // calling install_or_get and verifying inner is acquirable
+        // immediately after.
+        let cache = fresh_cache();
+        let outcome = cache.install_or_get(0, || make_stub(0));
+        assert!(matches!(outcome, InstallOutcome::InstalledNew(_)));
+        // If install_or_get had retained the guard, this lock() would
+        // block forever (host stub uses spin::Mutex; `try_lock` is
+        // the deadlock-safe probe).
+        let guard = cache.inner.try_lock();
+        assert!(guard.is_some(), "cache.inner must be free post install_or_get");
+    }
+
+    #[test]
+    fn lookup_drops_inner_before_returning() {
+        // Same split-lock discipline applies to the read side: the
+        // `lookup` fast path holds `cache.inner` only across
+        // `BTreeMap::get`, then drops the guard before handing the
+        // `Arc<CachePage>` clone back. A caller that hangs onto the
+        // returned Arc must still see `cache.inner` as releasable.
+        let cache = fresh_cache();
+        cache.install_or_get(0, || make_stub(0));
+        let _hit = cache.lookup(0);
+        let guard = cache.inner.try_lock();
+        assert!(guard.is_some(), "cache.inner must be free post lookup");
+    }
+
+    #[test]
+    fn snapshot_dirty_drops_inner_before_returning() {
+        // The writeback daemon path: `snapshot_dirty` collects under
+        // `cache.inner`, then returns. The mutex must be free before
+        // the daemon iterates the snapshot calling `writepage` (which
+        // is RFC 0007 §Lock-order: `cache.inner` is **never** held
+        // across `writepage`).
+        let cache = fresh_cache();
+        let stub = match cache.install_or_get(0, || make_stub(0)) {
+            InstallOutcome::InstalledNew(p) => p,
+            InstallOutcome::AlreadyPresent(_) => unreachable!(),
+        };
+        stub.publish_uptodate_and_unlock();
+        cache.mark_page_dirty(0);
+
+        let snap = cache.snapshot_dirty();
+        assert_eq!(snap.len(), 1);
+        // `cache.inner` must be free even while the snapshot is held.
+        let guard = cache.inner.try_lock();
+        assert!(
+            guard.is_some(),
+            "cache.inner must be free while writeback snapshot is alive",
+        );
+    }
+
+    #[test]
+    fn mark_page_dirty_drops_inner_before_returning() {
+        // The Shared-write fault dirty-publish: the bit-set + index
+        // enrollment commit under one critical section, then the
+        // mutex releases. Subsequent fast-path lookups on unrelated
+        // pgoffs must not block on a leftover guard.
+        let cache = fresh_cache();
+        let stub = match cache.install_or_get(0, || make_stub(0)) {
+            InstallOutcome::InstalledNew(p) => p,
+            InstallOutcome::AlreadyPresent(_) => unreachable!(),
+        };
+        stub.publish_uptodate_and_unlock();
+        assert!(cache.mark_page_dirty(0));
+        let guard = cache.inner.try_lock();
+        assert!(guard.is_some());
     }
 }


### PR DESCRIPTION
Closes #742

## Summary

Workstream A of epic #734 (RFC 0007 page cache + file mmap). Tests-only landing — no production code change. Pins three categories of normative contract from RFC 0007 against the already-merged page-cache primitives (#736, #738, #745) so a future eviction (#740) or fault-path wiring (#739) PR cannot silently regress them.

The host-stub `BlockingMutex` gains a `try_lock()` shim so the lock-order tests can probe whether a guard is currently held without deadlocking — this is the only non-test change.

### Eviction-gate matrix (page_cache.rs)

RFC 0007 §Refcount discipline mandates two independent counters with non-overlapping responsibilities. The future evictor must gate on **both**:

1. `Arc::strong_count(&CachePage) == 1` — no in-flight fault clone.
2. `mem::refcount(phys) <= 1` — no installed PTE.

Six tests cover every quadrant of the matrix:
- PTE-only blocks; in-flight clone blocks; cache-own only passes; both axes blocking.
- Writeback snapshot's `Arc` clone blocks eviction.
- The two disciplines are independent (bumping one never perturbs the other).

### `assert_no_spinlocks_held` regression (debug_lockdep.rs)

RFC 0007 §Lock-order ladder requires every `AddressSpaceOps` method body's first instruction to call `assert_no_spinlocks_held`. Six `#[should_panic]` regression tests exercise the contract from the caller side: holding a `SpinLock` across `readpage` / `writepage` / `readahead` / `truncate_below` (including the trait's default-method bodies) must trip. Two companion tests verify no false positives.

### Lock-order ladder (file_object.rs)

`LockOrderProbe` is a custom `AddressSpaceOps` whose `readpage` body `try_lock`s `cache.inner` from inside the dispatch. A real `FileObject::fault` drives the slow path; the probe asserts the cache mutex was free during `readpage` (RFC 0007 §Lock-order: level 4 dropped before level 6). Two more tests verify the fault hot path does not leak `Arc<CachePage>` clones that would block the future evictor's strong-count gate.

### Split-lock discipline (page_cache.rs)

Four short tests probe via `try_lock` that `cache.inner` is free immediately after `install_or_get`, `lookup`, `snapshot_dirty`, and `mark_page_dirty` — none of these helpers may retain the level-4 guard.

## Test plan

- [x] `cargo xtask build` — green.
- [x] `cargo xtask smoke` — all 42 markers present.
- [x] `cargo test -p vibix --lib --target x86_64-unknown-linux-gnu` — 625 passed; 0 failed (21 new tests).
- [x] `cargo xtask test` host phase — 625 passed.
- The pre-existing `kernel/tests/blocking_sync::rwlock_concurrent_readers` flake (#791) reproduces unchanged from main; not introduced by this PR.

## Out of scope

- Eviction implementation (#740) — these tests pin the predicates the future implementation must satisfy.
- Page-fault path wiring (#739).
- Workstream B/C/D files (#746/#749/#755) — not touched.