### PR TITLE
sys: rewire sys_mmap for fd != -1 with new errno table (#746)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -274,6 +274,10 @@ name = "syscall_mmap_family"
 harness = false
 
 [[test]]
+name = "syscall_mmap_file_backed"
+harness = false
+
+[[test]]
 name = "vfs_backend"
 harness = false
 

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -1412,8 +1412,8 @@ fn prot_pte_from_prot_user(prot: u32) -> u64 {
 /// | `off + len_rounded` overflows `i64` (`off_t`) | `EOVERFLOW` |
 /// | `off + len` past `i_size` | succeeds (SIGBUS at fault per POSIX) |
 unsafe fn sys_mmap(addr: u64, len: u64, prot: u64, flags: u64, fd: u64, off: u64) -> i64 {
-    use crate::fs::{EBADF, EEXIST, EINVAL, ENODEV, ENOMEM};
     use crate::fs::vfs::inode::InodeKind;
+    use crate::fs::{EBADF, EEXIST, EINVAL, ENODEV, ENOMEM};
     use crate::mem::pf::{
         validate_user_range, AddrAlign, MAP_ANONYMOUS, MAP_FIXED, MAP_FIXED_NOREPLACE,
         MAP_GROWSDOWN, MAP_PRIVATE, MAP_SHARED, MAP_STACK, PROT_EXEC, PROT_READ, PROT_WRITE,
@@ -1539,23 +1539,16 @@ unsafe fn sys_mmap(addr: u64, len: u64, prot: u64, flags: u64, fd: u64, off: u64
         // memory location — `fcntl(F_SETFL)` cannot mutate access-mode
         // bits per POSIX, so the snapshot is effectively a constant
         // for the OpenFile's lifetime.
-        let open_mode_acc = of
-            .flags
-            .load(core::sync::atomic::Ordering::Relaxed)
-            & crate::fs::flags::O_ACCMODE;
+        let open_mode_acc =
+            of.flags.load(core::sync::atomic::Ordering::Relaxed) & crate::fs::flags::O_ACCMODE;
 
         // Run the pure errno gate. Returns the page-aligned `(off, len)`
         // on success or the negative errno on rejection.
-        let (off_aligned, len_pages) = match crate::mem::pf::validate_file_mmap_args(
-            prot,
-            share,
-            off,
-            len,
-            open_mode_acc,
-        ) {
-            Ok(v) => v,
-            Err(e) => return e,
-        };
+        let (off_aligned, len_pages) =
+            match crate::mem::pf::validate_file_mmap_args(prot, share, off, len, open_mode_acc) {
+                Ok(v) => v,
+                Err(e) => return e,
+            };
 
         // Dispatch to the per-FS hook. The default `FileOps::mmap`
         // returns `ENODEV` so non-mmappable file types (and ext2 until
@@ -1611,7 +1604,6 @@ unsafe fn sys_mmap(addr: u64, len: u64, prot: u64, flags: u64, fd: u64, off: u64
     guard.insert(vma);
     start as i64
 }
-
 
 /// `munmap(addr, len)` — POSIX-conformant: returns 0 on success and on
 /// holes (partly-or-wholly unmapped ranges). `-EINVAL` only for the

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -1385,14 +1385,35 @@ fn prot_pte_from_prot_user(prot: u32) -> u64 {
     pte.bits()
 }
 
-/// `mmap(addr, len, prot, flags, fd, off)` — anon-private + anon-shared.
+/// `mmap(addr, len, prot, flags, fd, off)` — anonymous + file-backed.
 ///
 /// Supports `MAP_PRIVATE` / `MAP_SHARED` (mutually exclusive) with
-/// `MAP_ANONYMOUS`; honours `MAP_FIXED`, `MAP_FIXED_NOREPLACE`,
-/// `MAP_GROWSDOWN`, and `MAP_STACK`. `fd != -1` returns `-ENODEV`
-/// (file-backed path not implemented). Validation follows RFC 0001.
+/// optional `MAP_ANONYMOUS`; honours `MAP_FIXED`, `MAP_FIXED_NOREPLACE`,
+/// `MAP_GROWSDOWN`, and `MAP_STACK`.
+///
+/// File-backed (`MAP_ANONYMOUS` clear, `fd != -1`) is wired per RFC 0007
+/// (issue #746): `sys_mmap` looks up the [`OpenFile`], validates per the
+/// new errno table, dispatches to [`FileOps::mmap`], and plugs the
+/// returned [`VmObject`] into the VMA tree. Per-FS `FileOps::mmap`
+/// overrides are landed in follow-up issues (#747 ext2 / #751 ramfs/tarfs);
+/// until then the default `Err(ENODEV)` impl propagates verbatim.
+///
+/// `MAP_ANONYMOUS` ignores `fd` per Linux semantics. The file-backed
+/// errno gate (RFC 0007 §Errno table) covers:
+///
+/// | Condition | Errno |
+/// |---|---|
+/// | `fd` not open | `EBADF` |
+/// | File type not mmappable (socket, FIFO, directory, …) | `ENODEV` |
+/// | `MAP_SHARED + PROT_WRITE` and `OpenFile.f_mode` is not `O_RDWR` | `EACCES` |
+/// | `MAP_PRIVATE + PROT_WRITE` on `O_WRONLY` | `EACCES` |
+/// | `off` not page-aligned | `EINVAL` |
+/// | `len == 0` | `EINVAL` |
+/// | `off + len_rounded` overflows `i64` (`off_t`) | `EOVERFLOW` |
+/// | `off + len` past `i_size` | succeeds (SIGBUS at fault per POSIX) |
 unsafe fn sys_mmap(addr: u64, len: u64, prot: u64, flags: u64, fd: u64, off: u64) -> i64 {
-    use crate::fs::{EEXIST, EINVAL, ENODEV, ENOMEM};
+    use crate::fs::{EBADF, EEXIST, EINVAL, ENODEV, ENOMEM};
+    use crate::fs::vfs::inode::InodeKind;
     use crate::mem::pf::{
         validate_user_range, AddrAlign, MAP_ANONYMOUS, MAP_FIXED, MAP_FIXED_NOREPLACE,
         MAP_GROWSDOWN, MAP_PRIVATE, MAP_SHARED, MAP_STACK, PROT_EXEC, PROT_READ, PROT_WRITE,
@@ -1409,16 +1430,7 @@ unsafe fn sys_mmap(addr: u64, len: u64, prot: u64, flags: u64, fd: u64, off: u64
         return EINVAL;
     }
 
-    // File-backed path not implemented — Linux returns ENODEV for
-    // "file type not supported by mmap", matching RFC 0001.
-    if fd as i64 != -1 {
-        return ENODEV;
-    }
-    if off != 0 {
-        return EINVAL;
-    }
-
-    // Every supported bit must be one of the RFC set.
+    // Every supported flag bit must be one of the RFC set.
     let known = MAP_SHARED
         | MAP_PRIVATE
         | MAP_FIXED
@@ -1428,11 +1440,6 @@ unsafe fn sys_mmap(addr: u64, len: u64, prot: u64, flags: u64, fd: u64, off: u64
         | MAP_STACK;
     if flags & !known != 0 {
         return EINVAL;
-    }
-
-    // Anonymous-only for now.
-    if flags & MAP_ANONYMOUS == 0 {
-        return ENODEV;
     }
 
     // Exactly one of MAP_PRIVATE / MAP_SHARED must be set.
@@ -1447,6 +1454,13 @@ unsafe fn sys_mmap(addr: u64, len: u64, prot: u64, flags: u64, fd: u64, off: u64
         Share::Shared
     };
 
+    // RFC 0007 §Errno table: `len == 0` is EINVAL regardless of path.
+    // `validate_user_range` would also catch this, but enforcing it
+    // here keeps the errno path stable across align modes.
+    if len == 0 {
+        return EINVAL;
+    }
+
     // MAP_FIXED_NOREPLACE implies MAP_FIXED semantics for address handling.
     let fixed = flags & (MAP_FIXED | MAP_FIXED_NOREPLACE) != 0;
 
@@ -1459,6 +1473,106 @@ unsafe fn sys_mmap(addr: u64, len: u64, prot: u64, flags: u64, fd: u64, off: u64
     let range = match validate_user_range(addr, len, align) {
         Ok(r) => r,
         Err(_) => return EINVAL,
+    };
+
+    // ── File-backed vs anonymous split ─────────────────────────────────
+    //
+    // `MAP_ANONYMOUS` ignores `fd` and the file-backed errno table per
+    // Linux semantics (RFC 0007 §Kernel-Userspace Interface). The file
+    // path captures an `Arc<dyn VmObject>` (a `FileObject` constructed
+    // by the per-FS impl) before the VMA-insert critical section so the
+    // address-space lock is held only across the address-resolve and
+    // insert.
+    let anonymous = flags & MAP_ANONYMOUS != 0;
+    let (obj, object_offset): (Arc<dyn VmObject>, usize) = if anonymous {
+        // Preserve existing vibix invariant: anon callers pass `off == 0`.
+        // (Linux ignores `off` when `MAP_ANONYMOUS` is set; vibix
+        // historically returns `EINVAL` and `kernel/tests/syscall_open_mmap.rs`
+        // pins it as a regression anchor. Keep the stricter contract.)
+        if off != 0 {
+            return EINVAL;
+        }
+        let pages = range.len / 4096;
+        (AnonObject::new(Some(pages)) as Arc<dyn VmObject>, 0)
+    } else {
+        // RFC 0007 §Errno table — file-backed path.
+        //
+        // 1. EBADF: fd must be currently open.
+        // 2. ENODEV: backend must expose a VFS open file (sockets,
+        //    pipes, the legacy SerialBackend all return None from
+        //    `as_vfs`).
+        // 3. ENODEV: only regular files are mmappable; directories,
+        //    sockets, FIFOs, character/block devices keep the default
+        //    `FileOps::mmap` (which itself returns `ENODEV`), but
+        //    sys_mmap pre-empts that dispatch with the same errno so
+        //    the gate is single-source.
+        // 4. EINVAL: `off` must be page-aligned.
+        // 5. EOVERFLOW: `off + len_rounded` must fit in i64 (off_t).
+        // 6. EACCES: `MAP_SHARED + PROT_WRITE` requires `O_RDWR`;
+        //            `MAP_PRIVATE + PROT_WRITE` rejects `O_WRONLY`.
+        // The OOM check on the VMA insert below stays an `ENOMEM`.
+        if fd > u32::MAX as u64 {
+            return EBADF;
+        }
+        let fd = fd as u32;
+        let backend = {
+            let tbl = crate::task::current_fd_table();
+            let x = match tbl.lock().get(fd) {
+                Ok(b) => b,
+                Err(_) => return EBADF,
+            };
+            x
+        };
+        let of = match backend.as_vfs() {
+            Some(v) => v.open_file.clone(),
+            None => return ENODEV,
+        };
+        // Inode kind gate. Only regular files are mmappable today;
+        // future block/char-device mappings would override
+        // `FileOps::mmap` and need this gate widened in the same PR.
+        if of.inode.kind != InodeKind::Reg {
+            return ENODEV;
+        }
+
+        // Snapshot the OpenFile access mode for the EACCES gate. Use
+        // `Relaxed`: this read does not synchronise with any other
+        // memory location — `fcntl(F_SETFL)` cannot mutate access-mode
+        // bits per POSIX, so the snapshot is effectively a constant
+        // for the OpenFile's lifetime.
+        let open_mode_acc = of
+            .flags
+            .load(core::sync::atomic::Ordering::Relaxed)
+            & crate::fs::flags::O_ACCMODE;
+
+        // Run the pure errno gate. Returns the page-aligned `(off, len)`
+        // on success or the negative errno on rejection.
+        let (off_aligned, len_pages) = match crate::mem::pf::validate_file_mmap_args(
+            prot,
+            share,
+            off,
+            len,
+            open_mode_acc,
+        ) {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+
+        // Dispatch to the per-FS hook. The default `FileOps::mmap`
+        // returns `ENODEV` so non-mmappable file types (and ext2 until
+        // #753 lands) still propagate the correct errno verbatim.
+        let vmobj = match of
+            .ops
+            .clone()
+            .mmap(&of, off_aligned, len_pages, share, prot)
+        {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+        // The returned `Arc<dyn VmObject>` (a `FileObject`) already
+        // captures `file_offset_pages` internally — the VMA carries
+        // `object_offset = 0` so VMA-local fault offsets map directly
+        // to the FileObject's window (RFC 0007 §FileObject).
+        (vmobj, 0)
     };
 
     let aspace = crate::task::current_address_space();
@@ -1481,8 +1595,6 @@ unsafe fn sys_mmap(addr: u64, len: u64, prot: u64, flags: u64, fd: u64, off: u64
     };
 
     let pte_bits = prot_pte_from_prot_user(prot);
-    let pages = range.len / 4096;
-    let obj = AnonObject::new(Some(pages));
 
     let mut vma = Vma::new(
         start,
@@ -1490,8 +1602,8 @@ unsafe fn sys_mmap(addr: u64, len: u64, prot: u64, flags: u64, fd: u64, off: u64
         prot,
         pte_bits,
         share,
-        obj as Arc<dyn VmObject>,
-        0,
+        obj,
+        object_offset,
     );
     if flags & MAP_GROWSDOWN != 0 {
         vma.vma_flags |= VMA_GROWSDOWN;
@@ -1499,6 +1611,7 @@ unsafe fn sys_mmap(addr: u64, len: u64, prot: u64, flags: u64, fd: u64, off: u64
     guard.insert(vma);
     start as i64
 }
+
 
 /// `munmap(addr, len)` — POSIX-conformant: returns 0 on success and on
 /// holes (partly-or-wholly unmapped ranges). `-EINVAL` only for the

--- a/kernel/src/mem/pf.rs
+++ b/kernel/src/mem/pf.rs
@@ -691,34 +691,16 @@ mod tests {
             // path must read the page on miss before mutating, so O_WRONLY
             // cannot service the read.
             assert_eq!(
-                validate_file_mmap_args(
-                    PROT_READ | PROT_WRITE,
-                    Share::Shared,
-                    0,
-                    4096,
-                    O_RDONLY,
-                ),
+                validate_file_mmap_args(PROT_READ | PROT_WRITE, Share::Shared, 0, 4096, O_RDONLY,),
                 Err(EACCES),
             );
             assert_eq!(
-                validate_file_mmap_args(
-                    PROT_READ | PROT_WRITE,
-                    Share::Shared,
-                    0,
-                    4096,
-                    O_WRONLY,
-                ),
+                validate_file_mmap_args(PROT_READ | PROT_WRITE, Share::Shared, 0, 4096, O_WRONLY,),
                 Err(EACCES),
             );
             // O_RDWR succeeds.
             assert_eq!(
-                validate_file_mmap_args(
-                    PROT_READ | PROT_WRITE,
-                    Share::Shared,
-                    0,
-                    4096,
-                    O_RDWR,
-                ),
+                validate_file_mmap_args(PROT_READ | PROT_WRITE, Share::Shared, 0, 4096, O_RDWR,),
                 Ok((0, 1)),
             );
         }
@@ -728,33 +710,15 @@ mod tests {
             // MAP_PRIVATE + PROT_WRITE: O_WRONLY rejected (CoW needs to
             // read master page first); O_RDONLY *and* O_RDWR succeed.
             assert_eq!(
-                validate_file_mmap_args(
-                    PROT_READ | PROT_WRITE,
-                    Share::Private,
-                    0,
-                    4096,
-                    O_WRONLY,
-                ),
+                validate_file_mmap_args(PROT_READ | PROT_WRITE, Share::Private, 0, 4096, O_WRONLY,),
                 Err(EACCES),
             );
             assert_eq!(
-                validate_file_mmap_args(
-                    PROT_READ | PROT_WRITE,
-                    Share::Private,
-                    0,
-                    4096,
-                    O_RDONLY,
-                ),
+                validate_file_mmap_args(PROT_READ | PROT_WRITE, Share::Private, 0, 4096, O_RDONLY,),
                 Ok((0, 1)),
             );
             assert_eq!(
-                validate_file_mmap_args(
-                    PROT_READ | PROT_WRITE,
-                    Share::Private,
-                    0,
-                    4096,
-                    O_RDWR,
-                ),
+                validate_file_mmap_args(PROT_READ | PROT_WRITE, Share::Private, 0, 4096, O_RDWR,),
                 Ok((0, 1)),
             );
         }

--- a/kernel/src/mem/pf.rs
+++ b/kernel/src/mem/pf.rs
@@ -367,6 +367,109 @@ pub fn validate_user_range(addr: u64, len: u64, align: AddrAlign) -> Result<User
     })
 }
 
+// ── File-mmap errno gate (RFC 0007 §Errno table, issue #746) ────────────
+
+/// Pure errno-gate for the file-backed leg of `sys_mmap` (RFC 0007
+/// §Errno table). Extracted from `arch::x86_64::syscall::sys_mmap` so
+/// host unit tests can exercise every rejection branch without the
+/// `current_fd_table` / `current_address_space` / IDT plumbing the
+/// syscall wrapper carries.
+///
+/// `prot` is the raw `PROT_*` bitmask. `share` distinguishes
+/// `MAP_PRIVATE` from `MAP_SHARED`. `off` and `len` are the userspace
+/// arguments **before** any rounding; the helper enforces the EINVAL
+/// alignment rules and returns the page-aligned `(off, len_pages)` pair
+/// on success. `open_mode_acc` is the result of
+/// `OpenFile.flags & O_ACCMODE` (one of `O_RDONLY=0`, `O_WRONLY=1`,
+/// `O_RDWR=2` — pinned by the static asserts in `crate::fs::flags`).
+///
+/// Errors (matching RFC 0007 §Errno table verbatim):
+///
+/// - `EINVAL`  — `off` not page-aligned, or `len == 0`.
+/// - `EOVERFLOW` — `off + page-rounded(len)` overflows `i64` (`off_t`).
+/// - `EACCES`  — `MAP_SHARED + PROT_WRITE` with `open_mode != O_RDWR`,
+///   or `MAP_PRIVATE + PROT_WRITE` with `open_mode == O_WRONLY`.
+///
+/// `EBADF` (fd not open) and `ENODEV` (non-mmappable inode kind / non-VFS
+/// backend) are *upstream* of this gate — `sys_mmap` rejects them before
+/// it can even build the `(open_mode_acc, share, prot, off, len)`
+/// argument set.
+pub fn validate_file_mmap_args(
+    prot: u32,
+    share: crate::mem::vmatree::Share,
+    off: u64,
+    len: u64,
+    open_mode_acc: u32,
+) -> Result<(u64, usize), i64> {
+    use crate::mem::vmatree::Share;
+    use crate::mem::FRAME_SIZE;
+
+    // Errno values inlined as numeric literals (mirroring `crate::fs::*`)
+    // because `crate::fs` is gated to `#[cfg(any(test, target_os =
+    // "none"))]` while `mem::pf` is unconditional. The static asserts in
+    // `crate::fs` pin these values to the Linux x86_64 ABI; the same
+    // values appear in `crate::fs::{EACCES, EINVAL, EOVERFLOW}` and
+    // arrive here unchanged. The constants below are scoped to this fn
+    // so they cannot leak into the rest of the module.
+    const EACCES: i64 = -13;
+    const EINVAL: i64 = -22;
+    const EOVERFLOW: i64 = -75;
+    // `O_RDONLY = 0`, `O_WRONLY = 1`, `O_RDWR = 2` (pinned by the
+    // static asserts in `crate::fs::flags`).
+    const O_WRONLY: u32 = 1;
+    const O_RDWR: u32 = 2;
+
+    // EINVAL: len == 0.
+    if len == 0 {
+        return Err(EINVAL);
+    }
+    // EINVAL: off not page-aligned.
+    if off % FRAME_SIZE != 0 {
+        return Err(EINVAL);
+    }
+
+    // Page-round `len` up.
+    let len_rounded = match len.checked_add(FRAME_SIZE - 1) {
+        Some(v) => v & !(FRAME_SIZE - 1),
+        None => return Err(EOVERFLOW),
+    };
+
+    // EOVERFLOW: off + len_rounded must fit in i64 (off_t).
+    let end = match off.checked_add(len_rounded) {
+        Some(v) => v,
+        None => return Err(EOVERFLOW),
+    };
+    if end > i64::MAX as u64 {
+        return Err(EOVERFLOW);
+    }
+
+    // EACCES: write-permission gates.
+    let want_write = prot & PROT_WRITE != 0;
+    if want_write {
+        match share {
+            Share::Shared => {
+                // MAP_SHARED + PROT_WRITE requires O_RDWR. The
+                // write-fault path must read the page on miss before
+                // mutating it; an O_WRONLY-opened file cannot service
+                // that read (RFC 0007 §Kernel-Userspace Interface).
+                if open_mode_acc != O_RDWR {
+                    return Err(EACCES);
+                }
+            }
+            Share::Private => {
+                // MAP_PRIVATE + PROT_WRITE rejects O_WRONLY for the
+                // same reason: CoW needs the master page readable.
+                if open_mode_acc == O_WRONLY {
+                    return Err(EACCES);
+                }
+            }
+        }
+    }
+
+    let len_pages = (len_rounded / FRAME_SIZE) as usize;
+    Ok((off, len_pages))
+}
+
 #[cfg(test)]
 mod validate_range_tests {
     use super::*;
@@ -527,5 +630,201 @@ mod tests {
         assert!(is_present_fault(ERR_P | ERR_WR | ERR_US));
         assert!(!is_present_fault(ERR_US));
         assert!(!is_present_fault(0));
+    }
+
+    // ── validate_file_mmap_args (issue #746, RFC 0007 §Errno table) ──
+
+    mod file_mmap_errno {
+        use super::*;
+        use crate::mem::vmatree::Share;
+
+        // Mirror the numeric pins used inside `validate_file_mmap_args`.
+        const O_RDONLY: u32 = 0;
+        const O_WRONLY: u32 = 1;
+        const O_RDWR: u32 = 2;
+        const EACCES: i64 = -13;
+        const EINVAL: i64 = -22;
+        const EOVERFLOW: i64 = -75;
+
+        #[test]
+        fn zero_len_einval() {
+            // RFC 0007: `len == 0` → EINVAL regardless of share / prot / off.
+            assert_eq!(
+                validate_file_mmap_args(PROT_READ, Share::Shared, 0, 0, O_RDWR),
+                Err(EINVAL),
+            );
+        }
+
+        #[test]
+        fn unaligned_off_einval() {
+            // 0x100 is not page-aligned → EINVAL.
+            assert_eq!(
+                validate_file_mmap_args(PROT_READ, Share::Shared, 0x100, 4096, O_RDWR),
+                Err(EINVAL),
+            );
+            // 0x1FFF: just below a page boundary.
+            assert_eq!(
+                validate_file_mmap_args(PROT_READ, Share::Private, 0x1FFF, 4096, O_RDONLY),
+                Err(EINVAL),
+            );
+        }
+
+        #[test]
+        fn off_plus_len_overflow_eoverflow() {
+            // `off + page-rounded(len)` must fit in i64. A near-i64::MAX
+            // off plus a multi-page len overflows → EOVERFLOW.
+            let near_max = (i64::MAX as u64) & !0xFFF; // page-aligned, near max
+            assert_eq!(
+                validate_file_mmap_args(PROT_READ, Share::Shared, near_max, 8192, O_RDWR),
+                Err(EOVERFLOW),
+            );
+            // `len` itself near u64::MAX overflows during the page-round.
+            assert_eq!(
+                validate_file_mmap_args(PROT_READ, Share::Shared, 0, u64::MAX, O_RDWR),
+                Err(EOVERFLOW),
+            );
+        }
+
+        #[test]
+        fn shared_write_requires_o_rdwr() {
+            // MAP_SHARED + PROT_WRITE: only O_RDWR succeeds. The write-fault
+            // path must read the page on miss before mutating, so O_WRONLY
+            // cannot service the read.
+            assert_eq!(
+                validate_file_mmap_args(
+                    PROT_READ | PROT_WRITE,
+                    Share::Shared,
+                    0,
+                    4096,
+                    O_RDONLY,
+                ),
+                Err(EACCES),
+            );
+            assert_eq!(
+                validate_file_mmap_args(
+                    PROT_READ | PROT_WRITE,
+                    Share::Shared,
+                    0,
+                    4096,
+                    O_WRONLY,
+                ),
+                Err(EACCES),
+            );
+            // O_RDWR succeeds.
+            assert_eq!(
+                validate_file_mmap_args(
+                    PROT_READ | PROT_WRITE,
+                    Share::Shared,
+                    0,
+                    4096,
+                    O_RDWR,
+                ),
+                Ok((0, 1)),
+            );
+        }
+
+        #[test]
+        fn private_write_rejects_o_wronly() {
+            // MAP_PRIVATE + PROT_WRITE: O_WRONLY rejected (CoW needs to
+            // read master page first); O_RDONLY *and* O_RDWR succeed.
+            assert_eq!(
+                validate_file_mmap_args(
+                    PROT_READ | PROT_WRITE,
+                    Share::Private,
+                    0,
+                    4096,
+                    O_WRONLY,
+                ),
+                Err(EACCES),
+            );
+            assert_eq!(
+                validate_file_mmap_args(
+                    PROT_READ | PROT_WRITE,
+                    Share::Private,
+                    0,
+                    4096,
+                    O_RDONLY,
+                ),
+                Ok((0, 1)),
+            );
+            assert_eq!(
+                validate_file_mmap_args(
+                    PROT_READ | PROT_WRITE,
+                    Share::Private,
+                    0,
+                    4096,
+                    O_RDWR,
+                ),
+                Ok((0, 1)),
+            );
+        }
+
+        #[test]
+        fn read_only_prot_no_eacces() {
+            // PROT_WRITE clear: no permission gate fires regardless of
+            // share/open_mode (PROT_EXEC and PROT_READ alone are fine on a
+            // read-only open).
+            assert_eq!(
+                validate_file_mmap_args(PROT_READ, Share::Shared, 0, 4096, O_RDONLY),
+                Ok((0, 1)),
+            );
+            assert_eq!(
+                validate_file_mmap_args(PROT_EXEC, Share::Shared, 0, 4096, O_RDONLY),
+                Ok((0, 1)),
+            );
+            assert_eq!(
+                validate_file_mmap_args(PROT_READ, Share::Private, 0, 4096, O_WRONLY),
+                Ok((0, 1)),
+            );
+        }
+
+        #[test]
+        fn len_rounds_up_to_page_count() {
+            // 1 byte → 1 page, 4096 → 1 page, 4097 → 2 pages, 8192 → 2.
+            assert_eq!(
+                validate_file_mmap_args(PROT_READ, Share::Shared, 0, 1, O_RDWR),
+                Ok((0, 1)),
+            );
+            assert_eq!(
+                validate_file_mmap_args(PROT_READ, Share::Shared, 0, 4096, O_RDWR),
+                Ok((0, 1)),
+            );
+            assert_eq!(
+                validate_file_mmap_args(PROT_READ, Share::Shared, 0, 4097, O_RDWR),
+                Ok((0, 2)),
+            );
+            assert_eq!(
+                validate_file_mmap_args(PROT_READ, Share::Shared, 0, 8192, O_RDWR),
+                Ok((0, 2)),
+            );
+        }
+
+        #[test]
+        fn off_passes_through_unchanged() {
+            // The page-aligned `off` is returned verbatim — sys_mmap then
+            // forwards it as the byte offset to `FileOps::mmap`.
+            assert_eq!(
+                validate_file_mmap_args(PROT_READ, Share::Shared, 4096, 4096, O_RDWR),
+                Ok((4096, 1)),
+            );
+            assert_eq!(
+                validate_file_mmap_args(PROT_READ, Share::Shared, 0x1_0000, 8192, O_RDWR),
+                Ok((0x1_0000, 2)),
+            );
+        }
+
+        #[test]
+        fn off_plus_len_at_i64_max_succeeds() {
+            // Boundary case: end == i64::MAX rounded to page (0x7fff_ffff_ffff_f000).
+            // Actually with len_rounded == FRAME_SIZE and an off such
+            // that end == i64::MAX as u64 + 1, EOVERFLOW fires; check
+            // the strictly-less-than case still passes.
+            let off = 0u64;
+            let len = 4096u64;
+            assert_eq!(
+                validate_file_mmap_args(PROT_READ, Share::Shared, off, len, O_RDWR),
+                Ok((0, 1)),
+            );
+        }
     }
 }

--- a/kernel/tests/syscall_mmap_family.rs
+++ b/kernel/tests/syscall_mmap_family.rs
@@ -22,7 +22,7 @@ use core::panic::PanicInfo;
 
 use vibix::arch::x86_64::syscall::syscall_dispatch;
 use vibix::arch::x86_64::uaccess;
-use vibix::fs::{EEXIST, EINVAL, ENODEV, ENOMEM};
+use vibix::fs::{EEXIST, EINVAL, ENOMEM};
 use vibix::mem::pf::{
     MADV_DONTNEED, MAP_ANONYMOUS, MAP_FIXED, MAP_FIXED_NOREPLACE, MAP_PRIVATE, MAP_SHARED,
     PROT_READ, PROT_WRITE,
@@ -176,10 +176,15 @@ fn anon_rw(len: u64) -> u64 {
 // ── Tests ────────────────────────────────────────────────────────────────
 
 fn mmap_fd_nonneg_enodev() {
-    // File-backed mappings are not implemented: fd != -1 must yield ENODEV
-    // (not EINVAL) per RFC 0001.
+    // RFC 0007 §Kernel-Userspace Interface (#746): MAP_ANONYMOUS ignores
+    // `fd` per Linux semantics, so passing a non-negative fd alongside
+    // MAP_ANONYMOUS no longer trips the file-backed errno table — the
+    // mapping succeeds. Pre-746, vibix short-circuited every `fd != -1`
+    // to ENODEV; the new errno table runs only when MAP_ANONYMOUS is
+    // clear. The test name is preserved as a regression anchor for the
+    // Linux-compat semantics flip.
     let r = mmap(0, 4096, PROT_READ, MAP_ANONYMOUS | MAP_PRIVATE, 0, 0);
-    assert_eq!(r, ENODEV, "expected ENODEV for fd=0, got {}", r);
+    assert!(r > 0, "MAP_ANONYMOUS must ignore fd, got errno {}", r);
 }
 
 fn mmap_requires_exactly_one_share() {

--- a/kernel/tests/syscall_mmap_file_backed.rs
+++ b/kernel/tests/syscall_mmap_file_backed.rs
@@ -1,0 +1,474 @@
+//! Integration test for issue #746 — RFC 0007 Workstream B's `sys_mmap`
+//! file-backed rewire.
+//!
+//! Drives `syscall_dispatch(SYS_mmap, ...)` against a synthesized
+//! in-memory `FileOps::mmap` impl (NOT ext2 — issue #753 has not landed
+//! yet, ext2's default `FileOps::mmap` still returns ENODEV). Exercises
+//! every branch of the new errno table from RFC 0007 §Errno table:
+//!
+//! * EBADF — fd not open
+//! * ENODEV — non-VFS backend; non-Reg inode kind (Dir / Sock / Fifo)
+//! * EACCES — `MAP_SHARED + PROT_WRITE` without `O_RDWR`
+//! * EACCES — `MAP_PRIVATE + PROT_WRITE` on `O_WRONLY`
+//! * EINVAL — `len == 0`
+//! * EINVAL — `off` not page-aligned
+//! * EOVERFLOW — `off + len_rounded` overflows i64
+//! * Success — `MAP_PRIVATE + PROT_READ` on a Reg file with a custom
+//!   `FileOps::mmap` impl plugs the returned `VmObject` into the VMA tree
+//! * Success — `MAP_ANONYMOUS` ignores fd (Linux semantics)
+//! * Pre-emption — `FileOps::mmap`'s default `ENODEV` propagates verbatim
+//!   when the FS hasn't overridden it (regular file, no override)
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use core::panic::PanicInfo;
+
+use vibix::arch::x86_64::syscall::syscall_dispatch;
+use vibix::fs::flags;
+use vibix::fs::vfs::dentry::Dentry;
+use vibix::fs::vfs::inode::{Inode, InodeKind, InodeMeta};
+use vibix::fs::vfs::open_file::OpenFile;
+use vibix::fs::vfs::ops::{FileOps, InodeOps, SetAttr, Stat, StatFs, SuperOps};
+use vibix::fs::vfs::super_block::{SbActiveGuard, SbFlags, SuperBlock};
+use vibix::fs::vfs::{FsId, VfsBackend};
+use vibix::fs::{
+    EACCES, EBADF, EINVAL, ENODEV, EOVERFLOW, FileBackend, FileDescription,
+};
+use vibix::mem::pf::{
+    MAP_ANONYMOUS, MAP_PRIVATE, MAP_SHARED, PROT_READ, PROT_WRITE,
+};
+use vibix::mem::vmatree::{ProtUser, Share};
+use vibix::mem::vmobject::{AnonObject, VmObject};
+use vibix::{
+    exit_qemu, serial_println, task,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+const SYS_MMAP: u64 = 9;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        // ── EBADF / ENODEV gates ──────────────────────────────────
+        (
+            "file_mmap_invalid_fd_ebadf",
+            &(file_mmap_invalid_fd_ebadf as fn()),
+        ),
+        (
+            "file_mmap_dir_inode_enodev",
+            &(file_mmap_dir_inode_enodev as fn()),
+        ),
+        (
+            "file_mmap_default_fileops_propagates_enodev",
+            &(file_mmap_default_fileops_propagates_enodev as fn()),
+        ),
+        // ── EINVAL / EOVERFLOW arithmetic gates ──────────────────
+        (
+            "file_mmap_unaligned_off_einval",
+            &(file_mmap_unaligned_off_einval as fn()),
+        ),
+        (
+            "file_mmap_zero_len_einval",
+            &(file_mmap_zero_len_einval as fn()),
+        ),
+        (
+            "file_mmap_off_plus_len_overflow_eoverflow",
+            &(file_mmap_off_plus_len_overflow_eoverflow as fn()),
+        ),
+        // ── EACCES open-mode gates ───────────────────────────────
+        (
+            "file_mmap_shared_write_on_rdonly_eacces",
+            &(file_mmap_shared_write_on_rdonly_eacces as fn()),
+        ),
+        (
+            "file_mmap_shared_write_on_wronly_eacces",
+            &(file_mmap_shared_write_on_wronly_eacces as fn()),
+        ),
+        (
+            "file_mmap_private_write_on_wronly_eacces",
+            &(file_mmap_private_write_on_wronly_eacces as fn()),
+        ),
+        // ── Success path: custom FileOps::mmap override ──────────
+        (
+            "file_mmap_private_read_succeeds",
+            &(file_mmap_private_read_succeeds as fn()),
+        ),
+        (
+            "file_mmap_shared_rdwr_succeeds",
+            &(file_mmap_shared_rdwr_succeeds as fn()),
+        ),
+        (
+            "file_mmap_returned_vmobject_lands_in_vma_tree",
+            &(file_mmap_returned_vmobject_lands_in_vma_tree as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+// ── Stubs ──────────────────────────────────────────────────────────────
+
+struct StubInodeOps;
+impl InodeOps for StubInodeOps {
+    fn getattr(&self, _inode: &Inode, _out: &mut Stat) -> Result<(), i64> {
+        Ok(())
+    }
+    fn setattr(&self, _inode: &Inode, _attr: &SetAttr) -> Result<(), i64> {
+        Ok(())
+    }
+}
+
+struct StubSuperOps;
+impl SuperOps for StubSuperOps {
+    fn root_inode(&self) -> Arc<Inode> {
+        unreachable!("test stub")
+    }
+    fn statfs(&self) -> Result<StatFs, i64> {
+        Ok(StatFs::default())
+    }
+    fn unmount(&self) {}
+}
+
+/// `FileOps` impl that overrides `mmap` to return an `AnonObject`-backed
+/// `VmObject` of the requested size. The integration test asserts the
+/// returned object is plugged into the VMA tree at the correct va, with
+/// the correct `share` and `prot_user`.
+struct MmapableOps;
+impl FileOps for MmapableOps {
+    fn mmap(
+        &self,
+        _f: &OpenFile,
+        _file_offset: u64,
+        len_pages: usize,
+        _share: Share,
+        _prot: ProtUser,
+    ) -> Result<Arc<dyn VmObject>, i64> {
+        // The real ext2/ramfs/tarfs impls (#747/#751/#753) return an
+        // `Arc<FileObject>` against the inode's page cache. For this
+        // test we only need a concrete `VmObject` so sys_mmap's
+        // VMA-insert path can land it; AnonObject is the simplest one
+        // that satisfies the trait bound and doesn't drag the page
+        // cache (gated behind `feature = "page_cache"`) into a test
+        // build.
+        Ok(AnonObject::new(Some(len_pages)) as Arc<dyn VmObject>)
+    }
+}
+
+/// `FileOps` that uses every default impl — including the default
+/// `mmap` that returns `ENODEV`. This is the contract every non-mmappable
+/// FS (sockets, FIFOs, control nodes, and ext2 until #753) inherits.
+struct DefaultFileOps;
+impl FileOps for DefaultFileOps {}
+
+/// Build a fresh `OpenFile` against an inode of the requested kind
+/// using the requested `FileOps`. Inserts the resulting `VfsBackend`
+/// into the current task's fd table and returns the allocated fd.
+fn install_fd(
+    kind: InodeKind,
+    file_ops: Arc<dyn FileOps>,
+    open_flags: u32,
+    file_size: u64,
+) -> u32 {
+    let sb = Arc::new(SuperBlock::new(
+        FsId(746),
+        Arc::new(StubSuperOps),
+        "stub-mmap",
+        4096,
+        SbFlags::default(),
+    ));
+    let mut meta = InodeMeta::default();
+    meta.size = file_size;
+    let inode = Arc::new(Inode::new(
+        1,
+        Arc::downgrade(&sb),
+        Arc::new(StubInodeOps),
+        file_ops.clone(),
+        kind,
+        meta,
+    ));
+    let dentry = Dentry::new_root(inode.clone());
+    let guard = SbActiveGuard::try_acquire(&sb).expect("guard");
+    let of = OpenFile::new(dentry, inode, file_ops, sb.clone(), open_flags, guard);
+    let backend = Arc::new(VfsBackend { open_file: of }) as Arc<dyn FileBackend>;
+    let desc = Arc::new(FileDescription::new(backend, 0));
+    let tbl = task::current_fd_table();
+    let fd = tbl.lock().alloc_fd(desc).expect("alloc_fd");
+    fd
+}
+
+fn mmap(addr: u64, len: u64, prot: u32, flags: u32, fd: i64, off: u64) -> i64 {
+    unsafe {
+        syscall_dispatch(
+            core::ptr::null_mut(),
+            SYS_MMAP,
+            addr,
+            len,
+            prot as u64,
+            flags as u64,
+            fd as u64,
+            off,
+        )
+    }
+}
+
+// ── Tests: EBADF / ENODEV gates ────────────────────────────────────────
+
+fn file_mmap_invalid_fd_ebadf() {
+    // Without MAP_ANONYMOUS, sys_mmap looks up the fd. fd=999 is
+    // (almost certainly) not open in the test task → EBADF per RFC 0007
+    // §Errno table.
+    let r = mmap(0, 4096, PROT_READ, MAP_PRIVATE, 999, 0);
+    assert_eq!(r, EBADF, "fd=999 must trip EBADF, got {}", r);
+}
+
+fn file_mmap_dir_inode_enodev() {
+    // A directory inode is not mmappable per RFC 0007 §Errno table —
+    // sys_mmap pre-empts FileOps::mmap with ENODEV regardless of what
+    // the FS impl returns.
+    let fd = install_fd(
+        InodeKind::Dir,
+        Arc::new(MmapableOps),
+        flags::O_RDWR,
+        0,
+    );
+    let r = mmap(0, 4096, PROT_READ, MAP_PRIVATE, fd as i64, 0);
+    assert_eq!(
+        r, ENODEV,
+        "MAP_PRIVATE on a directory inode must trip ENODEV, got {}",
+        r
+    );
+}
+
+fn file_mmap_default_fileops_propagates_enodev() {
+    // The default FileOps::mmap returns -ENODEV. sys_mmap must
+    // propagate the FS-level errno verbatim — ext2 (until #753 lands)
+    // depends on this.
+    let fd = install_fd(
+        InodeKind::Reg,
+        Arc::new(DefaultFileOps),
+        flags::O_RDWR,
+        4096,
+    );
+    let r = mmap(0, 4096, PROT_READ, MAP_PRIVATE, fd as i64, 0);
+    assert_eq!(
+        r, ENODEV,
+        "default FileOps::mmap must propagate ENODEV verbatim, got {}",
+        r
+    );
+}
+
+// ── Tests: EINVAL / EOVERFLOW gates ───────────────────────────────────
+
+fn file_mmap_unaligned_off_einval() {
+    let fd = install_fd(
+        InodeKind::Reg,
+        Arc::new(MmapableOps),
+        flags::O_RDWR,
+        4096,
+    );
+    let r = mmap(0, 4096, PROT_READ, MAP_PRIVATE, fd as i64, 0x100);
+    assert_eq!(r, EINVAL, "non-aligned off must trip EINVAL, got {}", r);
+}
+
+fn file_mmap_zero_len_einval() {
+    let fd = install_fd(
+        InodeKind::Reg,
+        Arc::new(MmapableOps),
+        flags::O_RDWR,
+        4096,
+    );
+    let r = mmap(0, 0, PROT_READ, MAP_PRIVATE, fd as i64, 0);
+    assert_eq!(r, EINVAL, "len=0 must trip EINVAL, got {}", r);
+}
+
+fn file_mmap_off_plus_len_overflow_eoverflow() {
+    let fd = install_fd(
+        InodeKind::Reg,
+        Arc::new(MmapableOps),
+        flags::O_RDWR,
+        4096,
+    );
+    // off near i64::MAX + a multi-page len overflows i64 → EOVERFLOW.
+    let near_max = (i64::MAX as u64) & !0xFFF;
+    let r = mmap(0, 8192, PROT_READ, MAP_PRIVATE, fd as i64, near_max);
+    assert_eq!(
+        r, EOVERFLOW,
+        "off+len overflow must trip EOVERFLOW, got {}",
+        r
+    );
+}
+
+// ── Tests: EACCES open-mode gates ─────────────────────────────────────
+
+fn file_mmap_shared_write_on_rdonly_eacces() {
+    // MAP_SHARED + PROT_WRITE requires O_RDWR. O_RDONLY → EACCES.
+    let fd = install_fd(
+        InodeKind::Reg,
+        Arc::new(MmapableOps),
+        flags::O_RDONLY,
+        4096,
+    );
+    let r = mmap(
+        0,
+        4096,
+        PROT_READ | PROT_WRITE,
+        MAP_SHARED,
+        fd as i64,
+        0,
+    );
+    assert_eq!(
+        r, EACCES,
+        "MAP_SHARED+PROT_WRITE on O_RDONLY must trip EACCES, got {}",
+        r
+    );
+}
+
+fn file_mmap_shared_write_on_wronly_eacces() {
+    // MAP_SHARED + PROT_WRITE on O_WRONLY → EACCES (write-fault path
+    // can't service the read-on-miss).
+    let fd = install_fd(
+        InodeKind::Reg,
+        Arc::new(MmapableOps),
+        flags::O_WRONLY,
+        4096,
+    );
+    let r = mmap(
+        0,
+        4096,
+        PROT_READ | PROT_WRITE,
+        MAP_SHARED,
+        fd as i64,
+        0,
+    );
+    assert_eq!(
+        r, EACCES,
+        "MAP_SHARED+PROT_WRITE on O_WRONLY must trip EACCES, got {}",
+        r
+    );
+}
+
+fn file_mmap_private_write_on_wronly_eacces() {
+    // MAP_PRIVATE + PROT_WRITE on O_WRONLY → EACCES (CoW needs to
+    // read the master page first).
+    let fd = install_fd(
+        InodeKind::Reg,
+        Arc::new(MmapableOps),
+        flags::O_WRONLY,
+        4096,
+    );
+    let r = mmap(
+        0,
+        4096,
+        PROT_READ | PROT_WRITE,
+        MAP_PRIVATE,
+        fd as i64,
+        0,
+    );
+    assert_eq!(
+        r, EACCES,
+        "MAP_PRIVATE+PROT_WRITE on O_WRONLY must trip EACCES, got {}",
+        r
+    );
+}
+
+// ── Tests: Success path ──────────────────────────────────────────────
+
+fn file_mmap_private_read_succeeds() {
+    // MAP_PRIVATE + PROT_READ on a Reg file with a custom FileOps::mmap
+    // impl: sys_mmap calls the impl, gets back an `Arc<dyn VmObject>`,
+    // and lands a VMA at the chosen VA.
+    let fd = install_fd(
+        InodeKind::Reg,
+        Arc::new(MmapableOps),
+        flags::O_RDONLY,
+        4096,
+    );
+    let r = mmap(0, 4096, PROT_READ, MAP_PRIVATE, fd as i64, 0);
+    assert!(r > 0, "file-backed MAP_PRIVATE+PROT_READ must succeed, got {}", r);
+    let va = r as u64;
+    assert_eq!(va & 0xFFF, 0, "returned VA must be page-aligned: {:#x}", va);
+    // VMA must be visible in the current address space.
+    let aspace = vibix::task::current_address_space();
+    let guard = aspace.read();
+    let vma = guard.find(va as usize).expect("file-backed VMA missing");
+    assert_eq!(vma.start, va as usize);
+    assert_eq!(vma.end, (va as usize) + 4096);
+    assert_eq!(vma.share, Share::Private);
+    assert_eq!(vma.prot_user, PROT_READ);
+}
+
+fn file_mmap_shared_rdwr_succeeds() {
+    // MAP_SHARED + PROT_WRITE on O_RDWR — the only combination the
+    // EACCES gate permits with PROT_WRITE.
+    let fd = install_fd(
+        InodeKind::Reg,
+        Arc::new(MmapableOps),
+        flags::O_RDWR,
+        8192,
+    );
+    let r = mmap(
+        0,
+        8192,
+        PROT_READ | PROT_WRITE,
+        MAP_SHARED,
+        fd as i64,
+        0,
+    );
+    assert!(r > 0, "MAP_SHARED+RW on O_RDWR must succeed, got {}", r);
+    let va = r as u64;
+    let aspace = vibix::task::current_address_space();
+    let guard = aspace.read();
+    let vma = guard.find(va as usize).expect("file-backed VMA missing");
+    assert_eq!(vma.share, Share::Shared);
+    assert_eq!(vma.prot_user, PROT_READ | PROT_WRITE);
+    assert_eq!(vma.end - vma.start, 8192);
+}
+
+fn file_mmap_returned_vmobject_lands_in_vma_tree() {
+    // The Arc<dyn VmObject> returned by FileOps::mmap is the *same*
+    // Arc on the VMA. Verify by pointer-eq via the AnonObject's
+    // observable behaviour: a VMA pointing at an AnonObject of N pages
+    // exposes N pages, and vma.object's len_pages matches the syscall's
+    // len argument rounded up.
+    let fd = install_fd(
+        InodeKind::Reg,
+        Arc::new(MmapableOps),
+        flags::O_RDONLY,
+        16384,
+    );
+    let r = mmap(0, 16384, PROT_READ, MAP_PRIVATE, fd as i64, 0);
+    assert!(r > 0);
+    let va = r as u64;
+    let aspace = vibix::task::current_address_space();
+    let guard = aspace.read();
+    let vma = guard.find(va as usize).expect("file-backed VMA missing");
+    // The custom FileOps::mmap returns AnonObject::new(Some(4)); its
+    // len_pages observable through the VmObject trait must be 4.
+    assert_eq!(vma.object.len_pages(), Some(4));
+    // object_offset is 0 — sys_mmap forwards the file_offset *into*
+    // FileOps::mmap (which the FS impl burns into its returned object,
+    // typically a FileObject window). The VMA itself carries 0 so
+    // VMA-local offsets map directly through.
+    assert_eq!(vma.object_offset, 0);
+}

--- a/kernel/tests/syscall_mmap_file_backed.rs
+++ b/kernel/tests/syscall_mmap_file_backed.rs
@@ -35,12 +35,8 @@ use vibix::fs::vfs::open_file::OpenFile;
 use vibix::fs::vfs::ops::{FileOps, InodeOps, SetAttr, Stat, StatFs, SuperOps};
 use vibix::fs::vfs::super_block::{SbActiveGuard, SbFlags, SuperBlock};
 use vibix::fs::vfs::{FsId, VfsBackend};
-use vibix::fs::{
-    EACCES, EBADF, EINVAL, ENODEV, EOVERFLOW, FileBackend, FileDescription,
-};
-use vibix::mem::pf::{
-    MAP_ANONYMOUS, MAP_PRIVATE, MAP_SHARED, PROT_READ, PROT_WRITE,
-};
+use vibix::fs::{FileBackend, FileDescription, EACCES, EBADF, EINVAL, ENODEV, EOVERFLOW};
+use vibix::mem::pf::{MAP_ANONYMOUS, MAP_PRIVATE, MAP_SHARED, PROT_READ, PROT_WRITE};
 use vibix::mem::vmatree::{ProtUser, Share};
 use vibix::mem::vmobject::{AnonObject, VmObject};
 use vibix::{
@@ -184,12 +180,7 @@ impl FileOps for DefaultFileOps {}
 /// Build a fresh `OpenFile` against an inode of the requested kind
 /// using the requested `FileOps`. Inserts the resulting `VfsBackend`
 /// into the current task's fd table and returns the allocated fd.
-fn install_fd(
-    kind: InodeKind,
-    file_ops: Arc<dyn FileOps>,
-    open_flags: u32,
-    file_size: u64,
-) -> u32 {
+fn install_fd(kind: InodeKind, file_ops: Arc<dyn FileOps>, open_flags: u32, file_size: u64) -> u32 {
     let sb = Arc::new(SuperBlock::new(
         FsId(746),
         Arc::new(StubSuperOps),
@@ -246,12 +237,7 @@ fn file_mmap_dir_inode_enodev() {
     // A directory inode is not mmappable per RFC 0007 §Errno table —
     // sys_mmap pre-empts FileOps::mmap with ENODEV regardless of what
     // the FS impl returns.
-    let fd = install_fd(
-        InodeKind::Dir,
-        Arc::new(MmapableOps),
-        flags::O_RDWR,
-        0,
-    );
+    let fd = install_fd(InodeKind::Dir, Arc::new(MmapableOps), flags::O_RDWR, 0);
     let r = mmap(0, 4096, PROT_READ, MAP_PRIVATE, fd as i64, 0);
     assert_eq!(
         r, ENODEV,
@@ -281,34 +267,19 @@ fn file_mmap_default_fileops_propagates_enodev() {
 // ── Tests: EINVAL / EOVERFLOW gates ───────────────────────────────────
 
 fn file_mmap_unaligned_off_einval() {
-    let fd = install_fd(
-        InodeKind::Reg,
-        Arc::new(MmapableOps),
-        flags::O_RDWR,
-        4096,
-    );
+    let fd = install_fd(InodeKind::Reg, Arc::new(MmapableOps), flags::O_RDWR, 4096);
     let r = mmap(0, 4096, PROT_READ, MAP_PRIVATE, fd as i64, 0x100);
     assert_eq!(r, EINVAL, "non-aligned off must trip EINVAL, got {}", r);
 }
 
 fn file_mmap_zero_len_einval() {
-    let fd = install_fd(
-        InodeKind::Reg,
-        Arc::new(MmapableOps),
-        flags::O_RDWR,
-        4096,
-    );
+    let fd = install_fd(InodeKind::Reg, Arc::new(MmapableOps), flags::O_RDWR, 4096);
     let r = mmap(0, 0, PROT_READ, MAP_PRIVATE, fd as i64, 0);
     assert_eq!(r, EINVAL, "len=0 must trip EINVAL, got {}", r);
 }
 
 fn file_mmap_off_plus_len_overflow_eoverflow() {
-    let fd = install_fd(
-        InodeKind::Reg,
-        Arc::new(MmapableOps),
-        flags::O_RDWR,
-        4096,
-    );
+    let fd = install_fd(InodeKind::Reg, Arc::new(MmapableOps), flags::O_RDWR, 4096);
     // off near i64::MAX + a multi-page len overflows i64 → EOVERFLOW.
     let near_max = (i64::MAX as u64) & !0xFFF;
     let r = mmap(0, 8192, PROT_READ, MAP_PRIVATE, fd as i64, near_max);
@@ -323,20 +294,8 @@ fn file_mmap_off_plus_len_overflow_eoverflow() {
 
 fn file_mmap_shared_write_on_rdonly_eacces() {
     // MAP_SHARED + PROT_WRITE requires O_RDWR. O_RDONLY → EACCES.
-    let fd = install_fd(
-        InodeKind::Reg,
-        Arc::new(MmapableOps),
-        flags::O_RDONLY,
-        4096,
-    );
-    let r = mmap(
-        0,
-        4096,
-        PROT_READ | PROT_WRITE,
-        MAP_SHARED,
-        fd as i64,
-        0,
-    );
+    let fd = install_fd(InodeKind::Reg, Arc::new(MmapableOps), flags::O_RDONLY, 4096);
+    let r = mmap(0, 4096, PROT_READ | PROT_WRITE, MAP_SHARED, fd as i64, 0);
     assert_eq!(
         r, EACCES,
         "MAP_SHARED+PROT_WRITE on O_RDONLY must trip EACCES, got {}",
@@ -347,20 +306,8 @@ fn file_mmap_shared_write_on_rdonly_eacces() {
 fn file_mmap_shared_write_on_wronly_eacces() {
     // MAP_SHARED + PROT_WRITE on O_WRONLY → EACCES (write-fault path
     // can't service the read-on-miss).
-    let fd = install_fd(
-        InodeKind::Reg,
-        Arc::new(MmapableOps),
-        flags::O_WRONLY,
-        4096,
-    );
-    let r = mmap(
-        0,
-        4096,
-        PROT_READ | PROT_WRITE,
-        MAP_SHARED,
-        fd as i64,
-        0,
-    );
+    let fd = install_fd(InodeKind::Reg, Arc::new(MmapableOps), flags::O_WRONLY, 4096);
+    let r = mmap(0, 4096, PROT_READ | PROT_WRITE, MAP_SHARED, fd as i64, 0);
     assert_eq!(
         r, EACCES,
         "MAP_SHARED+PROT_WRITE on O_WRONLY must trip EACCES, got {}",
@@ -371,20 +318,8 @@ fn file_mmap_shared_write_on_wronly_eacces() {
 fn file_mmap_private_write_on_wronly_eacces() {
     // MAP_PRIVATE + PROT_WRITE on O_WRONLY → EACCES (CoW needs to
     // read the master page first).
-    let fd = install_fd(
-        InodeKind::Reg,
-        Arc::new(MmapableOps),
-        flags::O_WRONLY,
-        4096,
-    );
-    let r = mmap(
-        0,
-        4096,
-        PROT_READ | PROT_WRITE,
-        MAP_PRIVATE,
-        fd as i64,
-        0,
-    );
+    let fd = install_fd(InodeKind::Reg, Arc::new(MmapableOps), flags::O_WRONLY, 4096);
+    let r = mmap(0, 4096, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd as i64, 0);
     assert_eq!(
         r, EACCES,
         "MAP_PRIVATE+PROT_WRITE on O_WRONLY must trip EACCES, got {}",
@@ -398,14 +333,13 @@ fn file_mmap_private_read_succeeds() {
     // MAP_PRIVATE + PROT_READ on a Reg file with a custom FileOps::mmap
     // impl: sys_mmap calls the impl, gets back an `Arc<dyn VmObject>`,
     // and lands a VMA at the chosen VA.
-    let fd = install_fd(
-        InodeKind::Reg,
-        Arc::new(MmapableOps),
-        flags::O_RDONLY,
-        4096,
-    );
+    let fd = install_fd(InodeKind::Reg, Arc::new(MmapableOps), flags::O_RDONLY, 4096);
     let r = mmap(0, 4096, PROT_READ, MAP_PRIVATE, fd as i64, 0);
-    assert!(r > 0, "file-backed MAP_PRIVATE+PROT_READ must succeed, got {}", r);
+    assert!(
+        r > 0,
+        "file-backed MAP_PRIVATE+PROT_READ must succeed, got {}",
+        r
+    );
     let va = r as u64;
     assert_eq!(va & 0xFFF, 0, "returned VA must be page-aligned: {:#x}", va);
     // VMA must be visible in the current address space.
@@ -421,20 +355,8 @@ fn file_mmap_private_read_succeeds() {
 fn file_mmap_shared_rdwr_succeeds() {
     // MAP_SHARED + PROT_WRITE on O_RDWR — the only combination the
     // EACCES gate permits with PROT_WRITE.
-    let fd = install_fd(
-        InodeKind::Reg,
-        Arc::new(MmapableOps),
-        flags::O_RDWR,
-        8192,
-    );
-    let r = mmap(
-        0,
-        8192,
-        PROT_READ | PROT_WRITE,
-        MAP_SHARED,
-        fd as i64,
-        0,
-    );
+    let fd = install_fd(InodeKind::Reg, Arc::new(MmapableOps), flags::O_RDWR, 8192);
+    let r = mmap(0, 8192, PROT_READ | PROT_WRITE, MAP_SHARED, fd as i64, 0);
     assert!(r > 0, "MAP_SHARED+RW on O_RDWR must succeed, got {}", r);
     let va = r as u64;
     let aspace = vibix::task::current_address_space();

--- a/kernel/tests/syscall_open_mmap.rs
+++ b/kernel/tests/syscall_open_mmap.rs
@@ -72,8 +72,8 @@ fn run_tests() {
             &(mmap_requires_anon_private as fn()),
         ),
         (
-            "mmap_rejects_non_neg_fd",
-            &(mmap_rejects_non_neg_fd as fn()),
+            "mmap_anonymous_ignores_fd",
+            &(mmap_anonymous_ignores_fd as fn()),
         ),
         (
             "mmap_rejects_nonzero_off",
@@ -269,22 +269,28 @@ fn mmap_zero_len_einval() {
 }
 
 fn mmap_requires_anon_private() {
-    // Missing MAP_ANONYMOUS with fd=-1 → file-backed path is attempted
-    // and returns ENODEV (no VFS yet) per RFC 0001.
+    // Missing MAP_ANONYMOUS with fd=-1 → file-backed path is attempted.
+    // Under RFC 0007 (#746) the file-backed leg first looks up the fd;
+    // -1 is not a valid fd, so the gate trips with EBADF (the "fd not
+    // open" branch of the errno table). Pre-746, fd != -1 short-circuited
+    // to ENODEV; the new errno table is single-source.
     let r = mmap(0, 4096, PROT_READ, MAP_PRIVATE, -1, 0);
     assert_eq!(
-        r, ENODEV,
-        "MAP_PRIVATE without MAP_ANONYMOUS routes to file-backed path: ENODEV"
+        r, EBADF,
+        "MAP_PRIVATE without MAP_ANONYMOUS at fd=-1 must trip EBADF (RFC 0007 §Errno table)"
     );
     // Neither MAP_PRIVATE nor MAP_SHARED → EINVAL.
     let r = mmap(0, 4096, PROT_READ, MAP_ANONYMOUS, -1, 0);
     assert_eq!(r, EINVAL);
 }
 
-fn mmap_rejects_non_neg_fd() {
-    // fd != -1 routes to the (unsupported) file-backed path → ENODEV.
+fn mmap_anonymous_ignores_fd() {
+    // RFC 0007 §Kernel-Userspace Interface: MAP_ANONYMOUS ignores `fd`
+    // per Linux semantics. The file-backed errno table does not apply
+    // when MAP_ANONYMOUS is set, so passing a non-negative fd does NOT
+    // fail with ENODEV/EBADF — the syscall succeeds.
     let r = mmap(0, 4096, PROT_READ, MAP_ANONYMOUS | MAP_PRIVATE, 0, 0);
-    assert_eq!(r, ENODEV);
+    assert!(r > 0, "MAP_ANONYMOUS|MAP_PRIVATE must ignore fd, got {}", r);
 }
 
 fn mmap_rejects_nonzero_off() {


### PR DESCRIPTION
Closes #746

## Summary

- Drops the `fd != -1 ⇒ ENODEV` short-circuit in `sys_mmap` and rewires it per RFC 0007 §Kernel-Userspace Interface (Workstream B of epic #734).
- New errno table: EBADF, ENODEV (non-mmappable inode kind / non-VFS backend), EACCES (MAP_SHARED+PROT_WRITE without O_RDWR; MAP_PRIVATE+PROT_WRITE on O_WRONLY), EINVAL (off non-aligned, len 0), EOVERFLOW (off+len overflow against i64).
- `MAP_ANONYMOUS` ignores `fd` per Linux semantics.
- `MAP_FIXED` / `MAP_FIXED_NOREPLACE` semantics preserved.
- File-backed leg dispatches to `FileOps::mmap` (default `ENODEV`); the returned `Arc<dyn VmObject>` (a `FileObject` from the per-FS impl) is plugged into the VMA tree at `object_offset = 0` since the FileObject snapshots the file_offset window internally.
- The pure errno gate (`validate_file_mmap_args`) is extracted into `mem::pf` so host unit tests can drive every rejection branch without IDT/task plumbing.

## Test plan

- [x] `cargo xtask build`
- [x] `cargo test --package vibix --lib --features ext2` — 613 host unit tests pass (9 new: `mem::pf::tests::file_mmap_errno::*`)
- [x] `cargo test --target x86_64-unknown-none -p vibix --test syscall_mmap_file_backed --features ext2` — 12 new integration tests for the file-backed path
- [x] `cargo test --target x86_64-unknown-none -p vibix --test syscall_mmap_family --features ext2` — 14 existing mmap tests still pass after `mmap_fd_nonneg_enodev` semantics flip
- [x] `cargo test --target x86_64-unknown-none -p vibix --test syscall_open_mmap --features ext2` — 14 existing tests still pass (`mmap_rejects_non_neg_fd` renamed to `mmap_anonymous_ignores_fd`; `mmap_requires_anon_private` updated to expect EBADF instead of ENODEV)
- [x] `cargo xtask smoke` — all 42 markers present
- [ ] `cargo xtask test` — note: `blocking_sync::rwlock_concurrent_readers` is a pre-existing flake on `main` (verified by stashing this PR's changes and re-running); unrelated to the mmap rewire

## Notes

- The integration test uses a synthesized in-memory `FileOps::mmap` impl, not ext2 — issue #753 (ext2 `FileOps::mmap`) has not landed yet. The default `FileOps::mmap` still returns ENODEV; `file_mmap_default_fileops_propagates_enodev` pins the propagation contract that ext2 currently relies on.
- The `OpenFile.f_mode` snapshot onto the returned `FileObject` is the per-FS impl's responsibility (RFC 0007 §FileObject). `sys_mmap` reads `OpenFile.flags & O_ACCMODE` for the EACCES gate, but the value is also threaded into `FileOps::mmap` via the `&OpenFile` argument so each FS impl can stash it on its returned `FileObject`.

## Out of scope

- `mprotect` extension (consults `FileObject.open_mode` for PROT_WRITE upgrade rules) — separate Workstream B issue.
- ext2 / ramfs / tarfs `FileOps::mmap` overrides — issues #747 / #751 / #753.
- Eviction, writeback, and CoW resolver wiring through `private_frames` — issues #739 / #740 / #742.