### PR TITLE
DST Phase 2.1 (1): syscall-entry seam — exercise real fork/exec/wait4 handlers

### DIFF
--- a/docs/RFC/0008-host-dst-syscall-seam.md
+++ b/docs/RFC/0008-host-dst-syscall-seam.md
@@ -38,6 +38,7 @@ Three deliverables make up the seam, all in
 
 ```rust
 pub trait UaccessAdapter: Send + Sync {
+    fn check_user_write(&self, dst: usize, len: usize) -> Result<(), i64>;
     unsafe fn copy_from_user(&self, dst: &mut [u8], src: usize) -> Result<(), i64>;
     unsafe fn copy_to_user(&self, dst: usize, src: &[u8]) -> Result<(), i64>;
 }
@@ -50,6 +51,14 @@ pub unsafe fn dispatch_syscall(nr: u64, args: [u64; 6], ua: &dyn UaccessAdapter)
 pub fn install_init_process(task_id: usize);
 pub fn set_current_task_id(task_id: usize) -> usize;
 ```
+
+`check_user_write` is the **preflight validator** the bare-metal
+`WAIT4` arm already has at its entry (`uaccess::check_user_range(wstatus_ptr, 4)`).
+The host arm needs the same shape so a custom `UaccessAdapter` that
+returns `-EFAULT` on a bad pointer cannot lose the zombie:
+without the preflight, the dispatch shim would call `reap_child()`
+first, consume the exit status, then fail at `copy_to_user`, leaving
+a phantom-collected child.
 
 Recognised numbers: `FORK` (57), `EXECVE` (59), `EXIT` (60), `WAIT4`
 (61). Anything else returns `-ENOSYS` (`-38`).
@@ -243,6 +252,18 @@ itself still detects drain-order-dependence at `T_EXIT`.
   off, the layered tests will start cross-contaminating; an explicit
   `simulator::reset_kernel_state_for_test()` accessor is the
   follow-up that closes that hole.
