### PR TITLE
fs/ext2: route FileOps::read through the page cache when present (#754)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -418,6 +418,11 @@ harness = false
 required-features = ["ext2"]
 
 [[test]]
+name = "ext2_file_read_cache"
+harness = false
+required-features = ["ext2", "page_cache"]
+
+[[test]]
 name = "ext2_readpage"
 harness = false
 required-features = ["ext2"]

--- a/kernel/src/fs/ext2/file.rs
+++ b/kernel/src/fs/ext2/file.rs
@@ -212,6 +212,307 @@ pub fn read_file_at(
     Ok(copied)
 }
 
+/// Read at most `buf.len()` bytes from `inode` starting at `off` by
+/// walking the inode's [`PageCache`], faulting in any missing pages
+/// through [`crate::mem::aops::AddressSpaceOps::readpage`] and copying
+/// out from the cache frames.
+///
+/// This is the page-cache routing path for `read(2)` (RFC 0007 §
+/// `FileOps::read`, issue #754). When an inode has a non-`None`
+/// `mapping` slot, [`super::inode::Ext2Inode`]'s [`crate::fs::vfs::ops::FileOps::read`]
+/// dispatches here instead of [`read_file_at`] so a `read(2)` and a
+/// concurrent `mmap(2)` of the same file see the **same** backing
+/// copy — both consult the same `Arc<PageCache>` and observe the
+/// same per-page frame.
+///
+/// The walk mirrors the slow-path filler discipline in
+/// [`crate::mem::file_object::FileObject::fault`] minus the PTE /
+/// CoW / dirty-publish concerns:
+///
+/// 1. Bound the read by `i_size` (POSIX EOF rule); reads at or past
+///    `i_size` return `Ok(0)`.
+/// 2. For each 4 KiB page covering `[off, off + to_read)`:
+///    a. Fast path: cache hit on a `PG_UPTODATE` / `!PG_LOCKED`
+///       entry. memcpy out.
+///    b. Slow path: install a fresh stub via
+///       [`crate::mem::page_cache::PageCache::install_or_get`],
+///       drive [`crate::mem::aops::AddressSpaceOps::readpage`] with
+///       no cache lock held, then either
+///       [`crate::mem::page_cache::CachePage::publish_uptodate_and_unlock`]
+///       on success or
+///       [`crate::mem::page_cache::PageCache::abandon_locked_stub`]
+///       on filler error.
+///    c. Loser of the install race parks on the existing stub via
+///       [`crate::mem::page_cache::CachePage::wait_until_unlocked`],
+///       then re-enters the fast path.
+/// 3. Copy `[in_page_off, in_page_off + chunk)` out of the cached
+///    page's HHDM-mapped frame into the caller's buffer.
+///
+/// `readpage` returning `Ok(0)` on a page entirely past `i_size` is
+/// not surfaced here — the outer loop already clamps to `i_size`,
+/// so we never fault a page that lies entirely past EOF.
+///
+/// On `target_os = "none"` (real kernel) the copy goes through the
+/// HHDM mapping. On host (`cfg(test)`) the cache page's `phys` is
+/// fictitious and the helper falls back to invoking `readpage`
+/// directly into a stack buffer per page rather than dereferencing
+/// the frame; the cache index still tracks the page so a subsequent
+/// `read(2)` observes the install-once shape.
+///
+/// # Errno table (RFC 0007 §Errno table)
+///
+/// - `EIO` — propagated from `readpage` (buffer-cache I/O failure,
+///   indirect-walker corruption, mount tear-down). Surfaced
+///   *immediately* on a per-page filler error; partial copy from
+///   earlier pages is not discarded.
+///
+/// # Lock-order
+///
+/// `assert_no_spinlocks_held` is asserted at entry — every
+/// page-cache surface this method touches (`install_or_get`,
+/// `mark_page_dirty`, `lookup`, `clear_page_dirty`) takes the
+/// level-4 cache mutex internally; calling under any spin would
+/// invert the lock-order ladder.
+#[cfg(feature = "page_cache")]
+pub fn read_via_page_cache(
+    cache: &Arc<crate::mem::page_cache::PageCache>,
+    buf: &mut [u8],
+    off: u64,
+) -> Result<usize, i64> {
+    use crate::debug_lockdep::assert_no_spinlocks_held;
+    use crate::mem::FRAME_SIZE;
+
+    assert_no_spinlocks_held("ext2::read_via_page_cache");
+
+    if buf.is_empty() {
+        return Ok(0);
+    }
+
+    // Snapshot i_size off the cache; the cache mirrors the inode's
+    // size and is the source of truth for the in-flight read window
+    // (RFC 0007 §`PageCache.i_size`). A truncate that races with our
+    // walk shrinks this snapshot; later faults will observe the
+    // smaller value via the per-page recheck the filler performs.
+    let i_size = cache.i_size();
+    if off >= i_size {
+        return Ok(0);
+    }
+    let remaining_in_file = (i_size - off) as usize;
+    let to_read = core::cmp::min(buf.len(), remaining_in_file);
+    if to_read == 0 {
+        return Ok(0);
+    }
+
+    let mut copied = 0usize;
+    while copied < to_read {
+        let cur = off + copied as u64;
+        let pgoff = cur / FRAME_SIZE;
+        let in_page = (cur % FRAME_SIZE) as usize;
+        let page_remaining = (FRAME_SIZE as usize) - in_page;
+        let chunk = core::cmp::min(page_remaining, to_read - copied);
+
+        // Fault in / look up the cache page for `pgoff`.
+        let page = fault_in_cache_page(cache, pgoff)?;
+
+        // Copy out from the cache frame. On bare metal the frame is
+        // HHDM-mapped and we read the bytes directly. On host the
+        // frame is fictitious — the cache page exists for the
+        // index/state-bit invariants but cannot be dereferenced. The
+        // host fallback re-invokes `readpage` into a stack buffer
+        // and copies from there; the install-once shape (lookup hits,
+        // PG_UPTODATE set) is preserved, but byte content for host
+        // tests is sourced from the FS hook rather than the frame.
+        copy_out_of_cache_page(
+            cache,
+            &page,
+            pgoff,
+            in_page,
+            chunk,
+            &mut buf[copied..copied + chunk],
+        )?;
+
+        copied += chunk;
+    }
+
+    Ok(copied)
+}
+
+/// Fault in a single page of `cache` at `pgoff`, returning the
+/// `Arc<CachePage>` once it is `PG_UPTODATE` and unlocked. Mirrors
+/// the slow-path discipline in
+/// [`crate::mem::file_object::FileObject::fault`].
+#[cfg(feature = "page_cache")]
+fn fault_in_cache_page(
+    cache: &Arc<crate::mem::page_cache::PageCache>,
+    pgoff: u64,
+) -> Result<Arc<crate::mem::page_cache::CachePage>, i64> {
+    use crate::mem::page_cache::{InstallOutcome, PG_LOCKED, PG_UPTODATE};
+
+    // Bounded re-entry: at most two passes. After a winner publishes
+    // PG_UPTODATE the loser's wait_until_unlocked returns and the
+    // second pass is a fast-path hit. A spurious re-eviction between
+    // the wake and the lookup surfaces as one extra retry; the loop
+    // terminates on the first UPTODATE / !LOCKED observation.
+    loop {
+        // Fast path: cache hit on UPTODATE / unlocked entry.
+        if let Some(page) = cache.lookup(pgoff) {
+            let st = page.state.load(core::sync::atomic::Ordering::Acquire);
+            if st & PG_UPTODATE != 0 && st & PG_LOCKED == 0 {
+                return Ok(page);
+            }
+            // Hit-but-locked: park on the existing stub's wait queue
+            // rather than installing a fresh one. After the wake we
+            // re-enter the fast-path branch above.
+            page.wait_until_unlocked();
+            continue;
+        }
+
+        // Slow path: install-race + filler protocol.
+        let stub = alloc_locked_cache_stub(pgoff)?;
+        let stub_for_closure = stub.clone();
+        let outcome = cache.install_or_get(pgoff, move || stub_for_closure);
+        match outcome {
+            InstallOutcome::InstalledNew(page) => {
+                // We won. Drop the outer clone so the cache index is
+                // the sole strong-ref owner once filler completes.
+                drop(stub);
+                let mut buf = [0u8; 4096];
+                page.mark_in_flight();
+                let ops = cache.ops();
+                let read_res = ops.readpage(pgoff, &mut buf);
+                page.clear_in_flight();
+                match read_res {
+                    Ok(_n) => {
+                        // Copy the bytes through the HHDM into the
+                        // stub's physical frame. On host the frame is
+                        // fictitious — skip the memcpy; the host
+                        // fallback in `copy_out_of_cache_page`
+                        // re-invokes `readpage` for content.
+                        #[cfg(target_os = "none")]
+                        copy_into_cache_frame(page.phys, &buf);
+                        #[cfg(not(target_os = "none"))]
+                        let _ = buf;
+                        page.publish_uptodate_and_unlock();
+                        return Ok(page);
+                    }
+                    Err(e) => {
+                        cache.abandon_locked_stub(&page);
+                        return Err(e);
+                    }
+                }
+            }
+            InstallOutcome::AlreadyPresent(page) => {
+                // Lost the install race: `make_stub` never fired, so
+                // the closure clone was dropped silently. Reclaim the
+                // outer stub's frame before dropping it on the floor.
+                release_unused_cache_stub(&stub);
+                drop(stub);
+                // Park on the existing stub's wait queue then re-enter
+                // the fast path.
+                page.wait_until_unlocked();
+                continue;
+            }
+        }
+    }
+}
+
+/// Copy `chunk` bytes out of `page`'s frame at `[in_page_off,
+/// in_page_off + chunk)` into `dst`. Bare-metal goes through the
+/// HHDM; host falls back to a per-page `readpage` invocation since
+/// the host's `phys` is fictitious.
+#[cfg(feature = "page_cache")]
+fn copy_out_of_cache_page(
+    cache: &Arc<crate::mem::page_cache::PageCache>,
+    page: &Arc<crate::mem::page_cache::CachePage>,
+    pgoff: u64,
+    in_page_off: usize,
+    chunk: usize,
+    dst: &mut [u8],
+) -> Result<(), i64> {
+    debug_assert_eq!(dst.len(), chunk);
+    debug_assert!(in_page_off + chunk <= 4096);
+
+    #[cfg(target_os = "none")]
+    {
+        let _ = (cache, pgoff);
+        let hhdm = crate::mem::paging::hhdm_offset().as_u64();
+        // SAFETY: `page.phys` is a HHDM-mapped frame whose strong-ref
+        // we hold via the `Arc<CachePage>`. The page is `PG_UPTODATE`
+        // and `!PG_LOCKED` so no concurrent filler is writing it; a
+        // concurrent `writepage` only reads the frame. The HHDM
+        // mapping covers all USABLE phys.
+        unsafe {
+            let src = (hhdm + page.phys + in_page_off as u64) as *const u8;
+            core::ptr::copy_nonoverlapping(src, dst.as_mut_ptr(), chunk);
+        }
+        Ok(())
+    }
+    #[cfg(not(target_os = "none"))]
+    {
+        // Host: `phys` is a deterministic non-dereferenceable stand-in.
+        // Re-invoke `readpage` to source the bytes; the cache index
+        // still records the page so the install-once shape holds.
+        let _ = page;
+        let mut buf = [0u8; 4096];
+        let ops = cache.ops();
+        let n = ops.readpage(pgoff, &mut buf)?;
+        if n == 0 {
+            // Past-EOF surface — the outer loop already clamped to
+            // i_size, so this path is unreachable in normal usage.
+            // Return all-zero from the buf which was zeroed at decl.
+        }
+        dst.copy_from_slice(&buf[in_page_off..in_page_off + chunk]);
+        Ok(())
+    }
+}
+
+/// Allocate a freshly locked cache stub for the read path. Mirrors
+/// the same-named helper in `mem::file_object`. Bare-metal allocates
+/// + zero-fills a real frame; host hands back a deterministic
+/// non-dereferenceable stand-in `phys`.
+#[cfg(all(feature = "page_cache", target_os = "none"))]
+fn alloc_locked_cache_stub(pgoff: u64) -> Result<Arc<crate::mem::page_cache::CachePage>, i64> {
+    let phys = crate::mem::frame::alloc().ok_or(EIO)?;
+    let hhdm = crate::mem::paging::hhdm_offset().as_u64();
+    // SAFETY: `phys` was just allocated for us, is 4 KiB-aligned, and
+    // is covered by the HHDM mapping. We hold exclusive ownership
+    // until insertion into the cache index.
+    unsafe {
+        core::ptr::write_bytes((hhdm + phys) as *mut u8, 0, 4096);
+    }
+    Ok(crate::mem::page_cache::CachePage::new_locked(phys, pgoff))
+}
+
+#[cfg(all(feature = "page_cache", not(target_os = "none")))]
+fn alloc_locked_cache_stub(pgoff: u64) -> Result<Arc<crate::mem::page_cache::CachePage>, i64> {
+    let phys = 0x4_0000_0000 + pgoff * 4096;
+    Ok(crate::mem::page_cache::CachePage::new_locked(phys, pgoff))
+}
+
+/// Return a cache stub's frame to the global allocator when the
+/// install race is lost. Bare-metal-only; on host the frame is
+/// fictitious.
+#[cfg(all(feature = "page_cache", target_os = "none"))]
+fn release_unused_cache_stub(stub: &Arc<crate::mem::page_cache::CachePage>) {
+    crate::mem::frame::free(stub.phys);
+}
+
+#[cfg(all(feature = "page_cache", not(target_os = "none")))]
+fn release_unused_cache_stub(_stub: &Arc<crate::mem::page_cache::CachePage>) {}
+
+/// Copy `buf` into a cache stub's physical frame through the HHDM.
+/// Bare-metal-only.
+#[cfg(all(feature = "page_cache", target_os = "none"))]
+fn copy_into_cache_frame(phys: u64, buf: &[u8; 4096]) {
+    let hhdm = crate::mem::paging::hhdm_offset().as_u64();
+    // SAFETY: `phys` is the just-installed cache stub's frame; the
+    // filler holds PG_LOCKED so no other observer can be reading it.
+    // The HHDM mapping covers all USABLE phys.
+    unsafe {
+        core::ptr::copy_nonoverlapping(buf.as_ptr(), (hhdm + phys) as *mut u8, 4096);
+    }
+}
+
 /// Build the metadata-forbidden [`MetadataMap`] for `super_` from the
 /// parsed superblock + BGDT.
 ///

--- a/kernel/src/fs/ext2/inode.rs
+++ b/kernel/src/fs/ext2/inode.rs
@@ -400,9 +400,34 @@ pub struct Ext2FileOps;
 impl FileOps for Ext2FileOps {}
 
 impl FileOps for Ext2Inode {
-    /// Regular-file read through the buffer cache. See
-    /// [`super::file::read_file_at`] for the normative pipeline.
+    /// Regular-file read.
+    ///
+    /// When the inode has an installed [`crate::mem::page_cache::PageCache`]
+    /// (`mapping = Some(_)`), route through the cache via
+    /// [`super::file::read_via_page_cache`] so a `read(2)` and a
+    /// concurrent `mmap(2)` of the same file observe the same backing
+    /// copy (RFC 0007 §`FileOps::read` / Workstream C, issue #754).
+    /// When `mapping` is `None` (no FS-side `AddressSpaceOps` installed,
+    /// or the lazy install in
+    /// [`crate::fs::vfs::inode::Inode::page_cache_or_create`] hasn't
+    /// been triggered yet), fall back to the existing direct buffer-
+    /// cache pipeline in [`super::file::read_file_at`].
+    ///
+    /// The cache-routing path is feature-gated on `page_cache` so the
+    /// migration window's default-feature build (no `mapping` field
+    /// at all) compiles cleanly.
     fn read(&self, f: &OpenFile, buf: &mut [u8], off: u64) -> Result<usize, i64> {
+        #[cfg(feature = "page_cache")]
+        {
+            // Take only the read guard on `mapping` — `Inode::page_cache_or_create`
+            // is the install-once writer; once installed the slot is
+            // stable for the inode's lifetime, so the read-guard clone
+            // of the `Arc` is safe to consult outside the lock.
+            let cache_opt = f.inode.mapping.read().as_ref().map(Arc::clone);
+            if let Some(cache) = cache_opt {
+                return super::file::read_via_page_cache(&cache, buf, off);
+            }
+        }
         super::file::read_file_at(&f.inode, self, buf, off)
     }
 

--- a/kernel/src/fs/ext2/inode.rs
+++ b/kernel/src/fs/ext2/inode.rs
@@ -416,7 +416,22 @@ impl FileOps for Ext2Inode {
     /// The cache-routing path is feature-gated on `page_cache` so the
     /// migration window's default-feature build (no `mapping` field
     /// at all) compiles cleanly.
+    ///
+    /// The `InodeKind::Reg` gate at the top is essential: `read_file_at`
+    /// returns `EISDIR` / `EINVAL` for non-regular kinds, and the
+    /// page-cache route would silently bypass that errno surface for
+    /// any non-regular inode that ever gets a `mapping` slot
+    /// installed (today only `iget` for `Reg` inodes installs aops, but
+    /// the gate is defence-in-depth against a future caller that
+    /// installs aops on a different kind).
     fn read(&self, f: &OpenFile, buf: &mut [u8], off: u64) -> Result<usize, i64> {
+        // Non-regular inodes always go through `read_file_at` so the
+        // dispatch table for `Dir` / `Link` / `Chr` / `Blk` / `Fifo` /
+        // `Sock` (each producing a specific errno) stays authoritative.
+        // The page-cache route is for `InodeKind::Reg` only.
+        if !matches!(f.inode.kind, InodeKind::Reg) {
+            return super::file::read_file_at(&f.inode, self, buf, off);
+        }
         #[cfg(feature = "page_cache")]
         {
             // Take only the read guard on `mapping` — `Inode::page_cache_or_create`

--- a/kernel/tests/ext2_file_read_cache.rs
+++ b/kernel/tests/ext2_file_read_cache.rs
@@ -1,0 +1,404 @@
+//! Integration test for issue #754: ext2 [`FileOps::read`] routes
+//! through the per-inode [`PageCache`] when `Inode::mapping` is
+//! `Some(_)` (RFC 0007 Workstream C).
+//!
+//! Mounts the existing `read_test.img` fixture (small / large /
+//! sparse pre-populated inodes — see
+//! `kernel/src/fs/ext2/fixtures/README.md`) and exercises the
+//! cache-routing path end-to-end:
+//!
+//! - **read(2) of a file with mapping=Some returns the same bytes a
+//!   parallel mmap+read would** — install the inode's `Ext2Aops`,
+//!   trigger `Inode::page_cache_or_create()` (which materialises the
+//!   `Arc<PageCache>` in `mapping`), then issue a `read(2)` through
+//!   `FileOps::read`. Compare the bytes against the direct
+//!   `read_file_at` (buffer-cache) path. They must agree byte for
+//!   byte across direct, single-indirect, and double-indirect blocks.
+//! - **read past i_size returns 0** — even when the cache is
+//!   installed, a read whose `off >= i_size` returns `Ok(0)` and
+//!   leaves the caller buffer untouched.
+//! - **read across sparse holes returns zero bytes** — the sparse
+//!   fixture has hole regions; a cache-routed read must still
+//!   observe the same per-block zero-fill the direct path produces.
+//! - **read with mapping=None still works (back-compat)** — when
+//!   `Inode::page_cache_or_create()` is not invoked, `mapping` stays
+//!   `None`; `FileOps::read` falls back to `read_file_at` and
+//!   returns identical bytes.
+//! - **install-once Arc identity** — two consecutive `FileOps::read`
+//!   calls on the same inode go through the **same** `Arc<PageCache>`
+//!   (the install-once invariant of RFC 0007 §Inode-binding rule).
+//!   Verified by snapshotting the cache `Arc` before and after a
+//!   read and confirming `Arc::ptr_eq`.
+//!
+//! The test mounts RO so the fixture stays byte-identical across
+//! runs (a RW mount would stamp `s_state := EXT2_ERROR_FS` into the
+//! ramdisk copy on every invocation).
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use core::panic::PanicInfo;
+
+use vibix::block::BlockDevice;
+use vibix::fs::ext2::aops::Ext2Aops;
+use vibix::fs::ext2::{iget, Ext2Fs, Ext2Super};
+use vibix::fs::vfs::dentry::Dentry;
+use vibix::fs::vfs::inode::Inode;
+use vibix::fs::vfs::open_file::OpenFile;
+use vibix::fs::vfs::ops::{FileSystem as _, MountSource};
+use vibix::fs::vfs::super_block::{SbActiveGuard, SuperBlock};
+use vibix::fs::vfs::MountFlags;
+use vibix::mem::aops::AddressSpaceOps;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+const READ_IMG: &[u8; 1_048_576] = include_bytes!("../src/fs/ext2/fixtures/read_test.img");
+
+// Pre-assigned inos on the deterministic `mkfs.ext2` invocation that
+// generates `read_test.img` — see `fixtures/README.md`.
+const INO_SMALL: u32 = 12;
+const INO_LARGE: u32 = 13;
+const INO_SPARSE: u32 = 15;
+
+const SMALL_BYTES: &[u8] = b"hello ext2 read path #561\n";
+const SPARSE_SIZE: usize = 11 * 1024;
+const LARGE_SIZE: usize = 300 * 1024;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "read_small_file_via_cache_matches_direct",
+            &(read_small_file_via_cache_matches_direct as fn()),
+        ),
+        (
+            "read_large_file_via_cache_matches_direct",
+            &(read_large_file_via_cache_matches_direct as fn()),
+        ),
+        (
+            "read_sparse_via_cache_zero_fills_holes",
+            &(read_sparse_via_cache_zero_fills_holes as fn()),
+        ),
+        (
+            "read_past_i_size_returns_zero",
+            &(read_past_i_size_returns_zero as fn()),
+        ),
+        (
+            "read_with_mapping_none_falls_back",
+            &(read_with_mapping_none_falls_back as fn()),
+        ),
+        (
+            "mapping_is_install_once_across_reads",
+            &(mapping_is_install_once_across_reads as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+// Shared `RamDisk` — see kernel/tests/common/ext2_ramdisk.rs (issues
+// #627, #658).
+#[path = "common/ext2_ramdisk.rs"]
+mod ext2_ramdisk;
+use ext2_ramdisk::RamDisk;
+
+fn mount_ro() -> (Arc<SuperBlock>, Arc<Ext2Fs>, Arc<Ext2Super>) {
+    let disk = RamDisk::from_image(READ_IMG.as_slice(), 512);
+    let fs = Ext2Fs::new_with_device(disk as Arc<dyn BlockDevice>);
+    let sb = fs
+        .mount(MountSource::None, MountFlags::RDONLY)
+        .expect("RO mount of read_test.img must succeed");
+    let super_arc = fs
+        .current_super()
+        .expect("current_super must upgrade after mount");
+    (sb, fs, super_arc)
+}
+
+/// Install `Ext2Aops` for `inode` and force the `Inode::mapping`
+/// slot to materialise via `page_cache_or_create()`. After this
+/// returns, `inode.mapping.read().is_some()` and any subsequent
+/// `FileOps::read` call routes through the cache.
+fn install_cache(
+    super_arc: &Arc<Ext2Super>,
+    inode: &Arc<Inode>,
+) -> Arc<vibix::mem::page_cache::PageCache> {
+    use alloc::sync::Weak;
+    // Recover the `Arc<Ext2Inode>` from the per-mount parallel cache
+    // (see ext2_readpage.rs::iget_with_ext2 for the rationale).
+    let ext2_inode = {
+        let ecache = super_arc.ext2_inode_cache.lock();
+        ecache
+            .get(&(inode.ino as u32))
+            .and_then(Weak::upgrade)
+            .expect("ext2_inode_cache must hold a Weak<Ext2Inode> after iget")
+    };
+    let aops = Ext2Aops::new(super_arc, &ext2_inode);
+    // The bool return on `set_aops` is `true` on first install and
+    // `false` on subsequent attempts. Either is acceptable here
+    // because `iget` may have already installed it (Workstream C
+    // sibling #753 wires that path); the only invariant we care
+    // about is that `aops.is_some()` after this line.
+    let _ = inode.set_aops(aops as Arc<dyn AddressSpaceOps>);
+    inode
+        .page_cache_or_create()
+        .expect("aops installed; mapping must materialise")
+}
+
+/// Build a minimal `OpenFile` whose `inode` is set to `inode` and
+/// whose `ops` is the inode's own `file_ops`. The `dentry` slot is
+/// a synthesised root-style dentry — `FileOps::read` for ext2 reads
+/// only `f.inode` (and `f.inode.mapping`); the synthesised dentry
+/// is unobserved.
+fn open_file_for_read(sb: &Arc<SuperBlock>, inode: Arc<Inode>) -> Arc<OpenFile> {
+    let dentry = Dentry::new_root(inode.clone());
+    let file_ops = inode.file_ops.clone();
+    let guard = SbActiveGuard::try_acquire(sb).expect("SbActiveGuard::try_acquire");
+    OpenFile::new(dentry, inode, file_ops, sb.clone(), 0, guard)
+}
+
+/// Issue a read through `inode.file_ops` (the production dispatch).
+fn read_via_file_ops(
+    sb: &Arc<SuperBlock>,
+    inode: &Arc<Inode>,
+    buf: &mut [u8],
+    off: u64,
+) -> Result<usize, i64> {
+    let of = open_file_for_read(sb, inode.clone());
+    let r = of.ops.read(&of, buf, off);
+    drop(of);
+    r
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Read the small file (26 bytes, single page) through the cache and
+/// confirm the bytes match the known-good greeting. Then read again
+/// after dropping the cache install: a fresh mount + iget without
+/// install_cache must agree byte for byte (back-compat).
+fn read_small_file_via_cache_matches_direct() {
+    // Cache-routed read.
+    let (sb, _fs, super_arc) = mount_ro();
+    let inode = iget(&super_arc, &sb, INO_SMALL).expect("iget small");
+    let _cache = install_cache(&super_arc, &inode);
+    assert!(
+        inode.mapping.read().is_some(),
+        "mapping must be Some after page_cache_or_create"
+    );
+    let mut buf = [0u8; 64];
+    let n = read_via_file_ops(&sb, &inode, &mut buf, 0).expect("cache-routed read");
+    assert_eq!(n, SMALL_BYTES.len());
+    assert_eq!(&buf[..n], SMALL_BYTES);
+    drop(inode);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+/// Read the large 300 KiB file (crosses direct → single-indirect →
+/// double-indirect on a 1 KiB-block fixture) through the cache and
+/// compare every byte against the deterministic per-block markers
+/// the generator stamped down. Exercises the multi-page walk in
+/// `read_via_page_cache`.
+fn read_large_file_via_cache_matches_direct() {
+    let (sb, _fs, super_arc) = mount_ro();
+    let inode = iget(&super_arc, &sb, INO_LARGE).expect("iget large");
+    let _cache = install_cache(&super_arc, &inode);
+
+    // Read the whole file in one go through the cache.
+    let mut buf = alloc::vec::Vec::new();
+    buf.resize(LARGE_SIZE, 0xffu8);
+    let n = read_via_file_ops(&sb, &inode, &mut buf, 0).expect("cache-routed full read");
+    assert_eq!(n, LARGE_SIZE, "cache-routed read returns full i_size bytes");
+
+    // Verify per-1KiB-block marker + body. The fixture has 300
+    // logical blocks; logical 0..11 are direct, 12..267 single-
+    // indirect, 268..299 double-indirect.
+    for blk in 0..(LARGE_SIZE / 1024) {
+        let head = format_block_head(blk);
+        let off = blk * 1024;
+        assert_eq!(
+            &buf[off..off + head.len()],
+            head.as_slice(),
+            "logical block {blk} marker via cache",
+        );
+        for (i, &byte) in buf[off + head.len()..off + 1024].iter().enumerate() {
+            let expected = ((blk * 131 + i) & 0xff) as u8;
+            assert_eq!(
+                byte, expected,
+                "logical block {blk} body byte {i} via cache",
+            );
+        }
+    }
+
+    drop(inode);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+/// Read the sparse file (block 0 = 'X', blocks 1..3 = holes, block
+/// 10 = 'Z', i_size = 11264) through the cache and confirm the
+/// sparse-hole zero-fill semantics survive the cache routing.
+fn read_sparse_via_cache_zero_fills_holes() {
+    let (sb, _fs, super_arc) = mount_ro();
+    let inode = iget(&super_arc, &sb, INO_SPARSE).expect("iget sparse");
+    let _cache = install_cache(&super_arc, &inode);
+
+    let mut buf = alloc::vec::Vec::new();
+    buf.resize(SPARSE_SIZE, 0xffu8);
+    let n = read_via_file_ops(&sb, &inode, &mut buf, 0).expect("cache-routed sparse read");
+    assert_eq!(n, SPARSE_SIZE);
+
+    // Block 0: 'X' * 1024.
+    for (i, &b) in buf[0..1024].iter().enumerate() {
+        assert_eq!(b, b'X', "sparse block 0 byte {i} via cache");
+    }
+    // Blocks 1..=9: sparse holes — must be zero. (Block 10 is 'Z'.)
+    for blk in 1..=9usize {
+        for (i, &b) in buf[blk * 1024..(blk + 1) * 1024].iter().enumerate() {
+            assert_eq!(b, 0, "sparse block {blk} hole byte {i} via cache");
+        }
+    }
+    // Block 10: 'Z' * 1024.
+    for (i, &b) in buf[10 * 1024..11 * 1024].iter().enumerate() {
+        assert_eq!(b, b'Z', "sparse block 10 byte {i} via cache");
+    }
+
+    drop(inode);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+/// `read(2)` at or past `i_size` returns `Ok(0)` even when the
+/// cache is installed; the caller buffer is untouched.
+fn read_past_i_size_returns_zero() {
+    let (sb, _fs, super_arc) = mount_ro();
+    let inode = iget(&super_arc, &sb, INO_SMALL).expect("iget small");
+    let _cache = install_cache(&super_arc, &inode);
+
+    // small.bin is 26 bytes; off = 100 is well past i_size.
+    let mut buf = [0xa5u8; 32];
+    let n = read_via_file_ops(&sb, &inode, &mut buf, 100).expect("read past EOF");
+    assert_eq!(n, 0, "read at off >= i_size returns Ok(0)");
+    // Buffer untouched — sentinel survives.
+    for (i, &b) in buf.iter().enumerate() {
+        assert_eq!(b, 0xa5, "past-EOF read must not touch buf, byte {i}");
+    }
+    // Exactly at i_size also returns 0.
+    let n =
+        read_via_file_ops(&sb, &inode, &mut buf, SMALL_BYTES.len() as u64).expect("read at i_size");
+    assert_eq!(n, 0, "read exactly at i_size returns Ok(0)");
+
+    drop(inode);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+/// Without `install_cache`, `Inode::mapping` stays `None` and
+/// `FileOps::read` falls through to `read_file_at`. The bytes must
+/// match the cache-routed read so the back-compat fall-through is
+/// equivalent (closes the "no surprise on default-build" worry the
+/// migration window's `page_cache` feature gate exists to enforce).
+fn read_with_mapping_none_falls_back() {
+    let (sb, _fs, super_arc) = mount_ro();
+    let inode = iget(&super_arc, &sb, INO_SMALL).expect("iget small (mapping=None)");
+    // Sanity: no aops installed on this inode (well, #753's iget
+    // wiring may install one — but `page_cache_or_create` was never
+    // called on this iget, so `mapping` should still be None).
+    assert!(
+        inode.mapping.read().is_none(),
+        "mapping must be None when page_cache_or_create has not been called",
+    );
+
+    let mut buf = [0u8; 64];
+    let n = read_via_file_ops(&sb, &inode, &mut buf, 0).expect("fallback read");
+    assert_eq!(n, SMALL_BYTES.len());
+    assert_eq!(&buf[..n], SMALL_BYTES);
+
+    drop(inode);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+/// The `Arc<PageCache>` snapshotted at first install is the same
+/// `Arc` observed on every subsequent read of the same inode (RFC
+/// 0007 §Inode-binding rule). A second `read(2)` doesn't replace
+/// the mapping with a fresh cache.
+fn mapping_is_install_once_across_reads() {
+    let (sb, _fs, super_arc) = mount_ro();
+    let inode = iget(&super_arc, &sb, INO_SMALL).expect("iget small");
+    let cache_first = install_cache(&super_arc, &inode);
+
+    let mut buf = [0u8; 32];
+    let _ = read_via_file_ops(&sb, &inode, &mut buf, 0).expect("read 1");
+
+    let cache_second = inode
+        .mapping
+        .read()
+        .as_ref()
+        .map(Arc::clone)
+        .expect("mapping is Some");
+    assert!(
+        Arc::ptr_eq(&cache_first, &cache_second),
+        "mapping is install-once across reads",
+    );
+
+    let _ = read_via_file_ops(&sb, &inode, &mut buf, 0).expect("read 2");
+    let cache_third = inode
+        .mapping
+        .read()
+        .as_ref()
+        .map(Arc::clone)
+        .expect("mapping is Some");
+    assert!(
+        Arc::ptr_eq(&cache_first, &cache_third),
+        "mapping is install-once across more reads",
+    );
+
+    drop(inode);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Reproduce the generator's per-block marker (`BLKnnnnn`, no NUL,
+/// no trailing separator). Mirrors `kernel/tests/ext2_file_read.rs`
+/// and `kernel/tests/ext2_readpage.rs`.
+fn format_block_head(b: usize) -> alloc::vec::Vec<u8> {
+    let mut out = alloc::vec::Vec::with_capacity(8);
+    out.extend_from_slice(b"BLK");
+    let digits = [
+        ((b / 10_000) % 10) as u8,
+        ((b / 1_000) % 10) as u8,
+        ((b / 100) % 10) as u8,
+        ((b / 10) % 10) as u8,
+        (b % 10) as u8,
+    ];
+    for d in digits {
+        out.push(b'0' + d);
+    }
+    out
+}


### PR DESCRIPTION
Closes #754

## Summary
- When an inode has `mapping: Some(Arc<PageCache>)`, dispatch `Ext2Inode::FileOps::read` through the per-inode page cache instead of the buffer-cache direct path so a `read(2)` and a concurrent `mmap(2)` of the same file observe the same backing copy (RFC 0007 §FileOps::read, Workstream C of epic #734).
- The cache walk lives in a new `read_via_page_cache` helper in `fs/ext2/file.rs`. For each 4 KiB page covering the requested range it follows the slow-path filler discipline used by `mem::file_object::FileObject::fault` minus the PTE / CoW / dirty-publish concerns: `lookup` → `install_or_get` → `readpage` → `publish_uptodate_and_unlock` (or `abandon_locked_stub` on filler error). Bytes are copied out of the HHDM-mapped frame on bare metal; the host-side fallback re-invokes `readpage` into a stack buffer so the install-once shape (cache index hit, PG_UPTODATE set) holds without dereferencing the fictitious test `phys`.
- Feature-gated on `page_cache` so the migration window's default build (no `mapping` field) compiles cleanly. When `mapping` is `None` (no FS-side aops installed, or `page_cache_or_create` was never called), the read falls back to the existing `read_file_at` direct pipeline — fully back-compat.

## Test plan
New `kernel/tests/ext2_file_read_cache.rs` (`required-features = ["ext2", "page_cache"]`):
- [x] `read_small_file_via_cache_matches_direct` — small 26 B file, cache-routed read returns the known-good greeting.
- [x] `read_large_file_via_cache_matches_direct` — full 300 KiB read across direct → single-indirect → double-indirect blocks; per-1 KiB-block marker + body matches the deterministic fixture.
- [x] `read_sparse_via_cache_zero_fills_holes` — sparse fixture (block 0 = 'X', 1..=9 holes, 10 = 'Z'); cache path observes the same per-block zero-fill the direct path produces.
- [x] `read_past_i_size_returns_zero` — read at and past i_size returns Ok(0) with the caller buffer untouched.
- [x] `read_with_mapping_none_falls_back` — without `page_cache_or_create`, `mapping` stays None and `FileOps::read` falls through to `read_file_at`.
- [x] `mapping_is_install_once_across_reads` — the `Arc<PageCache>` snapshotted at first install is the same `Arc` observed across subsequent reads (install-once invariant of RFC 0007 §Inode-binding rule).

Locally verified:
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo xtask build` clean.
- [x] `cargo xtask test-unit` — 625 passed, 0 failed.
- [x] `cargo xtask test-integration --shard=3/4` (the shard that contains `ext2_file_read_cache`) green.
- [x] `cargo xtask smoke` — all 42 markers present.
- [x] Pre-existing `ext2_file_read`, `ext2_readpage`, `ext2_writepage` integration tests stay green against the new dispatch.

Note: shard 2 trips the pre-existing `blocking_sync::rwlock_concurrent_readers` flake tracked in #791 (unrelated to this change).