### PR TITLE
block: writeback_complete_wq with strong-count Drop kicks (#757)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -541,3 +541,8 @@ harness = false
 name = "block_writeback_inode_walk"
 harness = false
 required-features = ["page_cache"]
+
+[[test]]
+name = "writeback_complete_wq"
+harness = false
+required-features = ["page_cache"]

--- a/kernel/src/block/writeback.rs
+++ b/kernel/src/block/writeback.rs
@@ -89,10 +89,10 @@ pub fn is_disabled() -> bool {
     CONFIGURED_SECS.load(Ordering::SeqCst) == DISABLE_SENTINEL
 }
 
-/// Parse a kernel command-line string, looking for
-/// `writeback_secs=<N>`. Whitespace-delimited; `N` must parse as a
-/// `u64` or the token is silently ignored (we'd rather continue
-/// booting with the default than panic on a typo).
+/// Parse a kernel command-line string, looking for the writeback
+/// knobs. Whitespace-delimited; values must parse as a `u64` or the
+/// token is silently ignored (we'd rather continue booting with the
+/// default than panic on a typo).
 ///
 /// The parser recognises:
 ///
@@ -100,14 +100,18 @@ pub fn is_disabled() -> bool {
 ///   the sentinel).
 /// - `writeback_secs=N` for any other `N` → override the default to N
 ///   seconds.
+/// - `direct_reclaim_timeout_ms=N` → override the CLOCK-Pro
+///   direct-reclaim soft cap (RFC 0007 §Eviction liveness, issue
+///   #757). `0` resets to [`DEFAULT_DIRECT_RECLAIM_TIMEOUT_MS`].
 ///
 /// Multiple occurrences: last one wins, matching how Linux handles
 /// duplicate cmdline parameters.
 ///
-/// Returns `true` if any `writeback_secs=…` token was found (so the
-/// caller can log that the override was applied); `false` otherwise.
+/// Returns `true` if any recognised token was found (so the caller can
+/// log that an override was applied); `false` otherwise.
 pub fn parse_cmdline(cmdline: &[u8]) -> bool {
-    const PREFIX: &[u8] = b"writeback_secs=";
+    const SECS_PREFIX: &[u8] = b"writeback_secs=";
+    const RECLAIM_PREFIX: &[u8] = b"direct_reclaim_timeout_ms=";
     let mut matched = false;
     let mut i = 0;
     while i < cmdline.len() {
@@ -119,7 +123,7 @@ pub fn parse_cmdline(cmdline: &[u8]) -> bool {
             i += 1;
         }
         let token = &cmdline[start..i];
-        if let Some(rest) = token.strip_prefix(PREFIX) {
+        if let Some(rest) = token.strip_prefix(SECS_PREFIX) {
             if let Some(secs) = parse_u64(rest) {
                 if secs == 0 {
                     set_configured_secs(DISABLE_SENTINEL);
@@ -130,6 +134,13 @@ pub fn parse_cmdline(cmdline: &[u8]) -> bool {
             }
             // Unparseable value → ignore; boot continues with the
             // previously-set (or default) cadence.
+        } else if let Some(rest) = token.strip_prefix(RECLAIM_PREFIX) {
+            if let Some(ms) = parse_u64(rest) {
+                set_direct_reclaim_timeout_ms(ms);
+                matched = true;
+            }
+            // Unparseable value → ignore; same fail-soft policy as
+            // the writeback_secs branch above.
         }
     }
     matched
@@ -160,6 +171,55 @@ fn parse_u64(bytes: &[u8]) -> Option<u64> {
 #[doc(hidden)]
 pub fn reset_configured_for_tests() {
     CONFIGURED_SECS.store(0, Ordering::SeqCst);
+    DIRECT_RECLAIM_TIMEOUT_MS.store(0, Ordering::SeqCst);
+}
+
+// ---------------------------------------------------------------------------
+// Direct-reclaim soft-cap knob (RFC 0007 §Eviction liveness, issue #757).
+//
+// CLOCK-Pro direct reclaim (#740) parks on `PageCache::writeback_complete_wq`
+// for at most this many milliseconds before surfacing `ENOMEM`. Lives in
+// this module rather than `mem::page_cache` because the cmdline parser is
+// already here and the knob shares the parse-once-at-boot lifecycle.
+// ---------------------------------------------------------------------------
+
+/// Compile-time default: 2 seconds. RFC 0007 §Eviction liveness, item 3:
+/// "configurable via … `direct_reclaim_timeout_ms=<N>` override". The 2 s
+/// cap is the bounded-direct-reclaim option (a) from the academic
+/// blocking finding — long enough to wait out a typical writepage
+/// latency, short enough that a pathological workload cannot park a
+/// faulting thread for the full 30 s writeback interval.
+pub const DEFAULT_DIRECT_RECLAIM_TIMEOUT_MS: u64 = 2_000;
+
+/// Kernel-cmdline override, in milliseconds. `0` means "use
+/// [`DEFAULT_DIRECT_RECLAIM_TIMEOUT_MS`]"; any non-zero value replaces
+/// the default for every subsequent direct-reclaim park.
+///
+/// The consumer of this value (CLOCK-Pro eviction) lands in #740. This
+/// PR (#757) wires up the knob alongside the per-cache waitqueue
+/// primitive itself so the cmdline surface is stable from day one and
+/// #740 can read [`direct_reclaim_timeout_ms`] without re-litigating
+/// the parser.
+static DIRECT_RECLAIM_TIMEOUT_MS: AtomicU64 = AtomicU64::new(0);
+
+/// Install a kernel-cmdline `direct_reclaim_timeout_ms=<N>` override.
+/// `0` resets to [`DEFAULT_DIRECT_RECLAIM_TIMEOUT_MS`]; any other value
+/// becomes the new soft cap.
+pub fn set_direct_reclaim_timeout_ms(ms: u64) {
+    DIRECT_RECLAIM_TIMEOUT_MS.store(ms, Ordering::SeqCst);
+}
+
+/// Current direct-reclaim soft cap in milliseconds. Reflects the most
+/// recent [`set_direct_reclaim_timeout_ms`] value, falling back to
+/// [`DEFAULT_DIRECT_RECLAIM_TIMEOUT_MS`] if no override has been
+/// installed.
+pub fn direct_reclaim_timeout_ms() -> u64 {
+    let override_ = DIRECT_RECLAIM_TIMEOUT_MS.load(Ordering::SeqCst);
+    if override_ == 0 {
+        DEFAULT_DIRECT_RECLAIM_TIMEOUT_MS
+    } else {
+        override_
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -690,5 +750,62 @@ mod tests {
         reset_configured_for_tests();
         set_configured_secs(DISABLE_SENTINEL);
         assert!(is_disabled());
+    }
+
+    // --- direct_reclaim_timeout_ms knob (issue #757) ---------------------
+
+    #[test]
+    fn direct_reclaim_timeout_default_before_any_override() {
+        let _g = TEST_LOCK.lock();
+        reset_configured_for_tests();
+        assert_eq!(
+            direct_reclaim_timeout_ms(),
+            DEFAULT_DIRECT_RECLAIM_TIMEOUT_MS
+        );
+    }
+
+    #[test]
+    fn parse_cmdline_sets_direct_reclaim_timeout() {
+        let _g = TEST_LOCK.lock();
+        reset_configured_for_tests();
+        assert!(parse_cmdline(b"direct_reclaim_timeout_ms=500"));
+        assert_eq!(direct_reclaim_timeout_ms(), 500);
+    }
+
+    #[test]
+    fn parse_cmdline_direct_reclaim_zero_resets_to_default() {
+        let _g = TEST_LOCK.lock();
+        reset_configured_for_tests();
+        // First set a non-zero override...
+        assert!(parse_cmdline(b"direct_reclaim_timeout_ms=750"));
+        assert_eq!(direct_reclaim_timeout_ms(), 750);
+        // ...then a zero token clears it back to the default.
+        assert!(parse_cmdline(b"direct_reclaim_timeout_ms=0"));
+        assert_eq!(
+            direct_reclaim_timeout_ms(),
+            DEFAULT_DIRECT_RECLAIM_TIMEOUT_MS
+        );
+    }
+
+    #[test]
+    fn parse_cmdline_direct_reclaim_garbage_value_ignored() {
+        let _g = TEST_LOCK.lock();
+        reset_configured_for_tests();
+        assert!(!parse_cmdline(b"direct_reclaim_timeout_ms=xyz"));
+        assert_eq!(
+            direct_reclaim_timeout_ms(),
+            DEFAULT_DIRECT_RECLAIM_TIMEOUT_MS
+        );
+    }
+
+    #[test]
+    fn parse_cmdline_both_knobs_independently() {
+        let _g = TEST_LOCK.lock();
+        reset_configured_for_tests();
+        assert!(parse_cmdline(
+            b"writeback_secs=12 direct_reclaim_timeout_ms=1500"
+        ));
+        assert_eq!(configured_secs(), 12);
+        assert_eq!(direct_reclaim_timeout_ms(), 1500);
     }
 }

--- a/kernel/src/mem/page_cache.rs
+++ b/kernel/src/mem/page_cache.rs
@@ -94,6 +94,8 @@ use core::sync::atomic::{AtomicU32, AtomicU64, AtomicU8, Ordering};
 use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::sync::Arc;
 
+use spin::Once;
+
 use crate::mem::aops::AddressSpaceOps;
 
 // Sync primitives.
@@ -150,13 +152,36 @@ mod host_stub {
         }
     }
 
-    pub struct WaitQueue;
+    /// Host stand-in for [`crate::sync::WaitQueue`].
+    ///
+    /// `notify_all` does not actually wake any task (host tests don't
+    /// run under the kernel scheduler), but it bumps an internal
+    /// counter so issue #757's host tests can verify that
+    /// `CachePage::end_writeback` and `CachePage::Drop` *do* fire the
+    /// wake — even though the wake itself has no observable effect on
+    /// host because there is no parked task to wake.
+    pub struct WaitQueue {
+        notify_count: core::sync::atomic::AtomicU64,
+    }
 
     impl WaitQueue {
         pub const fn new() -> Self {
-            Self
+            Self {
+                notify_count: core::sync::atomic::AtomicU64::new(0),
+            }
         }
-        pub fn notify_all(&self) {}
+        pub fn notify_all(&self) {
+            self.notify_count
+                .fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+        }
+        /// Number of times `notify_all` has fired against this queue.
+        /// Test-only; the bare-metal queue does not expose a
+        /// notification counter.
+        #[allow(dead_code)]
+        pub fn notify_count(&self) -> u64 {
+            self.notify_count
+                .load(core::sync::atomic::Ordering::Relaxed)
+        }
         /// Host stand-in for the bare-metal park loop. Returns
         /// immediately; host unit tests do not cross-thread block on
         /// `PG_LOCKED`. If a future host test does need to exercise
@@ -271,6 +296,21 @@ pub struct CachePage {
     /// on [`PG_WRITEBACK`] to wait out an in-flight `writepage` before
     /// the FS is allowed to free the underlying blocks.
     pub(crate) wait: WaitQueue,
+
+    /// Owning [`PageCache`]'s `writeback_complete_wq`. Set exactly
+    /// once when the stub is installed into a [`PageCache`] via
+    /// [`PageCache::install_or_get`]; remains [`Once::get`] = `None`
+    /// for free-standing stubs (e.g. host unit tests that exercise
+    /// individual [`CachePage`] state transitions without ever
+    /// installing into a cache).
+    ///
+    /// RFC 0007 §Eviction liveness: kicked from
+    /// [`Self::end_writeback`] (the writeback-completion side) and
+    /// from [`Drop`] (the strong-count-reaches-1 side, so that a page
+    /// dropped without an explicit `end_writeback` still wakes
+    /// direct-reclaim parkers — closes the lost-wakeup window when a
+    /// `WritebackHandle` is dropped without `end_writeback`).
+    pub(crate) parent_wb_wq: Once<Arc<WaitQueue>>,
 }
 
 impl CachePage {
@@ -290,6 +330,7 @@ impl CachePage {
             pgoff,
             state: AtomicU8::new(PG_LOCKED),
             wait: WaitQueue::new(),
+            parent_wb_wq: Once::new(),
         })
     }
 
@@ -407,12 +448,22 @@ impl CachePage {
         self.state.fetch_or(PG_WRITEBACK, Ordering::AcqRel);
     }
 
-    /// Conclude writeback. Clears [`PG_WRITEBACK`] with `Release` and
-    /// wakes every parked waiter (truncate parks here while
-    /// `PG_WRITEBACK` is set).
+    /// Conclude writeback. Clears [`PG_WRITEBACK`] with `Release`,
+    /// wakes every parked waiter on the page-local queue (truncate
+    /// parks here while `PG_WRITEBACK` is set), and — if this stub
+    /// is installed in a [`PageCache`] — kicks the owning cache's
+    /// `writeback_complete_wq` so direct-reclaim parkers retry their
+    /// CLOCK-Pro sweep.
+    ///
+    /// RFC 0007 §Eviction liveness: a per-event retry — every
+    /// `writepage` completion gives the parked faulter one retry
+    /// opportunity bounded by the `direct_reclaim_timeout_ms` soft cap.
     pub fn end_writeback(&self) {
         self.state.fetch_and(!PG_WRITEBACK, Ordering::Release);
         self.wait.notify_all();
+        if let Some(wq) = self.parent_wb_wq.get() {
+            wq.notify_all();
+        }
     }
 
     /// Filler-abandon path: clear [`PG_LOCKED`] with `Release` and
@@ -432,6 +483,34 @@ impl CachePage {
     pub fn unlock_for_abandon(&self) {
         self.state.fetch_and(!PG_LOCKED, Ordering::Release);
         self.wait.notify_all();
+    }
+}
+
+impl Drop for CachePage {
+    /// Strong-count-reaches-zero kick for direct-reclaim waiters.
+    ///
+    /// `Drop` runs once the last `Arc<CachePage>` strong reference
+    /// goes away. RFC 0007 §Eviction liveness names this as one of
+    /// the two wake sources for `writeback_complete_wq`: a parked
+    /// reclaimer may be blocked because every CLOCK-Pro candidate
+    /// was *Arc-pinned* by an in-flight fault; once that in-flight
+    /// fault drops its clone and the strong count reaches 1 (cache
+    /// index only), then 0 (cache index also gone), the parker should
+    /// retry. Without this kick, a `WritebackHandle` that gets dropped
+    /// without an explicit `end_writeback` would leave reclaimers
+    /// parked until the next writepage or the soft-cap timeout —
+    /// the lost-wakeup case the issue body calls out.
+    ///
+    /// Cheap and unconditional: if `parent_wb_wq` was never attached
+    /// (free-standing stub), `Once::get()` returns `None` and the
+    /// notify is skipped. The wq is held via `Arc` so this notify is
+    /// safe even if the parent [`PageCache`] has itself been dropped —
+    /// the wq outlives the cache by exactly the strong-count of the
+    /// `Arc<WaitQueue>`s the surviving `CachePage`s hold.
+    fn drop(&mut self) {
+        if let Some(wq) = self.parent_wb_wq.get() {
+            wq.notify_all();
+        }
     }
 }
 
@@ -610,9 +689,10 @@ pub enum InstallOutcome {
 /// Per-inode page cache.
 ///
 /// Owned by the inode (the `mapping` field added by #745 wave-2
-/// VFS plumbing). The `ra_state` (#741) and `writeback_complete_wq`
-/// (#740) fields are still deferred to their respective sibling
-/// issues; the `ops` per-FS hook lands here (#737).
+/// VFS plumbing). The `ra_state` (#741) field is still deferred to
+/// its sibling issue; the `ops` per-FS hook lands here (#737); the
+/// `writeback_complete_wq` (#757) is the per-cache wake source
+/// CLOCK-Pro eviction (#740) parks on for direct reclaim.
 pub struct PageCache {
     /// Per-FS hook for backing I/O. Captured at construction and
     /// **never rebound** for the lifetime of this cache (RFC 0007
@@ -660,6 +740,33 @@ pub struct PageCache {
     /// counter into an `EIO` decision is wired up by the writeback
     /// workstream (#740/#742).
     pub wb_err: AtomicU32,
+
+    /// Per-cache writeback-completion waitqueue (RFC 0007 §Eviction
+    /// liveness). Direct-reclaim parks here when a CLOCK-Pro sweep
+    /// finds zero victims; wakes are produced by:
+    ///
+    /// 1. [`CachePage::end_writeback`] — every `writepage` completion,
+    ///    success or error, kicks the queue (a `PG_DIRTY`-pinned
+    ///    page may now be evictable).
+    /// 2. [`CachePage`]'s `Drop` — the last `Arc<CachePage>` strong
+    ///    reference dropping kicks the queue (an `Arc::clone`-pinned
+    ///    page may now be evictable). This closes the lost-wakeup
+    ///    window where a writeback handle is dropped without
+    ///    `end_writeback`.
+    ///
+    /// Held via `Arc` so each [`CachePage`] in this cache can clone a
+    /// strong reference into its `parent_wb_wq` slot — the wq then
+    /// outlives the [`PageCache`] itself by exactly the strong-count
+    /// the surviving pages hold (a `Drop`-side notify on a
+    /// long-since-decommissioned cache is a harmless no-op against an
+    /// empty waitqueue).
+    ///
+    /// Lock-order: level 6.5 in the RFC 0007 ladder — between the
+    /// buffer cache (level 6) and the refcount/frame layer (levels
+    /// 7–8). The wq's internal mutex is taken only to enqueue
+    /// (waiters) or dequeue (wakers); it does not nest under any
+    /// other cache lock.
+    writeback_complete_wq: Arc<WaitQueue>,
 }
 
 impl PageCache {
@@ -678,6 +785,7 @@ impl PageCache {
             i_size: AtomicU64::new(i_size),
             inode_id,
             wb_err: AtomicU32::new(0),
+            writeback_complete_wq: Arc::new(WaitQueue::new()),
         }
     }
 
@@ -732,6 +840,14 @@ impl PageCache {
             stub.is_locked() && !stub.is_uptodate(),
             "page_cache: fresh stub must be PG_LOCKED and !PG_UPTODATE",
         );
+        // Attach this cache's `writeback_complete_wq` to the stub so
+        // `CachePage::end_writeback` and `CachePage::Drop` both kick
+        // direct-reclaim parkers. `Once::call_once` is idempotent: a
+        // closure that hands back a previously-built stub (e.g. via
+        // a future test harness that recycles entries) gets the same
+        // wq attached and the second call is a cheap no-op.
+        stub.parent_wb_wq
+            .call_once(|| Arc::clone(&self.writeback_complete_wq));
         inner.pages.insert(pgoff, stub.clone());
         InstallOutcome::InstalledNew(stub)
     }
@@ -958,6 +1074,32 @@ impl PageCache {
     /// (which is part of #740).
     pub fn store_i_size(&self, new_size: u64) {
         self.i_size.store(new_size, Ordering::Release);
+    }
+
+    /// Borrow the per-cache writeback-completion waitqueue.
+    ///
+    /// Returned as an `Arc` clone so callers (CLOCK-Pro direct
+    /// reclaim — #740) can move it into a deadline park without
+    /// holding any reference into `self`. Public so the eviction
+    /// path's `wait_while` can call `wq.wait_while(|| !sweep_found_victim)`
+    /// directly; the wakers (`end_writeback` and `Drop`) reach the
+    /// same Arc through each [`CachePage`]'s `parent_wb_wq` slot.
+    pub fn writeback_complete_wq(&self) -> Arc<WaitQueue> {
+        Arc::clone(&self.writeback_complete_wq)
+    }
+
+    /// Convenience park: blocks the current task on the per-cache
+    /// `writeback_complete_wq` while `cond()` returns `true`, with
+    /// the same lost-wakeup guarantees as [`WaitQueue::wait_while`].
+    ///
+    /// The intended consumer is the CLOCK-Pro direct-reclaim path
+    /// (#740), which calls this with `cond = || sweep_found_no_victim()`.
+    /// Each `end_writeback` / `CachePage::Drop` kick re-runs the sweep;
+    /// the soft-cap timeout that bounds total wait time lives at the
+    /// caller (issue #740) so the primitive itself stays free of
+    /// timeout-policy.
+    pub fn wait_writeback_complete<F: FnMut() -> bool>(&self, cond: F) {
+        self.writeback_complete_wq.wait_while(cond);
     }
 }
 
@@ -1936,5 +2078,180 @@ mod tests {
         assert!(cache.mark_page_dirty(0));
         let guard = cache.inner.try_lock();
         assert!(guard.is_some());
+    }
+
+    // --- writeback_complete_wq plumbing (issue #757) -------------------
+    //
+    // These tests verify the structural plumbing of the new per-cache
+    // wait queue: the wq exists on the cache, it is attached to every
+    // installed `CachePage`, `end_writeback` and `Drop` both kick it.
+    // The host stub's `WaitQueue::notify_count()` lets us see the
+    // wakes even though the host has no real parked tasks; the
+    // bare-metal park-and-wake protocol is exercised by the QEMU
+    // integration test `writeback_complete_wq.rs`.
+
+    #[test]
+    fn cache_owns_writeback_complete_wq() {
+        let cache = fresh_cache();
+        let wq = cache.writeback_complete_wq();
+        // Identical Arc on every call (no fresh allocation per
+        // accessor) — RFC 0007 §Eviction liveness: a single per-cache
+        // queue is the wake fan-in for direct reclaim.
+        let wq2 = cache.writeback_complete_wq();
+        assert!(Arc::ptr_eq(&wq, &wq2));
+    }
+
+    #[test]
+    fn install_or_get_attaches_writeback_wq_to_stub() {
+        let cache = fresh_cache();
+        let stub = match cache.install_or_get(0, || make_stub(0)) {
+            InstallOutcome::InstalledNew(p) => p,
+            InstallOutcome::AlreadyPresent(_) => unreachable!(),
+        };
+        let attached = stub
+            .parent_wb_wq
+            .get()
+            .expect("install_or_get must attach the cache's wb wq");
+        assert!(Arc::ptr_eq(attached, &cache.writeback_complete_wq()));
+    }
+
+    #[test]
+    fn freestanding_stub_has_no_wb_wq() {
+        // A stub built with `CachePage::new_locked` directly (without
+        // going through `install_or_get`) has no parent wq. This is
+        // the path host unit tests for the per-page state machine
+        // take; the absence of an attached wq must keep their
+        // `end_writeback` / `Drop` paths working as no-ops.
+        let stub = make_stub(0);
+        assert!(stub.parent_wb_wq.get().is_none());
+        // Calling end_writeback / dropping is a non-panicking no-op.
+        stub.publish_uptodate_and_unlock();
+        stub.begin_writeback();
+        stub.end_writeback();
+        drop(stub); // exercises the Drop kick on a freestanding page
+    }
+
+    #[test]
+    fn end_writeback_kicks_cache_wq() {
+        // PG_WRITEBACK clear must wake the per-cache wq. Host stub
+        // counts the wake; the real bare-metal queue's `notify_all`
+        // does the same plus actually waking parkers.
+        let cache = fresh_cache();
+        let stub = match cache.install_or_get(0, || make_stub(0)) {
+            InstallOutcome::InstalledNew(p) => p,
+            InstallOutcome::AlreadyPresent(_) => unreachable!(),
+        };
+        stub.publish_uptodate_and_unlock();
+        let wq = cache.writeback_complete_wq();
+        let before = wq.notify_count();
+        stub.begin_writeback();
+        // begin_writeback does NOT kick the wq (the wake is reserved
+        // for completion).
+        assert_eq!(wq.notify_count(), before);
+        stub.end_writeback();
+        // end_writeback must have fired exactly one wake on the wq.
+        assert_eq!(
+            wq.notify_count(),
+            before + 1,
+            "end_writeback must kick the cache's writeback_complete_wq",
+        );
+    }
+
+    #[test]
+    fn cachepage_drop_kicks_cache_wq() {
+        // Drop kick: the lost-wakeup defence — a writeback handle
+        // dropped without `end_writeback` must still wake direct
+        // reclaim. We model this by removing the cache's index entry
+        // and dropping our own outer Arc, taking strong_count to 0.
+        let cache = fresh_cache();
+        let stub = match cache.install_or_get(0, || make_stub(0)) {
+            InstallOutcome::InstalledNew(p) => p,
+            InstallOutcome::AlreadyPresent(_) => unreachable!(),
+        };
+        stub.publish_uptodate_and_unlock();
+        let wq = cache.writeback_complete_wq();
+        let before = wq.notify_count();
+        // Drop the index strong-ref so our outer `stub` is the sole
+        // holder; then drop `stub` and observe the wake.
+        cache.inner.lock().pages.remove(&0);
+        // strong_count is now 1 (just our `stub`). Dropping fires Drop.
+        drop(stub);
+        assert_eq!(
+            wq.notify_count(),
+            before + 1,
+            "CachePage::Drop must kick the cache's writeback_complete_wq",
+        );
+    }
+
+    #[test]
+    fn end_writeback_and_drop_each_fire_independent_kicks() {
+        // The two wake sources are independent: a page that
+        // *completes* writeback (one kick) and is later evicted from
+        // the cache and dropped (second kick) produces two
+        // notifications, not one. RFC 0007 §Eviction liveness item 4
+        // — "per-event retry": each wake gives the parked faulter
+        // one CLOCK-Pro retry opportunity.
+        let cache = fresh_cache();
+        let stub = match cache.install_or_get(0, || make_stub(0)) {
+            InstallOutcome::InstalledNew(p) => p,
+            InstallOutcome::AlreadyPresent(_) => unreachable!(),
+        };
+        stub.publish_uptodate_and_unlock();
+        let wq = cache.writeback_complete_wq();
+        let before = wq.notify_count();
+
+        stub.begin_writeback();
+        stub.end_writeback();
+        cache.inner.lock().pages.remove(&0);
+        drop(stub);
+
+        assert_eq!(
+            wq.notify_count(),
+            before + 2,
+            "end_writeback and Drop must each kick the wq once",
+        );
+    }
+
+    #[test]
+    fn writeback_wq_outlives_cache_for_alive_pages() {
+        // The `writeback_complete_wq` is held via `Arc`, so a
+        // surviving `CachePage` clone keeps the wq alive even after
+        // the parent `PageCache` itself drops. The Drop notify on
+        // such a clone is a harmless no-op against an empty queue —
+        // there is no parked task on it because the only consumer
+        // (CLOCK-Pro reclaim) parks via `cache.wait_writeback_complete`
+        // and cannot park if the cache itself is gone.
+        let cache = fresh_cache();
+        let stub = match cache.install_or_get(0, || make_stub(0)) {
+            InstallOutcome::InstalledNew(p) => p,
+            InstallOutcome::AlreadyPresent(_) => unreachable!(),
+        };
+        stub.publish_uptodate_and_unlock();
+        // Snapshot the wq Arc *before* dropping the cache so we can
+        // observe its notify_count after the cache is gone.
+        let wq = cache.writeback_complete_wq();
+        let before = wq.notify_count();
+        drop(cache); // index entry's strong-ref goes away.
+                     // `stub` still holds an Arc on the wq via parent_wb_wq.
+        drop(stub);
+        // The Drop kick fires against the surviving wq.
+        assert_eq!(
+            wq.notify_count(),
+            before + 1,
+            "Drop kick must fire even after the parent cache is gone",
+        );
+    }
+
+    #[test]
+    fn wait_writeback_complete_invokes_predicate() {
+        // The convenience park: just verifies the predicate is
+        // called. The real park/wake handshake is QEMU-only.
+        let cache = fresh_cache();
+        let mut calls = 0;
+        cache.wait_writeback_complete(|| {
+            calls += 1;
+            false // returns immediately on host stub
+        });
+        assert!(calls >= 1);
     }
 }

--- a/kernel/tests/writeback_complete_wq.rs
+++ b/kernel/tests/writeback_complete_wq.rs
@@ -1,0 +1,331 @@
+//! Integration test for issue #757: per-cache `writeback_complete_wq`
+//! park/wake protocol.
+//!
+//! Three properties are exercised under the real round-robin scheduler
+//! (the host stub in `mem::page_cache` cannot really park tasks, so the
+//! park-side test must run on bare metal):
+//!
+//! 1. **Park while writeback in-flight.** A waiter calls
+//!    `cache.wait_writeback_complete(|| in_flight)` and stays parked
+//!    until the predicate goes false. We assert the waiter does not
+//!    make progress before the wake.
+//! 2. **`PG_WRITEBACK` clear wakes parked waiters.** After flipping the
+//!    in-flight flag, the driver calls `page.end_writeback()` (which
+//!    clears `PG_WRITEBACK` and notifies the cache wq). Every parked
+//!    waiter wakes and progresses past the park.
+//! 3. **`Drop` kick wakes parked waiters even without explicit
+//!    `end_writeback`.** A separate workload installs a page, takes an
+//!    extra `Arc::clone` (so dropping the cache index entry does not
+//!    take strong-count to 0), parks a waiter on the cache wq, then
+//!    drops the extra clone. The Drop notify on the surviving page
+//!    fires the wake.
+//!
+//! These three properties are the contract documented in RFC 0007
+//! §Eviction liveness — landing them unblocks #740 (CLOCK-Pro
+//! direct-reclaim), which parks on the same wq.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use spin::Mutex as SpinMutex;
+
+use vibix::mem::aops::AddressSpaceOps;
+use vibix::mem::page_cache::{CachePage, InodeId, InstallOutcome, PageCache};
+use vibix::sync::WaitQueue;
+use vibix::{
+    exit_qemu, serial_println, task,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "park_blocks_until_pg_writeback_clears",
+            &(park_blocks_until_pg_writeback_clears as fn()),
+        ),
+        (
+            "end_writeback_wakes_all_parked_waiters",
+            &(end_writeback_wakes_all_parked_waiters as fn()),
+        ),
+        (
+            "cachepage_drop_wakes_parked_waiters",
+            &(cachepage_drop_wakes_parked_waiters as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+// --- Test fixture ---------------------------------------------------------
+
+/// Trivial in-memory `AddressSpaceOps` so [`PageCache::new`] is happy.
+/// The wq tests never invoke `readpage` / `writepage`, so all four hooks
+/// can return placeholder values; the test only exercises the install-
+/// then-park / wake protocol.
+struct NullOps;
+
+impl AddressSpaceOps for NullOps {
+    fn readpage(&self, _pgoff: u64, _buf: &mut [u8; 4096]) -> Result<usize, i64> {
+        // Required-method contract: assert_no_spinlocks_held first.
+        // The wq tests never invoke this — it's only here so the impl
+        // type-checks.
+        vibix::debug_lockdep::assert_no_spinlocks_held("NullOps::readpage");
+        Ok(4096)
+    }
+    fn writepage(&self, _pgoff: u64, _buf: &[u8; 4096]) -> Result<(), i64> {
+        vibix::debug_lockdep::assert_no_spinlocks_held("NullOps::writepage");
+        Ok(())
+    }
+}
+
+fn fresh_cache() -> Arc<PageCache> {
+    let ops: Arc<dyn AddressSpaceOps> = Arc::new(NullOps);
+    Arc::new(PageCache::new(InodeId::new(0xfeed_face, 1), 0, ops))
+}
+
+/// Allocate a fresh frame so each test gets a non-aliased `phys`.
+/// The wq tests never actually dereference the frame, but the cache
+/// holds a `frame::put` discipline (will land in #740) so honest
+/// allocation keeps invariants happy.
+fn fresh_phys() -> u64 {
+    vibix::mem::frame::alloc().expect("frame::alloc")
+}
+
+/// Driver-side park: spin-with-`hlt` until `parked()` reports `expected`
+/// waiters have actually enqueued themselves on the wq under test.
+/// Same pattern as `blocking_sync.rs::wait_for_parked`.
+fn wait_for_parked<F: Fn() -> usize>(parked: F, expected: usize, deadline_ticks: usize) {
+    for _ in 0..deadline_ticks {
+        if parked() >= expected {
+            return;
+        }
+        x86_64::instructions::hlt();
+    }
+    if parked() >= expected {
+        return;
+    }
+    panic!(
+        "waiters didn't park in time: parked={}/{}",
+        parked(),
+        expected
+    );
+}
+
+// --- park_blocks_until_pg_writeback_clears -------------------------------
+
+static T1_CACHE: SpinMutex<Option<Arc<PageCache>>> = SpinMutex::new(None);
+static T1_INFLIGHT: AtomicBool = AtomicBool::new(false);
+static T1_PROGRESS: AtomicUsize = AtomicUsize::new(0);
+static T1_PAGE: SpinMutex<Option<Arc<CachePage>>> = SpinMutex::new(None);
+
+fn t1_waiter() -> ! {
+    let cache = T1_CACHE.lock().clone().expect("T1_CACHE not set");
+    cache.wait_writeback_complete(|| T1_INFLIGHT.load(Ordering::SeqCst));
+    T1_PROGRESS.fetch_add(1, Ordering::SeqCst);
+    task::exit();
+}
+
+fn park_blocks_until_pg_writeback_clears() {
+    let cache = fresh_cache();
+    let stub = match cache.install_or_get(0, || CachePage::new_locked(fresh_phys(), 0)) {
+        InstallOutcome::InstalledNew(p) => p,
+        InstallOutcome::AlreadyPresent(_) => unreachable!(),
+    };
+    stub.publish_uptodate_and_unlock();
+    stub.begin_writeback();
+
+    *T1_CACHE.lock() = Some(Arc::clone(&cache));
+    *T1_PAGE.lock() = Some(Arc::clone(&stub));
+    T1_INFLIGHT.store(true, Ordering::SeqCst);
+    T1_PROGRESS.store(0, Ordering::SeqCst);
+
+    task::spawn(t1_waiter);
+
+    // Wait until the worker has actually parked on the cache wq.
+    let wq: Arc<WaitQueue> = cache.writeback_complete_wq();
+    wait_for_parked(|| wq.waiter_count(), 1, 200);
+
+    // Critical assertion: the waiter has not made progress while the
+    // in-flight flag is still set. (We've idled enough hlt cycles for
+    // a runaway worker to fall through; if it had, this would be 1.)
+    assert_eq!(
+        T1_PROGRESS.load(Ordering::SeqCst),
+        0,
+        "waiter progressed past the park before the wake fired"
+    );
+
+    // Flip the predicate, then conclude writeback. end_writeback's
+    // notify_all on the cache wq is the wake that frees the parker.
+    T1_INFLIGHT.store(false, Ordering::SeqCst);
+    stub.end_writeback();
+
+    // Worker should observe the wake and bump the counter.
+    for _ in 0..1_000 {
+        if T1_PROGRESS.load(Ordering::SeqCst) == 1 {
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+    assert_eq!(
+        T1_PROGRESS.load(Ordering::SeqCst),
+        1,
+        "end_writeback didn't wake the parked waiter"
+    );
+
+    // Cleanup hand-offs.
+    *T1_CACHE.lock() = None;
+    *T1_PAGE.lock() = None;
+}
+
+// --- end_writeback_wakes_all_parked_waiters ------------------------------
+
+static T2_CACHE: SpinMutex<Option<Arc<PageCache>>> = SpinMutex::new(None);
+static T2_INFLIGHT: AtomicBool = AtomicBool::new(false);
+static T2_WOKEN: AtomicUsize = AtomicUsize::new(0);
+
+fn t2_waiter() -> ! {
+    let cache = T2_CACHE.lock().clone().expect("T2_CACHE not set");
+    cache.wait_writeback_complete(|| T2_INFLIGHT.load(Ordering::SeqCst));
+    T2_WOKEN.fetch_add(1, Ordering::SeqCst);
+    task::exit();
+}
+
+fn end_writeback_wakes_all_parked_waiters() {
+    // Multiple parked waiters: a single end_writeback's notify_all
+    // must wake every one of them.
+    let cache = fresh_cache();
+    let stub = match cache.install_or_get(0, || CachePage::new_locked(fresh_phys(), 0)) {
+        InstallOutcome::InstalledNew(p) => p,
+        InstallOutcome::AlreadyPresent(_) => unreachable!(),
+    };
+    stub.publish_uptodate_and_unlock();
+    stub.begin_writeback();
+
+    *T2_CACHE.lock() = Some(Arc::clone(&cache));
+    T2_INFLIGHT.store(true, Ordering::SeqCst);
+    T2_WOKEN.store(0, Ordering::SeqCst);
+
+    task::spawn(t2_waiter);
+    task::spawn(t2_waiter);
+    task::spawn(t2_waiter);
+
+    let wq: Arc<WaitQueue> = cache.writeback_complete_wq();
+    wait_for_parked(|| wq.waiter_count(), 3, 200);
+    assert_eq!(
+        T2_WOKEN.load(Ordering::SeqCst),
+        0,
+        "waiters woke before the wake fired"
+    );
+
+    // Flip predicate, conclude writeback — one notify_all wakes all 3.
+    T2_INFLIGHT.store(false, Ordering::SeqCst);
+    stub.end_writeback();
+
+    for _ in 0..2_000 {
+        if T2_WOKEN.load(Ordering::SeqCst) == 3 {
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+    assert_eq!(
+        T2_WOKEN.load(Ordering::SeqCst),
+        3,
+        "end_writeback's notify_all didn't wake every parked waiter"
+    );
+
+    *T2_CACHE.lock() = None;
+}
+
+// --- cachepage_drop_wakes_parked_waiters ---------------------------------
+
+static T3_CACHE: SpinMutex<Option<Arc<PageCache>>> = SpinMutex::new(None);
+static T3_PINNED: AtomicBool = AtomicBool::new(false);
+static T3_PROGRESS: AtomicUsize = AtomicUsize::new(0);
+
+fn t3_waiter() -> ! {
+    let cache = T3_CACHE.lock().clone().expect("T3_CACHE not set");
+    cache.wait_writeback_complete(|| T3_PINNED.load(Ordering::SeqCst));
+    T3_PROGRESS.fetch_add(1, Ordering::SeqCst);
+    task::exit();
+}
+
+fn cachepage_drop_wakes_parked_waiters() {
+    // The Drop kick: a CachePage that gets dropped *without* an
+    // explicit `end_writeback` must still wake direct-reclaim parkers.
+    // Models the path RFC 0007 §Eviction liveness item 3(b) calls out:
+    // an `Arc::clone`-pinned page becoming unpinned should give the
+    // parker a retry opportunity.
+    let cache = fresh_cache();
+    let stub = match cache.install_or_get(0, || CachePage::new_locked(fresh_phys(), 0)) {
+        InstallOutcome::InstalledNew(p) => p,
+        InstallOutcome::AlreadyPresent(_) => unreachable!(),
+    };
+    stub.publish_uptodate_and_unlock();
+
+    *T3_CACHE.lock() = Some(Arc::clone(&cache));
+    // Predicate: parked while the extra clone exists. We'll flip it
+    // *and* drop the clone in lockstep.
+    T3_PINNED.store(true, Ordering::SeqCst);
+    T3_PROGRESS.store(0, Ordering::SeqCst);
+
+    // Take a separate clone that mirrors the "in-flight fault clone"
+    // RFC 0007 §Refcount discipline describes. We then evict the
+    // page from the cache index *and* drop our own outer `stub` so
+    // this clone is the sole strong-count holder.
+    let extra_clone = Arc::clone(&stub);
+    cache.inner.lock().pages.remove(&0);
+    drop(stub); // strong_count: index gone, outer gone, only `extra_clone` left.
+
+    task::spawn(t3_waiter);
+
+    let wq: Arc<WaitQueue> = cache.writeback_complete_wq();
+    wait_for_parked(|| wq.waiter_count(), 1, 200);
+    assert_eq!(
+        T3_PROGRESS.load(Ordering::SeqCst),
+        0,
+        "waiter progressed before the Drop kick"
+    );
+
+    // Flip the predicate, then drop the last strong holder. Drop
+    // fires `parent_wb_wq.notify_all()` which wakes the parker.
+    T3_PINNED.store(false, Ordering::SeqCst);
+    drop(extra_clone);
+
+    for _ in 0..1_000 {
+        if T3_PROGRESS.load(Ordering::SeqCst) == 1 {
+            break;
+        }
+        x86_64::instructions::hlt();
+    }
+    assert_eq!(
+        T3_PROGRESS.load(Ordering::SeqCst),
+        1,
+        "CachePage Drop kick didn't wake the parked waiter"
+    );
+
+    *T3_CACHE.lock() = None;
+}


### PR DESCRIPTION
Closes #757

## Summary
- Adds the per-`PageCache` `writeback_complete_wq` waitqueue from RFC 0007 §Eviction liveness — kicked by `CachePage::end_writeback` and by `CachePage::Drop` so direct-reclaim parkers don't lose wakeups when a writeback handle is dropped without explicit `end_writeback` (the lost-wakeup window the issue body calls out).
- Each `CachePage` carries a `Once<Arc<WaitQueue>>` slot; `PageCache::install_or_get` attaches the cache's wq on insert. Free-standing stubs (host unit-test path) skip the notify cleanly via `Once::get() == None`.
- Public surface for #740 to park on: `PageCache::writeback_complete_wq()` and `PageCache::wait_writeback_complete(cond)`.
- Plumbs the `direct_reclaim_timeout_ms=<N>` cmdline knob (default 2 000 ms) named by the same RFC section so #740 can read the configured cap when it lands. The 2 s policy itself is not enforced here — that lives at the consumer.

This PR is the primitive #740 CLOCK-Pro eviction parks on; landing it unblocks #740.

## Test plan
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo xtask build` — clean
- [x] `cargo xtask smoke` — `all 42 markers present ✓`
- [x] `cargo test --package vibix --lib mem::page_cache::tests` — 52/52 ok (8 new tests for wq attachment, end_writeback kick, Drop kick, freestanding-stub no-op, wq-outlives-cache, independence of the two wake sources)
- [x] `cargo test --package vibix --lib block::writeback` — 13/13 ok (5 new tests covering the `direct_reclaim_timeout_ms` knob)
- [x] `cargo xtask test --test writeback_complete_wq` — 3/3 ok under the real round-robin scheduler:
  1. `park_blocks_until_pg_writeback_clears` — waiter parks while `PG_WRITEBACK` set, doesn't progress past the park before the wake fires
  2. `end_writeback_wakes_all_parked_waiters` — `notify_all` from `end_writeback` wakes all 3 parked waiters
  3. `cachepage_drop_wakes_parked_waiters` — `CachePage::Drop` kick wakes the parked waiter when a writeback handle is dropped without explicit `end_writeback`

### Pre-existing main flake (not addressed)
`blocking_sync.rs::rwlock_concurrent_readers` fails on `cargo xtask test` against `main` independent of this PR — tracked in #791. Skipping past that test, every other suite is green.