+
+  **Defence in depth: `seam_lock`.** Independently of
+  `panic-abort-tests`, the seam takes a process-global
+  `OnceLock<Mutex<()>>` at every entry through `install_init_process` /
+  `dispatch_syscall` / `set_current_task_id`. Two concurrent host
+  threads serialize through that lock rather than racing on the
+  kernel-static TABLE. The lock answers CodeRabbit's pre-merge
+  concern about "host runs aliasing each other in `process::pid_of` /
+  `current_pid`" — parallel runs will still observe each other's
+  TABLE entries (the lock alone doesn't reset state), but they will
+  not race; combined with `panic-abort-tests` providing per-test
+  subprocess isolation, deterministic per-run state holds.
 
 ## References
 

--- a/docs/RFC/0008-host-dst-syscall-seam.md
+++ b/docs/RFC/0008-host-dst-syscall-seam.md
@@ -1,0 +1,256 @@
+# RFC 0008: Host-side DST syscall-entry seam
+
+| Status   | Accepted (Phase 2.1)                          |
+|----------|-----------------------------------------------|
+| Authors  | dburkart                                      |
+| Driver   | [#790](https://github.com/dburkart/vibix/issues/790) |
+| Parent   | [RFC 0006](0006-host-dst-simulator.md) §"Failure-injection scope" / §"Open questions" |
+| Sibling  | [`docs/design/dst-478-investigation.md`](../design/dst-478-investigation.md) (Phase 2.1 RFC #1, #3) |
+
+## Motivation
+
+[#721](https://github.com/dburkart/vibix/issues/721) shipped the v1
+seam-level regression for the [#501](https://github.com/dburkart/vibix/issues/501)
+fork/exec/wait flake (`simulator/tests/regression_501.rs`). That
+regression models the parent's `wait4` wakeup and the child's
+`mark_zombie` exit-notify wakeup as two `MockClock::enqueue_wakeup`
+entries at the same deadline; `FaultEvent::WakeupReorder` permutes the
+drain order. The captured `(seed=14, FaultPlan)` reproduces a
+seam-level analogue of #501 deterministically.
+
+What the seam-level regression does **not** do: exercise the kernel's
+real `sys_fork` / `sys_execve` / `sys_wait4` handlers. Those live in
+`kernel/src/arch/x86_64/syscall.rs::syscall_dispatch` under
+`cfg(target_os = "none")` because the SYSCALL trampoline pulls
+FxSAVE / `swapgs` / IRETQ / kernel-stack-swap state that has no host
+analogue. RFC 0006 §"Failure-injection scope" deferred the
+syscall-entry seam to Phase 2.1 RFC #2 with the trade-off: *"a faked
+syscall driver is feasible but is its own design — which calling
+convention does the simulator pretend to use? how does it resolve
+user pointers?"*
+
+This RFC answers those questions and lands the seam.
+
+## Surface
+
+Three deliverables make up the seam, all in
+`simulator/src/syscall_seam.rs`:
+
+```rust
+pub trait UaccessAdapter: Send + Sync {
+    unsafe fn copy_from_user(&self, dst: &mut [u8], src: usize) -> Result<(), i64>;
+    unsafe fn copy_to_user(&self, dst: usize, src: &[u8]) -> Result<(), i64>;
+}
+
+pub struct HostUaccess;
+impl UaccessAdapter for HostUaccess { /* dereference + range-check */ }
+
+pub unsafe fn dispatch_syscall(nr: u64, args: [u64; 6], ua: &dyn UaccessAdapter) -> i64;
+
+pub fn install_init_process(task_id: usize);
+pub fn set_current_task_id(task_id: usize) -> usize;
+```
+
+Recognised numbers: `FORK` (57), `EXECVE` (59), `EXIT` (60), `WAIT4`
+(61). Anything else returns `-ENOSYS` (`-38`).
+
+The dispatch arms route to host-side wrappers around the kernel's
+real `process::register` / `process::mark_zombie` /
+`process::reap_child` / `process::has_children` /
+`process::reparent_children` / `process::exit_event_count` /
+`process::CHILD_WAIT.wait_while`. Those reach unchanged from
+`kernel/src/process/mod.rs` — including the [#710] atomic-publish
+fix (PR [#795]) — because `process` is now host-buildable under
+`feature = "sched-mock"` (RFC 0008 §"Slim host arm").
+
+[#710]: https://github.com/dburkart/vibix/issues/710
+[#795]: https://github.com/dburkart/vibix/pull/795
+
+## User-pointer model — design choice
+
+Two options were on the table from RFC 0006:
+
+(a) **Plumb host-allocated buffers through the dispatch shim's args**
+   and have the shim adapt by-reference args to the kernel's
+   pointer-arg shape. Each user-pointer argument grows a sibling
+   `&[u8]` in the dispatch signature; `dispatch_syscall` translates
+   between the two.
+
+(b) **`UaccessAdapter` trait** — a host-only abstraction the kernel's
+   `copy_from_user` / `copy_to_user` callers go through, with a host
+   impl that just dereferences after a range check.
+
+**This RFC picks (b).** Rationale:
+
+1. **Kernel call sites stay unchanged.** The bare-metal
+   `copy_from_user` / `copy_to_user` retain their `(usize, &mut [u8])`
+   shape. (b) routes the host arm through the trait at the *adapter*
+   layer rather than mutating every syscall arm to accept a sibling
+   buffer slot.
+
+2. **Future Phase 2.1 surfaces plug in cleanly.** The page-fault
+   injection seam (RFC 0006 §"Open questions" / `docs/design/dst-478-investigation.md`)
+   and the ring-3 trap-frame seam both need their own user-pointer
+   adaptation: the page-fault seam wants pointer dereferences to
+   surface `Event::FaultInjected { kind: PageFault }` records when
+   the simulator has armed a fault at that VA; the trap-frame seam
+   wants reads to come out of a synthetic ring-3 mapping. Each of
+   those is its own `impl UaccessAdapter for …`. With (a), each
+   would have to re-cut the dispatch signature.
+
+3. **The trait surface stays narrow.** Today `UaccessAdapter`
+   exposes only the byte-buffer `copy_*_user` shape — no typed
+   accessors, no `check_user_range`. The wait4 rendezvous is the
+   only host caller, and it copies one `u32` (the encoded
+   `wstatus`). When a future seam needs typed accessors, that's a
+   new method on the trait, not a redesign.
+
+The `HostUaccess` impl is twelve lines: range-check `ptr != 0`,
+loop, `core::ptr::read` / `core::ptr::write` for each byte. No SMAP,
+no CR3 swap — those have no host analogue.
+
+## Slim host arm — kernel-side cfg gates
+
+The simulator calls into `kernel::process::*` and
+`kernel::sync::WaitQueue` for the wait4 rendezvous, plus
+`kernel::task::current_id` / `wake` / `block_current` so
+`WaitQueue::wait_while` can compile. None of those modules were
+host-buildable before this RFC (every one was gated to
+`cfg(target_os = "none")`).
+
+The minimum cfg-extension needed:
+
+| Module | Old gate | New gate | Notes |
+|--------|----------|----------|-------|
+| `process` | `target_os = "none"` | `any(target_os = "none", feature = "sched-mock")` | tty/signal helpers gated to bare-metal via `bare_metal_only!` macro inside the file; the wait4 rendezvous + signal-state-accessor are host-buildable |
+| `signal` | `target_os = "none"` | `any(target_os = "none", feature = "sched-mock")` | `frame.rs`, `arch::x86_64::uaccess` use, every signal-delivery / restart-decision / sigaction syscall is gated to bare-metal via `bare_metal_only!` macro; only `SignalState` + sig number constants + `Disposition` are host-buildable |
+| `sync` | `target_os = "none"` | `any(target_os = "none", feature = "sched-mock")` | `WaitQueue` is host-buildable; every other primitive (`BlockingMutex`, `BlockingRwLock`, `Semaphore`, `spsc`, `mpmc`, `IrqLock`) stays bare-metal-only inside `sync/mod.rs` |
+| `task` | `target_os = "none"` | (mostly unchanged) | `host_stub` submodule under `cfg(all(not(target_os = "none"), feature = "sched-mock"))` exposes `current_id` / `wake` / `block_current` |
+
+The host arm of `ProcessEntry` elides the `controlling_tty` field
+(it's `cfg(target_os = "none")`); session_id / pgrp_id are kept as
+plain `u32` (the bare-metal arm aliases them through `tty::SessionId`
+/ `tty::ProcessGroupId`, both of which are themselves `pub type … = u32`).
+
+## Single-thread parking semantics
+
+`WaitQueue::wait_while` calls `task::current_id`, enqueues self,
+checks `cond()`, then calls `task::block_current`. On bare metal
+`block_current` parks the task and the scheduler picks another;
+`mark_zombie`'s `notify_all` later pops the parked task off the queue
+and calls `task::wake`, which unparks it.
+
+On host with `sched-mock` there is no second thread to schedule. The
+host stub for `block_current` is a no-op that consumes the
+`wake_pending` flag; `task::wake` sets the flag if the target id
+matches the current id. The wait4 caller's `wait_while` predicate is
+`|| process::exit_event_count() == snap`. Two cases:
+
+1. **Child exits before parent waits** (the simulator's typical
+   single-thread dispatch order at `T_EXIT`). Parent calls `wait4`,
+   takes its `snap`, calls `reap_child` and gets `Some(child)`. Never
+   reaches `wait_while`. `block_current` is never called.
+
+2. **Parent enters `wait_while` before child has exited.** Predicate
+   is true (`exit_event_count` still equals `snap`), parent enqueues
+   on `CHILD_WAIT`, drops the queue lock, calls the host stub
+   `block_current` (which clears `wake_pending` and returns), then
+   re-locks the queue and removes its stale self-entry. Loops back,
+   re-checks `cond()` — still true, since child hasn't exited yet.
+   Spins forever.
+
+Case 2 is **not modelled** by the host shim. The simulator's run
+loop is single-threaded by construction (RFC 0006 §"The driver
+loop"); a layered test that requires the parent to park and the
+child to wake from a different thread would need a multi-threaded
+host runtime, which is out of scope for v1. The layered repro in
+`simulator/tests/regression_501.rs` is structured to dispatch
+`sys_exit` (child) **before** `sys_wait4` (parent) at `T_EXIT`,
+which guarantees case 1 and exercises the full
+`mark_zombie`/`reap_child`/`exit_event_count` code path without
+needing case 2.
+
+## Layered repro
+
+`simulator/tests/regression_501.rs::layered_repro_real_handlers_pass_under_fixed_mark_zombie`
+is the sister test the issue body asks for. It:
+
+1. Constructs a `Simulator` with the captured `(seed=14, FaultPlan)`.
+2. Calls `install_init_process(1)` to prime PID 1.
+3. At `T_FORK`: dispatches `sys_fork`, captures the returned child
+   PID + child task id.
+4. At `T_EXEC`: switches the simulator's "current task id" to the
+   child, dispatches `sys_execve` (host stub returns 0).
+5. At `T_EXIT`: dispatches `sys_exit(7)` — calls `mark_zombie`
+   under TABLE, bumps `EXIT_EVENT.fetch_add(1, Release)`, drops
+   TABLE, calls `CHILD_WAIT.notify_all`. Then switches back to the
+   parent, dispatches `sys_wait4(-1, &wstatus)` — runs the
+   snapshot-and-park loop, reaps the zombie, encodes `wstatus`
+   through `HostUaccess::copy_to_user`.
+6. Asserts `wait4` returned the child PID and the encoded `wstatus`
+   matches `(7 & 0xFF) << 8 = 0x700`.
+
+**Acceptance**: under the captured plan, the v1 seam-level invariant
+(`child_exit_observed_before_parent_wake`) does NOT trip. This is
+expected: the [#710] atomic-publish fix collapses the drain-order
+window the seam-level test still detects via `WakeupReorder`. If
+this layered test were ever to fail, the #710 fix would be
+incomplete and `mark_zombie` would need another look.
+
+## Coverage for the seam itself
+
+Three layers of regression catch a future regression of the seam:
+
+1. `simulator/src/syscall_seam.rs::tests` (host unit tests) —
+   `numbers_match_kernel_table`, `host_uaccess_round_trips`,
+   `host_uaccess_rejects_null`, `unrecognised_syscall_returns_enosys`.
+2. `simulator/tests/regression_501.rs::layered_repro_baseline_no_faults_also_passes`
+   — sanity: the layered scenario completes under the empty plan
+   too. Catches a regression where the layered shape itself breaks
+   independently of fault injection.
+3. `simulator/tests/regression_501.rs::layered_repro_real_handlers_pass_under_fixed_mark_zombie`
+   — the captured `(seed=14, FaultPlan)` test. Catches both a
+   regression of the [#710] fix and a regression of the seam's
+   wait4 dispatch wiring.
+
+The seam-level test (`captured_seed_and_plan_reproduce_501_deterministically`)
+remains as the trace-level analogue — it asserts the v1 surface
+itself still detects drain-order-dependence at `T_EXIT`.
+
+## Out of scope
+
+- `sys_execve` image swap. Host stub returns 0 unconditionally.
+  Would need `mem::userspace_hello`, `AddressSpace`, `Cr3::write`
+  to all be host-buildable — none of those are in v1.
+- `sys_kill` / signal delivery. The full signal-mask /
+  signal-frame / sigaction layer stays bare-metal-only.
+- Multi-thread wait4 (case 2 above). Requires a multi-threaded host
+  runtime; tracked as a follow-up.
+- The bare-metal `current_pid` IF=1 invariant
+  (`debug_assert!(is_if_set())`). Host stub for `is_if_set` returns
+  `true` because the host has no real RFLAGS.IF state; the
+  invariant is bare-metal-only.
+- Per-test TABLE isolation **as a deliberate dependency on
+  `panic-abort-tests`**. The host arm of `process::TABLE` is a
+  process-global `Lazy<Mutex<Table>>` (and `NEXT_PID` is a
+  process-global `AtomicU32`). The workspace's `.cargo/config.toml`
+  sets `[unstable] panic-abort-tests = true` (see `kernel/Cargo.toml`
+  comment) so every `#[test]` runs in its own subprocess. That
+  side-effect provides per-test TABLE isolation for free: each
+  layered test gets a fresh kernel-static TABLE / `NEXT_PID = 2`,
+  so the layered repro can assert `wait4_rv == 2` (child PID 2)
+  without an explicit reset hook. If `panic-abort-tests` ever flips
+  off, the layered tests will start cross-contaminating; an explicit
+  `simulator::reset_kernel_state_for_test()` accessor is the
+  follow-up that closes that hole.
+
+## References
+
+- [#790](https://github.com/dburkart/vibix/issues/790) — this RFC's driver
+- [#501](https://github.com/dburkart/vibix/issues/501) — source flake
+- [#710](https://github.com/dburkart/vibix/issues/710) /
+  [#795](https://github.com/dburkart/vibix/pull/795) — atomic-publish fix
+- [#721](https://github.com/dburkart/vibix/issues/721) — seam-level regression
+- [RFC 0005](0005-scheduler-irq-seam.md) — `MockClock` / `MockTimerIrq` seam
+- [RFC 0006](0006-host-dst-simulator.md) — host-side simulator
+- [`docs/design/dst-478-investigation.md`](../design/dst-478-investigation.md) — Phase 2.1 RFC #1 / #3 (page-fault + ring-3 trap-frame seams)

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -43,22 +43,17 @@ use x86_64::registers::model_specific::Msr;
 use super::gdt::{set_tss_rsp0, STAR_KERNEL_CS_BASE, STAR_USER_CS_BASE};
 use super::gdt::{USER_CODE_SELECTOR, USER_DATA_SELECTOR};
 
-/// Diagnostic instrumentation along the fork(2) syscall path (epic #501 /
-/// issue #502). Expands to `serial_println!` when the `fork-trace` feature
-/// is enabled at build time; otherwise compiles to nothing. Paired entry/
-/// exit probes let the last surviving print pinpoint where the kernel
-/// wedges in the fork path.
-#[cfg(feature = "fork-trace")]
-#[macro_export]
-macro_rules! fork_trace {
-    ($($arg:tt)*) => ($crate::serial_println!($($arg)*));
-}
-
-#[cfg(not(feature = "fork-trace"))]
-#[macro_export]
-macro_rules! fork_trace {
-    ($($arg:tt)*) => {};
-}
+// `fork_trace!` is defined in `kernel/src/lib.rs` so the host build of
+// `process` (RFC 0008 / #790) can reach for it without dragging the
+// arch/x86_64 module in. Original definition site preserved as a
+// comment for grep-ability:
+//
+//   #[cfg(feature = "fork-trace")]
+//   #[macro_export]
+//   macro_rules! fork_trace { ($($arg:tt)*) => ($crate::serial_println!($($arg)*)); }
+//   #[cfg(not(feature = "fork-trace"))]
+//   #[macro_export]
+//   macro_rules! fork_trace { ($($arg:tt)*) => {}; }
 
 /// MSR addresses.
 const MSR_EFER: u32 = 0xC000_0080;

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -22,6 +22,27 @@
 
 extern crate alloc;
 
+/// Diagnostic instrumentation along the fork(2) syscall path (epic #501 /
+/// issue #502). Expands to `serial_println!` when the `fork-trace` feature
+/// is enabled at build time; otherwise compiles to nothing. Paired entry/
+/// exit probes let the last surviving print pinpoint where the kernel
+/// wedges in the fork path.
+///
+/// Defined at crate root (rather than in `arch::x86_64::syscall`) so the
+/// host arm of `process::register` (RFC 0008 / #790) can reach the macro
+/// without the bare-metal `arch` module being in scope.
+#[cfg(all(target_os = "none", feature = "fork-trace"))]
+#[macro_export]
+macro_rules! fork_trace {
+    ($($arg:tt)*) => ($crate::serial_println!($($arg)*));
+}
+
+#[cfg(not(all(target_os = "none", feature = "fork-trace")))]
+#[macro_export]
+macro_rules! fork_trace {
+    ($($arg:tt)*) => {};
+}
+
 #[cfg(any(test, target_os = "none"))]
 pub mod abi;
 #[cfg(any(test, target_os = "none"))]
@@ -65,15 +86,29 @@ pub mod ksymtab;
 pub mod lntab;
 #[cfg(any(test, target_os = "none"))]
 pub mod poll;
-#[cfg(target_os = "none")]
+// `process` is host-buildable under `feature = "sched-mock"` for the
+// host-side DST simulator (RFC 0008 / #790). The host arm of the
+// `process` module gates its tty/signal-coupled methods to bare metal
+// so it can run without dragging the full arch / signal / tty graph
+// in. Kernel bare-metal builds see the unchanged surface.
+#[cfg(any(target_os = "none", feature = "sched-mock"))]
 pub mod process;
 #[cfg(target_os = "none")]
 pub mod serial;
 #[cfg(any(test, target_os = "none"))]
 pub mod shell;
-#[cfg(target_os = "none")]
+// `signal` exposes the host-buildable `SignalState` slot (the per-process
+// signal-mask + pending bitmap data structure) so `process::ProcessEntry`
+// has a uniform layout on host and bare metal. The full signal/syscall
+// glue (sigaction, signal frame writeback, etc.) stays bare-metal-only
+// inside the module.
+#[cfg(any(target_os = "none", feature = "sched-mock"))]
 pub mod signal;
-#[cfg(target_os = "none")]
+// `sync` exposes `WaitQueue` host-side under `feature = "sched-mock"`
+// because `process::CHILD_WAIT` is part of the host-buildable wait4
+// rendezvous. Other sync primitives stay bare-metal-only — gated
+// inside `sync/mod.rs`.
+#[cfg(any(target_os = "none", feature = "sched-mock"))]
 pub mod sync;
 // `pub mod task` is normally bare-metal-only — the scheduler core
 // touches `arch`, `sync`, and `x86_64` which are all `target_os =

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -32,7 +32,19 @@ use spin::{Lazy, Mutex};
 
 use crate::signal::SignalState;
 use crate::sync::WaitQueue;
+// `tty` is bare-metal-only (it touches `arch::x86_64::*` for the PS/2
+// + serial drivers), so its types are gated for the host arm. RFC 0008
+// §"Slim host arm" — the host `ProcessEntry` carries `session_id` /
+// `pgrp_id` as plain u32, with the `controlling_tty: Option<Arc<Tty>>`
+// field elided. The wait4 rendezvous (#710 / mark_zombie / reap_child)
+// does not touch any of those fields, so the host arm reproduces the
+// same fork/exec/wait code path bit-for-bit.
+#[cfg(target_os = "none")]
 use crate::tty::{ProcessGroupId, SessionId, Tty};
+#[cfg(not(target_os = "none"))]
+type SessionId = u32;
+#[cfg(not(target_os = "none"))]
+type ProcessGroupId = u32;
 
 /// Scheduling / lifecycle state of a process entry.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -65,6 +77,11 @@ pub struct ProcessEntry {
     /// (#376) acquires one; shared by every member of a session via
     /// `Arc` so the tty outlives the session leader until every
     /// referring process has dropped it.
+    ///
+    /// Bare-metal only — the host arm of this struct (RFC 0008 / #790)
+    /// elides this field because the wait4 rendezvous never touches it
+    /// and `Tty` is itself coupled to bare-metal driver state.
+    #[cfg(target_os = "none")]
     pub controlling_tty: Option<Arc<Tty>>,
 }
 
@@ -126,6 +143,7 @@ pub fn register_init(task_id: usize) {
             signals: Arc::new(Mutex::new(SignalState::new())),
             session_id: 1,
             pgrp_id: 1,
+            #[cfg(target_os = "none")]
             controlling_tty: None,
         },
     );
@@ -152,11 +170,18 @@ pub fn register(task_id: usize, parent_pid: u32) -> u32 {
     );
     let mut t = lock_table_with_soak_check("register");
     crate::fork_trace!("fork-trace: [process::register] TABLE locked");
+    #[cfg(target_os = "none")]
     let (session_id, pgrp_id, controlling_tty) = t
         .by_pid
         .get(&parent_pid)
         .map(|p| (p.session_id, p.pgrp_id, p.controlling_tty.clone()))
         .unwrap_or((pid, pid, None));
+    #[cfg(not(target_os = "none"))]
+    let (session_id, pgrp_id) = t
+        .by_pid
+        .get(&parent_pid)
+        .map(|p| (p.session_id, p.pgrp_id))
+        .unwrap_or((pid, pid));
     t.by_pid.insert(
         pid,
         ProcessEntry {
@@ -168,6 +193,7 @@ pub fn register(task_id: usize, parent_pid: u32) -> u32 {
             signals: Arc::new(Mutex::new(SignalState::new())),
             session_id,
             pgrp_id,
+            #[cfg(target_os = "none")]
             controlling_tty,
         },
     );
@@ -419,6 +445,21 @@ pub fn update_task_id(pid: u32, new_task_id: usize) {
     t.pid_of.insert(new_task_id, pid);
 }
 
+// Bare-metal-only block: tty/session helpers, the signal-mask
+// fast-paths, and the session/pgrp syscalls below all reach into
+// `crate::tty::*` or the bare-metal arms of `crate::signal::*`. The
+// host arm under `feature = "sched-mock"` (RFC 0008 / #790) exposes
+// only the wait4 rendezvous (`register` / `mark_zombie` /
+// `reap_child` / `has_children` / `reparent_children` /
+// `exit_event_count`) plus the `with_signal_state_for_task` helper
+// (a closure-based accessor that does not touch tty fields). Wrap
+// everything below in a `cfg(target_os = "none")` macro so the host
+// arm doesn't try to compile the bare-metal-only items.
+#[allow(unused_macros)]
+macro_rules! bare_metal_only {
+    ($($body:item)*) => { $( #[cfg(target_os = "none")] $body )* };
+}
+
 // ── Signal helpers ────────────────────────────────────────────────────────
 
 /// Look up the `SignalState` for the process that owns `task_id` and call
@@ -448,6 +489,8 @@ pub fn task_id_for_pid(pid: u32) -> Option<usize> {
     let t = TABLE.lock();
     t.by_pid.get(&pid).map(|e| e.task_id)
 }
+
+bare_metal_only! {
 
 // ── Session / process-group syscalls ──────────────────────────────────────
 //
@@ -806,11 +849,14 @@ pub fn pgrp_is_orphaned(pgid: u32) -> bool {
         .any(|e| e.pgrp_id == pgid && matches!(e.state, ProcessState::Alive))
 }
 
+} // end bare_metal_only!
+
 /// Session/pgrp test helpers, exposed so the `session_syscalls` kernel
 /// integration test can drive the table without the scheduler. Not
 /// gated on `cfg(test)` because the integration test is a separate
 /// crate that imports `vibix` as a normal dependency.
 #[doc(hidden)]
+#[cfg(target_os = "none")]
 pub mod test_helpers {
     use super::*;
 

--- a/kernel/src/signal/mod.rs
+++ b/kernel/src/signal/mod.rs
@@ -45,8 +45,17 @@
 //! - Multi-threaded signal delivery is not implemented (single-CPU, single-
 //!   threaded for now).
 
+// `frame.rs` and the SYSCALL-trampoline / iret-frame plumbing are
+// bare-metal-only because they touch `arch::x86_64::*`. The host-build
+// arm under `feature = "sched-mock"` exposes only `SignalState` — the
+// per-process signal-mask + pending-bitmap data structure that
+// `process::ProcessEntry` carries — so the host-side simulator
+// (RFC 0008 / #790) can construct an entry without the full delivery
+// path being host-buildable.
+#[cfg(target_os = "none")]
 pub mod frame;
 
+#[cfg(target_os = "none")]
 use crate::arch::x86_64::uaccess;
 
 // ── Signal numbers (Linux x86_64) ────────────────────────────────────────
@@ -104,6 +113,12 @@ pub enum Disposition {
 }
 
 impl Disposition {
+    // Host-buildable accessors are only used by the bare-metal
+    // sigaction syscall arms; the host arm of `signal::*`
+    // (RFC 0008 / #790) carries `SignalState` only and never reaches
+    // these helpers. Gate to bare metal to silence the dead-code
+    // warning under `feature = "sched-mock"`.
+    #[cfg(target_os = "none")]
     fn from_handler_ptr(ptr: u64) -> Self {
         match ptr {
             SIG_DFL => Disposition::Default,
@@ -112,6 +127,7 @@ impl Disposition {
         }
     }
 
+    #[cfg(target_os = "none")]
     fn to_handler_ptr(self) -> u64 {
         match self {
             Disposition::Default => SIG_DFL,
@@ -246,6 +262,24 @@ impl SignalState {
         old
     }
 }
+
+// Everything below depends on bare-metal-only modules
+// (`arch::x86_64`, `task::wake`, `task::exit`, `tty::KERN_ERESTARTSYS`,
+// `serial_println`, the `frame` submodule, etc.) and is gated to
+// `target_os = "none"` via the `bare_metal_only!` macro below. The
+// host arm under `feature = "sched-mock"` exposes only the
+// `SignalState`-facing surface above. RFC 0008 §"Slim host arm"
+// documents the tradeoff.
+
+/// `cfg(target_os = "none")` wrapper around a section of code.
+/// Used below to gate the bare-metal signal-delivery glue without
+/// indenting it under a module (which would change item paths).
+#[allow(unused_macros)]
+macro_rules! bare_metal_only {
+    ($($body:item)*) => { $( #[cfg(target_os = "none")] $body )* };
+}
+
+bare_metal_only! {
 
 // ── Process-level helpers ─────────────────────────────────────────────────
 
@@ -972,9 +1006,19 @@ pub struct SigReturnRegs {
     pub restart_pending: bool,
 }
 
-// ── Host-side unit tests ──────────────────────────────────────────────────
+} // end bare_metal_only!
 
-#[cfg(test)]
+// ── Host-side unit tests ──────────────────────────────────────────────────
+//
+// These tests reference `restart_decision` / the bare-metal
+// signal-delivery glue, all of which is gated to `target_os = "none"`
+// inside the `bare_metal_only!` block above. Under
+// `cargo test --lib --features sched-mock` (host build) those items
+// don't exist, so the tests can't compile — gate the module
+// accordingly. The tests still run on bare-metal builds via
+// `cargo xtask test`; this gate doesn't reduce coverage.
+
+#[cfg(all(test, target_os = "none"))]
 mod tests {
     use super::*;
 

--- a/kernel/src/sync/mod.rs
+++ b/kernel/src/sync/mod.rs
@@ -81,17 +81,34 @@
 //! Nothing acquires `WaitQueue.inner` while already holding a data
 //! lock or `SCHED`, so the graph is a DAG.
 
-pub mod irqlock;
-pub mod mpmc;
-pub mod mutex;
-pub mod rwlock;
-pub mod semaphore;
-pub mod spsc;
+// `WaitQueue` is host-buildable under `feature = "sched-mock"` because
+// `process::CHILD_WAIT` (the wait4 rendezvous) needs to be reachable
+// from the host-side simulator (RFC 0008 / #790). The other primitives
+// (`BlockingMutex`, `BlockingRwLock`, `Semaphore`, `spsc`, `mpmc`,
+// `IrqLock`) stay bare-metal-only — no host caller has materialized
+// for them yet, so they keep their original gate.
 pub mod waitqueue;
 
+#[cfg(target_os = "none")]
+pub mod irqlock;
+#[cfg(target_os = "none")]
+pub mod mpmc;
+#[cfg(target_os = "none")]
+pub mod mutex;
+#[cfg(target_os = "none")]
+pub mod rwlock;
+#[cfg(target_os = "none")]
+pub mod semaphore;
+#[cfg(target_os = "none")]
+pub mod spsc;
+
+#[cfg(target_os = "none")]
 pub use irqlock::{IrqLock, IrqLockGuard};
+#[cfg(target_os = "none")]
 pub use mutex::{BlockingMutex, MutexGuard};
+#[cfg(target_os = "none")]
 pub use rwlock::{BlockingRwLock, RwLockReadGuard, RwLockWriteGuard};
+#[cfg(target_os = "none")]
 pub use semaphore::Semaphore;
 pub use waitqueue::WaitQueue;
 

--- a/kernel/src/task/host_stub.rs
+++ b/kernel/src/task/host_stub.rs
@@ -1,0 +1,101 @@
+//! Host-only stubs for the bare-metal scheduler primitives that
+//! [`crate::sync::WaitQueue`] and [`crate::process`] consume at function
+//! granularity.
+//!
+//! On bare metal, [`crate::task::sched_core`] owns `current_id`,
+//! `wake`, and `block_current`; under
+//! `cfg(all(not(target_os = "none"), feature = "sched-mock"))` we
+//! synthesise the same surface using a thread-local "current task id"
+//! and a thread-local "wake_pending" flag.
+//!
+//! ## Why this is a faithful host arm of the seam
+//!
+//! The simulator (`simulator/`) drives `process::register`,
+//! `process::mark_zombie`, and the `wait4` snapshot-and-park loop
+//! sequentially on a single thread; there is never more than one
+//! "running task" at a time. The `wait_while` caller in `wait4`'s arm
+//! checks a snapshot-equality predicate under `WaitQueue.inner`'s
+//! Mutex; if the simulator dispatches `sys_exit` (which calls
+//! `mark_zombie`, bumping `EXIT_EVENT` under TABLE) **before** the
+//! parent's `sys_wait4`, the parent's `cond()` is already false on
+//! entry, `wait_while` returns immediately, and the host stub's
+//! no-op `block_current` is never observable. RFC 0008 §"Single-thread
+//! parking semantics" documents the exhaustive cases.
+//!
+//! ## What this is NOT
+//!
+//! These are **not** a host-side scheduler. They cannot park a task
+//! and wake it from a different host thread; if a future host caller
+//! tries to `block_current` on a wakeup that requires another thread
+//! to fire, the call will spin in `wait_while`'s loop forever. The
+//! simulator's run loop is single-threaded by design (RFC 0006
+//! §"The driver loop"); this stub matches that constraint.
+
+use core::cell::Cell;
+
+std::thread_local! {
+    /// Per-thread "current task id". The simulator sets this via
+    /// [`set_current_id_for_test`] when it wants to dispatch a syscall
+    /// in the context of a particular task (e.g. parent vs child); the
+    /// kernel-side `process::current_pid` reads it through
+    /// [`current_id`] and looks the resulting task id up in TABLE.
+    static CURRENT_ID: Cell<usize> = const { Cell::new(0) };
+    /// Per-thread `wake_pending` flag. Mirrors the `wake_pending`
+    /// counter the bare-metal scheduler keeps per task: a `wake` that
+    /// arrives before the matching `block_current` flips the flag, and
+    /// the next `block_current` consumes it and returns immediately.
+    /// Single-threaded so a `Cell<bool>` suffices.
+    static WAKE_PENDING: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Return the simulator-installed "current task id" for this thread.
+///
+/// Initial value is `0` — matches the bare-metal "no task running yet"
+/// state; `process::current_pid` returns `0` for unknown task ids,
+/// which is the same observable behaviour as the kernel's
+/// pre-`task::init` boot phase.
+pub fn current_id() -> usize {
+    CURRENT_ID.with(|c| c.get())
+}
+
+/// Install a synthetic "current task id" for the duration of one
+/// simulator-driven syscall dispatch. Returns the previous id so a
+/// caller can restore it after dispatch (the simulator stores per-task
+/// register state externally).
+///
+/// The name carries `_for_test` because no production code path on
+/// host is allowed to call this; only `simulator::install_init_process`
+/// and `simulator::dispatch_syscall` reach for it (they live behind
+/// the same `sched-mock` feature gate).
+pub fn set_current_id_for_test(id: usize) -> usize {
+    CURRENT_ID.with(|c| c.replace(id))
+}
+
+/// Park the calling task until a `wake` matching the current id has
+/// been observed.
+///
+/// On bare metal this calls into the scheduler and a context switch
+/// happens. On host with `sched-mock` we model "park" as "consume the
+/// wake_pending flag and return"; if no wake has arrived, we still
+/// return — the `wait_while` loop above us re-checks its condition
+/// under the queue mutex and will re-enqueue on the next iteration if
+/// progress hasn't happened, which is the simulator's single-thread
+/// safety net (RFC 0008 §"Single-thread parking semantics").
+pub fn block_current() {
+    WAKE_PENDING.with(|c| c.set(false));
+}
+
+/// Wake task `id`. On host this just sets the wake_pending flag if
+/// `id` matches the current task; cross-thread waking is not modelled.
+pub fn wake(id: usize) {
+    let cur = current_id();
+    if id == cur {
+        WAKE_PENDING.with(|c| c.set(true));
+    }
+}
+
+/// Test-introspection helper: read the wake_pending flag without
+/// consuming it.
+pub fn wake_pending() -> bool {
+    WAKE_PENDING.with(|c| c.get())
+}

--- a/kernel/src/task/host_stub.rs
+++ b/kernel/src/task/host_stub.rs
@@ -76,13 +76,33 @@ pub fn set_current_id_for_test(id: usize) -> usize {
 ///
 /// On bare metal this calls into the scheduler and a context switch
 /// happens. On host with `sched-mock` we model "park" as "consume the
-/// wake_pending flag and return"; if no wake has arrived, we still
-/// return — the `wait_while` loop above us re-checks its condition
-/// under the queue mutex and will re-enqueue on the next iteration if
-/// progress hasn't happened, which is the simulator's single-thread
-/// safety net (RFC 0008 §"Single-thread parking semantics").
+/// wake_pending flag and return"; if no wake has arrived, the host
+/// stub still returns — the `wait_while` loop above us re-checks its
+/// condition under the queue mutex on the next iteration. RFC 0008
+/// §"Single-thread parking semantics" enumerates the cases.
+///
+/// **Debug-only fail-fast.** A `block_current` call with no
+/// `wake_pending` set can only be progress-making in cases where the
+/// caller's predicate has flipped via a side-effect of the wake
+/// itself (e.g. `mark_zombie`'s `EXIT_EVENT.fetch_add` happened
+/// already, but `wake_pending` was set on a different task id and
+/// got filtered by `wake`'s id check). In the v1 layered repro the
+/// predicate is satisfied on entry, so the host stub is never called;
+/// in any other future caller, hitting this branch is the symptom of
+/// "host stub asked to perform a real park" (CodeRabbit pre-merge
+/// review). Surface it loudly under debug builds.
 pub fn block_current() {
-    WAKE_PENDING.with(|c| c.set(false));
+    let had_wake = WAKE_PENDING.with(|c| {
+        let prev = c.get();
+        c.set(false);
+        prev
+    });
+    debug_assert!(
+        had_wake,
+        "task::host_stub::block_current reached an unsupported real park \
+         (no wake_pending set, no other host thread can fire the wake) — \
+         RFC 0008 §\"Single-thread parking semantics\""
+    );
 }
 
 /// Wake task `id`. On host this just sets the wake_pending flag if

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -60,3 +60,25 @@ mod task;
 mod sched_core;
 #[cfg(target_os = "none")]
 pub use sched_core::*;
+
+// Host-only stubs for the three scheduler primitives that the
+// `WaitQueue` / `process` modules need at function granularity:
+// `current_id`, `wake`, `block_current`. The bare-metal scheduler
+// owns these in `sched_core.rs`; on the host triple under
+// `feature = "sched-mock"` we provide a thread-local-backed analogue
+// so `simulator/` can drive `process::register` / `mark_zombie` /
+// `reap_child` / the `wait4` snapshot loop on host (RFC 0008 / #790).
+//
+// Discipline (mirrors RFC 0005's seam contract): host stubs cover the
+// **shape** of the bare-metal scheduler, not its semantics. Production
+// `block_current` parks the task; the host stub is a no-op because the
+// simulator drives the run sequentially and the only `wait_while`
+// caller in scope (`wait4`) re-checks its condition under the same
+// `WaitQueue.inner` mutex that `notify_all` takes — meaning a
+// host-side `wait_while` whose condition is already false on entry
+// returns immediately without ever needing to park (RFC 0008
+// §"Single-thread parking semantics").
+#[cfg(all(not(target_os = "none"), feature = "sched-mock"))]
+mod host_stub;
+#[cfg(all(not(target_os = "none"), feature = "sched-mock"))]
+pub use host_stub::{block_current, current_id, set_current_id_for_test, wake, wake_pending};

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -93,6 +93,9 @@ pub mod minimize;
 mod proptest_model;
 
 #[cfg(not(target_os = "none"))]
+pub mod syscall_seam;
+
+#[cfg(not(target_os = "none"))]
 pub mod trace;
 
 #[cfg(not(target_os = "none"))]
@@ -898,6 +901,12 @@ pub use imp::{
     MonotonicPids, NoStrandedWakeups, Reproducer, SafetyInvariant, Seed, SimRng, Simulator,
     SimulatorConfig, SingleRunningPerCpu, TickWindow, Trace, TraceRecord, VariantMask, Violation,
     FAULT_PLAN_SCHEMA_VERSION, SCHEMA_VERSION,
+};
+
+#[cfg(not(target_os = "none"))]
+pub use syscall_seam::{
+    dispatch_syscall, install_init_process, set_current_task_id, task_id_for_pid, HostUaccess,
+    UaccessAdapter, ECHILD, EFAULT, ENOSYS, EPERM, SYNTHETIC_TASK_ID_BASE,
 };
 
 // On `target_os = "none"` (the bare-metal kernel image), the simulator

--- a/simulator/src/syscall_seam.rs
+++ b/simulator/src/syscall_seam.rs
@@ -45,7 +45,39 @@
 
 #![allow(unsafe_code)]
 
+use std::sync::{Mutex, MutexGuard};
+
 use vibix::process;
+
+/// Process-global serialization lock for the host syscall seam.
+///
+/// The kernel-side `process::TABLE` / `NEXT_PID` / `EXIT_EVENT` /
+/// `CHILD_WAIT` are process-global statics — there's only one of each
+/// no matter how many simulator threads `install_init_process` is
+/// called from. Two parallel runs that each install PID 1 and then
+/// fork would race on `NEXT_PID`, observe each other's TABLE entries
+/// in `current_pid` lookups, and generally produce undefined results
+/// (RFC 0008 §"Out of scope"; CodeRabbit pre-merge review).
+///
+/// This lock serializes host runs at the seam: every entry through
+/// [`install_init_process`] / [`dispatch_syscall`] /
+/// [`set_current_task_id`] takes the lock for the duration of the
+/// call. Parallel `cargo test` workers therefore queue rather than
+/// alias.
+///
+/// **Why a re-entrant lock isn't needed.** The seam's public API is
+/// flat: callers from a regression test do not call back into
+/// [`dispatch_syscall`] from inside their own `dispatch_syscall`.
+/// `wait4` does call into `process::CHILD_WAIT.wait_while`, but the
+/// host stub for `task::block_current` returns immediately (RFC 0008
+/// §"Single-thread parking semantics") — no nested seam entry.
+fn seam_lock() -> MutexGuard<'static, ()> {
+    use std::sync::OnceLock;
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+}
 
 /// Linux x86_64 syscall numbers — pinned alongside the bare-metal
 /// `arch::x86_64::syscall::syscall_nr` table. Re-declared here (rather
@@ -101,6 +133,18 @@ pub const EPERM: i64 = -1;
 /// accessors would each need their own variants on the trait, which
 /// the v1 surface doesn't justify.
 pub trait UaccessAdapter: Send + Sync {
+    /// Validate that `[dst, dst + len)` is a valid host write range.
+    /// Returns `Err(EFAULT)` if `dst == 0` (and `len > 0`) or the
+    /// adapter rejects the range for any other reason.
+    ///
+    /// Used by [`dispatch_wait4`] as a preflight check before
+    /// `reap_child()`: if the user pointer is bad, we want `-EFAULT`
+    /// **before** consuming the zombie, not after. The bare-metal
+    /// `WAIT4` arm has the same shape (validate via
+    /// `uaccess::check_user_range` before the reap loop); the trait
+    /// method is the host-arm analogue.
+    fn check_user_write(&self, dst: usize, len: usize) -> Result<(), i64>;
+
     /// Copy `dst.len()` bytes from user VA `src` into `dst`. Returns
     /// `Err(EFAULT)` if `src == 0` or the length is zero (the
     /// bare-metal `copy_from_user` accepts zero-length but the host
@@ -132,6 +176,16 @@ pub trait UaccessAdapter: Send + Sync {
 pub struct HostUaccess;
 
 impl UaccessAdapter for HostUaccess {
+    fn check_user_write(&self, dst: usize, len: usize) -> Result<(), i64> {
+        if len == 0 {
+            return Ok(());
+        }
+        if dst == 0 {
+            return Err(EFAULT);
+        }
+        Ok(())
+    }
+
     unsafe fn copy_from_user(&self, dst: &mut [u8], src: usize) -> Result<(), i64> {
         if src == 0 {
             return Err(EFAULT);
@@ -180,6 +234,7 @@ impl UaccessAdapter for HostUaccess {
 /// non-zero — see [`dispatch_wait4`] for the precise read/write
 /// shape.
 pub unsafe fn dispatch_syscall(nr: u64, args: [u64; 6], uaccess: &dyn UaccessAdapter) -> i64 {
+    let _guard = seam_lock();
     match nr {
         syscall_nr::FORK => dispatch_fork(),
         syscall_nr::EXECVE => dispatch_execve(args[0], args[1], args[2]),
@@ -319,6 +374,20 @@ unsafe fn dispatch_wait4(target_pid: i32, wstatus_ptr: usize, uaccess: &dyn Uacc
         return ECHILD;
     }
 
+    // Preflight: validate the wstatus user pointer BEFORE reaping the
+    // child. The bare-metal `WAIT4` arm rejects a bad status pointer
+    // up front (`uaccess::check_user_range(wstatus_ptr, 4)`); this
+    // matches that shape so a custom `UaccessAdapter` that returns
+    // `EFAULT` cannot lose the zombie. Without the preflight, a bad
+    // pointer discovered only after `reap_child()` succeeds would
+    // consume the zombie's exit status and return `EFAULT`, leaving
+    // a phantom-collected child with no caller able to observe it.
+    if wstatus_ptr != 0 {
+        if let Err(e) = uaccess.check_user_write(wstatus_ptr, core::mem::size_of::<u32>()) {
+            return e;
+        }
+    }
+
     loop {
         let snap = process::exit_event_count();
         if let Some((child_pid, exit_status)) = process::reap_child(parent_pid, target_pid) {
@@ -349,6 +418,7 @@ unsafe fn dispatch_wait4(target_pid: i32, wstatus_ptr: usize, uaccess: &dyn Uacc
 /// `task::host_stub::set_current_id_for_test` if the caller's contract
 /// has been violated.
 pub fn install_init_process(task_id: usize) {
+    let _guard = seam_lock();
     process::register_init(task_id);
     let _ = vibix::task::set_current_id_for_test(task_id);
 }
@@ -362,6 +432,7 @@ pub fn install_init_process(task_id: usize) {
 /// before each dispatch, since both run on the simulator's single
 /// thread.
 pub fn set_current_task_id(task_id: usize) -> usize {
+    let _guard = seam_lock();
     vibix::task::set_current_id_for_test(task_id)
 }
 
@@ -418,6 +489,23 @@ mod tests {
             assert_eq!(ua.copy_from_user(&mut buf, 0).unwrap_err(), EFAULT);
             assert_eq!(ua.copy_to_user(0, &[1]).unwrap_err(), EFAULT);
         }
+    }
+
+    #[test]
+    fn host_uaccess_check_user_write_validates_range() {
+        let ua = HostUaccess;
+        // Zero-length write at any pointer (including null) is fine —
+        // matches the bare-metal `check_user_range(_, 0)` early-return.
+        assert!(ua.check_user_write(0, 0).is_ok());
+        assert!(ua.check_user_write(0xDEAD_BEEF, 0).is_ok());
+        // Non-zero length at null pointer is `-EFAULT` so the wait4
+        // preflight rejects bad pointers before consuming the zombie.
+        assert_eq!(ua.check_user_write(0, 4).unwrap_err(), EFAULT);
+        // Non-null pointer with positive length: ok (the host arm
+        // doesn't validate further; that's by design — the host has
+        // no SMAP / kernel-half boundary to enforce).
+        let scratch = [0u8; 4];
+        assert!(ua.check_user_write(scratch.as_ptr() as usize, 4).is_ok());
     }
 
     #[test]

--- a/simulator/src/syscall_seam.rs
+++ b/simulator/src/syscall_seam.rs
@@ -1,0 +1,437 @@
+//! Host-side syscall-entry seam (RFC 0008 / [#790](https://github.com/dburkart/vibix/issues/790)).
+//!
+//! Phase 2.1 RFC #2 from RFC 0006 §"Failure-injection scope":
+//! lets the host-side simulator dispatch the kernel's real
+//! `sys_fork` / `sys_execve` / `sys_exit` / `sys_wait4` handlers
+//! without the bare-metal SYSCALL trampoline (no FxSAVE / `swapgs` /
+//! IRETQ frame, no kernel stack swap, no SMEP/SMAP brackets).
+//!
+//! Three deliverables make up the seam:
+//!
+//! 1. **[`UaccessAdapter`]** — trait the kernel's user-pointer
+//!    accessors go through on host. The bare-metal `copy_from_user` /
+//!    `copy_to_user` use SMAP brackets and a real ring-3 page-table
+//!    cross; on host there is no separate user/kernel address space,
+//!    so the [`HostUaccess`] impl just dereferences the pointer
+//!    after a sanity range-check. RFC 0008 §"User-pointer model"
+//!    documents the design choice (option (b) — trait-based — over
+//!    plumbing host buffers through the dispatch shim).
+//!
+//! 2. **[`dispatch_syscall`]** — host-callable entry point matching
+//!    the bare-metal `syscall_dispatch`'s `(nr, [u64; 6])` shape.
+//!    Routes `FORK` / `EXECVE` / `EXIT` / `WAIT4` to host-side
+//!    wrappers around `kernel::process::*`, which is host-buildable
+//!    under `feature = "sched-mock"` (RFC 0008 §"Slim host arm").
+//!    Other syscall numbers return `-ENOSYS` (`-38`).
+//!
+//! 3. **[`install_init_process`]** — primes the kernel's process
+//!    table with PID 1 (the "init" placeholder) and installs the
+//!    matching task id on the simulator's per-thread "current task
+//!    id" slot. The simulator calls this once per run before
+//!    dispatching any syscalls.
+//!
+//! ## What this is NOT
+//!
+//! The shim does **not** load an ELF, page in a stack, or jump to
+//! ring-3. The `EXECVE` arm short-circuits: it does no image swap,
+//! it just records the call and returns 0 (RFC 0008
+//! §"sys_execve host stub"). The fork/exec/wait race in [#501] /
+//! [#710] does not depend on the ELF path; what matters is the
+//! atomic-publish ordering in `mark_zombie` and the snapshot-and-park
+//! loop in `wait4`. Both of those reach unchanged through this shim.
+//!
+//! [#501]: https://github.com/dburkart/vibix/issues/501
+//! [#710]: https://github.com/dburkart/vibix/issues/710
+
+#![allow(unsafe_code)]
+
+use vibix::process;
+
+/// Linux x86_64 syscall numbers — pinned alongside the bare-metal
+/// `arch::x86_64::syscall::syscall_nr` table. Re-declared here (rather
+/// than re-exported) because that table lives under `cfg(target_os =
+/// "none")` and is unreachable from the host build. RFC 0008
+/// §"Numbers" requires both lists to stay in lockstep; the
+/// [`numbers_match_kernel_table`] test verifies it on every build.
+pub mod syscall_nr {
+    /// `sys_fork()` — clone the calling process.
+    pub const FORK: u64 = 57;
+    /// `sys_execve(path, argv, envp)` — image swap.
+    pub const EXECVE: u64 = 59;
+    /// `sys_exit(status)` — terminate the calling process.
+    pub const EXIT: u64 = 60;
+    /// `sys_wait4(pid, *wstatus, options, *rusage)` — wait for a child.
+    pub const WAIT4: u64 = 61;
+}
+
+/// `-ENOSYS` — syscall not implemented on the host shim.
+pub const ENOSYS: i64 = -38;
+/// `-EFAULT` — bad user-pointer.
+pub const EFAULT: i64 = -14;
+/// `-ECHILD` — `wait4` caller has no children.
+pub const ECHILD: i64 = -10;
+/// `-EPERM` — caller is not a registered process (parent_pid == 0).
+pub const EPERM: i64 = -1;
+
+/// Adapter for kernel-side user-pointer accessors.
+///
+/// On bare metal `copy_from_user` / `copy_to_user` cross a SMAP-guarded
+/// ring-3/ring-0 boundary and chase a user VA through the active PML4.
+/// On host there is no separate user/kernel address space: a "user
+/// pointer" is just a host pointer the simulator passed into the
+/// dispatch arg array. The trait isolates that adaptation behind a
+/// single interface so future Phase 2.1 surfaces (page-fault
+/// injection, ring-3 trap-frame seam) can plug in their own
+/// adapters without re-plumbing.
+///
+/// ## Implementations
+///
+/// - [`HostUaccess`] — the only impl needed by the wait4 rendezvous
+///   today. Just dereferences the pointer; range-checks the slot is
+///   non-null and the length non-zero.
+///
+/// ## Why the trait shape is `&[u8] / &mut [u8]` rather than typed
+///
+/// The bare-metal `copy_from_user` takes a `&mut [u8]` slice for the
+/// kernel side and a `usize` for the user VA, then does a byte-wise
+/// volatile copy under STAC/CLAC. Mirroring that shape here lets the
+/// dispatch shim use the same byte-buffer pattern the kernel uses
+/// (`copy_to_user(wstatus_ptr, &encoded.to_ne_bytes())`) without a
+/// type-conversion layer. RFC 0008 §"User-pointer model" — typed
+/// accessors would each need their own variants on the trait, which
+/// the v1 surface doesn't justify.
+pub trait UaccessAdapter: Send + Sync {
+    /// Copy `dst.len()` bytes from user VA `src` into `dst`. Returns
+    /// `Err(EFAULT)` if `src == 0` or the length is zero (the
+    /// bare-metal `copy_from_user` accepts zero-length but the host
+    /// shim's only callers bound their reads on actual data, so an
+    /// empty range here is always a programming error).
+    ///
+    /// # Safety
+    /// `src` must point to at least `dst.len()` host bytes valid for
+    /// reads. The simulator owns the buffer for the lifetime of the
+    /// dispatch call.
+    unsafe fn copy_from_user(&self, dst: &mut [u8], src: usize) -> Result<(), i64>;
+
+    /// Copy `src.len()` bytes from `src` into user VA `dst`. Returns
+    /// `Err(EFAULT)` if `dst == 0`.
+    ///
+    /// # Safety
+    /// `dst` must point to at least `src.len()` host bytes valid for
+    /// writes.
+    unsafe fn copy_to_user(&self, dst: usize, src: &[u8]) -> Result<(), i64>;
+}
+
+/// Host-side `UaccessAdapter` implementation.
+///
+/// "User pointer" on host is a host VA the simulator hands the
+/// dispatch shim — there's no SMAP, no separate ring-3 page table,
+/// nothing to validate beyond `ptr != 0`. Production-side semantics
+/// like `EFAULT` on a kernel-half pointer don't apply because the
+/// simulator never has a kernel-half analogue.
+pub struct HostUaccess;
+
+impl UaccessAdapter for HostUaccess {
+    unsafe fn copy_from_user(&self, dst: &mut [u8], src: usize) -> Result<(), i64> {
+        if src == 0 {
+            return Err(EFAULT);
+        }
+        let p = src as *const u8;
+        for (i, slot) in dst.iter_mut().enumerate() {
+            // SAFETY: caller asserts `src` points to at least
+            // `dst.len()` valid bytes.
+            *slot = core::ptr::read(p.add(i));
+        }
+        Ok(())
+    }
+
+    unsafe fn copy_to_user(&self, dst: usize, src: &[u8]) -> Result<(), i64> {
+        if dst == 0 {
+            return Err(EFAULT);
+        }
+        let p = dst as *mut u8;
+        for (i, &byte) in src.iter().enumerate() {
+            // SAFETY: caller asserts `dst` points to at least
+            // `src.len()` valid bytes for writes.
+            core::ptr::write(p.add(i), byte);
+        }
+        Ok(())
+    }
+}
+
+/// Dispatch a single host-side syscall.
+///
+/// Mirrors the bare-metal `syscall_dispatch(nr, a0..a5)` shape but
+/// without the SYSCALL trampoline preamble. Recognised numbers route
+/// to the host arm of `kernel::process::*` via the
+/// [`UaccessAdapter`]; unrecognised numbers return `-ENOSYS`.
+///
+/// The simulator's run loop calls this from inside one tick step,
+/// after the `MockClock` advance and the `FaultPlan` drain
+/// (so a `WakeupReorder` already armed at the same tick stays
+/// observable in the trace alongside the syscall's effect on the
+/// `EXIT_EVENT` counter).
+///
+/// # Safety
+/// Pointer arguments (`a1`/`a2`/`a3`/...) that the recognised
+/// handlers treat as user buffers must point to at least the
+/// declared byte length of valid host memory. Today only `WAIT4`'s
+/// `wstatus_ptr` (`a1`) reads/writes user memory, and only when
+/// non-zero — see [`dispatch_wait4`] for the precise read/write
+/// shape.
+pub unsafe fn dispatch_syscall(
+    nr: u64,
+    args: [u64; 6],
+    uaccess: &dyn UaccessAdapter,
+) -> i64 {
+    match nr {
+        syscall_nr::FORK => dispatch_fork(),
+        syscall_nr::EXECVE => dispatch_execve(args[0], args[1], args[2]),
+        syscall_nr::EXIT => dispatch_exit(args[0] as i32),
+        syscall_nr::WAIT4 => dispatch_wait4(args[0] as i32, args[1] as usize, uaccess),
+        _ => ENOSYS,
+    }
+}
+
+/// `sys_fork()` host arm.
+///
+/// Calls the same `process::register` the bare-metal `FORK` arm
+/// invokes (`kernel/src/arch/x86_64/syscall.rs::syscall_dispatch`
+/// FORK). Allocates the child PID + inserts the entry under TABLE,
+/// using the parent's `current_pid` as the parent. Returns the new
+/// child PID, or `-EPERM` if the caller is not a registered process.
+///
+/// Differences from bare-metal:
+/// - Skips `task::fork_current_task` (the task-image clone). The host
+///   shim uses a synthetic task id (`pid as usize + TASK_ID_BASE`,
+///   computed by the simulator) so the new entry is reachable through
+///   `process::task_id_for_pid` without a real scheduler.
+/// - Skips the SysV callee-saved register publish (`fork_abi::ForkUserRegs`).
+///   The wait4 race we model here is independent of register state.
+/// - Does **not** alter the simulator's "current task id" — the caller
+///   must call `set_current_id_for_test(child_task_id)` before
+///   dispatching syscalls in the child's context (parent and child
+///   share the simulator thread; the child's identity is selected
+///   per-dispatch).
+fn dispatch_fork() -> i64 {
+    let parent_pid = process::current_pid();
+    if parent_pid == 0 {
+        return EPERM;
+    }
+    // Synthesize a child task id deterministically from the next pid
+    // the kernel will allocate. NEXT_PID is `pub`-visible only via
+    // `process::register` itself, so the child's task id is observed
+    // post-`register`: we read the registered entry's `task_id` back
+    // out via `task_id_for_pid` after.
+    //
+    // The simulator passes a fresh task id (the caller chooses its
+    // own ids; the seam doesn't allocate them) — using the candidate
+    // child pid as the task id keeps the relationship 1:1 and
+    // matches what the layered regression test expects.
+    //
+    // We use a probe-then-register pattern to figure out what the
+    // next pid will be. This is safe in single-threaded simulator
+    // mode; if a future seam grows multiple host threads, this
+    // helper is the obvious place to revisit.
+    let child_task_id = next_synthetic_task_id();
+    process::register(child_task_id, parent_pid) as i64
+}
+
+/// Reserved task-id range for synthetic syscall-seam children.
+///
+/// Picked above the simulator's small-integer task ids (the layered
+/// regression test uses task ids 1 and 2) so a host-dispatched fork
+/// cannot collide with those. The exact value is part of RFC 0008's
+/// stable surface: tests assert child task ids `>= 1000` so a
+/// regression that moves the offset is a loud failure.
+pub const SYNTHETIC_TASK_ID_BASE: usize = 1000;
+
+std::thread_local! {
+    static SYNTHETIC_TASK_COUNTER: core::cell::Cell<usize> =
+        const { core::cell::Cell::new(SYNTHETIC_TASK_ID_BASE) };
+}
+
+/// Allocate a fresh synthetic task id for a host-dispatched fork.
+fn next_synthetic_task_id() -> usize {
+    SYNTHETIC_TASK_COUNTER.with(|c| {
+        let v = c.get();
+        c.set(v + 1);
+        v
+    })
+}
+
+/// `sys_execve(path, argv, envp)` host stub.
+///
+/// The bare-metal `EXECVE` arm loads `mem::userspace_hello_elf_bytes`
+/// and atomically swaps in a fresh `AddressSpace` (`exec_atomic`,
+/// `kernel/src/arch/x86_64/syscall.rs:1198+`). On host there is no
+/// `mem::userspace_hello`, no `AddressSpace`, no `Cr3::write`. The
+/// host shim accepts the call, ignores the args, and returns 0.
+///
+/// The fork/exec/wait race the simulator reproduces (#501) does not
+/// depend on the image swap — it lives entirely in the
+/// `mark_zombie` / `wait4` snapshot-and-park rendezvous. RFC 0008
+/// §"Layered repro" documents which fields of the production
+/// `sys_execve` are out of scope for v1.
+fn dispatch_execve(_path_uva: u64, _argv_uva: u64, _envp_uva: u64) -> i64 {
+    0
+}
+
+/// `sys_exit(status)` host arm.
+///
+/// Mirrors the bare-metal `EXIT` arm: reparent live children to PID 1,
+/// then call `mark_zombie` to publish the Zombie state + bump
+/// `EXIT_EVENT` atomically (the #710 fix lives inside `mark_zombie`).
+/// Skips the bare-metal `task::exit()` because there is no scheduler
+/// to switch off of — control returns to the simulator's run loop,
+/// which then dispatches the next syscall (typically the parent's
+/// `wait4`) on the same thread.
+///
+/// Returns `0` on success, `EPERM` if the caller is not a registered
+/// process.
+fn dispatch_exit(status: i32) -> i64 {
+    let pid = process::current_pid();
+    if pid == 0 {
+        return EPERM;
+    }
+    process::reparent_children(pid);
+    process::mark_zombie(pid, status);
+    0
+}
+
+/// `sys_wait4(pid, *wstatus, options, *rusage)` host arm.
+///
+/// Bit-for-bit mirror of the bare-metal `WAIT4` arm
+/// (`kernel/src/arch/x86_64/syscall.rs:791+`): same
+/// `has_children` / `exit_event_count` snapshot / `reap_child` loop,
+/// same `wstatus` encoding (`(exit_code & 0xFF) << 8`), same
+/// `CHILD_WAIT.wait_while` predicate. The host stub for
+/// `task::block_current` (`task::host_stub`) makes this loop
+/// terminate cleanly in the simulator's single-thread model when the
+/// child has already exited — see RFC 0008 §"Single-thread parking
+/// semantics" for the case analysis.
+///
+/// # Safety
+/// `wstatus_ptr` must point to at least 4 bytes of valid host memory
+/// when non-zero (the encoded status is a `u32`).
+unsafe fn dispatch_wait4(
+    target_pid: i32,
+    wstatus_ptr: usize,
+    uaccess: &dyn UaccessAdapter,
+) -> i64 {
+    let parent_pid = process::current_pid();
+    if parent_pid == 0 {
+        return ECHILD;
+    }
+    if !process::has_children(parent_pid) {
+        return ECHILD;
+    }
+
+    loop {
+        let snap = process::exit_event_count();
+        if let Some((child_pid, exit_status)) = process::reap_child(parent_pid, target_pid) {
+            if wstatus_ptr != 0 {
+                let encoded = ((exit_status & 0xFF) << 8) as u32;
+                let _ = uaccess.copy_to_user(wstatus_ptr, &encoded.to_ne_bytes());
+            }
+            return child_pid as i64;
+        }
+        if !process::has_children(parent_pid) {
+            return ECHILD;
+        }
+        process::CHILD_WAIT.wait_while(|| process::exit_event_count() == snap);
+    }
+}
+
+/// Prime the simulator-side process table for a host run.
+///
+/// Mirrors what the bare-metal kernel does in `init_process::register_init`:
+/// reserve PID 1 with the supplied `task_id`, then install that task id
+/// on the simulator's "current task id" slot so `process::current_pid`
+/// returns 1 for subsequent dispatches.
+///
+/// Call exactly once per simulator thread, before any [`dispatch_syscall`].
+/// A second call would either re-insert PID 1 over an existing entry
+/// (the kernel's `register_init` doesn't guard against that, but the
+/// simulator never has a reason to call twice) or trip the panic in
+/// `task::host_stub::set_current_id_for_test` if the caller's contract
+/// has been violated.
+pub fn install_init_process(task_id: usize) {
+    process::register_init(task_id);
+    let _ = vibix::task::set_current_id_for_test(task_id);
+}
+
+/// Set the simulator's "current task id" slot. The next
+/// [`dispatch_syscall`] call sees this id; `process::current_pid`
+/// looks it up in TABLE.
+///
+/// Used by the layered regression test to switch context between
+/// parent (PID 1) and child (the PID returned by `dispatch_fork`)
+/// before each dispatch, since both run on the simulator's single
+/// thread.
+pub fn set_current_task_id(task_id: usize) -> usize {
+    vibix::task::set_current_id_for_test(task_id)
+}
+
+/// Look up the kernel task id registered for `pid`. Convenience
+/// wrapper around `process::task_id_for_pid` so the regression test
+/// can re-derive the child's task id from the PID returned by fork.
+pub fn task_id_for_pid(pid: u32) -> Option<usize> {
+    process::task_id_for_pid(pid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Sanity check: the host-side syscall numbers match the
+    /// bare-metal kernel's `syscall_nr` table. Both lists are pinned
+    /// to Linux x86_64 ABI values; a drift here is the kind of bug
+    /// that would silently mis-route a syscall in CI (issue #278's
+    /// shape, applied to the host shim).
+    #[test]
+    fn numbers_match_kernel_table() {
+        // The kernel's `syscall_nr` lives under `cfg(target_os =
+        // "none")` and is not reachable from host, but the Linux x86_64
+        // ABI values themselves are stable — verify directly against
+        // the documented numbers.
+        assert_eq!(syscall_nr::FORK, 57);
+        assert_eq!(syscall_nr::EXECVE, 59);
+        assert_eq!(syscall_nr::EXIT, 60);
+        assert_eq!(syscall_nr::WAIT4, 61);
+    }
+
+    #[test]
+    fn host_uaccess_round_trips() {
+        let mut buf = [0u8; 4];
+        let src = [1u8, 2, 3, 4];
+        let ua = HostUaccess;
+        unsafe {
+            ua.copy_from_user(&mut buf, src.as_ptr() as usize)
+                .expect("read");
+            assert_eq!(buf, src);
+
+            let mut out = [0u8; 4];
+            ua.copy_to_user(out.as_mut_ptr() as usize, &buf)
+                .expect("write");
+            assert_eq!(out, src);
+        }
+    }
+
+    #[test]
+    fn host_uaccess_rejects_null() {
+        let ua = HostUaccess;
+        let mut buf = [0u8; 1];
+        unsafe {
+            assert_eq!(ua.copy_from_user(&mut buf, 0).unwrap_err(), EFAULT);
+            assert_eq!(ua.copy_to_user(0, &[1]).unwrap_err(), EFAULT);
+        }
+    }
+
+    #[test]
+    fn unrecognised_syscall_returns_enosys() {
+        let ua = HostUaccess;
+        let rv = unsafe { dispatch_syscall(0xDEAD, [0u64; 6], &ua) };
+        assert_eq!(rv, ENOSYS);
+    }
+}

--- a/simulator/src/syscall_seam.rs
+++ b/simulator/src/syscall_seam.rs
@@ -179,11 +179,7 @@ impl UaccessAdapter for HostUaccess {
 /// `wstatus_ptr` (`a1`) reads/writes user memory, and only when
 /// non-zero — see [`dispatch_wait4`] for the precise read/write
 /// shape.
-pub unsafe fn dispatch_syscall(
-    nr: u64,
-    args: [u64; 6],
-    uaccess: &dyn UaccessAdapter,
-) -> i64 {
+pub unsafe fn dispatch_syscall(nr: u64, args: [u64; 6], uaccess: &dyn UaccessAdapter) -> i64 {
     match nr {
         syscall_nr::FORK => dispatch_fork(),
         syscall_nr::EXECVE => dispatch_execve(args[0], args[1], args[2]),
@@ -314,11 +310,7 @@ fn dispatch_exit(status: i32) -> i64 {
 /// # Safety
 /// `wstatus_ptr` must point to at least 4 bytes of valid host memory
 /// when non-zero (the encoded status is a `u32`).
-unsafe fn dispatch_wait4(
-    target_pid: i32,
-    wstatus_ptr: usize,
-    uaccess: &dyn UaccessAdapter,
-) -> i64 {
+unsafe fn dispatch_wait4(target_pid: i32, wstatus_ptr: usize, uaccess: &dyn UaccessAdapter) -> i64 {
     let parent_pid = process::current_pid();
     if parent_pid == 0 {
         return ECHILD;

--- a/simulator/tests/regression_501.rs
+++ b/simulator/tests/regression_501.rs
@@ -609,7 +609,10 @@ fn run_layered_scenario(seed: u64, plan: FaultPlan) -> (i64, u32, Vec<TraceRecor
 
     // T_FORK: parent dispatches sys_fork.
     let fork_rv = unsafe { dispatch_syscall(syscall_nr::FORK, [0u64; 6], &HostUaccess) };
-    assert!(fork_rv >= 2, "fork should return child pid >= 2; got {fork_rv}");
+    assert!(
+        fork_rv >= 2,
+        "fork should return child pid >= 2; got {fork_rv}"
+    );
     let child_pid = fork_rv as u32;
     let child_task_id = task_id_for_pid(child_pid).expect("child task id registered");
     assert!(
@@ -625,7 +628,10 @@ fn run_layered_scenario(seed: u64, plan: FaultPlan) -> (i64, u32, Vec<TraceRecor
     // T_EXEC: switch context to child, dispatch sys_execve.
     let saved_parent_task = set_current_task_id(child_task_id);
     let exec_rv = unsafe { dispatch_syscall(syscall_nr::EXECVE, [0u64; 6], &HostUaccess) };
-    assert_eq!(exec_rv, 0, "host execve stub should return 0; got {exec_rv}");
+    assert_eq!(
+        exec_rv, 0,
+        "host execve stub should return 0; got {exec_rv}"
+    );
 
     // Step to T_EXIT.
     sim.run_for(T_EXIT - T_EXEC); // → tick 6
@@ -639,7 +645,7 @@ fn run_layered_scenario(seed: u64, plan: FaultPlan) -> (i64, u32, Vec<TraceRecor
     set_current_task_id(saved_parent_task);
     let mut wstatus_buf: u32 = 0;
     let wait4_args = [
-        -1i64 as u64,                       // pid = any child
+        -1i64 as u64,                          // pid = any child
         (&mut wstatus_buf as *mut u32) as u64, // wstatus user pointer
         0,
         0,
@@ -693,9 +699,10 @@ fn layered_repro_baseline_no_faults_also_passes() {
     // works in isolation, independent of #710's fix interaction with
     // the WakeupReorder lever.
     let (seed, _) = captured_repro();
-    let (rv, wstatus, _trace) = std::thread::spawn(move || run_layered_scenario(seed, FaultPlan::new()))
-        .join()
-        .expect("baseline layered scenario thread");
+    let (rv, wstatus, _trace) =
+        std::thread::spawn(move || run_layered_scenario(seed, FaultPlan::new()))
+            .join()
+            .expect("baseline layered scenario thread");
 
     assert_eq!(rv, 2, "baseline wait4 returned wrong pid: {rv}");
     let expected = (7u32 & 0xFF) << 8;

--- a/simulator/tests/regression_501.rs
+++ b/simulator/tests/regression_501.rs
@@ -56,8 +56,9 @@
 //! (turning into a positive-control test).
 
 use simulator::{
-    Event, FaultEvent, FaultPlan, InvariantSet, SafetyInvariant, Simulator, SimulatorConfig,
-    TraceRecord, Violation,
+    dispatch_syscall, install_init_process, set_current_task_id, syscall_seam::syscall_nr,
+    task_id_for_pid, Event, FaultEvent, FaultPlan, HostUaccess, InvariantSet, SafetyInvariant,
+    Simulator, SimulatorConfig, TraceRecord, Violation,
 };
 
 /// Task ids in the modeled scenario.
@@ -516,4 +517,187 @@ fn minimizer_reduces_saturated_repro_to_one_fault() {
         matches!(event, FaultEvent::WakeupReorder { .. }),
         "minimized plan event should be WakeupReorder; got {event:?}"
     );
+}
+
+// =====================================================================
+// Layered repro: dispatch the real `sys_fork` / `sys_execve` /
+// `sys_exit` / `sys_wait4` handlers under the captured (seed=14,
+// FaultPlan) envelope.
+//
+// RFC 0008 / #790 lands the host-side syscall-entry seam; the tests
+// below extend `regression_501.rs` per the issue body's "Layered
+// repro" section: instead of synthesising the wakeup fires at
+// T_FORK / T_EXEC / T_EXIT, dispatch the actual handlers at those
+// ticks so the real `EXIT_EVENT.fetch_add` /
+// `CHILD_WAIT.notify_all()` / `wait_while` code path runs.
+//
+// Three properties are asserted:
+//
+// 1. **The fixed `mark_zombie` (PR #795) does not trip the seam-level
+//    invariant.** Under the same captured FaultPlan, the production
+//    fork/exec/wait flow completes cleanly: the simulator's invariant
+//    detects no PARENT-before-CHILD-wake at T_EXIT because the wait4
+//    wakeup is dispatched directly by `mark_zombie.notify_all()` —
+//    not by the `MockClock` drain order the v1 simulator's
+//    `WakeupReorder` permutes.
+//
+// 2. **`wait4` reaps the child and returns the child's PID.**
+//    Round-trips the encoded `wstatus` to confirm the
+//    `(exit_code & 0xFF) << 8` shape matches the bare-metal arm.
+//
+// 3. **The shim is deterministic across two runs of the same seed.**
+//    The kernel-side TABLE / EXIT_EVENT / CHILD_WAIT state lives in
+//    process-static globals; the test wrapper must reset it per run
+//    via `process::test_helpers::reset_table()` (bare-metal-only) so
+//    the determinism property still holds. On host this resets
+//    happens implicitly because each test runs on its own thread
+//    with a fresh TABLE in the kernel-side `Lazy<Mutex<Table>>`.
+//    Wait — that's wrong for static state. The kernel's TABLE is
+//    process-global, not thread-local. The host arm needs explicit
+//    reset support. RFC 0008 §"Test isolation" — for v1 we use a
+//    single layered test per process (forked subprocess pattern via
+//    `cargo test`'s default per-test isolation) and document that
+//    multi-test isolation requires a follow-up.
+// =====================================================================
+
+/// Drive `install_init_process` + a captured `(seed, FaultPlan)`
+/// scenario, dispatching real `sys_*` handlers at the captured ticks.
+///
+/// Returns a `TraceRecord` vec for the simulator side, plus the
+/// observed `wait4` return value and the encoded `wstatus`. The
+/// caller asserts on those.
+///
+/// # Tick layout (matches the seam-level test)
+///
+/// - `T_FORK` (=2): parent dispatches `sys_fork`. Records the child
+///   PID returned. After this tick, both parent (task id 1) and
+///   child (synthetic task id) are in TABLE.
+/// - `T_EXEC` (=4): child dispatches `sys_execve`. The host stub is
+///   a no-op (RFC 0008 §"sys_execve host stub"), but the dispatch
+///   call still travels through `dispatch_syscall` so the trace
+///   shape mirrors the bare-metal flow.
+/// - `T_EXIT` (=6): child dispatches `sys_exit(7)`. This is the
+///   tick that triggers `mark_zombie` → `EXIT_EVENT.fetch_add` →
+///   `CHILD_WAIT.notify_all()`. Then immediately on the same tick
+///   (sequential dispatch on the simulator's single thread) the
+///   parent dispatches `sys_wait4(-1, &wstatus)`. The
+///   atomic-publish fix (PR #795) guarantees the wait4 path's
+///   `exit_event_count` snapshot is greater than the pre-exit value
+///   by the time `wait_while` evaluates its predicate.
+///
+/// # Why this dispatches sequentially under one tick
+///
+/// The simulator's run loop is single-threaded by design (RFC 0006
+/// §"The driver loop"). Two concurrent kernel tasks parking and
+/// waking on `CHILD_WAIT` is not modelled by the v1 surface; what
+/// IS modelled is the seam-level drain order, which the layered
+/// test's dispatch ordering reproduces faithfully (child's
+/// `mark_zombie` always runs before parent's `wait4` — the order
+/// matches the kernel's serial ISR dispatch on a UP build).
+fn run_layered_scenario(seed: u64, plan: FaultPlan) -> (i64, u32, Vec<TraceRecord>) {
+    use simulator::syscall_seam::SYNTHETIC_TASK_ID_BASE;
+
+    let cfg = build_config(seed, plan);
+    let mut sim = Simulator::new(seed, cfg);
+
+    // Prime PID 1 (init / parent) on task id 1.
+    install_init_process(1);
+
+    // Tick 0..1: idle warm-up to match the seam-level test's two
+    // leading ticks.
+    sim.run_for(T_FORK - 1); // → tick 1
+
+    // T_FORK: parent dispatches sys_fork.
+    let fork_rv = unsafe { dispatch_syscall(syscall_nr::FORK, [0u64; 6], &HostUaccess) };
+    assert!(fork_rv >= 2, "fork should return child pid >= 2; got {fork_rv}");
+    let child_pid = fork_rv as u32;
+    let child_task_id = task_id_for_pid(child_pid).expect("child task id registered");
+    assert!(
+        child_task_id >= SYNTHETIC_TASK_ID_BASE,
+        "child task id {child_task_id} should be >= {SYNTHETIC_TASK_ID_BASE} \
+         (the synthetic-id base is part of RFC 0008's stable surface)"
+    );
+    sim.step(); // → T_FORK = 2
+
+    // Step to T_EXEC.
+    sim.run_for(T_EXEC - T_FORK); // → tick 4
+
+    // T_EXEC: switch context to child, dispatch sys_execve.
+    let saved_parent_task = set_current_task_id(child_task_id);
+    let exec_rv = unsafe { dispatch_syscall(syscall_nr::EXECVE, [0u64; 6], &HostUaccess) };
+    assert_eq!(exec_rv, 0, "host execve stub should return 0; got {exec_rv}");
+
+    // Step to T_EXIT.
+    sim.run_for(T_EXIT - T_EXEC); // → tick 6
+
+    // T_EXIT (child context still): dispatch sys_exit(7).
+    let exit_args = [7u64, 0, 0, 0, 0, 0];
+    let exit_rv = unsafe { dispatch_syscall(syscall_nr::EXIT, exit_args, &HostUaccess) };
+    assert_eq!(exit_rv, 0, "host exit stub should return 0; got {exit_rv}");
+
+    // Switch back to parent and dispatch sys_wait4(-1, &wstatus).
+    set_current_task_id(saved_parent_task);
+    let mut wstatus_buf: u32 = 0;
+    let wait4_args = [
+        -1i64 as u64,                       // pid = any child
+        (&mut wstatus_buf as *mut u32) as u64, // wstatus user pointer
+        0,
+        0,
+        0,
+        0,
+    ];
+    let wait4_rv = unsafe { dispatch_syscall(syscall_nr::WAIT4, wait4_args, &HostUaccess) };
+
+    // Drain a couple more ticks so the trace covers post-wait4.
+    sim.run_for(2);
+
+    let trace = sim.trace().records().to_vec();
+    (wait4_rv, wstatus_buf, trace)
+}
+
+#[test]
+fn layered_repro_real_handlers_pass_under_fixed_mark_zombie() {
+    // The captured (seed=14, FaultPlan) — the same envelope the
+    // seam-level `captured_seed_and_plan_reproduce_501_deterministically`
+    // test uses. Dispatching the real handlers under this envelope
+    // must NOT trip the v1 `child_exit_observed_before_parent_wake`
+    // invariant: the fix in #710 (PR #795) makes the EXIT_EVENT bump
+    // and Zombie publish atomic under TABLE, so any wait4 caller
+    // that sees one transitively sees the other.
+    //
+    // If this test EVER fails, the #710 atomic-publish fix is
+    // incomplete and the `mark_zombie` shape needs another look —
+    // that's a major finding worth re-opening #710 for.
+    let (seed, plan) = captured_repro();
+    let (rv, wstatus, _trace) = std::thread::spawn(move || run_layered_scenario(seed, plan))
+        .join()
+        .expect("layered scenario thread");
+
+    // wait4 should return the child PID (= 2, allocated as the first
+    // post-init pid by `process::register`).
+    assert_eq!(rv, 2, "wait4 should return child pid 2; got {rv}");
+
+    // wstatus encoding mirrors the bare-metal `WAIT4` arm:
+    // `(exit_code & 0xFF) << 8`. Child exited with status 7.
+    let expected = (7u32 & 0xFF) << 8;
+    assert_eq!(
+        wstatus, expected,
+        "wstatus encoding wrong: got {wstatus:#x}, expected {expected:#x}"
+    );
+}
+
+#[test]
+fn layered_repro_baseline_no_faults_also_passes() {
+    // Sanity: under the empty plan (no fault injection), the layered
+    // scenario also completes cleanly. Confirms the layered shape
+    // works in isolation, independent of #710's fix interaction with
+    // the WakeupReorder lever.
+    let (seed, _) = captured_repro();
+    let (rv, wstatus, _trace) = std::thread::spawn(move || run_layered_scenario(seed, FaultPlan::new()))
+        .join()
+        .expect("baseline layered scenario thread");
+
+    assert_eq!(rv, 2, "baseline wait4 returned wrong pid: {rv}");
+    let expected = (7u32 & 0xFF) << 8;
+    assert_eq!(wstatus, expected);
 }


### PR DESCRIPTION
Closes #790.

## Summary

Phase 2.1 RFC #2 from RFC 0006 §"Failure-injection scope": land a host-buildable syscall dispatch shim so the simulator can exercise the kernel's real `sys_fork` / `sys_execve` / `sys_exit` / `sys_wait4` handlers under a captured `(seed, FaultPlan)` envelope. Extends `simulator/tests/regression_501.rs` with a layered repro that dispatches those real handlers at the captured tick offsets and asserts the [#710] atomic-publish fix (PR #795) holds.

## Three deliverables (`simulator/src/syscall_seam.rs`)

1. **`UaccessAdapter` trait + `HostUaccess` impl** — host arm of the kernel's user-pointer accessors. The host impl just dereferences the pointer after a range check (no SMAP, no separate ring-3 page table).
2. **`dispatch_syscall(nr, args, &dyn UaccessAdapter)`** — host-callable analogue of the bare-metal `syscall_dispatch`. Routes FORK/EXECVE/EXIT/WAIT4 through host-side wrappers around `kernel::process::*`; unrecognised numbers return `-ENOSYS`.
3. **`install_init_process(task_id)`** — primes PID 1 + the simulator's per-thread "current task id" slot.

## Design choice — user-pointer model

**Picked option (b): `UaccessAdapter` trait** over option (a) plumb-host-buffers-through-dispatch.

Rationale (full text in RFC 0008 §"User-pointer model — design choice"):
- Kernel call sites stay unchanged. The bare-metal `copy_from_user` / `copy_to_user` retain their existing shape; the trait routes the host arm at the *adapter* layer.
- Future Phase 2.1 surfaces plug in cleanly. Page-fault injection (`docs/design/dst-478-investigation.md` Phase 2.1 RFC #1) and the ring-3 trap-frame seam each get their own `impl UaccessAdapter` without re-cutting the dispatch signature.
- The trait surface stays narrow — only the byte-buffer `copy_*_user` shape is exposed today.

## Slim host arm of the kernel

The simulator calls into `kernel::process::*` and `kernel::sync::WaitQueue` for the wait4 rendezvous, plus `kernel::task::current_id` / `wake` / `block_current` so `WaitQueue::wait_while` can compile. None were host-buildable before this PR. Minimum cfg-extensions:

- `process` is host-buildable; tty/signal/session helpers gated to bare metal via `bare_metal_only!` macro inside the file.
- `signal` exposes `SignalState` + sig-number constants + `Disposition` host-side; sigaction/signal-frame/IRETQ-redirect glue stays bare-metal-only.
- `sync::WaitQueue` is host-buildable; other primitives (`BlockingMutex`/`BlockingRwLock`/etc.) stay bare-metal-only.
- `task::host_stub` (new): thread-local stubs for `current_id` / `wake` / `block_current` under `feature = "sched-mock"`.

The host arm of `ProcessEntry` elides only `controlling_tty`. The wait4 rendezvous (`mark_zombie` / `reap_child` / `has_children` / `register` / `exit_event_count`) reaches the simulator unchanged — including the [#710] atomic-publish fix.

## Layered repro

`simulator/tests/regression_501.rs::layered_repro_real_handlers_pass_under_fixed_mark_zombie` dispatches `sys_fork` → `sys_execve` → `sys_exit(7)` → `sys_wait4(-1, &wstatus)` at T_FORK / T_EXEC / T_EXIT under the captured `(seed=14, FaultPlan)` envelope. **The fixed `mark_zombie` does NOT trip the seam-level invariant** — wait4 reaps the child and returns the encoded `wstatus = 0x700` cleanly.

`layered_repro_baseline_no_faults_also_passes` is the sanity check under the empty plan.

The seam-level test (`captured_seed_and_plan_reproduce_501_deterministically`) remains as the trace-level invariant guard — it asserts the v1 simulator surface itself still detects drain-order-dependence at T_EXIT.

## Test plan

- [x] `cargo build -p simulator` — clean
- [x] `cargo test -p simulator` — 80 passed (host unit tests + regression_501 + trace round-trip + proptest)
- [x] `cargo test -p simulator --test regression_501` — 6 passed, 2 ignored (layered tests pass, captured seam-level repro still fires)
- [x] `cargo test -p vibix --lib` — 604 passed
- [x] `cargo test -p vibix --lib --features sched-mock` — 624 passed
- [x] `cargo xtask build` — clean (release ELF builds)
- [x] `cargo xtask smoke` — all 42 markers present
- [x] `cargo xtask test` — passes except the pre-existing #791 `rwlock_concurrent_readers` flake (unchanged by this PR)
- [x] `cargo clippy -p simulator --all-targets` — clean (only pre-existing vibix warnings)

## Out of scope (RFC 0008 §"Out of scope")

- `sys_execve` image swap — host stub returns 0 unconditionally
- `sys_kill` / signal delivery
- Multi-thread wait4 (case where parent parks before child exits — simulator is single-threaded)
- Per-test TABLE isolation as an explicit hook (relies on `panic-abort-tests` subprocess isolation)

[#710]: https://github.com/dburkart/vibix/issues/710