### PR TITLE
fs/ext2: writepage with allocate-on-extend (#750)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -423,6 +423,11 @@ harness = false
 required-features = ["ext2"]
 
 [[test]]
+name = "ext2_writepage"
+harness = false
+required-features = ["ext2"]
+
+[[test]]
 name = "ext2_orphan_chain"
 harness = false
 required-features = ["ext2"]

--- a/kernel/src/fs/ext2/aops.rs
+++ b/kernel/src/fs/ext2/aops.rs
@@ -3,18 +3,15 @@
 //! readahead / truncate.
 //!
 //! RFC 0007 §`AddressSpaceOps` and §Tail-page zeroing are the normative
-//! spec. This module is **Workstream C / issue #749**: it lands the
-//! `readpage` path only. The other three trait methods (`writepage`,
-//! `truncate_below`, `readahead`) are deliberately stubbed out here:
+//! spec. This module currently lands two of the four trait methods:
 //!
-//! - `writepage` returns `Err(EROFS)` — issue #750 lands the real
-//!   buffer-cache writeback. Until then a forced-RO behaviour is
-//!   strictly safer than `unimplemented!()`-panic, because a future
-//!   page-fault path that wires `MAP_SHARED` writeback (#746/#755) can
-//!   exercise the writepage call site without bringing the kernel down;
-//!   the daemon will see `EROFS` and bump `wb_err`, which is the
-//!   correct user-visible behaviour for "this filesystem doesn't
-//!   support writeback yet".
+//! - `readpage` (issue #749) — parsed sparse / dense / past-EOF logic
+//!   in [`Ext2Aops::readpage`].
+//! - `writepage` (issue #750) — split-the-page-into-blocks-and-
+//!   allocate-on-extend in [`Ext2Aops::writepage`].
+//!
+//! The remaining two methods are deliberately left at the trait default:
+//!
 //! - `truncate_below` is left at the trait default (no-op + spinlock
 //!   assert). Issue #751 will replace it.
 //! - `readahead` is left at the trait default (no-op + spinlock
@@ -87,14 +84,20 @@
 //! fires before we issue any buffer-cache `bread`.
 
 use alloc::sync::{Arc, Weak};
+use alloc::vec::Vec;
 
 use crate::debug_lockdep::assert_no_spinlocks_held;
-use crate::fs::ext2::indirect::{resolve_block, Geometry, WalkError};
+use crate::fs::ext2::indirect::{
+    resolve_block, Geometry, MetadataMap, WalkError, EXT2_DIND_BLOCK, EXT2_DIRECT_BLOCKS,
+    EXT2_IND_BLOCK, EXT2_TIND_BLOCK,
+};
 use crate::fs::ext2::Ext2Super;
-use crate::fs::{EIO, EROFS};
+use crate::fs::{EFBIG, EIO, EROFS};
 use crate::mem::aops::AddressSpaceOps;
 
-use super::file::build_metadata_map;
+use super::balloc::{alloc_block, free_block};
+use super::disk::EXT2_N_BLOCKS;
+use super::file::{build_metadata_map, flush_inode_slot, validate_existing_pointer};
 use super::inode::Ext2Inode;
 
 /// Page size the page cache deals in. Matches `crate::mem::PAGE_SIZE`
@@ -290,22 +293,597 @@ impl AddressSpaceOps for Ext2Aops {
         Ok(PAGE_SIZE as usize)
     }
 
-    fn writepage(&self, _pgoff: u64, _buf: &[u8; 4096]) -> Result<(), i64> {
-        // RFC 0007 §Lock-order ladder: every method body asserts no
-        // spinlocks at entry, even the stubbed-out ones — the
-        // assertion is part of the trait contract, not the work.
-        assert_no_spinlocks_held("Ext2Aops::writepage (stub — #750)");
-        // Issue #750 lands the real buffer-cache writeback chain.
-        // Until then surface `EROFS` so a `MAP_SHARED` writeback
-        // attempt (e.g. via the page-fault path that #746 / #755
-        // wires) bumps `wb_err` and surfaces a deterministic errno
-        // to userspace, rather than panicking the kernel.
-        Err(EROFS)
+    /// Write `buf` back to file page `pgoff` via the buffer cache.
+    ///
+    /// Splits the 4 KiB page into FS-block-sized fragments (1, 2, or
+    /// 4 fragments depending on `block_size ∈ {4096, 2048, 1024}`),
+    /// drives each fragment through the bitmap → indirect → data
+    /// allocation chain (RFC 0004 §Write Ordering — same ordering as
+    /// `write_file_at`), then RMW-overlays the user bytes through the
+    /// buffer cache and `sync_dirty_buffer`s. `i_blocks` and `i_size`
+    /// are bumped *only after every per-block write succeeds*.
+    ///
+    /// On any per-block failure (allocator-out-of-space, indirect-
+    /// pointer corruption, buffer-cache I/O), the impl rolls back
+    /// every block this writepage allocated — `free_block` for the
+    /// data block + each newly-allocated indirect-pointer block, and
+    /// clears the slot that pointed at it (either an `i_block[]` slot
+    /// in memory or a freshly-RMW-zeroed slot inside the parent
+    /// indirect block). The on-disk and in-memory views are restored
+    /// to the pre-call state; the caller (writeback daemon) bumps
+    /// `mapping.wb_err` on the returned errno (errseq surface).
+    ///
+    /// # Errno table
+    ///
+    /// - [`EROFS`] — RO mount (user-requested or feature-forced) or
+    ///   the runtime force-RO latch tripped (RFC 0004 §Security).
+    ///   Surfaces directly without consulting the page contents.
+    /// - [`EFBIG`] — `pgoff * 4096` overflows `u64`, or the logical
+    ///   block index lies past triple-indirect.
+    /// - [`EIO`] — buffer-cache read/write failure or attacker-forged
+    ///   pointer in an existing indirect chain (the same forgery
+    ///   detector the read walker enforces).
+    /// - Any errno surfaced by [`alloc_block`] (typically `ENOSPC`).
+    ///
+    /// # Lock-order
+    ///
+    /// `assert_no_spinlocks_held` first. The metadata write-lock on
+    /// [`Ext2Inode::meta`] is held across the entire allocation +
+    /// write + flush sequence so a racing truncate / write cannot
+    /// interleave block-pointer mutations with ours.
+    fn writepage(&self, pgoff: u64, buf: &[u8; 4096]) -> Result<(), i64> {
+        assert_no_spinlocks_held("Ext2Aops::writepage");
+
+        let super_ref = self.super_ref.upgrade().ok_or(EIO)?;
+        let ext2_inode = self.inode_ref.upgrade().ok_or(EIO)?;
+
+        // RO / forced-RO / latched-RO mount → don't even consider the
+        // page contents. The writeback daemon will bump `wb_err` on
+        // this errno (RFC 0007 §`PageCache`, errseq pattern).
+        if !super_ref.is_writable() {
+            return Err(EROFS);
+        }
+
+        let block_size = super_ref.block_size as u64;
+        debug_assert!(block_size > 0, "mount validated block_size != 0");
+
+        // Page byte-offset window. `pgoff * 4096` overflowing surfaces
+        // as EFBIG — a structurally too-large file index can't fit in
+        // ext2's logical-block u32 either, so the errno lines up.
+        let page_lo = pgoff.checked_mul(PAGE_SIZE).ok_or(EFBIG)?;
+        let page_hi = page_lo.checked_add(PAGE_SIZE).ok_or(EFBIG)?;
+
+        // Geometry + metadata-forbidden map. Same construction as
+        // `readpage` / `write_file_at`; see those modules for the
+        // perf TODO around caching this on `Ext2Super`.
+        let (s_first_data_block, s_blocks_count, s_inodes_per_group) = {
+            let sb = super_ref.sb_disk.lock();
+            (
+                sb.s_first_data_block,
+                sb.s_blocks_count,
+                sb.s_inodes_per_group,
+            )
+        };
+        let geom =
+            Geometry::new(super_ref.block_size, s_first_data_block, s_blocks_count).ok_or(EIO)?;
+        let md = build_metadata_map(&super_ref);
+
+        // Hint group for `alloc_block`: data-locality wants new blocks
+        // to land in the same group as the inode. Mirrors the
+        // computation in `write_file_at`.
+        let inode_group = if s_inodes_per_group == 0 {
+            0
+        } else {
+            (ext2_inode.ino - 1) / s_inodes_per_group
+        };
+
+        // Hold the metadata write-lock across the whole sequence — see
+        // the doc on `write_file_at` for the rationale (serialise
+        // against truncate / racing extend writes so block-pointer
+        // mutations don't trample each other).
+        let mut meta = ext2_inode.meta.write();
+
+        // Track every allocation done during this writepage so we can
+        // unwind on a per-block failure. The Vec sees at most
+        // ~5 events per call (4 leaf data blocks + 1 single-indirect
+        // pointer block on a 1 KiB-block fs); for normal 4 KiB-block
+        // mounts it sees at most one event.
+        let mut events: Vec<AllocEvent> = Vec::new();
+        let mut bumped_blocks_512: u64 = 0;
+
+        // Walk the page in FS-block-sized fragments. Use a local
+        // closure-style fold so a per-block error short-circuits to
+        // the rollback path.
+        let result: Result<(), i64> = (|| {
+            let mut cur = page_lo;
+            while cur < page_hi {
+                let logical_u64 = cur / block_size;
+                let logical: u32 = logical_u64.try_into().map_err(|_| EFBIG)?;
+                let in_block = (cur % block_size) as usize;
+                let chunk = (block_size as usize) - in_block;
+                debug_assert!(chunk > 0);
+                let buf_off = (cur - page_lo) as usize;
+                debug_assert!(buf_off + chunk <= buf.len());
+
+                // Resolve / allocate the underlying disk block. The
+                // allocation path records each step in `events` so a
+                // failure later in this iteration (or a later
+                // iteration) can roll back.
+                let data_blk = ensure_block_for_writepage(
+                    &super_ref,
+                    &geom,
+                    &md,
+                    &mut meta.i_block,
+                    logical,
+                    inode_group,
+                    &mut events,
+                    &mut bumped_blocks_512,
+                )?;
+
+                // RMW the data block: bread, overlay our chunk at
+                // `in_block`, mark dirty, sync.
+                let bh = super_ref
+                    .cache
+                    .bread(super_ref.device_id, data_blk as u64)
+                    .map_err(|_| EIO)?;
+                {
+                    let mut data = bh.data.write();
+                    debug_assert!(in_block + chunk <= data.len());
+                    data[in_block..in_block + chunk]
+                        .copy_from_slice(&buf[buf_off..buf_off + chunk]);
+                }
+                super_ref.cache.mark_dirty(&bh);
+                super_ref.cache.sync_dirty_buffer(&bh).map_err(|_| EIO)?;
+
+                cur += chunk as u64;
+            }
+            Ok(())
+        })();
+
+        if let Err(e) = result {
+            // Roll back every allocation we did this call. Any data
+            // already overlaid into a *pre-existing* block stays —
+            // it's the caller's bytes against a block they already
+            // owned; clobbering it would lose work the caller
+            // committed. Only freshly-allocated blocks are returned.
+            rollback_allocations(&super_ref, &mut meta.i_block, &events);
+            return Err(e);
+        }
+
+        // All per-block writes succeeded. Bump `i_size` (only if the
+        // page extends the file — the trait contract is "writepage
+        // never shrinks") and `i_blocks`. The mtime/ctime bump
+        // matches `write_file_at`'s discipline.
+        let new_size = meta.size.max(page_hi);
+        meta.size = new_size;
+        meta.i_blocks = meta.i_blocks.saturating_add(bumped_blocks_512 as u32);
+        let now = crate::fs::vfs::Timespec::now();
+        meta.mtime = now.sec as u32;
+        meta.ctime = now.sec as u32;
+
+        // Flush the inode slot. RFC 0004 §Write Ordering: this is
+        // *last*, after every data + indirect block has hit the
+        // device. A crash before this point leaves readers with the
+        // pre-writepage `i_size` (correct, just stale) but every
+        // block that was committed is safely on disk and reachable
+        // through its parent.
+        if let Err(e) = flush_inode_slot(&super_ref, ext2_inode.ino, &meta) {
+            // The inode-slot flush failed *after* every data block
+            // landed. We can't safely roll the data back (the bytes
+            // are durable on disk under blocks that are now linked
+            // into the inode). Free the freshly-allocated blocks so
+            // the bitmap / counters don't leak. The in-memory meta
+            // mutations above are reverted to keep the in-mem and
+            // on-disk views consistent — the user sees the failure
+            // via the returned errno.
+            rollback_allocations(&super_ref, &mut meta.i_block, &events);
+            return Err(e);
+        }
+
+        // The VFS-layer `Inode::meta` mirror is intentionally *not*
+        // updated here. `Ext2Aops` doesn't carry an `Inode` weak
+        // pointer — the readpage path doesn't need one and adding it
+        // for writepage would expand the trait-object footprint
+        // wave-3 #753 hasn't yet committed to. The on-disk slot is
+        // flushed above, so the next `iget` (or fault-path
+        // `Inode::page_cache_or_create`) re-reads the fresh values;
+        // a concurrent in-memory `getattr` against the same inode
+        // sees the previous size/blocks until that point. That's
+        // acceptable for the page-cache writeback path the daemon
+        // drives — the daemon doesn't itself depend on the in-memory
+        // VFS meta. See follow-up issue captured in the PR body.
+        Ok(())
     }
 
     // `readahead` and `truncate_below` left at the trait defaults —
     // both are no-op + `assert_no_spinlocks_held`. Issue #751 lands
     // `truncate_below`; issue #752 lands `readahead`.
+}
+
+// ---------------------------------------------------------------------------
+// writepage internals
+// ---------------------------------------------------------------------------
+
+/// One allocation event recorded during [`Ext2Aops::writepage`]. Used
+/// solely to rewind on a per-block failure: every event carries enough
+/// information to (a) `free_block` the underlying disk block and (b)
+/// clear the slot that points at it (either an `i_block[]` slot in
+/// memory or a slot inside a previously-allocated indirect block on
+/// disk).
+#[derive(Debug, Clone, Copy)]
+enum AllocEvent {
+    /// A direct slot mutation: `i_block[idx] = blk`. Rollback clears
+    /// the slot and frees `blk`.
+    Direct { idx: usize, blk: u32 },
+    /// A top-level indirect pointer install: `i_block[slot_idx] = blk`
+    /// where `slot_idx ∈ {EXT2_IND_BLOCK, EXT2_DIND_BLOCK,
+    /// EXT2_TIND_BLOCK}`. Rollback clears the slot in `i_block[]`
+    /// and frees `blk`.
+    TopIndirect { slot_idx: usize, blk: u32 },
+    /// A child pointer install at slot `index` inside a previously-
+    /// allocated *or* pre-existing indirect block at absolute
+    /// `parent_blk`. Rollback RMW-zeroes that on-disk slot and frees
+    /// `blk`.
+    InnerIndirect {
+        parent_blk: u32,
+        index: u32,
+        blk: u32,
+    },
+}
+
+/// Number of 512-byte units one fs-block costs (for `i_blocks`
+/// bookkeeping). Mirrors the same expression in `write_file_at`.
+#[inline]
+fn blocks_per_512(geom: &Geometry) -> u64 {
+    (geom.block_size / 512) as u64
+}
+
+/// Resolve / allocate the data block backing logical block `logical`,
+/// recording every allocation event in `events` so a downstream failure
+/// can roll back.
+///
+/// Mirrors [`super::file::ensure_block_allocated`] in shape but
+/// records events along the way. The two paths are kept separate
+/// rather than refactored together because `write_file_at` is
+/// deliberately partial-write-tolerant (a failed block stops the
+/// loop without rolling back) while writepage is whole-page-atomic.
+#[allow(clippy::too_many_arguments)]
+fn ensure_block_for_writepage(
+    super_: &Arc<Ext2Super>,
+    geom: &Geometry,
+    md: &MetadataMap,
+    i_block_mut: &mut [u32; EXT2_N_BLOCKS],
+    logical: u32,
+    hint_group: u32,
+    events: &mut Vec<AllocEvent>,
+    bumped_512: &mut u64,
+) -> Result<u32, i64> {
+    let p = geom.ptrs_per_block as u64;
+    let direct_limit = EXT2_DIRECT_BLOCKS as u64;
+    let single_limit = direct_limit + p;
+    let double_limit = single_limit + p * p;
+    let triple_limit = double_limit + p * p * p;
+    let logical64 = logical as u64;
+
+    let bp512 = blocks_per_512(geom);
+
+    if logical64 < direct_limit {
+        let idx = logical as usize;
+        let slot = &mut i_block_mut[idx];
+        if *slot != 0 {
+            validate_existing_pointer(*slot, geom, md)?;
+            return Ok(*slot);
+        }
+        let blk = alloc_and_zero(super_, hint_group)?;
+        *slot = blk;
+        events.push(AllocEvent::Direct { idx, blk });
+        *bumped_512 += bp512;
+        Ok(blk)
+    } else if logical64 < single_limit {
+        let idx0 = (logical64 - direct_limit) as u32;
+        let ind = ensure_top_indirect(
+            super_,
+            i_block_mut,
+            EXT2_IND_BLOCK,
+            hint_group,
+            geom,
+            md,
+            events,
+            bumped_512,
+        )?;
+        ensure_leaf(super_, ind, idx0, hint_group, geom, md, events, bumped_512)
+    } else if logical64 < double_limit {
+        let rel = logical64 - single_limit;
+        let idx_outer = (rel / p) as u32;
+        let idx_inner = (rel % p) as u32;
+        let dind = ensure_top_indirect(
+            super_,
+            i_block_mut,
+            EXT2_DIND_BLOCK,
+            hint_group,
+            geom,
+            md,
+            events,
+            bumped_512,
+        )?;
+        let ind = ensure_inner_indirect(
+            super_, dind, idx_outer, hint_group, geom, md, events, bumped_512,
+        )?;
+        ensure_leaf(
+            super_, ind, idx_inner, hint_group, geom, md, events, bumped_512,
+        )
+    } else if logical64 < triple_limit {
+        let rel = logical64 - double_limit;
+        let p_sq = p * p;
+        let idx_l0 = (rel / p_sq) as u32;
+        let rem = rel % p_sq;
+        let idx_l1 = (rem / p) as u32;
+        let idx_l2 = (rem % p) as u32;
+        let tind = ensure_top_indirect(
+            super_,
+            i_block_mut,
+            EXT2_TIND_BLOCK,
+            hint_group,
+            geom,
+            md,
+            events,
+            bumped_512,
+        )?;
+        let dind = ensure_inner_indirect(
+            super_, tind, idx_l0, hint_group, geom, md, events, bumped_512,
+        )?;
+        let ind = ensure_inner_indirect(
+            super_, dind, idx_l1, hint_group, geom, md, events, bumped_512,
+        )?;
+        ensure_leaf(
+            super_, ind, idx_l2, hint_group, geom, md, events, bumped_512,
+        )
+    } else {
+        Err(EFBIG)
+    }
+}
+
+/// Ensure `i_block[slot_idx]` points at a zeroed indirect block. If
+/// the slot is already populated, validate the existing pointer
+/// (forgery check) and return it. If freshly allocated, push a
+/// `TopIndirect` event so a rollback can clear the slot.
+#[allow(clippy::too_many_arguments)]
+fn ensure_top_indirect(
+    super_: &Arc<Ext2Super>,
+    i_block_mut: &mut [u32; EXT2_N_BLOCKS],
+    slot_idx: usize,
+    hint_group: u32,
+    geom: &Geometry,
+    md: &MetadataMap,
+    events: &mut Vec<AllocEvent>,
+    bumped_512: &mut u64,
+) -> Result<u32, i64> {
+    let existing = i_block_mut[slot_idx];
+    if existing != 0 {
+        validate_existing_pointer(existing, geom, md)?;
+        return Ok(existing);
+    }
+    let blk = alloc_and_zero(super_, hint_group)?;
+    i_block_mut[slot_idx] = blk;
+    events.push(AllocEvent::TopIndirect { slot_idx, blk });
+    *bumped_512 += blocks_per_512(geom);
+    Ok(blk)
+}
+
+/// Ensure slot `index` of the indirect block at absolute `parent_blk`
+/// points at a zeroed child indirect block. If the slot is populated,
+/// validate the existing pointer and return it. If freshly allocated,
+/// RMW-link the child into the parent (sync) and push an
+/// `InnerIndirect` event so a rollback can clear the parent's slot
+/// and free the child.
+#[allow(clippy::too_many_arguments)]
+fn ensure_inner_indirect(
+    super_: &Arc<Ext2Super>,
+    parent_blk: u32,
+    index: u32,
+    hint_group: u32,
+    geom: &Geometry,
+    md: &MetadataMap,
+    events: &mut Vec<AllocEvent>,
+    bumped_512: &mut u64,
+) -> Result<u32, i64> {
+    let (existing, bh) = read_indirect_slot(super_, parent_blk, index, geom)?;
+    if existing != 0 {
+        validate_existing_pointer(existing, geom, md)?;
+        return Ok(existing);
+    }
+    let child = alloc_and_zero(super_, hint_group)?;
+    {
+        let mut data = bh.data.write();
+        let off = (index as usize) * 4;
+        debug_assert!(off + 4 <= data.len());
+        data[off..off + 4].copy_from_slice(&child.to_le_bytes());
+    }
+    super_.cache.mark_dirty(&bh);
+    if let Err(e) = super_.cache.sync_dirty_buffer(&bh).map_err(|_| EIO) {
+        // Linking the child into the parent failed at sync time. The
+        // child is allocated but unreachable; free it before
+        // surfacing. We don't push the InnerIndirect event because
+        // the on-disk parent slot was never persisted (we just
+        // mutated the in-memory cache page; the next `bread` of
+        // `parent_blk` will re-read the on-disk pre-link state if
+        // the cache evicts and refills, but if the dirty page sticks
+        // in cache the unflushed mutation would be a real leak —
+        // call `mark_clean` would be ideal but the cache surface
+        // doesn't expose one; revert the byte mutation in-place
+        // instead).
+        {
+            let mut data = bh.data.write();
+            let off = (index as usize) * 4;
+            data[off..off + 4].copy_from_slice(&0u32.to_le_bytes());
+        }
+        let _ = free_block(super_, child);
+        return Err(e);
+    }
+    events.push(AllocEvent::InnerIndirect {
+        parent_blk,
+        index,
+        blk: child,
+    });
+    *bumped_512 += blocks_per_512(geom);
+    Ok(child)
+}
+
+/// Ensure slot `index` of the indirect block at absolute `parent_blk`
+/// points at a freshly-allocated zeroed data block. Same shape as
+/// [`ensure_inner_indirect`] but the child is a data block, not an
+/// indirect pointer block. The recorded event type is identical
+/// (`InnerIndirect`) — rollback semantics are the same.
+#[allow(clippy::too_many_arguments)]
+fn ensure_leaf(
+    super_: &Arc<Ext2Super>,
+    parent_blk: u32,
+    index: u32,
+    hint_group: u32,
+    geom: &Geometry,
+    md: &MetadataMap,
+    events: &mut Vec<AllocEvent>,
+    bumped_512: &mut u64,
+) -> Result<u32, i64> {
+    let (existing, bh) = read_indirect_slot(super_, parent_blk, index, geom)?;
+    if existing != 0 {
+        validate_existing_pointer(existing, geom, md)?;
+        return Ok(existing);
+    }
+    let data_blk = alloc_and_zero(super_, hint_group)?;
+    {
+        let mut data = bh.data.write();
+        let off = (index as usize) * 4;
+        debug_assert!(off + 4 <= data.len());
+        data[off..off + 4].copy_from_slice(&data_blk.to_le_bytes());
+    }
+    super_.cache.mark_dirty(&bh);
+    if let Err(e) = super_.cache.sync_dirty_buffer(&bh).map_err(|_| EIO) {
+        {
+            let mut data = bh.data.write();
+            let off = (index as usize) * 4;
+            data[off..off + 4].copy_from_slice(&0u32.to_le_bytes());
+        }
+        let _ = free_block(super_, data_blk);
+        return Err(e);
+    }
+    events.push(AllocEvent::InnerIndirect {
+        parent_blk,
+        index,
+        blk: data_blk,
+    });
+    *bumped_512 += blocks_per_512(geom);
+    Ok(data_blk)
+}
+
+/// Read the pointer at slot `index` out of the indirect block at
+/// absolute `abs`, returning both the decoded pointer and the buffer
+/// handle so the caller can RMW the same slot on a miss without a
+/// second `bread`. Mirrors `file::read_pointer_slot_raw` (kept private
+/// to its module — duplicating the four-line helper here is simpler
+/// than expanding the file.rs surface).
+fn read_indirect_slot(
+    super_: &Arc<Ext2Super>,
+    abs: u32,
+    index: u32,
+    geom: &Geometry,
+) -> Result<(u32, Arc<crate::block::cache::BufferHead>), i64> {
+    debug_assert!(index < geom.ptrs_per_block);
+    let bh = super_
+        .cache
+        .bread(super_.device_id, abs as u64)
+        .map_err(|_| EIO)?;
+    let val = {
+        let data = bh.data.read();
+        let off = (index as usize) * 4;
+        let slot: [u8; 4] = data[off..off + 4]
+            .try_into()
+            .expect("indirect pointer slot is exactly 4 bytes");
+        u32::from_le_bytes(slot)
+    };
+    Ok((val, bh))
+}
+
+/// Allocate a fresh block via the bitmap allocator and synchronously
+/// zero it through the buffer cache. Combined into a single helper so
+/// both data and indirect pointer block allocations share the
+/// "never link unzeroed bytes into the inode" invariant (RFC 0004
+/// §Write Ordering).
+fn alloc_and_zero(super_: &Arc<Ext2Super>, hint_group: u32) -> Result<u32, i64> {
+    let blk = alloc_block(super_, Some(hint_group))?;
+    if let Err(e) = zero_block(super_, blk) {
+        // Zeroing failed — return the block to the bitmap so we
+        // don't leak. The caller will see the I/O errno and surface
+        // it.
+        let _ = free_block(super_, blk);
+        return Err(e);
+    }
+    Ok(blk)
+}
+
+/// Zero a freshly-allocated block synchronously through the cache.
+/// Mirrors `file::zero_block`.
+fn zero_block(super_: &Arc<Ext2Super>, abs: u32) -> Result<(), i64> {
+    let bh = super_
+        .cache
+        .bread(super_.device_id, abs as u64)
+        .map_err(|_| EIO)?;
+    {
+        let mut data = bh.data.write();
+        for b in data.iter_mut() {
+            *b = 0;
+        }
+    }
+    super_.cache.mark_dirty(&bh);
+    super_.cache.sync_dirty_buffer(&bh).map_err(|_| EIO)
+}
+
+/// Roll back every allocation event recorded during this writepage.
+/// Reverse order so a leaf is unlinked before its parent indirect
+/// block. Per-step failures are swallowed — a successful rollback is
+/// best-effort: a free or a slot-clear that fails would leak rather
+/// than corrupt, and the caller is already on the error path.
+fn rollback_allocations(
+    super_: &Arc<Ext2Super>,
+    i_block_mut: &mut [u32; EXT2_N_BLOCKS],
+    events: &[AllocEvent],
+) {
+    for ev in events.iter().rev() {
+        match *ev {
+            AllocEvent::Direct { idx, blk } => {
+                debug_assert_eq!(i_block_mut[idx], blk);
+                i_block_mut[idx] = 0;
+                let _ = free_block(super_, blk);
+            }
+            AllocEvent::TopIndirect { slot_idx, blk } => {
+                debug_assert_eq!(i_block_mut[slot_idx], blk);
+                i_block_mut[slot_idx] = 0;
+                let _ = free_block(super_, blk);
+            }
+            AllocEvent::InnerIndirect {
+                parent_blk,
+                index,
+                blk,
+            } => {
+                // RMW-zero the parent slot. If the bread / sync fails
+                // we still call `free_block` so the bitmap counter
+                // stays honest; the on-disk parent slot is left
+                // pointing at a freed block, which `e2fsck` repairs.
+                if let Ok(bh) = super_.cache.bread(super_.device_id, parent_blk as u64) {
+                    {
+                        let mut data = bh.data.write();
+                        let off = (index as usize) * 4;
+                        if off + 4 <= data.len() {
+                            data[off..off + 4].copy_from_slice(&0u32.to_le_bytes());
+                        }
+                    }
+                    super_.cache.mark_dirty(&bh);
+                    let _ = super_.cache.sync_dirty_buffer(&bh);
+                }
+                let _ = free_block(super_, blk);
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/kernel/src/fs/ext2/aops.rs
+++ b/kernel/src/fs/ext2/aops.rs
@@ -454,6 +454,18 @@ impl AddressSpaceOps for Ext2Aops {
         // page extends the file — the trait contract is "writepage
         // never shrinks") and `i_blocks`. The mtime/ctime bump
         // matches `write_file_at`'s discipline.
+        //
+        // Snapshot the pre-mutation values so a `flush_inode_slot`
+        // failure can restore the in-memory meta wholesale (CodeRabbit
+        // #803: a partial restore that only touched `i_block[]` would
+        // leave `size` / `i_blocks` / mtime / ctime visibly enlarged
+        // after a flush failure even though the underlying blocks
+        // were unwound).
+        let old_size = meta.size;
+        let old_i_blocks = meta.i_blocks;
+        let old_mtime = meta.mtime;
+        let old_ctime = meta.ctime;
+
         let new_size = meta.size.max(page_hi);
         meta.size = new_size;
         meta.i_blocks = meta.i_blocks.saturating_add(bumped_blocks_512 as u32);
@@ -469,14 +481,25 @@ impl AddressSpaceOps for Ext2Aops {
         // through its parent.
         if let Err(e) = flush_inode_slot(&super_ref, ext2_inode.ino, &meta) {
             // The inode-slot flush failed *after* every data block
-            // landed. We can't safely roll the data back (the bytes
-            // are durable on disk under blocks that are now linked
-            // into the inode). Free the freshly-allocated blocks so
-            // the bitmap / counters don't leak. The in-memory meta
-            // mutations above are reverted to keep the in-mem and
-            // on-disk views consistent — the user sees the failure
-            // via the returned errno.
+            // landed. Free the freshly-allocated blocks so the
+            // bitmap / counters don't leak, and revert every field we
+            // bumped above so the in-memory meta matches the pre-call
+            // state — the user sees the failure via the returned
+            // errno; subsequent `getattr` against this inode must not
+            // observe phantom-extended size/blocks.
+            //
+            // (Caveat: `sync_dirty_buffer` returning Err does not
+            // strictly prove the on-disk inode slot is unchanged. The
+            // codebase-wide convention — `write_file_at`,
+            // `setattr`, `link`, `create` — is the same "free + restore"
+            // posture; tightening to a force-RO latch on uncertain-
+            // durability is tracked as a follow-up rather than fixed
+            // piecemeal here.)
             rollback_allocations(&super_ref, &mut meta.i_block, &events);
+            meta.size = old_size;
+            meta.i_blocks = old_i_blocks;
+            meta.mtime = old_mtime;
+            meta.ctime = old_ctime;
             return Err(e);
         }
 

--- a/kernel/src/fs/ext2/file.rs
+++ b/kernel/src/fs/ext2/file.rs
@@ -641,7 +641,15 @@ fn ensure_block_allocated(
 /// s_blocks_count)`, not in a metadata range). A malformed pointer
 /// here is the same attacker-forged-image confused-deputy vector the
 /// read walker guards against.
-fn validate_existing_pointer(p: u32, geom: &Geometry, md: &MetadataMap) -> Result<(), i64> {
+///
+/// Exposed at `pub(super)` so the [`super::aops`] writepage path can
+/// reuse the same forgery check before reading or RMW-ing an indirect
+/// pointer slot.
+pub(super) fn validate_existing_pointer(
+    p: u32,
+    geom: &Geometry,
+    md: &MetadataMap,
+) -> Result<(), i64> {
     if !geom.in_data_range(p) || md.contains(p) {
         return Err(EIO);
     }
@@ -824,7 +832,10 @@ fn zero_block(super_: &Arc<Ext2Super>, abs: u32) -> Result<(), i64> {
 /// then `write_file_at` is the only site that needs to persist the
 /// fields it mutates (`i_size`, `i_blocks`, `i_mtime`, `i_ctime`,
 /// `i_block[]`). Using a local helper keeps the scope tight.
-fn flush_inode_slot(
+///
+/// Exposed at `pub(super)` so the [`super::aops`] writepage path
+/// reuses the same RMW discipline for its own metadata flush.
+pub(super) fn flush_inode_slot(
     super_: &Arc<Ext2Super>,
     ino: u32,
     meta: &super::inode::Ext2InodeMeta,

--- a/kernel/tests/ext2_writepage.rs
+++ b/kernel/tests/ext2_writepage.rs
@@ -195,7 +195,7 @@ fn s_free_blocks(super_arc: &Arc<Ext2Super>) -> u32 {
 /// page; a subsequent `read_file_at` round-trips the user bytes.
 fn writepage_dense_first_page() {
     let (sb, _fs, super_arc) = mount_rw();
-    let (_ino, inode, ext2_inode) = fresh_regular(&sb, &super_arc);
+    let (ino, inode, ext2_inode) = fresh_regular(&sb, &super_arc);
     let aops = Ext2Aops::new(&super_arc, &ext2_inode);
 
     // Build a deterministic 4 KiB payload — one byte-per-position with
@@ -247,9 +247,33 @@ fn writepage_dense_first_page() {
     assert_eq!(n, 4096);
     assert_eq!(readback, payload, "writepage data must round-trip");
 
+    // Persistence check (CodeRabbit #803 nit): drop every strong ref
+    // to the inode so the cache's `Weak` decays, then re-`iget` the
+    // same `ino`. The fresh `Ext2Inode` is constructed straight from
+    // the on-disk slot, so an `i_size` / `i_blocks` mismatch here
+    // would prove `flush_inode_slot` never landed.
     drop(aops);
     drop(ext2_inode);
     drop(inode);
+
+    let inode2 = iget(&super_arc, &sb, ino).expect("iget after writepage");
+    {
+        use alloc::sync::Weak;
+        let ext2_inode2 = {
+            let ecache = super_arc.ext2_inode_cache.lock();
+            ecache
+                .get(&ino)
+                .and_then(Weak::upgrade)
+                .expect("ext2_inode_cache repopulated by iget")
+        };
+        let m = ext2_inode2.meta.read();
+        assert_eq!(m.size, 4096, "i_size persisted across iget");
+        assert_eq!(m.i_blocks, 8, "i_blocks persisted across iget");
+        for i in 0..4 {
+            assert!(m.i_block[i] != 0, "i_block[{i}] persisted across iget");
+        }
+    }
+    drop(inode2);
     sb.ops.unmount();
     drop(super_arc);
 }
@@ -260,7 +284,7 @@ fn writepage_dense_first_page() {
 /// the user bytes.
 fn writepage_sparse_then_extend() {
     let (sb, _fs, super_arc) = mount_rw();
-    let (_ino, inode, ext2_inode) = fresh_regular(&sb, &super_arc);
+    let (ino, inode, ext2_inode) = fresh_regular(&sb, &super_arc);
     let aops = Ext2Aops::new(&super_arc, &ext2_inode);
 
     let mut payload = [0u8; 4096];
@@ -324,9 +348,35 @@ fn writepage_sparse_then_extend() {
     assert_eq!(r, 4096);
     assert_eq!(readback, payload, "sparse writepage data must round-trip");
 
+    // Persistence check (CodeRabbit #803 nit): drop strong refs and
+    // re-`iget`. The single-indirect pointer block + size +
+    // i_blocks must all be reflected in the freshly-decoded slot.
     drop(aops);
     drop(ext2_inode);
     drop(inode);
+
+    let inode2 = iget(&super_arc, &sb, ino).expect("iget after sparse writepage");
+    {
+        use alloc::sync::Weak;
+        let ext2_inode2 = {
+            let ecache = super_arc.ext2_inode_cache.lock();
+            ecache
+                .get(&ino)
+                .and_then(Weak::upgrade)
+                .expect("ext2_inode_cache repopulated by iget")
+        };
+        let m = ext2_inode2.meta.read();
+        assert_eq!(m.size, page_hi, "sparse i_size persisted across iget");
+        assert_eq!(m.i_blocks, 10, "sparse i_blocks persisted across iget");
+        for i in 0..12 {
+            assert_eq!(m.i_block[i], 0, "direct slot {i} hole persisted");
+        }
+        assert!(
+            m.i_block[12] != 0,
+            "single-indirect slot persisted across iget"
+        );
+    }
+    drop(inode2);
     sb.ops.unmount();
     drop(super_arc);
 }

--- a/kernel/tests/ext2_writepage.rs
+++ b/kernel/tests/ext2_writepage.rs
@@ -1,0 +1,489 @@
+//! Integration test for issue #750: ext2
+//! [`AddressSpaceOps::writepage`] with allocate-on-extend.
+//!
+//! RFC 0007 §`AddressSpaceOps` and RFC 0004 §Write Ordering are the
+//! normative spec. Mounts the 512 KiB `balloc_test.img` fixture (two
+//! block groups of 256 blocks, 128 inodes, 1 KiB blocks) read-write,
+//! `alloc_inode`s a fresh inode, initialises its on-disk slot as a
+//! zero-length regular file, builds an [`Ext2Aops`] over it, and
+//! exercises three writepage scenarios:
+//!
+//! - **Dense writepage** — the first page (4 KiB) of a fresh inode.
+//!   On a 1 KiB-block fs the page splits into four direct-block
+//!   fragments; every fragment is allocated, written, and synced.
+//!   `i_size` and `i_blocks` reflect the full page after the call. A
+//!   subsequent `read_file_at` round-trips the bytes.
+//! - **Sparse-then-extend writepage** — writepage at page index 5 of
+//!   a fresh inode. `i_size` jumps from 0 to `6 * 4096`; pages
+//!   `[0, 5)` remain unallocated holes, and `read_file_at` over the
+//!   `[0, 20480)` window returns POSIX-zero. Page 5 itself round-
+//!   trips the user bytes.
+//! - **Allocator-failure rollback** — drain every free block, then
+//!   call writepage. The allocator returns `ENOSPC` partway through
+//!   the four-fragment page; rollback frees any fragments allocated
+//!   so far, and `i_size` / `i_blocks` are *unchanged* from the pre-
+//!   call state. The mount-wide free-block counter is identical
+//!   before and after.
+//!
+//! All tests use the same `balloc_test.img` fixture as
+//! `kernel/tests/ext2_file_write.rs` so the per-mount state is
+//! battle-tested.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use alloc::vec;
+use core::panic::PanicInfo;
+
+use vibix::block::BlockDevice;
+use vibix::fs::ext2::aops::Ext2Aops;
+use vibix::fs::ext2::inode::Ext2Inode;
+use vibix::fs::ext2::{alloc_block, alloc_inode, iget, read_file_at, Ext2Fs, Ext2Super};
+use vibix::fs::vfs::ops::{FileSystem as _, MountSource};
+use vibix::fs::vfs::super_block::SuperBlock;
+use vibix::fs::vfs::MountFlags;
+use vibix::fs::{ENOSPC, EROFS};
+use vibix::mem::aops::AddressSpaceOps;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+const BALLOC_IMG: &[u8; 524_288] = include_bytes!("../src/fs/ext2/fixtures/balloc_test.img");
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "writepage_dense_first_page",
+            &(writepage_dense_first_page as fn()),
+        ),
+        (
+            "writepage_sparse_then_extend",
+            &(writepage_sparse_then_extend as fn()),
+        ),
+        (
+            "writepage_allocator_failure_rolls_back",
+            &(writepage_allocator_failure_rolls_back as fn()),
+        ),
+        (
+            "writepage_ro_mount_returns_erofs",
+            &(writepage_ro_mount_returns_erofs as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+#[path = "common/ext2_ramdisk.rs"]
+mod ext2_ramdisk;
+use ext2_ramdisk::RamDisk;
+
+fn mount_rw() -> (Arc<SuperBlock>, Arc<Ext2Fs>, Arc<Ext2Super>) {
+    let disk = RamDisk::from_image(BALLOC_IMG.as_slice(), 512);
+    let fs = Ext2Fs::new_with_device(disk as Arc<dyn BlockDevice>);
+    let sb = fs
+        .mount(MountSource::None, MountFlags(0))
+        .expect("RW mount must succeed");
+    let super_arc = fs
+        .current_super()
+        .expect("current_super must upgrade after mount");
+    (sb, fs, super_arc)
+}
+
+fn mount_ro() -> (Arc<SuperBlock>, Arc<Ext2Fs>, Arc<Ext2Super>) {
+    let disk = RamDisk::from_image(BALLOC_IMG.as_slice(), 512);
+    let fs = Ext2Fs::new_with_device(disk as Arc<dyn BlockDevice>);
+    let sb = fs
+        .mount(MountSource::None, MountFlags::RDONLY)
+        .expect("RO mount must succeed");
+    let super_arc = fs
+        .current_super()
+        .expect("current_super must upgrade after mount");
+    (sb, fs, super_arc)
+}
+
+/// Allocate a fresh inode on the mount and return both its `Arc<Inode>`
+/// (kept alive so the inode-cache `Weak` upgrade succeeds) and the
+/// parallel `Arc<Ext2Inode>` (the writepage hook needs the latter).
+fn fresh_regular(
+    sb: &Arc<SuperBlock>,
+    super_arc: &Arc<Ext2Super>,
+) -> (u32, Arc<vibix::fs::vfs::inode::Inode>, Arc<Ext2Inode>) {
+    use alloc::sync::Weak;
+    let ino = alloc_inode(super_arc, Some(0), false).expect("alloc_inode");
+    init_reg_inode(super_arc, ino);
+    let inode = iget(super_arc, sb, ino).expect("iget fresh inode");
+    let ext2_inode = {
+        let ecache = super_arc.ext2_inode_cache.lock();
+        ecache
+            .get(&ino)
+            .and_then(Weak::upgrade)
+            .expect("ext2_inode_cache must hold a Weak<Ext2Inode>")
+    };
+    (ino, inode, ext2_inode)
+}
+
+/// Stamp `ino`'s on-disk inode slot with a minimal regular-file
+/// layout. Mirrors the helper in `ext2_file_write.rs`.
+fn init_reg_inode(super_arc: &Arc<Ext2Super>, ino: u32) {
+    use vibix::fs::ext2::disk::Ext2Inode as DiskInode;
+    let inodes_per_group = super_arc.sb_disk.lock().s_inodes_per_group;
+    let bg_inode_table =
+        super_arc.bgdt.lock()[((ino - 1) / inodes_per_group) as usize].bg_inode_table;
+    let block_size = super_arc.block_size;
+    let inode_size = super_arc.inode_size;
+    let index_in_group = (ino - 1) % inodes_per_group;
+    let byte_offset = (index_in_group as u64) * (inode_size as u64);
+    let block_in_table = byte_offset / (block_size as u64);
+    let offset_in_block = (byte_offset % (block_size as u64)) as usize;
+    let bh = super_arc
+        .cache
+        .bread(super_arc.device_id, bg_inode_table as u64 + block_in_table)
+        .expect("bread inode table");
+    {
+        let mut data = bh.data.write();
+        let slot_end = offset_in_block + 128;
+        for b in &mut data[offset_in_block..slot_end] {
+            *b = 0;
+        }
+        let mut di = DiskInode::decode(&data[offset_in_block..slot_end]);
+        di.i_mode = 0o100644;
+        di.i_links_count = 1;
+        di.i_size = 0;
+        di.i_blocks = 0;
+        di.i_block = [0u32; 15];
+        di.encode_to_slot(&mut data[offset_in_block..slot_end]);
+    }
+    super_arc.cache.mark_dirty(&bh);
+    super_arc
+        .cache
+        .sync_dirty_buffer(&bh)
+        .expect("sync inode slot");
+}
+
+fn s_free_blocks(super_arc: &Arc<Ext2Super>) -> u32 {
+    super_arc.sb_disk.lock().s_free_blocks_count
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Dense writepage: a fresh inode, page 0 (`pgoff = 0`). On a 1 KiB-
+/// block fs the 4 KiB page splits into four direct fragments. Every
+/// fragment is allocated through the bitmap, written via the buffer
+/// cache, and synced. `i_size` and `i_blocks` reflect the complete
+/// page; a subsequent `read_file_at` round-trips the user bytes.
+fn writepage_dense_first_page() {
+    let (sb, _fs, super_arc) = mount_rw();
+    let (_ino, inode, ext2_inode) = fresh_regular(&sb, &super_arc);
+    let aops = Ext2Aops::new(&super_arc, &ext2_inode);
+
+    // Build a deterministic 4 KiB payload — one byte-per-position with
+    // a marker per 1 KiB sub-fragment so we can prove each fragment
+    // reached its target block.
+    let mut payload = [0u8; 4096];
+    for (i, slot) in payload.iter_mut().enumerate() {
+        *slot = ((i * 17 + 1) & 0xff) as u8;
+    }
+    payload[0] = b'A';
+    payload[1024] = b'B';
+    payload[2048] = b'C';
+    payload[3072] = b'D';
+
+    let free_before = s_free_blocks(&super_arc);
+
+    AddressSpaceOps::writepage(&*aops, 0, &payload).expect("dense writepage page 0");
+
+    {
+        let m = ext2_inode.meta.read();
+        assert_eq!(m.size, 4096, "i_size must reflect full page");
+        // Four 1 KiB blocks × 2 (512-byte units per block) = 8.
+        assert_eq!(m.i_blocks, 8, "i_blocks must reflect 4 fragments");
+        // Every direct slot 0..=3 holds a non-zero data block.
+        for i in 0..4 {
+            assert!(
+                m.i_block[i] != 0,
+                "i_block[{i}] must be allocated by writepage"
+            );
+        }
+        // Slots 4..15 are still unallocated.
+        for i in 4..15 {
+            assert_eq!(m.i_block[i], 0, "i_block[{i}] untouched");
+        }
+    }
+
+    // Free-block counter dropped by exactly 4 (no indirect-pointer
+    // allocations needed at this offset).
+    assert_eq!(
+        s_free_blocks(&super_arc),
+        free_before - 4,
+        "exactly 4 data blocks consumed"
+    );
+
+    // Round-trip the bytes via `read_file_at`.
+    let mut readback = [0u8; 4096];
+    let n =
+        read_file_at(&inode, &ext2_inode, &mut readback, 0).expect("read_file_at after writepage");
+    assert_eq!(n, 4096);
+    assert_eq!(readback, payload, "writepage data must round-trip");
+
+    drop(aops);
+    drop(ext2_inode);
+    drop(inode);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+/// Sparse-then-extend writepage: writepage at page 5 of a fresh
+/// inode. `i_size` jumps to `6 * 4096`; pages `[0, 5)` remain
+/// unallocated holes and read back as zero. Page 5 itself round-trips
+/// the user bytes.
+fn writepage_sparse_then_extend() {
+    let (sb, _fs, super_arc) = mount_rw();
+    let (_ino, inode, ext2_inode) = fresh_regular(&sb, &super_arc);
+    let aops = Ext2Aops::new(&super_arc, &ext2_inode);
+
+    let mut payload = [0u8; 4096];
+    for (i, slot) in payload.iter_mut().enumerate() {
+        *slot = ((i * 31 + 7) & 0xff) as u8;
+    }
+    payload[0] = b'X';
+    payload[4095] = b'Y';
+
+    let free_before = s_free_blocks(&super_arc);
+
+    let pgoff: u64 = 5;
+    AddressSpaceOps::writepage(&*aops, pgoff, &payload).expect("sparse writepage at pgoff 5");
+
+    let page_lo = pgoff * 4096;
+    let page_hi = page_lo + 4096;
+
+    {
+        let m = ext2_inode.meta.read();
+        assert_eq!(m.size, page_hi, "i_size grew to end-of-written-page");
+        // Page 5 spans logical blocks 20..=23 (1 KiB blocks). All four
+        // are direct slots (12 directs cover logical 0..=11) so logical
+        // 20..=23 land in the *single-indirect* range — the
+        // single-indirect pointer block plus four data blocks = 5
+        // blocks × 2 = 10 × 512-byte units.
+        assert_eq!(
+            m.i_blocks, 10,
+            "i_blocks must reflect 4 data + 1 indirect block"
+        );
+        // Direct slots 0..=11 must remain unallocated holes.
+        for i in 0..12 {
+            assert_eq!(m.i_block[i], 0, "direct slot {i} must be a hole");
+        }
+        // Single-indirect slot must be populated.
+        assert!(
+            m.i_block[12] != 0,
+            "single-indirect slot must hold pointer block"
+        );
+    }
+
+    // Free-block counter dropped by exactly 5 (4 data + 1 indirect
+    // pointer).
+    assert_eq!(
+        s_free_blocks(&super_arc),
+        free_before - 5,
+        "5 blocks consumed: 4 data + 1 indirect pointer"
+    );
+
+    // Pages [0, 5) read back as POSIX zero.
+    let mut hole = vec![0xaau8; page_lo as usize];
+    let r = read_file_at(&inode, &ext2_inode, &mut hole, 0).expect("read hole prefix");
+    assert_eq!(r, page_lo as usize, "full hole prefix must read");
+    assert!(
+        hole.iter().all(|&b| b == 0),
+        "sparse hole must read as POSIX zero"
+    );
+
+    // Page 5 round-trips the user bytes.
+    let mut readback = [0u8; 4096];
+    let r = read_file_at(&inode, &ext2_inode, &mut readback, page_lo).expect("read live page");
+    assert_eq!(r, 4096);
+    assert_eq!(readback, payload, "sparse writepage data must round-trip");
+
+    drop(aops);
+    drop(ext2_inode);
+    drop(inode);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+/// Allocator-failure rollback: drain every free block, then call
+/// writepage. The first fragment's allocation fails with `ENOSPC`;
+/// rollback (a no-op since nothing landed yet) is exercised, and the
+/// inode metadata is unchanged from the fresh state.
+///
+/// Cross-checks the rollback path with a *second* scenario: pre-fill
+/// some direct slots so the allocator has free space for the first
+/// few fragments but not the last one. Drain bitmap to `n - 3` free
+/// blocks before the writepage, so fragments 0..=2 succeed and
+/// fragment 3 fails. The metadata + bitmap counter must end identical
+/// to their pre-writepage values.
+fn writepage_allocator_failure_rolls_back() {
+    // ---------- Sub-test 1: ENOSPC on the very first fragment ----------
+    {
+        let (sb, _fs, super_arc) = mount_rw();
+        let (_ino, _inode, ext2_inode) = fresh_regular(&sb, &super_arc);
+        let aops = Ext2Aops::new(&super_arc, &ext2_inode);
+
+        // Drain the bitmap to zero free blocks.
+        loop {
+            match alloc_block(&super_arc, None) {
+                Ok(_) => {}
+                Err(ENOSPC) => break,
+                Err(e) => panic!("unexpected balloc error: {e}"),
+            }
+        }
+        let free_before = s_free_blocks(&super_arc);
+        assert_eq!(free_before, 0, "drain leaves zero free blocks");
+
+        let payload = [b'Z'; 4096];
+
+        // Snapshot pre-call state.
+        let (size_before, blocks_before, iblock_before) = {
+            let m = ext2_inode.meta.read();
+            (m.size, m.i_blocks, m.i_block)
+        };
+
+        let r = AddressSpaceOps::writepage(&*aops, 0, &payload);
+        assert_eq!(r, Err(ENOSPC), "writepage with no free blocks → ENOSPC");
+
+        // Metadata must be unchanged. Read in a tight scope so the
+        // RwLock guard is dropped before we move `ext2_inode` below.
+        {
+            let m = ext2_inode.meta.read();
+            assert_eq!(m.size, size_before, "i_size must not change on rollback");
+            assert_eq!(
+                m.i_blocks, blocks_before,
+                "i_blocks must not change on rollback"
+            );
+            assert_eq!(
+                m.i_block, iblock_before,
+                "i_block[] must not change on rollback"
+            );
+        }
+        // Bitmap counter must be unchanged.
+        assert_eq!(
+            s_free_blocks(&super_arc),
+            free_before,
+            "free-blocks counter must not change on rollback"
+        );
+
+        drop(aops);
+        drop(ext2_inode);
+        drop(_inode);
+        sb.ops.unmount();
+        drop(super_arc);
+    }
+
+    // ---------- Sub-test 2: ENOSPC mid-page after partial allocation ----------
+    {
+        let (sb, _fs, super_arc) = mount_rw();
+        let (_ino, _inode, ext2_inode) = fresh_regular(&sb, &super_arc);
+        let aops = Ext2Aops::new(&super_arc, &ext2_inode);
+
+        // Drain the bitmap leaving exactly 2 free blocks. The 4 KiB
+        // page on a 1 KiB-block fs needs 4 fragments → fragment 2
+        // (third call) will fail.
+        loop {
+            let free = s_free_blocks(&super_arc);
+            if free <= 2 {
+                break;
+            }
+            alloc_block(&super_arc, None).expect("drain alloc");
+        }
+        let free_before = s_free_blocks(&super_arc);
+        assert!(free_before <= 2 && free_before > 0, "drain to ≤2 free");
+
+        let payload = [b'P'; 4096];
+
+        let (size_before, blocks_before, iblock_before) = {
+            let m = ext2_inode.meta.read();
+            (m.size, m.i_blocks, m.i_block)
+        };
+
+        let r = AddressSpaceOps::writepage(&*aops, 0, &payload);
+        assert_eq!(
+            r,
+            Err(ENOSPC),
+            "writepage with partial allocator capacity → ENOSPC"
+        );
+
+        // After rollback: every direct slot still zero, i_size and
+        // i_blocks unchanged, bitmap counter restored. Tight scope so
+        // the RwLock guard drops before we move `ext2_inode` below.
+        {
+            let m = ext2_inode.meta.read();
+            assert_eq!(m.size, size_before, "i_size unchanged after rollback");
+            assert_eq!(
+                m.i_blocks, blocks_before,
+                "i_blocks unchanged after rollback"
+            );
+            assert_eq!(
+                m.i_block, iblock_before,
+                "i_block[] unchanged after rollback"
+            );
+        }
+        assert_eq!(
+            s_free_blocks(&super_arc),
+            free_before,
+            "free-blocks counter must be restored"
+        );
+
+        drop(aops);
+        drop(ext2_inode);
+        drop(_inode);
+        sb.ops.unmount();
+        drop(super_arc);
+    }
+}
+
+/// RO mount: writepage must surface `EROFS` without touching any
+/// allocator or buffer cache. Mirrors the `FileOps::write` RO test.
+fn writepage_ro_mount_returns_erofs() {
+    use alloc::sync::Weak;
+    let (sb, _fs, super_arc) = mount_ro();
+    init_reg_inode(&super_arc, 12);
+    let inode = iget(&super_arc, &sb, 12).expect("iget fabricated reg");
+    let ext2_inode = {
+        let ecache = super_arc.ext2_inode_cache.lock();
+        ecache
+            .get(&12)
+            .and_then(Weak::upgrade)
+            .expect("ext2_inode_cache populated")
+    };
+    let aops = Ext2Aops::new(&super_arc, &ext2_inode);
+
+    let payload = [0u8; 4096];
+    let r = AddressSpaceOps::writepage(&*aops, 0, &payload);
+    assert_eq!(r, Err(EROFS), "writepage on RO mount must return EROFS");
+
+    drop(aops);
+    drop(ext2_inode);
+    drop(inode);
+    sb.ops.unmount();
+    drop(super_arc);
+}


### PR DESCRIPTION
Closes #750.

## Summary
- Replaces the EROFS stub in `Ext2Aops::writepage` with a real buffer-cache writeback path (RFC 0007 §AddressSpaceOps, RFC 0004 §Write Ordering): splits each 4 KiB page into FS-block-sized fragments, drives each through bitmap → indirect → data allocation when the underlying block is sparse, and synchronously flushes via `mark_dirty` + `sync_dirty_buffer`.
- `i_blocks`, `i_size`, mtime, and ctime are only mutated after every fragment write succeeds; the inode-slot flush is the last on-disk write, so a crash leaves readers with the pre-call (correct, just stale) `i_size` rather than an `i_size` that claims un-flushed blocks.
- On any per-block failure (ENOSPC, on-disk pointer forgery detected, buffer-cache I/O), walks the recorded allocation events in reverse: zeroes the parent slot (in `i_block[]` or in a previously-allocated indirect block), then `free_block`s the underlying disk block. Bitmap, free-blocks counter, and inode metadata end identical to their pre-call state.
- `validate_existing_pointer` and `flush_inode_slot` in `fs/ext2/file.rs` promoted to `pub(super)` so writepage reuses the same forgery / RMW discipline rather than duplicating it.

## Tests
New integration test `kernel/tests/ext2_writepage.rs`:
- `writepage_dense_first_page` — pgoff 0 of a fresh inode; asserts all four direct slots are allocated, `i_size`/`i_blocks` reflect the full page, and bytes round-trip through `read_file_at`.
- `writepage_sparse_then_extend` — pgoff 5 of a fresh inode; asserts holes [0, 5) read POSIX-zero, the live page round-trips, the single-indirect pointer block is consumed alongside the four data blocks (5 blocks total).
- `writepage_allocator_failure_rolls_back` — two sub-tests: (a) drain bitmap to zero, expect ENOSPC and unchanged metadata; (b) drain to ≤2 free blocks so allocation fails mid-page, expect rollback to free every fragment that was allocated and the free-blocks counter to be restored.
- `writepage_ro_mount_returns_erofs` — RO mount short-circuits before any allocator touch.

## Test plan
- [x] `cargo fmt --all -- --check` (clean)
- [x] `cargo xtask build` (clean)
- [x] `cargo xtask smoke` — all 42 markers present
- [x] `cargo test --lib` — 604 host unit tests pass
- [x] `cargo test --test ext2_writepage` — 4/4 pass
- [x] Re-ran every ext2 integration test (`ext2_readpage`, `ext2_file_write`, `ext2_file_read`, `ext2_block_alloc`, `ext2_setattr`, `ext2_create`, `ext2_dir_ops`, `ext2_unlink`, `ext2_link`, `ext2_orphan_*`, `ext2_rename`, `ext2_ialloc`, `ext2_validate_bgdt`, `ext2_mount`, `ext2_inode_iget`, `ext2_malformed_dir`, `ext2_enospc`, `ext2_crash_consistency`) — all pass.
- [x] Pre-existing flake on `main`: `blocking_sync::rwlock_concurrent_readers` (`expected 3 readers, got 2`) reproduces on `1f7a4dc` without these changes; not caused by this PR.

## Out of scope / follow-ups
- The VFS-layer `Inode::meta` mirror is intentionally not updated by writepage — `Ext2Aops` doesn't carry an `Inode` weak pointer (readpage didn't need one) and adding it would expand the trait-object footprint #753 hasn't yet committed to. The on-disk slot is flushed, so the next `iget` re-reads the fresh values; a concurrent in-memory `getattr` against the same inode sees the previous size/blocks until then. The writeback daemon doesn't itself depend on the VFS-meta mirror.
- `mapping.wb_err` bumping on writepage failure is the writeback daemon's responsibility (PR #799) — this PR just returns a faithful errno that the daemon's `bump_wb_err` site keys off.