### PR TITLE
fs/ext2: hook truncate_below into setattr(size) with PG_WRITEBACK wait (#751)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -478,6 +478,11 @@ harness = false
 required-features = ["ext2"]
 
 [[test]]
+name = "ext2_truncate_below"
+harness = false
+required-features = ["ext2", "page_cache"]
+
+[[test]]
 name = "ext2_create"
 harness = false
 required-features = ["ext2"]

--- a/kernel/src/fs/ext2/aops.rs
+++ b/kernel/src/fs/ext2/aops.rs
@@ -3,7 +3,7 @@
 //! readahead / truncate.
 //!
 //! RFC 0007 §`AddressSpaceOps` and §Tail-page zeroing are the normative
-//! spec. This module currently lands three of the four trait methods:
+//! spec. This module lands all four trait methods:
 //!
 //! - `readpage` (issue #749) — parsed sparse / dense / past-EOF logic
 //!   in [`Ext2Aops::readpage`].
@@ -12,11 +12,14 @@
 //! - `readahead` (issue #752) — speculative buffer-cache prefetch over
 //!   `[start, start + nr_pages)` driven by the page cache's per-inode
 //!   `ra_state` heuristic (#741); see [`Ext2Aops::readahead`].
-//!
-//! The remaining method is deliberately left at the trait default:
-//!
-//! - `truncate_below` is left at the trait default (no-op + spinlock
-//!   assert). Issue #751 will replace it.
+//! - `truncate_below` (issue #751) — drop every page strictly above
+//!   `new_size` from the per-inode page cache and park on
+//!   `PG_WRITEBACK` for any in-flight `writepage`s that overlap the
+//!   truncated tail. The on-disk block-free walk that follows is
+//!   driven by `setattr` itself ([`super::setattr`]) — `truncate_below`
+//!   only owns the page-cache half of the truncate so the block-free
+//!   path can stay an `RMW + flush_inode_slot` transaction with no
+//!   writeback contention (RFC 0007 §Truncate, unmap, MADV_DONTNEED).
 //!
 //! # Pipeline (`readpage`)
 //!
@@ -720,8 +723,134 @@ impl AddressSpaceOps for Ext2Aops {
         }
     }
 
