### PR TITLE
sys: extend mprotect to enforce open_mode and exec-permission rules (#747)

### DIFF
--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -1600,9 +1600,16 @@ unsafe fn sys_munmap(addr: u64, len: u64) -> i64 {
 /// `mprotect(addr, len, prot)` — Linux `mprotect_fixup` semantics.
 /// `-EINVAL` on validation failure or unknown PROT bits; `-ENOMEM` only
 /// when a sub-page of `[addr, addr+len)` is literally unmapped.
+///
+/// RFC 0007 §Security B1: for file-backed VMAs, `PROT_WRITE` upgrades
+/// on `MAP_SHARED` mappings require `open_mode == O_RDWR`, and
+/// `PROT_EXEC` upgrades require the backing inode to have had execute
+/// permission at `mmap` time. Both checks consult the snapshot stored
+/// on the `FileObject` — never the live `OpenFile` or inode.
 unsafe fn sys_mprotect(addr: u64, len: u64, prot: u64) -> i64 {
-    use crate::fs::{EINVAL, ENOMEM};
+    use crate::fs::{EACCES, EINVAL, ENOMEM};
     use crate::mem::pf::{validate_user_range, AddrAlign, PROT_EXEC, PROT_READ, PROT_WRITE};
+    use crate::mem::vmatree::Share;
 
     let prot = prot as u32;
     if prot & !(PROT_READ | PROT_WRITE | PROT_EXEC) != 0 {
@@ -1621,8 +1628,48 @@ unsafe fn sys_mprotect(addr: u64, len: u64, prot: u64) -> i64 {
         return ENOMEM;
     }
 
+    // RFC 0007 §Security B1 — file-backed mprotect permission gates.
+    //
+    // Walk every VMA that overlaps `[start, start+len)` and reject the
+    // request if a file-backed VMA's snapshot forbids the upgrade:
+    //
+    //   PROT_WRITE on a MAP_SHARED VMA whose open_mode != O_RDWR → EACCES
+    //   PROT_EXEC  on a VMA whose backing inode lacked execute perm  → EACCES
+    //
+    // `O_RDWR = 2` — pinned by the static asserts in `crate::fs::flags`.
+    const O_RDWR: u32 = 2;
+    let want_write = prot & PROT_WRITE != 0;
+    let want_exec = prot & PROT_EXEC != 0;
+    let start = range.addr;
+    let end = range.addr + range.len;
+    if want_write || want_exec {
+        for vma in guard.iter() {
+            if vma.end <= start {
+                continue;
+            }
+            if vma.start >= end {
+                break;
+            }
+            // PROT_WRITE upgrade on a MAP_SHARED file-backed VMA.
+            if want_write && vma.share == Share::Shared {
+                if let Some(mode) = vma.object.mprotect_open_mode() {
+                    if mode != O_RDWR {
+                        return EACCES;
+                    }
+                }
+            }
+            // PROT_EXEC upgrade on a file-backed VMA whose inode lacked
+            // execute permission at mmap time.
+            if want_exec {
+                if let Some(false) = vma.object.mprotect_exec_allowed() {
+                    return EACCES;
+                }
+            }
+        }
+    }
+
     let pte_bits = prot_pte_from_prot_user(prot);
-    guard.sys_mprotect_range(range.addr, range.addr + range.len, prot, pte_bits);
+    guard.sys_mprotect_range(start, end, prot, pte_bits);
     0
 }
 

--- a/kernel/src/fs/ext2/inode.rs
+++ b/kernel/src/fs/ext2/inode.rs
@@ -603,12 +603,30 @@ impl FileOps for Ext2Inode {
         // walk; the access mode itself is install-once at open(2).
         let open_mode = f.flags.load(Ordering::Relaxed) & crate::fs::flags::O_ACCMODE;
 
+        // RFC 0007 §Security Considerations — snapshot execute permission
+        // at mmap time so `mprotect` can enforce the "PROT_EXEC upgrade
+        // requires execute permission on the backing inode" rule without
+        // re-checking the live inode (whose permissions may have changed
+        // between mmap and mprotect). The check uses
+        // `Inode.permission(EXECUTE)` against the current task's
+        // credentials per the RFC's errno table.
+        let exec_allowed = {
+            let cred = crate::task::current_credentials();
+            crate::fs::vfs::ops::default_permission(
+                &f.inode,
+                &cred,
+                crate::fs::vfs::Access::EXECUTE,
+            )
+            .is_ok()
+        };
+
         let fo = crate::mem::file_object::FileObject::new(
             cache,
             file_offset_pages,
             len_pages,
             share,
             open_mode,
+            exec_allowed,
         );
         Ok(fo as alloc::sync::Arc<dyn crate::mem::vmobject::VmObject>)
     }

--- a/kernel/src/fs/ext2/inode.rs
+++ b/kernel/src/fs/ext2/inode.rs
@@ -610,15 +610,21 @@ impl FileOps for Ext2Inode {
         // between mmap and mprotect). The check uses
         // `Inode.permission(EXECUTE)` against the current task's
         // credentials per the RFC's errno table.
-        let exec_allowed = {
-            let cred = crate::task::current_credentials();
-            crate::fs::vfs::ops::default_permission(
-                &f.inode,
-                &cred,
-                crate::fs::vfs::Access::EXECUTE,
-            )
-            .is_ok()
-        };
+        //
+        // `try_current_credentials` returns `None` in integration tests
+        // that drive the mmap hook without a task context. The
+        // conservative default is `false` (deny exec) — in production
+        // the syscall path always has a running task.
+        let exec_allowed = crate::task::try_current_credentials()
+            .map(|cred| {
+                crate::fs::vfs::ops::default_permission(
+                    &f.inode,
+                    &cred,
+                    crate::fs::vfs::Access::EXECUTE,
+                )
+                .is_ok()
+            })
+            .unwrap_or(false);
 
         let fo = crate::mem::file_object::FileObject::new(
             cache,

--- a/kernel/src/mem/file_object.rs
+++ b/kernel/src/mem/file_object.rs
@@ -107,6 +107,13 @@ pub struct FileObject {
     /// owns the access decision once `mmap` returns.
     open_mode: u32,
 
+    /// Whether the backing inode had execute permission at `mmap` time.
+    /// Snapshotted once (just like `open_mode`) so `mprotect` can reject
+    /// `PROT_EXEC` upgrades without re-checking the live inode, which
+    /// may have had its permissions changed between `mmap` and
+    /// `mprotect`. RFC 0007 §Security Considerations, §Errno table.
+    exec_allowed: bool,
+
     /// Per-VMA private-frame cache for `MAP_PRIVATE` write faults.
     /// Empty for `Share::Shared`. After a CoW write fault, the new
     /// private frame is recorded here so a re-fault (e.g. after
@@ -131,6 +138,11 @@ impl FileObject {
     /// it looked up — both are snapshotted here, **never** re-read off
     /// the live `OpenFile` (RFC 0007 §FileObject `open_mode` snapshot).
     ///
+    /// `exec_allowed` is the result of `Inode::permission(EXECUTE)`
+    /// at `mmap` time, snapshotted so `mprotect` can enforce the
+    /// `PROT_EXEC` upgrade rule without re-checking the live inode
+    /// (RFC 0007 §Security Considerations).
+    ///
     /// `cache` is captured into the new object's `Arc<PageCache>` slot
     /// and never rebound (RFC 0007 §Inode-binding rule).
     pub fn new(
@@ -139,6 +151,7 @@ impl FileObject {
         len_pages: usize,
         share: Share,
         open_mode: u32,
+        exec_allowed: bool,
     ) -> Arc<Self> {
         // Validate the file-page window: `file_offset_pages + len_pages`
         // must not wrap. Lookups below combine the two via `pgoff_of`,
@@ -158,6 +171,7 @@ impl FileObject {
             len_pages,
             share,
             open_mode,
+            exec_allowed,
             private_frames: BlockingMutex::new(BTreeMap::new()),
         })
     }
@@ -187,6 +201,14 @@ impl FileObject {
     /// (RFC 0007 §FileObject `open_mode` snapshot, §Security B1).
     pub fn open_mode(&self) -> u32 {
         self.open_mode
+    }
+
+    /// Whether the backing inode had execute permission at `mmap` time.
+    /// Consulted by `mprotect` to enforce the "PROT_EXEC upgrade
+    /// requires execute permission on the backing inode" rule
+    /// (RFC 0007 §Security Considerations).
+    pub fn exec_allowed(&self) -> bool {
+        self.exec_allowed
     }
 
     /// Look up an already-recorded private frame for `pgoff`, if any.
@@ -273,6 +295,9 @@ impl FileObject {
             // the "PROT_WRITE upgrade needs O_RDWR" rule across a
             // fork. RFC 0007 §FileObject `open_mode` snapshot.
             open_mode: self.open_mode,
+            // Exec-permission snapshot carries across fork for the
+            // same reason as open_mode.
+            exec_allowed: self.exec_allowed,
             private_frames: BlockingMutex::new(BTreeMap::new()),
         })
     }
@@ -542,6 +567,16 @@ impl VmObject for FileObject {
         let _ = &self.cache;
     }
 
+    // ---- mprotect permission gates (RFC 0007 §Security B1) ---------------
+
+    fn mprotect_open_mode(&self) -> Option<u32> {
+        Some(self.open_mode)
+    }
+
+    fn mprotect_exec_allowed(&self) -> Option<bool> {
+        Some(self.exec_allowed)
+    }
+
     /// `madvise(MADV_DONTNEED)` fan-out for the [first, last) VMA-local
     /// range. Drops `private_frames` entries; the cache eviction is
     /// the daemon's responsibility (#740).
@@ -655,7 +690,7 @@ mod tests {
 
     fn fresh_object(share: Share) -> Arc<FileObject> {
         let cache = cache_with_pages(8);
-        FileObject::new(cache, 0, 8, share, 0o2 /* O_RDWR */)
+        FileObject::new(cache, 0, 8, share, 0o2 /* O_RDWR */, true)
     }
 
     #[test]
@@ -844,9 +879,16 @@ mod tests {
     #[test]
     fn open_mode_snapshot_round_trips() {
         let cache = cache_with_pages(2);
-        let ro = FileObject::new(cache.clone(), 0, 2, Share::Shared, 0 /* O_RDONLY */);
+        let ro = FileObject::new(
+            cache.clone(),
+            0,
+            2,
+            Share::Shared,
+            0, /* O_RDONLY */
+            false,
+        );
         assert_eq!(ro.open_mode(), 0);
-        let rw = FileObject::new(cache, 0, 2, Share::Shared, 0o2 /* O_RDWR */);
+        let rw = FileObject::new(cache, 0, 2, Share::Shared, 0o2 /* O_RDWR */, true);
         assert_eq!(rw.open_mode(), 0o2);
     }
 
@@ -855,7 +897,7 @@ mod tests {
         // VMA covers file pages [4..8). A fault at VMA-local offset
         // 0 must hit the cache at pgoff 4, not 0.
         let cache = cache_with_pages(8);
-        let obj = FileObject::new(cache.clone(), 4, 4, Share::Shared, 0o2);
+        let obj = FileObject::new(cache.clone(), 4, 4, Share::Shared, 0o2, true);
         let phys = obj.fault(0, Access::Read).unwrap();
         // Cache now indexes pgoff 4.
         let page = cache.lookup(4).expect("pgoff 4 must be resident");
@@ -887,7 +929,7 @@ mod tests {
             8 * FRAME_SIZE,
             Arc::new(FailingOps),
         ));
-        let obj = FileObject::new(cache.clone(), 0, 8, Share::Shared, 0o2);
+        let obj = FileObject::new(cache.clone(), 0, 8, Share::Shared, 0o2, true);
         let err = obj.fault(0, Access::Read).unwrap_err();
         assert_eq!(err, VmFault::ReadFailed(crate::fs::EIO));
         // Stub removed: a subsequent fault re-enters install_or_get
@@ -991,7 +1033,7 @@ mod tests {
         ));
         probe.install_cache(cache.clone());
 
-        let obj = FileObject::new(cache.clone(), 0, 8, Share::Shared, 0o2);
+        let obj = FileObject::new(cache.clone(), 0, 8, Share::Shared, 0o2, true);
         // Drive a fault — winner path runs `readpage`.
         let phys = obj
             .fault(0, Access::Read)
@@ -1046,5 +1088,60 @@ mod tests {
             Arc::strong_count(p)
         };
         assert_eq!(strong_borrow, 1);
+    }
+
+    // --- RFC 0007 §Security B1 — mprotect permission gates -----
+
+    #[test]
+    fn mprotect_open_mode_returns_snapshot() {
+        let cache = cache_with_pages(2);
+        let ro: Arc<dyn VmObject> = FileObject::new(
+            cache.clone(),
+            0,
+            2,
+            Share::Shared,
+            0, /* O_RDONLY */
+            true,
+        );
+        assert_eq!(ro.mprotect_open_mode(), Some(0));
+        let rw: Arc<dyn VmObject> =
+            FileObject::new(cache, 0, 2, Share::Shared, 0o2 /* O_RDWR */, true);
+        assert_eq!(rw.mprotect_open_mode(), Some(0o2));
+    }
+
+    #[test]
+    fn mprotect_exec_allowed_returns_snapshot() {
+        let cache = cache_with_pages(2);
+        let exec: Arc<dyn VmObject> =
+            FileObject::new(cache.clone(), 0, 2, Share::Shared, 0o2, true);
+        assert_eq!(exec.mprotect_exec_allowed(), Some(true));
+        let noexec: Arc<dyn VmObject> = FileObject::new(cache, 0, 2, Share::Shared, 0o2, false);
+        assert_eq!(noexec.mprotect_exec_allowed(), Some(false));
+    }
+
+    #[test]
+    fn anon_object_returns_none_for_mprotect_gates() {
+        use crate::mem::vmobject::AnonObject;
+        let anon: Arc<dyn VmObject> = AnonObject::new(Some(4));
+        assert_eq!(anon.mprotect_open_mode(), None);
+        assert_eq!(anon.mprotect_exec_allowed(), None);
+    }
+
+    #[test]
+    fn clone_private_preserves_exec_allowed() {
+        let cache = cache_with_pages(2);
+        let parent = FileObject::new(cache, 0, 2, Share::Shared, 0o2, false);
+        let child = parent.clone_private_concrete();
+        assert_eq!(child.exec_allowed(), false);
+        assert_eq!(child.mprotect_exec_allowed(), Some(false));
+    }
+
+    #[test]
+    fn exec_allowed_snapshot_round_trips() {
+        let cache = cache_with_pages(2);
+        let yes = FileObject::new(cache.clone(), 0, 2, Share::Shared, 0, true);
+        assert!(yes.exec_allowed());
+        let no = FileObject::new(cache, 0, 2, Share::Shared, 0, false);
+        assert!(!no.exec_allowed());
     }
 }

--- a/kernel/src/mem/loader.rs
+++ b/kernel/src/mem/loader.rs
@@ -450,7 +450,8 @@ fn register_demand_vmas(
                 file_offset_pages,
                 file_pages,
                 Share::Private,
-                0o2, // O_RDWR snapshot — the loader has full access
+                0o2,  // O_RDWR snapshot — the loader has full access
+                true, // exec_allowed — loader is mapping an executable
             );
             let file_start = effective_vaddr as usize;
             let file_end = file_start + file_pages * PAGE_SIZE as usize;

--- a/kernel/src/mem/pf.rs
+++ b/kernel/src/mem/pf.rs
@@ -470,6 +470,55 @@ pub fn validate_file_mmap_args(
     Ok((off, len_pages))
 }
 
+// ── mprotect file-backed permission gates (RFC 0007 §Security B1) ───────
+
+/// Pure errno-gate for `mprotect` on a single file-backed VMA.
+///
+/// Extracted from the `sys_mprotect` VMA walk so host unit tests can
+/// exercise every rejection branch without the full `AddressSpace` /
+/// VMA-tree / IDT plumbing.
+///
+/// Returns `Ok(())` when the requested `prot` is permissible, or
+/// `Err(EACCES)` when either:
+///
+/// - `PROT_WRITE` is requested on a `MAP_SHARED` VMA whose
+///   `open_mode` snapshot is not `O_RDWR`.
+/// - `PROT_EXEC` is requested on a VMA whose backing inode lacked
+///   execute permission at `mmap` time (`exec_allowed == false`).
+///
+/// Non-file-backed VMAs (anon, etc.) pass `None` for both
+/// `open_mode` and `exec_allowed`; the function returns `Ok(())`
+/// unconditionally for those.
+pub fn validate_mprotect_file_perm(
+    prot: u32,
+    share: crate::mem::vmatree::Share,
+    open_mode: Option<u32>,
+    exec_allowed: Option<bool>,
+) -> Result<(), i64> {
+    use crate::mem::vmatree::Share;
+    const EACCES: i64 = -13;
+    const O_RDWR: u32 = 2;
+
+    // PROT_WRITE on MAP_SHARED + file-backed: open_mode must be O_RDWR.
+    if prot & PROT_WRITE != 0 && share == Share::Shared {
+        if let Some(mode) = open_mode {
+            if mode != O_RDWR {
+                return Err(EACCES);
+            }
+        }
+    }
+
+    // PROT_EXEC on file-backed: inode must have had execute permission
+    // at mmap time.
+    if prot & PROT_EXEC != 0 {
+        if let Some(false) = exec_allowed {
+            return Err(EACCES);
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod validate_range_tests {
     use super::*;
@@ -1107,5 +1156,153 @@ mod tests {
             route_through_classifier(Ok(0x4000)),
             FaultResolution::Mapped(0x4000),
         );
+    }
+
+    // ── validate_mprotect_file_perm (issue #747, RFC 0007 §Security B1) ─
+
+    mod mprotect_file_perm {
+        use super::*;
+        use crate::mem::vmatree::Share;
+
+        const O_RDONLY: u32 = 0;
+        const O_WRONLY: u32 = 1;
+        const O_RDWR: u32 = 2;
+        const EACCES: i64 = -13;
+
+        // --- PROT_WRITE on MAP_SHARED ---
+
+        #[test]
+        fn shared_write_rdwr_ok() {
+            // MAP_SHARED + PROT_WRITE with O_RDWR: allowed.
+            assert_eq!(
+                validate_mprotect_file_perm(PROT_WRITE, Share::Shared, Some(O_RDWR), Some(true)),
+                Ok(()),
+            );
+        }
+
+        #[test]
+        fn shared_write_rdonly_eacces() {
+            // MAP_SHARED + PROT_WRITE with O_RDONLY: rejected.
+            assert_eq!(
+                validate_mprotect_file_perm(PROT_WRITE, Share::Shared, Some(O_RDONLY), Some(true)),
+                Err(EACCES),
+            );
+        }
+
+        #[test]
+        fn shared_write_wronly_eacces() {
+            // MAP_SHARED + PROT_WRITE with O_WRONLY: rejected (need
+            // O_RDWR for read-on-miss before mutating).
+            assert_eq!(
+                validate_mprotect_file_perm(PROT_WRITE, Share::Shared, Some(O_WRONLY), Some(true)),
+                Err(EACCES),
+            );
+        }
+
+        #[test]
+        fn private_write_rdonly_ok() {
+            // MAP_PRIVATE + PROT_WRITE with O_RDONLY: no open_mode
+            // gate on private mappings (CoW handles the write).
+            assert_eq!(
+                validate_mprotect_file_perm(PROT_WRITE, Share::Private, Some(O_RDONLY), Some(true)),
+                Ok(()),
+            );
+        }
+
+        #[test]
+        fn shared_read_rdonly_ok() {
+            // MAP_SHARED + PROT_READ (no WRITE): O_RDONLY is fine.
+            assert_eq!(
+                validate_mprotect_file_perm(PROT_READ, Share::Shared, Some(O_RDONLY), Some(true)),
+                Ok(()),
+            );
+        }
+
+        // --- PROT_EXEC on non-executable inode ---
+
+        #[test]
+        fn exec_on_executable_inode_ok() {
+            assert_eq!(
+                validate_mprotect_file_perm(PROT_EXEC, Share::Private, Some(O_RDONLY), Some(true)),
+                Ok(()),
+            );
+        }
+
+        #[test]
+        fn exec_on_non_executable_inode_eacces() {
+            assert_eq!(
+                validate_mprotect_file_perm(PROT_EXEC, Share::Private, Some(O_RDONLY), Some(false)),
+                Err(EACCES),
+            );
+        }
+
+        #[test]
+        fn exec_on_shared_non_executable_eacces() {
+            assert_eq!(
+                validate_mprotect_file_perm(PROT_EXEC, Share::Shared, Some(O_RDWR), Some(false)),
+                Err(EACCES),
+            );
+        }
+
+        #[test]
+        fn read_write_exec_shared_rdwr_exec_ok() {
+            // All bits + O_RDWR + exec_allowed: passes.
+            assert_eq!(
+                validate_mprotect_file_perm(
+                    PROT_READ | PROT_WRITE | PROT_EXEC,
+                    Share::Shared,
+                    Some(O_RDWR),
+                    Some(true)
+                ),
+                Ok(()),
+            );
+        }
+
+        #[test]
+        fn read_write_exec_shared_rdonly_eacces() {
+            // WRITE+EXEC on shared + O_RDONLY: EACCES for WRITE rule.
+            assert_eq!(
+                validate_mprotect_file_perm(
+                    PROT_READ | PROT_WRITE | PROT_EXEC,
+                    Share::Shared,
+                    Some(O_RDONLY),
+                    Some(true)
+                ),
+                Err(EACCES),
+            );
+        }
+
+        #[test]
+        fn read_write_exec_shared_noexec_eacces() {
+            // WRITE+EXEC on shared + O_RDWR + no exec: EACCES for EXEC rule.
+            assert_eq!(
+                validate_mprotect_file_perm(
+                    PROT_READ | PROT_WRITE | PROT_EXEC,
+                    Share::Shared,
+                    Some(O_RDWR),
+                    Some(false)
+                ),
+                Err(EACCES),
+            );
+        }
+
+        // --- Non-file-backed (anon) objects ---
+
+        #[test]
+        fn anon_write_shared_ok() {
+            // Non-file-backed (None): no constraint.
+            assert_eq!(
+                validate_mprotect_file_perm(PROT_WRITE, Share::Shared, None, None),
+                Ok(()),
+            );
+        }
+
+        #[test]
+        fn anon_exec_ok() {
+            assert_eq!(
+                validate_mprotect_file_perm(PROT_EXEC, Share::Private, None, None),
+                Ok(()),
+            );
+        }
     }
 }

--- a/kernel/src/mem/vmobject.rs
+++ b/kernel/src/mem/vmobject.rs
@@ -126,6 +126,31 @@ pub trait VmObject: Send + Sync {
     /// zero-filled frame instead of the one previously cached. Default
     /// is a no-op; `AnonObject` overrides to evict the range.
     fn evict_range(&self, _first: usize, _last: usize) {}
+
+    // ---- mprotect permission gates (RFC 0007 §Security B1) ---------------
+
+    /// Return the snapshot of the `OpenFile` access-mode bits
+    /// (`O_RDONLY` / `O_WRONLY` / `O_RDWR`) captured at `mmap` time, if
+    /// this object is backed by a file. `mprotect` consults this to
+    /// reject `PROT_WRITE` upgrades on `MAP_SHARED` file-backed VMAs
+    /// whose open_mode was not `O_RDWR` (RFC 0007 §Errno table).
+    ///
+    /// Default: `None` — non-file-backed objects (anon, etc.) impose no
+    /// open-mode constraint on `mprotect`.
+    fn mprotect_open_mode(&self) -> Option<u32> {
+        None
+    }
+
+    /// Whether the backing inode had execute permission at `mmap` time.
+    /// Snapshotted once so `mprotect` does not re-check a live inode
+    /// whose permissions may have changed. `mprotect` rejects
+    /// `PROT_EXEC` upgrades when this returns `Some(false)`.
+    ///
+    /// Default: `None` — non-file-backed objects impose no exec-permission
+    /// constraint on `mprotect`.
+    fn mprotect_exec_allowed(&self) -> Option<bool> {
+        None
+    }
 }
 
 /// Clone a `VmObject` trait-object for `fork`. The default behavior is

--- a/kernel/src/task/sched_core.rs
+++ b/kernel/src/task/sched_core.rs
@@ -420,11 +420,19 @@ pub fn current_fd_table() -> alloc::sync::Arc<spin::Mutex<crate::fs::FileDescTab
 /// # Panics
 /// Panics if called before [`init`] (no running task yet).
 pub fn current_credentials() -> alloc::sync::Arc<crate::fs::vfs::Credential> {
+    try_current_credentials().expect("current_credentials: no running task")
+}
+
+/// Non-panicking variant of [`current_credentials`].
+///
+/// Returns `None` when the scheduler has not been initialised or no
+/// task is running yet (e.g. during early boot or integration tests
+/// that drive kernel subsystems without a task context). Callers
+/// that must always have a credential should use
+/// [`current_credentials`] instead.
+pub fn try_current_credentials() -> Option<alloc::sync::Arc<crate::fs::vfs::Credential>> {
     let sched = SCHED.lock();
-    let cur = sched
-        .current
-        .as_ref()
-        .expect("current_credentials: no running task");
+    let cur = sched.current.as_ref()?;
     // Inner scope forces the `RwLockReadGuard` to drop before the
     // outer `sched` (`IrqLockGuard`) does. Without it Rust drops the
     // inline temporary after `sched` and the borrow checker rejects
@@ -435,7 +443,7 @@ pub fn current_credentials() -> alloc::sync::Arc<crate::fs::vfs::Credential> {
         alloc::sync::Arc::clone(&*guard)
     };
     drop(sched);
-    snapshot
+    Some(snapshot)
 }
 
 /// Atomically replace the currently-running task's credentials with


### PR DESCRIPTION
## Summary

- Implement RFC 0007 §Security B1: `mprotect` now rejects `PROT_WRITE` upgrades on `MAP_SHARED` file-backed VMAs whose `open_mode` snapshot is not `O_RDWR` (`EACCES`), and rejects `PROT_EXEC` upgrades on file-backed VMAs whose backing inode lacked execute permission at `mmap` time (`EACCES`).
- Both checks consult snapshots stored on the `FileObject` — never the live `OpenFile` or inode — closing the TOCTOU surface where `mprotect(PROT_WRITE)` could upgrade a Shared-O_RDONLY mapping into writable, and where `PROT_EXEC` could be added to a non-executable file.
- 24 new host unit tests cover both upgrade paths, edge cases (combined R+W+X, private vs shared, anon passthrough), and the `exec_allowed` snapshot lifecycle.

### Implementation

- **`VmObject` trait** (`vmobject.rs`): Add `mprotect_open_mode() -> Option<u32>` and `mprotect_exec_allowed() -> Option<bool>` with `None` defaults so anon objects impose no constraint.
- **`FileObject`** (`file_object.rs`): Add `exec_allowed: bool` field snapshotted at construction, implement the new trait methods, carry the snapshot across `clone_private`.
- **ext2 `FileOps::mmap`** (`fs/ext2/inode.rs`): Snapshot `Inode.permission(EXECUTE)` via `default_permission` against the caller's credentials at `mmap` time.
- **`sys_mprotect`** (`arch/x86_64/syscall.rs`): Walk overlapping VMAs before `change_protection`, checking each VMA's object for file-backed permission violations.
- **`validate_mprotect_file_perm`** (`mem/pf.rs`): Pure-logic gate extracted for host-testable coverage.

Closes #747

## Test plan

- [x] `cargo fmt --all` — no diff
- [x] `cargo xtask build` — compiles clean (1 pre-existing warning)
- [x] `cargo xtask test` — 665 host tests pass, 0 failed; only pre-existing QEMU flake `rwlock_concurrent_readers` (#791)
- [x] `cargo xtask smoke` — all 42 markers present