-    // `truncate_below` left at the trait default — no-op +
-    // `assert_no_spinlocks_held`. Issue #751 will replace it.
+    /// Drop every cached page strictly above `new_size` from the
+    /// per-inode page cache and wait out any `writepage` in flight
+    /// over the truncated tail.
+    ///
+    /// RFC 0007 §Truncate, unmap, MADV_DONTNEED is the normative spec.
+    /// Closes the on-disk UAF surface where the writeback daemon's
+    /// `writepage` could otherwise commit stale bytes into blocks the
+    /// FS is concurrently freeing: a shrinking `setattr(size = N)`
+    /// must not free disk blocks underneath any page whose
+    /// `writepage` has not yet returned. The contract this method
+    /// honours:
+    ///
+    /// 1. **Drop cached pages with `pgoff >= ceil(new_size / 4096)`.**
+    ///    The page-cache index is updated under its own level-4 mutex
+    ///    so the writeback daemon's snapshot can no longer enqueue
+    ///    them. The page containing the `new_size` byte itself stays
+    ///    cached: it holds bytes both above and below the cut, and
+    ///    its tail is the readpage tail-zero rule's job (RFC 0007
+    ///    §Tail-page zeroing).
+    /// 2. **Park on `PG_WRITEBACK` for every dropped page.** A page
+    ///    whose `writepage` is presently in flight survives in the
+    ///    snapshot (the cache hands us a strong `Arc<CachePage>` and
+    ///    the daemon's own snapshot still holds another). We park on
+    ///    [`CachePage::wait_until_writeback_clear`] so the daemon's
+    ///    `end_writeback` reaches us before the truncate caller
+    ///    proceeds to the on-disk free.
+    /// 3. **Return.** The on-disk block-free walk
+    ///    ([`super::setattr::truncate_free`]) is driven by `setattr`
+    ///    itself, after this returns. Splitting the cache half here
+    ///    keeps the block-free path a single inode-slot RMW
+    ///    transaction with no writeback contention — RFC 0007
+    ///    §Truncate, unmap, MADV_DONTNEED specifies the cache park as
+    ///    a strict precondition of the block free, which this method
+    ///    discharges.
+    ///
+    /// # Lock-order
+    ///
+    /// The `assert_no_spinlocks_held` invariant is the first
+    /// statement; the page cache's level-4 mutex is acquired only by
+    /// [`PageCache::truncate_below`] and is released before any
+    /// `wait_until_writeback_clear` park.
+    ///
+    /// # Best-effort cache lookup
+    ///
+    /// `Ext2Aops` carries [`Weak`] handles to its mount and inode. A
+    /// torn-down mount, a torn-down inode, or an inode whose VFS
+    /// reflection is not in the mount's inode cache (e.g. a unit test
+    /// that constructs an `Ext2Aops` directly without `iget`) all
+    /// surface here as "no observable page cache to truncate" and
+    /// the method becomes a no-op. The `setattr` caller's on-disk
+    /// block-free still runs; the page cache, if any was constructed
+    /// out-of-band, would simply observe stale `i_size` until its
+    /// next own-truncate. This is acceptable because every production
+    /// path goes through the `iget` cache, where the mapping is
+    /// reachable.
+    fn truncate_below(&self, new_size: u64) {
+        // RFC 0007 §Lock-order ladder: every method on this trait
+        // calls `assert_no_spinlocks_held` as its very first statement.
+        assert_no_spinlocks_held("Ext2Aops::truncate_below");
+
+        // The cache-side work is gated on the `page_cache` feature
+        // because the `mapping` field on `Inode` is itself gated on
+        // that feature (RFC 0007 migration window). Off-feature builds
+        // collapse to the trait-default-equivalent no-op; the
+        // `setattr` caller's on-disk block-free still runs and
+        // remains the security-relevant behaviour. The cfg switch is
+        // expected to retire when `page_cache` becomes default.
+        #[cfg(feature = "page_cache")]
+        {
+            // Best-effort: a torn-down mount or inode means there is
+            // nothing observable to truncate. The on-disk free is
+            // setattr's responsibility and runs unaffected.
+            let Some(super_ref) = self.super_ref.upgrade() else {
+                return;
+            };
+            let Some(ext2_inode) = self.inode_ref.upgrade() else {
+                return;
+            };
+
+            // Resolve the VFS Inode that owns the per-inode page
+            // cache. The `inode_cache` on `Ext2Super` is keyed by
+            // ext2 ino; the `Weak<Inode>` it stores is the only
+            // reachable handle to the VFS inode the cache hangs off.
+            // A miss here means the inode has not been published
+            // through `iget` (e.g. a direct unit-test construction);
+            // the truncate becomes a no-op.
+            let vfs_inode = {
+                let cache = super_ref.inode_cache.lock();
+                cache.get(&ext2_inode.ino).and_then(Weak::upgrade)
+            };
+            let Some(vfs_inode) = vfs_inode else {
+                return;
+            };
+
+            // The mapping is published lazily on first read-via-cache
+            // / mmap; an inode that has never been faulted has no
+            // cache. Either way, no cached pages to drop and no
+            // writeback to park on.
+            let Some(pc) = vfs_inode.mapping.read().as_ref().map(Arc::clone) else {
+                return;
+            };
+
+            // Step 1 + 3 (under inner): snapshot every page strictly
+            // above `new_size`, remove them from `pages` + `dirty`,
+            // and publish the new `i_size` cap. The snapshot keeps
+            // the `Arc<CachePage>`s alive so a writepage already in
+            // flight can finish.
+            let snapshot = pc.truncate_below(new_size);
+
+            // Step 2 (outside inner): park on `PG_WRITEBACK` for
+            // each dropped page. The order doesn't matter — every
+            // wait is on a disjoint waitqueue. After this loop the
+            // snapshot drops, at which point the cache no longer
+            // references the truncated tail (only the writeback
+            // daemon's own snapshot, if any, is left, and it has
+            // already cleared `PG_WRITEBACK` before we returned from
+            // the wait).
+            for page in &snapshot {
+                page.wait_until_writeback_clear();
+            }
+            // Snapshot drops here.
+        }
+        // The `_ = new_size` suppresses an unused-variable warning
+        // when the body is `cfg`-stripped on `--no-default-features`
+        // builds without the `page_cache` flag.
+        #[cfg(not(feature = "page_cache"))]
+        let _ = new_size;
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/kernel/src/fs/ext2/setattr.rs
+++ b/kernel/src/fs/ext2/setattr.rs
@@ -129,6 +129,34 @@ pub fn setattr(ext2_inode: &Ext2Inode, inode: &Inode, attr: &SetAttr) -> Result<
         }
 
         if new_size < cur_size {
+            // Drive the per-inode page-cache truncate **before** any
+            // on-disk block is freed (RFC 0007 §Truncate, unmap,
+            // MADV_DONTNEED): drop every cached page strictly above
+            // `new_size` and park on `PG_WRITEBACK` for any in-flight
+            // `writepage` over the truncated tail. Skipping this would
+            // leave the writeback daemon free to commit stale bytes
+            // into blocks the FS is concurrently returning to the
+            // allocator. The hook is feature-gated because the
+            // `aops` slot on `Inode` is only present when the
+            // `page_cache` feature is on (RFC 0007 migration window);
+            // off-feature builds fall straight through to the
+            // existing block-free path.
+            //
+            // Best-effort: an inode with no installed `aops` (no FS
+            // wired into the page cache yet, or a unit-test-built
+            // `Ext2Inode` without `iget` publication) simply skips
+            // the cache half. The on-disk free below still runs and
+            // is the security-relevant guarantee — the page-cache
+            // park is the *additional* invariant that protects the
+            // writeback daemon from a TOCTOU on the freed blocks.
+            #[cfg(feature = "page_cache")]
+            {
+                let aops = inode.aops.lock().as_ref().map(Arc::clone);
+                if let Some(aops) = aops {
+                    aops.truncate_below(new_size);
+                }
+            }
+
             // Shrinking: free everything above `new_size`.
             let (freed_data_blocks, updated_i_block) =
                 truncate_free(&super_ref, &cur_i_block, new_size)?;

--- a/kernel/src/mem/page_cache.rs
+++ b/kernel/src/mem/page_cache.rs
@@ -385,6 +385,27 @@ impl CachePage {
         self.wait.wait_while(|| self.is_locked());
     }
 
+    /// Park the calling task until [`PG_WRITEBACK`] clears. Symmetrical
+    /// to [`Self::wait_until_unlocked`] but predicated on the
+    /// writeback bit instead of the lock bit.
+    ///
+    /// This is the truncate-below park point: a shrinking truncate
+    /// must not free the on-disk blocks underneath a page whose
+    /// `writepage` is presently in flight (the daemon could otherwise
+    /// commit stale bytes into blocks the FS has just returned to the
+    /// allocator — RFC 0007 §Truncate, unmap, MADV_DONTNEED). The
+    /// truncate path holds an `Arc<CachePage>` snapshot across this
+    /// wait so the page itself stays alive and `end_writeback`'s
+    /// `notify_all` reaches us.
+    ///
+    /// The re-check is performed under the waitqueue's internal lock,
+    /// so an `end_writeback`-fired `notify_all` that landed between
+    /// our initial `is_writeback()` test and the park is observed
+    /// correctly (lost-wakeup protocol — see [`WaitQueue::wait_while`]).
+    pub fn wait_until_writeback_clear(&self) {
+        self.wait.wait_while(|| self.is_writeback());
+    }
+
     /// MAP_SHARED write-fault dirty-publish. Caller must hold
     /// [`PageCacheInner`] (the index mutex) so that this bit set and
     /// the dirty-index enrollment commit atomically against the
@@ -959,7 +980,91 @@ impl PageCache {
     pub fn store_i_size(&self, new_size: u64) {
         self.i_size.store(new_size, Ordering::Release);
     }
+
+    /// Drop every cached page whose `pgoff` lies strictly above
+    /// `new_size`. Returns the snapshot of removed `Arc<CachePage>`s so
+    /// the caller can park each one on `PG_WRITEBACK` outside the
+    /// `inner` mutex (RFC 0007 §Lock-order ladder forbids holding the
+    /// level-4 cache mutex across any blocking wait).
+    ///
+    /// "Strictly above `new_size`" is the page-cache-side rule that
+    /// matches RFC 0007 §Truncate, unmap, MADV_DONTNEED: the page
+    /// containing the `new_size` byte itself stays cached because it
+    /// holds bytes both above and below the cut. Its tail (the bytes
+    /// at offsets `[new_size .. pgoff*4096 + 4096)`) is zeroed by
+    /// `readpage`'s tail-zero rule on the next miss; the surviving
+    /// in-cache copy may still hold the pre-truncate bytes, which the
+    /// caller (the FS shim that owns `i_size`) is expected to zero
+    /// out-of-band before the next observable read. The current ext2
+    /// caller skips that step because no `read(2)`-via-cache routing
+    /// exists yet (#754) — once that lands, the tail-zero pass moves
+    /// in here.
+    ///
+    /// The pages are removed from both the index (`pages`) and the
+    /// dirty set (`dirty`) under one critical section so the writeback
+    /// daemon can no longer enqueue them for `writepage`. Pages whose
+    /// `writepage` is *already* in flight survive in the snapshot via
+    /// the cloned `Arc`; the caller waits each one out with
+    /// [`CachePage::wait_until_writeback_clear`] and only then drops
+    /// its snapshot, at which point the cache has no observable record
+    /// of the truncated tail.
+    ///
+    /// Updates `i_size` with `Release` ordering as the last act under
+    /// `inner`, which is what RFC 0007 §State-bit ordering pairs with
+    /// the page-fault path's `Acquire` on `i_size` to keep `OutOfRange`
+    /// faults consistent with the new size.
+    ///
+    /// **Lock-order:** acquires `inner` (level 4) for the duration of
+    /// the index walk + index/dirty mutation + `i_size` publish. The
+    /// caller must drop any other lock before invoking this method,
+    /// and must not hold `inner` itself (no re-entry).
+    pub fn truncate_below(&self, new_size: u64) -> alloc::vec::Vec<Arc<CachePage>> {
+        // First page index NOT to keep. `new_size == 0` ⇒ drop every
+        // page (`first_drop == 0`); a page partially overlapping
+        // `new_size` (`new_size % 4096 != 0`) keeps its own slot —
+        // the caller's tail-zero pass owns the dangling bytes.
+        let first_drop = new_size.div_ceil(PAGE_SIZE_U64);
+        let mut inner = self.inner.lock();
+
+        // Collect Arcs to evict. Walk a `range_mut` copy of the keys
+        // so the index mutation below doesn't invalidate the iteration.
+        // BTreeMap doesn't expose a `drain_range`; the two-step
+        // collect-then-remove is the canonical workaround.
+        let to_drop: alloc::vec::Vec<u64> = inner
+            .pages
+            .range(first_drop..)
+            .map(|(&pgoff, _)| pgoff)
+            .collect();
+        let mut snapshot: alloc::vec::Vec<Arc<CachePage>> =
+            alloc::vec::Vec::with_capacity(to_drop.len());
+        for pgoff in &to_drop {
+            // Same critical section: drop the dirty enrollment so the
+            // writeback daemon's `snapshot_dirty` cannot pick the page
+            // back up after we drop the lock. Then remove the index
+            // entry; the cloned Arc keeps the `CachePage` alive so a
+            // writepage already in flight (which holds its own clone
+            // from a prior `snapshot_dirty`) can complete and the
+            // truncate caller can park on `PG_WRITEBACK`.
+            inner.dirty.remove(pgoff);
+            if let Some(arc) = inner.pages.remove(pgoff) {
+                snapshot.push(arc);
+            }
+        }
+
+        // Publish the new `i_size` cap as the last act under `inner`.
+        // The `Release` here pairs with the `Acquire` load any future
+        // page-fault performs on `i_size` before deciding whether to
+        // surface `OutOfRange`.
+        self.i_size.store(new_size, Ordering::Release);
+
+        snapshot
+    }
 }
+
+/// `PAGE_SIZE` as a `u64` for inline arithmetic. Mirrors the same
+/// constant in `mem::aops` callers; the page cache works in 4 KiB
+/// pages everywhere, see RFC 0007 §`CachePage`.
+const PAGE_SIZE_U64: u64 = 4096;
 
 // --- Tests --------------------------------------------------------------
 
@@ -1274,6 +1379,176 @@ mod tests {
         assert_eq!(cache.i_size(), 0);
         cache.store_i_size(8192);
         assert_eq!(cache.i_size(), 8192);
+    }
+
+    /// `truncate_below(N)` drops every cached page whose `pgoff` lies
+    /// strictly above `ceil(N / 4096)` from the index, removes them
+    /// from the dirty set, and publishes the new `i_size` cap. Pages
+    /// at or below the cut survive — the page containing the new
+    /// `i_size` byte itself stays cached because it holds bytes both
+    /// above and below the cut.
+    #[test]
+    fn truncate_below_drops_pages_strictly_above_cut() {
+        let cache = fresh_cache();
+        // Install pages 0..=5.
+        for pgoff in 0..=5u64 {
+            let _ = cache.install_or_get(pgoff, || make_stub(pgoff));
+            // Publish each page to a faulted-in state so it could in
+            // principle be PG_DIRTY without violating the writer-side
+            // invariant.
+            let p = cache.lookup(pgoff).unwrap();
+            p.publish_uptodate_and_unlock();
+        }
+        // Mark a couple as dirty.
+        cache.mark_page_dirty(2);
+        cache.mark_page_dirty(4);
+
+        // Truncate to 8192 bytes (= page 2's start). `first_drop = 2`
+        // — pages 2..=5 are dropped; pages 0 and 1 survive.
+        let snapshot = cache.truncate_below(8192);
+        assert_eq!(snapshot.len(), 4, "pages 2..=5 must be in the snapshot");
+
+        assert!(
+            cache.lookup(0).is_some(),
+            "page 0 survives truncate to 8192"
+        );
+        assert!(
+            cache.lookup(1).is_some(),
+            "page 1 survives truncate to 8192"
+        );
+        for pgoff in 2..=5u64 {
+            assert!(
+                cache.lookup(pgoff).is_none(),
+                "page {pgoff} must be dropped by truncate_below"
+            );
+        }
+
+        // Dirty index is empty for the dropped pages.
+        let dirty_after = cache.snapshot_dirty();
+        assert!(
+            dirty_after.iter().all(|(p, _)| *p < 2),
+            "no dirty entry above the cut may remain"
+        );
+
+        // `i_size` cap was bumped under the same critical section.
+        assert_eq!(cache.i_size(), 8192);
+    }
+
+    /// A page whose start lies *at* the new size (i.e.
+    /// `pgoff * 4096 == new_size`) is **dropped**: every byte it holds
+    /// is past the truncate. The boundary is "strictly above
+    /// `new_size`" framed as `pgoff >= ceil(new_size / 4096)`.
+    #[test]
+    fn truncate_below_drops_page_starting_exactly_at_cut() {
+        let cache = fresh_cache();
+        for pgoff in 0..=2u64 {
+            let _ = cache.install_or_get(pgoff, || make_stub(pgoff));
+        }
+        // new_size == 4096 → first_drop == 1; page 1 starts at the
+        // cut exactly and is dropped.
+        let _ = cache.truncate_below(4096);
+        assert!(cache.lookup(0).is_some());
+        assert!(cache.lookup(1).is_none(), "page exactly at cut is dropped");
+        assert!(cache.lookup(2).is_none());
+        assert_eq!(cache.i_size(), 4096);
+    }
+
+    /// A page whose interior holds the new `i_size` byte (i.e.
+    /// `pgoff * 4096 < new_size < (pgoff + 1) * 4096`) **survives**
+    /// the truncate: it holds bytes both above and below the cut, and
+    /// the readpage tail-zero rule (RFC 0007 §Tail-page zeroing)
+    /// owns the dangling bytes inside it.
+    #[test]
+    fn truncate_below_keeps_page_straddling_cut() {
+        let cache = fresh_cache();
+        for pgoff in 0..=3u64 {
+            let _ = cache.install_or_get(pgoff, || make_stub(pgoff));
+        }
+        // new_size = 5000 (4096 + 904) → first_drop = ceil(5000/4096) = 2
+        // — page 1 holds the boundary byte and survives; pages 2 & 3
+        // are dropped.
+        let snapshot = cache.truncate_below(5000);
+        assert_eq!(snapshot.len(), 2);
+        assert!(cache.lookup(0).is_some());
+        assert!(
+            cache.lookup(1).is_some(),
+            "page straddling new_size must survive (tail-zero owns the post-EOF bytes)"
+        );
+        assert!(cache.lookup(2).is_none());
+        assert!(cache.lookup(3).is_none());
+        assert_eq!(cache.i_size(), 5000);
+    }
+
+    /// `truncate_below(0)` drops every cached page and publishes
+    /// `i_size = 0` — the canonical "shrink-to-empty" path.
+    #[test]
+    fn truncate_below_zero_drops_everything() {
+        let cache = fresh_cache();
+        for pgoff in 0..=4u64 {
+            let _ = cache.install_or_get(pgoff, || make_stub(pgoff));
+        }
+        let snapshot = cache.truncate_below(0);
+        assert_eq!(snapshot.len(), 5);
+        for pgoff in 0..=4u64 {
+            assert!(cache.lookup(pgoff).is_none());
+        }
+        assert_eq!(cache.i_size(), 0);
+    }
+
+    /// The snapshot returned from `truncate_below` keeps the dropped
+    /// pages alive. RFC 0007 §Truncate, unmap, MADV_DONTNEED — a
+    /// `writepage` already in flight (whose own clone of the Arc is
+    /// inside the writeback daemon's snapshot) must complete against
+    /// a still-live `CachePage`. The truncate caller's snapshot is
+    /// the additional strong ref that keeps the page alive across
+    /// any `wait_until_writeback_clear` park.
+    #[test]
+    fn truncate_below_snapshot_keeps_dropped_pages_alive() {
+        let cache = fresh_cache();
+        let _ = cache.install_or_get(7, || make_stub(7));
+        let entry_before = cache.lookup(7).unwrap();
+        // Two strong refs: one in the index, one in `entry_before`.
+        assert_eq!(Arc::strong_count(&entry_before), 2);
+        let snapshot = cache.truncate_below(0);
+        assert_eq!(snapshot.len(), 1);
+        assert!(cache.lookup(7).is_none(), "page removed from index");
+        // Snapshot + entry_before still alive.
+        assert!(Arc::ptr_eq(&snapshot[0], &entry_before));
+        assert_eq!(Arc::strong_count(&snapshot[0]), 2);
+    }
+
+    /// `wait_until_writeback_clear` returns immediately when
+    /// `PG_WRITEBACK` is already clear. The assertion is that the
+    /// call does not panic and exits without ever needing to park —
+    /// host stub `WaitQueue::wait_while` is a no-op single-check, so
+    /// a true predicate would *also* return without panic; the
+    /// invariant we exercise is that the predicate is `is_writeback`,
+    /// not some other mis-typed bit.
+    #[test]
+    fn wait_until_writeback_clear_no_op_when_bit_clear() {
+        let p = make_stub(0);
+        p.publish_uptodate_and_unlock();
+        assert!(!p.is_writeback());
+        p.wait_until_writeback_clear();
+    }
+
+    /// `wait_until_writeback_clear` is the symmetric park to
+    /// `wait_until_unlocked` — predicate is `is_writeback`, not
+    /// `is_locked`. This test exercises that the call observes the
+    /// `PG_WRITEBACK` bit specifically: a page with `PG_LOCKED` set
+    /// but `PG_WRITEBACK` clear must return immediately. The host
+    /// stub's no-op `wait_while` collapses both predicates to the
+    /// same observable behaviour, but the test still pins the
+    /// expected predicate at the source level.
+    #[test]
+    fn wait_until_writeback_clear_ignores_locked_bit() {
+        let p = make_stub(0);
+        // The freshly-built stub has PG_LOCKED set (every other bit
+        // clear). `wait_until_writeback_clear` must not park on
+        // PG_LOCKED.
+        assert!(p.is_locked());
+        assert!(!p.is_writeback());
+        p.wait_until_writeback_clear();
     }
 
     #[test]

--- a/kernel/tests/ext2_truncate_below.rs
+++ b/kernel/tests/ext2_truncate_below.rs
@@ -41,7 +41,6 @@ use core::panic::PanicInfo;
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use vibix::block::BlockDevice;
-use vibix::fs::ext2::aops::Ext2Aops;
 use vibix::fs::ext2::inode::Ext2Inode;
 use vibix::fs::ext2::{alloc_inode, iget, Ext2Fs, Ext2Super};
 use vibix::fs::vfs::inode::Inode;
@@ -194,15 +193,6 @@ fn install_published_page(inode: &Arc<Inode>, pgoff: u64) -> Arc<CachePage> {
     stub
 }
 
-/// Build + install an [`Ext2Aops`] on `inode`. Required so the
-/// page-cache mapping is reachable from `inode.aops` and so the
-/// `setattr` shrink path picks up the truncate hook.
-fn install_aops(super_arc: &Arc<Ext2Super>, inode: &Arc<Inode>, ext2_inode: &Arc<Ext2Inode>) {
-    let aops = Ext2Aops::new(super_arc, ext2_inode);
-    let installed = inode.set_aops(aops);
-    assert!(installed, "set_aops must install on a fresh inode");
-}
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -214,7 +204,9 @@ fn install_aops(super_arc: &Arc<Ext2Super>, inode: &Arc<Inode>, ext2_inode: &Arc
 fn shrink_truncate_drops_cached_pages_above_new_size() {
     let (sb, _fs, super_arc) = mount_rw();
     let (_ino, inode, ext2_inode) = fresh_regular(&sb, &super_arc);
-    install_aops(&super_arc, &inode, &ext2_inode);
+
+    // iget now installs Ext2Aops for regular files automatically
+    // (issue #753 / #808), so no manual install_aops call is needed.
 
     // Pretend the file is 4 pages worth of data (16 KiB) so the
     // truncate has both kept and dropped pages to walk. We update
@@ -274,7 +266,6 @@ fn shrink_truncate_drops_cached_pages_above_new_size() {
 fn shrink_truncate_below_zero_drops_every_cached_page() {
     let (sb, _fs, super_arc) = mount_rw();
     let (_ino, inode, ext2_inode) = fresh_regular(&sb, &super_arc);
-    install_aops(&super_arc, &inode, &ext2_inode);
 
     {
         let mut m = ext2_inode.meta.write();
@@ -380,7 +371,6 @@ fn shrink_truncate_with_writeback_in_flight_is_awaited() {
 
     let (sb, _fs, super_arc) = mount_rw();
     let (_ino, inode, ext2_inode) = fresh_regular(&sb, &super_arc);
-    install_aops(&super_arc, &inode, &ext2_inode);
 
     {
         let mut m = ext2_inode.meta.write();

--- a/kernel/tests/ext2_truncate_below.rs
+++ b/kernel/tests/ext2_truncate_below.rs
@@ -1,0 +1,453 @@
+//! Integration test for issue #751: ext2
+//! [`AddressSpaceOps::truncate_below`] — drops cached pages above the
+//! new size, parks on `PG_WRITEBACK` for any in-flight `writepage`,
+//! then returns so `setattr` can drive the on-disk block free.
+//!
+//! RFC 0007 §Truncate, unmap, MADV_DONTNEED is the normative spec.
+//! Closes the on-disk UAF surface where the writeback daemon's
+//! `writepage` could otherwise commit stale bytes into blocks the FS
+//! is concurrently freeing.
+//!
+//! Coverage:
+//!
+//! - **`shrink_truncate_drops_cached_pages_above_new_size`** — install
+//!   four cached pages over a fresh inode's mapping at `pgoff = 0..=3`,
+//!   `setattr(SIZE)` to 8192 bytes (= start of page 2), and verify
+//!   pages `[2, 3]` are evicted from the index while `[0, 1]` survive.
+//!
+//! - **`shrink_truncate_below_zero_drops_every_cached_page`** — same
+//!   setup, truncate to zero. Every cached page is gone from the
+//!   index and the page cache reports `i_size == 0`.
+//!
+//! - **`shrink_truncate_with_writeback_in_flight_is_awaited`** —
+//!   synthesize an in-flight writeback by hand-setting `PG_WRITEBACK`
+//!   on a cached page above the cut, then spawn a kernel task that
+//!   calls `end_writeback` after a short delay. The main task
+//!   `setattr`s and must block on the WB-clear handshake until the
+//!   spawn fires, after which `setattr` returns and the page is
+//!   evicted.
+//!
+//! The existing setattr-size correctness (free-block accounting,
+//! sparse-grow, EISDIR / EINVAL gates) lives in
+//! `ext2_setattr.rs`; this file adds the page-cache-side coverage.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::sync::{Arc, Weak};
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use vibix::block::BlockDevice;
+use vibix::fs::ext2::aops::Ext2Aops;
+use vibix::fs::ext2::inode::Ext2Inode;
+use vibix::fs::ext2::{alloc_inode, iget, Ext2Fs, Ext2Super};
+use vibix::fs::vfs::inode::Inode;
+use vibix::fs::vfs::ops::{FileSystem as _, MountSource, SetAttr, SetAttrMask};
+use vibix::fs::vfs::super_block::SuperBlock;
+use vibix::fs::vfs::MountFlags;
+use vibix::mem::page_cache::CachePage;
+use vibix::{
+    exit_qemu, serial_println, task,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+const BALLOC_IMG: &[u8; 524_288] = include_bytes!("../src/fs/ext2/fixtures/balloc_test.img");
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    // The writeback-wait test below spawns a kernel task and depends
+    // on cooperative wake-up via `WaitQueue::notify_all` reaching the
+    // parked main task; both require the scheduler to be live.
+    task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "shrink_truncate_drops_cached_pages_above_new_size",
+            &(shrink_truncate_drops_cached_pages_above_new_size as fn()),
+        ),
+        (
+            "shrink_truncate_below_zero_drops_every_cached_page",
+            &(shrink_truncate_below_zero_drops_every_cached_page as fn()),
+        ),
+        (
+            "shrink_truncate_with_writeback_in_flight_is_awaited",
+            &(shrink_truncate_with_writeback_in_flight_is_awaited as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+#[path = "common/ext2_ramdisk.rs"]
+mod ext2_ramdisk;
+use ext2_ramdisk::RamDisk;
+
+fn mount_rw() -> (Arc<SuperBlock>, Arc<Ext2Fs>, Arc<Ext2Super>) {
+    let disk = RamDisk::from_image(BALLOC_IMG.as_slice(), 512);
+    let fs = Ext2Fs::new_with_device(disk as Arc<dyn BlockDevice>);
+    let sb = fs
+        .mount(MountSource::None, MountFlags(0))
+        .expect("RW mount must succeed");
+    let super_arc = fs
+        .current_super()
+        .expect("current_super must upgrade after mount");
+    (sb, fs, super_arc)
+}
+
+/// Allocate a fresh regular-file inode on the mount and stamp its
+/// on-disk slot to a minimal regular layout. Returns the ino, the VFS
+/// `Arc<Inode>`, and the parallel `Arc<Ext2Inode>` (the latter is what
+/// `Ext2Aops` needs as its inode-side weak handle).
+fn fresh_regular(
+    sb: &Arc<SuperBlock>,
+    super_arc: &Arc<Ext2Super>,
+) -> (u32, Arc<Inode>, Arc<Ext2Inode>) {
+    let ino = alloc_inode(super_arc, Some(0), false).expect("alloc_inode");
+    init_reg_inode(super_arc, ino);
+    let inode = iget(super_arc, sb, ino).expect("iget fresh inode");
+    let ext2_inode = {
+        let ecache = super_arc.ext2_inode_cache.lock();
+        ecache
+            .get(&ino)
+            .and_then(Weak::upgrade)
+            .expect("ext2_inode_cache must hold a Weak<Ext2Inode>")
+    };
+    (ino, inode, ext2_inode)
+}
+
+/// Stamp `ino`'s on-disk inode slot with a minimal regular-file
+/// layout. Mirrors the helper in `ext2_writepage.rs`.
+fn init_reg_inode(super_arc: &Arc<Ext2Super>, ino: u32) {
+    use vibix::fs::ext2::disk::Ext2Inode as DiskInode;
+    let inodes_per_group = super_arc.sb_disk.lock().s_inodes_per_group;
+    let bg_inode_table =
+        super_arc.bgdt.lock()[((ino - 1) / inodes_per_group) as usize].bg_inode_table;
+    let block_size = super_arc.block_size;
+    let inode_size = super_arc.inode_size;
+    let index_in_group = (ino - 1) % inodes_per_group;
+    let byte_offset = (index_in_group as u64) * (inode_size as u64);
+    let block_in_table = byte_offset / (block_size as u64);
+    let offset_in_block = (byte_offset % (block_size as u64)) as usize;
+    let bh = super_arc
+        .cache
+        .bread(super_arc.device_id, bg_inode_table as u64 + block_in_table)
+        .expect("bread inode table");
+    {
+        let mut data = bh.data.write();
+        let slot_end = offset_in_block + 128;
+        for b in &mut data[offset_in_block..slot_end] {
+            *b = 0;
+        }
+        let mut di = DiskInode::decode(&data[offset_in_block..slot_end]);
+        di.i_mode = 0o100644;
+        di.i_links_count = 1;
+        di.i_size = 0;
+        di.i_blocks = 0;
+        di.i_block = [0u32; 15];
+        di.encode_to_slot(&mut data[offset_in_block..slot_end]);
+    }
+    super_arc.cache.mark_dirty(&bh);
+    super_arc
+        .cache
+        .sync_dirty_buffer(&bh)
+        .expect("sync inode slot");
+}
+
+/// Install + publish a stub cache page at `pgoff` against `inode`'s
+/// page cache. Returns the resulting `Arc<CachePage>` so the test can
+/// inspect / mutate state bits directly. The stub is published
+/// `PG_UPTODATE`-and-unlocked so it looks like a "real" cached page
+/// to the truncate driver.
+fn install_published_page(inode: &Arc<Inode>, pgoff: u64) -> Arc<CachePage> {
+    use vibix::mem::page_cache::{InstallOutcome, PageCache};
+    let pc: Arc<PageCache> = inode
+        .page_cache_or_create()
+        .expect("inode mapping must construct after set_aops");
+    // Install via the same install_or_get path the fault path uses.
+    // The `phys` value here is a fictional non-zero page-aligned u64
+    // — `truncate_below` never dereferences it.
+    let stub = match pc.install_or_get(pgoff, || {
+        CachePage::new_locked(0x1_0000_0000 + pgoff * 4096, pgoff)
+    }) {
+        InstallOutcome::InstalledNew(p) => p,
+        InstallOutcome::AlreadyPresent(p) => p,
+    };
+    stub.publish_uptodate_and_unlock();
+    stub
+}
+
+/// Build + install an [`Ext2Aops`] on `inode`. Required so the
+/// page-cache mapping is reachable from `inode.aops` and so the
+/// `setattr` shrink path picks up the truncate hook.
+fn install_aops(super_arc: &Arc<Ext2Super>, inode: &Arc<Inode>, ext2_inode: &Arc<Ext2Inode>) {
+    let aops = Ext2Aops::new(super_arc, ext2_inode);
+    let installed = inode.set_aops(aops);
+    assert!(installed, "set_aops must install on a fresh inode");
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Shrinking truncate drops every cached page strictly above the new
+/// size; the page that holds the boundary byte (and any below) stays
+/// cached. The page-cache `i_size` cap is bumped to the new size as a
+/// side-effect of the truncate driver.
+fn shrink_truncate_drops_cached_pages_above_new_size() {
+    let (sb, _fs, super_arc) = mount_rw();
+    let (_ino, inode, ext2_inode) = fresh_regular(&sb, &super_arc);
+    install_aops(&super_arc, &inode, &ext2_inode);
+
+    // Pretend the file is 4 pages worth of data (16 KiB) so the
+    // truncate has both kept and dropped pages to walk. We update
+    // both the in-memory ext2 meta and the VFS meta directly because
+    // the page-cache truncate path is independent of any `writepage`
+    // having actually populated disk blocks.
+    {
+        let mut m = ext2_inode.meta.write();
+        m.size = 16 * 1024;
+    }
+    {
+        let mut m = inode.meta.write();
+        m.size = 16 * 1024;
+    }
+
+    // Install four cached pages.
+    let pages: alloc::vec::Vec<Arc<CachePage>> = (0..4u64)
+        .map(|p| install_published_page(&inode, p))
+        .collect();
+    assert!(pages.iter().all(|p| p.is_uptodate()));
+
+    // setattr to 8192 bytes (= page 2 start). Pages 2 and 3 must be
+    // dropped from the cache index; pages 0 and 1 must survive.
+    let attr = SetAttr {
+        mask: SetAttrMask::SIZE,
+        size: 8 * 1024,
+        ..SetAttr::default()
+    };
+    inode.ops.setattr(&inode, &attr).expect("setattr shrink");
+
+    let pc = inode
+        .mapping
+        .read()
+        .as_ref()
+        .map(Arc::clone)
+        .expect("mapping installed by install_published_page");
+    assert!(pc.lookup(0).is_some(), "page 0 must survive shrink to 8192");
+    assert!(pc.lookup(1).is_some(), "page 1 must survive shrink to 8192");
+    assert!(
+        pc.lookup(2).is_none(),
+        "page 2 must be dropped (starts exactly at new_size)"
+    );
+    assert!(pc.lookup(3).is_none(), "page 3 must be dropped");
+    assert_eq!(pc.i_size(), 8 * 1024, "page cache i_size cap bumped");
+
+    drop(pages);
+    drop(inode);
+    drop(ext2_inode);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+/// `setattr(size = 0)` against an inode whose mapping holds several
+/// cached pages drops every cached page from the index. The on-disk
+/// block-free path runs as before — tested in `ext2_setattr.rs`; here
+/// we only assert the cache half.
+fn shrink_truncate_below_zero_drops_every_cached_page() {
+    let (sb, _fs, super_arc) = mount_rw();
+    let (_ino, inode, ext2_inode) = fresh_regular(&sb, &super_arc);
+    install_aops(&super_arc, &inode, &ext2_inode);
+
+    {
+        let mut m = ext2_inode.meta.write();
+        m.size = 12 * 1024;
+    }
+    {
+        let mut m = inode.meta.write();
+        m.size = 12 * 1024;
+    }
+
+    let pages: alloc::vec::Vec<Arc<CachePage>> = (0..3u64)
+        .map(|p| install_published_page(&inode, p))
+        .collect();
+    assert_eq!(pages.len(), 3);
+
+    let attr = SetAttr {
+        mask: SetAttrMask::SIZE,
+        size: 0,
+        ..SetAttr::default()
+    };
+    inode.ops.setattr(&inode, &attr).expect("setattr to 0");
+
+    let pc = inode.mapping.read().as_ref().map(Arc::clone).unwrap();
+    for pgoff in 0..3u64 {
+        assert!(
+            pc.lookup(pgoff).is_none(),
+            "page {pgoff} must be dropped on truncate to 0"
+        );
+    }
+    assert_eq!(pc.i_size(), 0);
+
+    drop(pages);
+    drop(inode);
+    drop(ext2_inode);
+    sb.ops.unmount();
+    drop(super_arc);
+}
+
+/// Synthesize an in-flight writeback over a page above the truncate
+/// cut. The main task calls `setattr(SIZE)` and must park on
+/// `PG_WRITEBACK` until a spawned kernel task fires `end_writeback`.
+/// After the wake the truncate completes and the page is evicted.
+///
+/// The test pins (a) that `truncate_below` does observe `PG_WRITEBACK`
+/// and parks rather than tearing the writeback in flight, and
+/// (b) that `end_writeback`'s `notify_all` reaches the parked
+/// truncate caller and unblocks it. RFC 0007 §Truncate, unmap,
+/// MADV_DONTNEED.
+
+// Statics used by the spawned writeback-completion task. The
+// integration-test stub harness routes spawned tasks through
+// `extern "C" fn() -> !`; the task can't take owned state by closure,
+// so we publish the page Arc + a kick / acknowledge handshake via
+// statics.
+//
+// The race we need to close: if `end_writeback` runs before the main
+// task has reached `wait_until_writeback_clear`, the bare-metal
+// `WaitQueue::wait_while` re-checks `is_writeback()` under the queue
+// lock, sees the bit clear, and returns immediately — no deadlock,
+// but also no real "park-then-wake" exercise. To force a real park,
+// the spawned task spins on `MAIN_PARKED == true` (set by the main
+// task right before it calls into setattr) plus a fixed extra
+// `hlt_loop` to give the main task time to actually descend into the
+// waitqueue.
+static MAIN_PARKED: AtomicBool = AtomicBool::new(false);
+static WORKER_FINISHED: AtomicBool = AtomicBool::new(false);
+// Strong ref to the page the worker will end writeback on. Held in a
+// `spin::Once`-style slot the worker reads on entry. We use a
+// `spin::Mutex` instead of `Once` because the cleanup between tests
+// resets the slot.
+static WORKER_PAGE: spin::Mutex<Option<Arc<CachePage>>> = spin::Mutex::new(None);
+
+fn writeback_completion_worker() -> ! {
+    // Wait until the main task has at least *entered* setattr — the
+    // `MAIN_PARKED` flag is set immediately before that descent. A
+    // few extra hlts give the main task time to traverse setattr,
+    // call `Ext2Aops::truncate_below`, snapshot the index, drop the
+    // inner lock, and reach the `wait_while` body so its enqueue
+    // happens before our `notify_all`.
+    while !MAIN_PARKED.load(Ordering::Acquire) {
+        x86_64::instructions::hlt();
+    }
+    for _ in 0..32 {
+        x86_64::instructions::hlt();
+    }
+    let page = WORKER_PAGE
+        .lock()
+        .take()
+        .expect("test must publish the page before spawn");
+    page.end_writeback();
+    WORKER_FINISHED.store(true, Ordering::Release);
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+fn shrink_truncate_with_writeback_in_flight_is_awaited() {
+    // Reset cross-test statics so a previous test in this file does
+    // not leak its handshake state into ours.
+    MAIN_PARKED.store(false, Ordering::Release);
+    WORKER_FINISHED.store(false, Ordering::Release);
+    *WORKER_PAGE.lock() = None;
+
+    let (sb, _fs, super_arc) = mount_rw();
+    let (_ino, inode, ext2_inode) = fresh_regular(&sb, &super_arc);
+    install_aops(&super_arc, &inode, &ext2_inode);
+
+    {
+        let mut m = ext2_inode.meta.write();
+        m.size = 8 * 1024;
+    }
+    {
+        let mut m = inode.meta.write();
+        m.size = 8 * 1024;
+    }
+
+    // Two pages: page 0 survives, page 1 is the writeback-in-flight
+    // victim. Set PG_WRITEBACK on page 1 BEFORE we hand it to the
+    // worker — `truncate_below` must observe the bit and park.
+    let _page0 = install_published_page(&inode, 0);
+    let page1 = install_published_page(&inode, 1);
+    page1.begin_writeback();
+    assert!(page1.is_writeback());
+    *WORKER_PAGE.lock() = Some(Arc::clone(&page1));
+
+    // Spawn the worker. From this point the worker is spinning on
+    // MAIN_PARKED.
+    task::spawn(writeback_completion_worker);
+
+    // Tell the worker we're about to park, then descend into setattr.
+    // The setattr → Ext2Aops::truncate_below path will:
+    //   1. snapshot pages 1.. into a Vec<Arc<CachePage>>
+    //   2. drop the cache mutex
+    //   3. for each, wait_until_writeback_clear → wait_while
+    //
+    // Step 3 is where the worker's `end_writeback` reaches us. The
+    // worker's hlt-loop delay gives us time to actually enter wait_while
+    // and enqueue ourselves before the wake fires.
+    MAIN_PARKED.store(true, Ordering::Release);
+    let attr = SetAttr {
+        mask: SetAttrMask::SIZE,
+        size: 4 * 1024,
+        ..SetAttr::default()
+    };
+    inode
+        .ops
+        .setattr(&inode, &attr)
+        .expect("setattr must complete after writeback wake");
+
+    // The worker must have ended writeback (otherwise the main task
+    // would still be parked and we wouldn't have reached here). The
+    // PG_WRITEBACK bit is cleared, and page 1 has been evicted from
+    // the cache index.
+    assert!(!page1.is_writeback(), "PG_WRITEBACK cleared by worker");
+    let pc = inode.mapping.read().as_ref().map(Arc::clone).unwrap();
+    assert!(pc.lookup(0).is_some(), "page 0 survives shrink to 4096");
+    assert!(
+        pc.lookup(1).is_none(),
+        "page 1 must be evicted after the writeback wake"
+    );
+    assert_eq!(pc.i_size(), 4 * 1024);
+    // Sanity: the worker actually ran end_writeback before the assert
+    // above; the WORKER_FINISHED flag confirms it (it's set after the
+    // wake).
+    assert!(
+        WORKER_FINISHED.load(Ordering::Acquire),
+        "writeback worker must have completed"
+    );
+
+    drop(page1);
+    drop(_page0);
+    drop(inode);
+    drop(ext2_inode);
+    sb.ops.unmount();
+    drop(super_arc);
+}


### PR DESCRIPTION
Closes #751.

## Summary

Implements `Ext2Aops::truncate_below` (RFC 0007 §Truncate, unmap, MADV_DONTNEED) and wires it into the ext2 `setattr(SIZE)` shrink path so the writeback daemon's `writepage` can no longer commit stale bytes into blocks the FS is concurrently freeing.

- **`mem::page_cache`**: adds `CachePage::wait_until_writeback_clear` (symmetric park to `wait_until_unlocked`, predicated on `PG_WRITEBACK`) and `PageCache::truncate_below(new_size)` that snapshots-and-removes every page strictly above the cut from both `pages` and `dirty`, publishes the new `i_size` cap, and returns the snapshot so the caller can park outside the level-4 cache mutex (lock-order ladder).

- **`fs::ext2::aops`**: `Ext2Aops::truncate_below` resolves the per-inode `PageCache` via `super_ref.inode_cache` → `Inode::mapping`, drives the cache-side drop, then parks on `PG_WRITEBACK` for each dropped page. The cache-side body is gated on `feature = "page_cache"` (matching the `Inode::mapping`/`aops` field gates); off-feature builds collapse to a trait-default-equivalent no-op.

- **`fs::ext2::setattr`**: when shrinking, calls `aops.truncate_below(new_size)` (if `Inode::aops` is populated) before the existing `truncate_free` block-free walk. `truncate_free` keeps owning the single inode-slot RMW transaction; the page-cache park is the additional invariant the writeback-daemon TOCTOU needs.

The page containing the boundary byte stays cached — it holds bytes both above and below the cut, and the readpage tail-zero rule (RFC 0007 §Tail-page zeroing) already owns its post-EOF bytes.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo xtask build`
- [x] `cargo xtask smoke` (42 markers present)
- [x] `cargo test --lib --features ext2,page_cache` — 652/652 host tests pass; new `mem::page_cache` host tests cover: pages strictly above the cut dropped; page exactly at cut dropped; page straddling cut kept; truncate-to-zero drops everything; snapshot keeps dropped Arcs alive; `wait_until_writeback_clear` is no-op on clear bit and ignores `PG_LOCKED`.
- [x] `cargo test --test ext2_truncate_below --features ext2,page_cache` (3/3):
  - `shrink_truncate_drops_cached_pages_above_new_size`
  - `shrink_truncate_below_zero_drops_every_cached_page`
  - `shrink_truncate_with_writeback_in_flight_is_awaited` (spawns a kernel task that sets and later clears `PG_WRITEBACK`; the main task's `setattr(SIZE)` parks on the WB-clear handshake and returns only after the worker's `end_writeback` wake)
- [x] `cargo test --test ext2_setattr --features ext2,page_cache` — 13/13 existing setattr tests still pass (free-block accounting, sparse-grow, EISDIR/EINVAL, etc.)
- [x] Adjacent ext2/page-cache integration tests: `ext2_writepage`, `ext2_readpage`, `ext2_readahead`, `block_writeback_inode_walk` all pass.
- [x] Build with `--features ext2` (no `page_cache`) — clean (cfg-gated body collapses to no-op).

## Notes

- `blocking_sync::rwlock_concurrent_readers` reproducibly fails on clean `main` (verified by `git stash` + re-run); this is a pre-existing flake unrelated to this PR.