### PR TITLE
block: writeback ordering — page cache before BlockCache::sync_fs (#756)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -547,6 +547,10 @@ name = "syscall_fsync"
 harness = false
 
 [[test]]
+name = "syscall_sync"
+harness = false
+
+[[test]]
 name = "block_writeback_inode_walk"
 harness = false
 required-features = ["page_cache"]

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -630,6 +630,13 @@ pub unsafe extern "C" fn syscall_dispatch(
         // for the data_only-vs-fsync split.
         FDATASYNC => super::syscalls::vfs::sys_fsync_impl(a0, true),
 
+        // sync() — flush all dirty pages and buffers across every
+        // mount to stable storage. RFC 0007 §Ordering vs fsync
+        // (issue #756): two-stage ordering — page-cache pages first,
+        // then BlockCache::sync_fs fences the rest. Always returns 0
+        // (Linux semantics: sync(2) is infallible).
+        SYNC => super::syscalls::vfs::sys_sync_impl(),
+
         // dup2(oldfd, newfd)
         DUP2 => {
             let oldfd = a0 as i32;
@@ -1898,6 +1905,7 @@ pub mod syscall_nr {
     pub const FCNTL: u64 = 72;
     pub const FSYNC: u64 = 74;
     pub const FDATASYNC: u64 = 75;
+    pub const SYNC: u64 = 162;
     pub const FSTAT: u64 = 5;
     pub const STAT: u64 = 4;
     pub const LSTAT: u64 = 6;
@@ -1980,6 +1988,7 @@ mod tests {
         assert_eq!(syscall_nr::FCNTL, 72, "SYS_fcntl must be 72");
         assert_eq!(syscall_nr::FSYNC, 74, "SYS_fsync must be 74");
         assert_eq!(syscall_nr::FDATASYNC, 75, "SYS_fdatasync must be 75");
+        assert_eq!(syscall_nr::SYNC, 162, "SYS_sync must be 162");
         assert_eq!(syscall_nr::LSEEK, 8, "SYS_lseek must be 8");
 
         // Memory management

--- a/kernel/src/arch/x86_64/syscalls/vfs.rs
+++ b/kernel/src/arch/x86_64/syscalls/vfs.rs
@@ -1458,6 +1458,17 @@ pub fn sys_fsync_impl(fd_raw: u64, data_only: bool) -> i64 {
     }
 }
 
+/// `sync()` syscall body. Flushes all dirty pages and buffers across
+/// every mount to stable storage using the RFC 0007 two-stage ordering:
+/// page-cache dirty pages first, then `BlockCache::sync_fs` fences the
+/// buffer cache. Always returns 0 — Linux `sync(2)` is infallible.
+///
+/// Issue #756 (Workstream D).
+pub fn sys_sync_impl() -> i64 {
+    crate::block::writeback::sync_all_mounts();
+    0
+}
+
 /// Resolve the inode behind an fd for the fchmod/fchown family. Returns
 /// `EBADF` on an out-of-range fd, or on any backend that doesn't expose
 /// a VFS inode (e.g. a pure `SerialBackend`) since there is nothing to

--- a/kernel/src/block/writeback.rs
+++ b/kernel/src/block/writeback.rs
@@ -1,15 +1,18 @@
-//! Per-mount writeback daemon.
+//! Per-mount writeback daemon and `sync(2)` support.
 //!
 //! Implements RFC 0004 §Buffer cache writeback (Workstream C, wave 1,
-//! issue #555). Each call to [`start`] spawns one kernel task that:
+//! issue #555) and RFC 0007 §Ordering vs fsync (Workstream D, issue
+//! #756). Each call to [`start`] spawns one kernel task that:
 //!
 //! 1. Sleeps for the configured writeback interval (default 30 s,
 //!    configurable via `writeback_secs=<N>` on the kernel command
 //!    line).
 //! 2. Acquires an [`SbActiveGuard`] on the mount's superblock to pin it
 //!    for the duration of the flush.
-//! 3. Calls [`BlockCache::sync_fs`] with the mount's [`DeviceId`],
-//!    which flushes every dirty buffer belonging to this mount.
+//! 3. Flushes page-cache dirty pages first (`writepage` with its
+//!    internal bitmap -> indirect -> data ordering), then calls
+//!    [`BlockCache::sync_fs`] to fence the buffer cache — the
+//!    two-stage ordering specified by RFC 0007 §Ordering vs fsync.
 //! 4. Drops the guard and repeats.
 //!
 //! Shutdown is driven by [`WritebackHandle::join`]:
@@ -472,6 +475,29 @@ mod daemon {
                 }
             };
 
+            // RFC 0007 §Ordering vs fsync (issue #756): two-stage
+            // writeback ordering — page-cache pages are flushed first
+            // (`writepage` drives its own bitmap -> indirect -> data
+            // ordering internally), then `BlockCache::sync_fs` fences
+            // the buffer cache. This ensures that page-cache data
+            // written through `writepage` (which marks buffer-cache
+            // buffers dirty as a side-effect) is committed to stable
+            // storage by the subsequent `sync_fs` fence.
+            //
+            // Stage 1: page-cache dirty-page sweep. Snapshot-then-
+            // writepage discipline: dirty pgoffs are collected under
+            // `cache.inner.lock()` (via [`PageCache::snapshot_dirty`]),
+            // the lock is dropped, and then `writepage` runs against
+            // the snapshot. Skip-on-shutdown: re-check `sb.draining`
+            // between inodes so a `sys_umount` racing the sweep
+            // observes a prompt exit rather than serving the entire
+            // inode list.
+            sweep_inode_mappings(state);
+
+            // Stage 2: buffer-cache fence. Flushes every dirty buffer
+            // belonging to this mount — including any buffers that
+            // `writepage` (stage 1) marked dirty as a side-effect of
+            // writing page-cache data through the block layer.
             if let Err(e) = state.cache.sync_fs(state.device_id) {
                 crate::serial_println!(
                     "writeback: sync_fs failed on fs_id={} device={:?}: {:?}",
@@ -480,22 +506,6 @@ mod daemon {
                     e,
                 );
             }
-
-            // RFC 0007 §MAP_SHARED writeback (issue #755): after the
-            // buffer-cache flush, walk every superblock-mounted inode's
-            // `mapping` and call `writepage` on each dirty `pgoff`.
-            // Snapshot-then-writepage discipline: dirty pgoffs are
-            // collected under `cache.inner.lock()` (via
-            // [`PageCache::snapshot_dirty`]), the lock is dropped, and
-            // then `writepage` runs against the snapshot.
-            //
-            // Skip-on-shutdown: re-check `sb.draining` between inodes
-            // so a `sys_umount` racing the sweep observes a prompt
-            // exit rather than serving the entire inode list. The bare
-            // hook here is what the issue calls for; #760 will harden
-            // the predicate (e.g. by promoting the check into a real
-            // `SbActiveGuard::is_draining` query path).
-            sweep_inode_mappings(state);
 
             state.bump_sweeps();
             drop(guard);
@@ -674,10 +684,145 @@ mod daemon {
             clock.now() < deadline
         });
     }
+
+    // -----------------------------------------------------------------
+    // sync(2) support — immediate two-stage flush across all mounts.
+    //
+    // RFC 0007 §Ordering vs fsync (Workstream D, issue #756): `sync(2)`
+    // triggers an immediate page-cache + buffer-cache flush across
+    // every live mount. The two-stage ordering (page cache first, then
+    // BlockCache::sync_fs) matches the daemon's main loop.
+    // -----------------------------------------------------------------
+
+    /// Perform an immediate two-stage writeback flush across every
+    /// mount in the global mount table.
+    ///
+    /// For each non-draining mount:
+    ///   1. Page-cache dirty pages are flushed via `writepage`
+    ///      (with the FS-internal bitmap -> indirect -> data ordering).
+    ///   2. `BlockCache::sync_fs` fences the buffer cache.
+    ///
+    /// This is the kernel-side implementation of `sync(2)`. Returns
+    /// only after every reachable dirty page and buffer is on stable
+    /// storage (best-effort: individual writepage/sync_fs failures are
+    /// logged but do not abort the sweep of other mounts).
+    ///
+    /// Called from `sys_sync_impl` (the `sync(2)` syscall handler).
+    pub fn sync_all_mounts() {
+        use alloc::vec::Vec;
+
+        use crate::fs::vfs::mount_table::MOUNT_TABLE;
+        use crate::fs::vfs::super_block::SbActiveGuard;
+
+        // Snapshot the mount table under the read lock. We clone the
+        // `Arc<MountEdge>` refs so the table lock is released before
+        // any I/O begins — no flush runs under the table lock.
+        let edges: Vec<_> = {
+            let table = MOUNT_TABLE.read();
+            table.iter().cloned().collect()
+        };
+
+        for edge in edges {
+            let sb = &edge.super_block;
+
+            // Pin the superblock for the duration of this mount's
+            // flush. If the SB is draining (unmount in progress),
+            // skip it — the unmount path's own sync_fs will handle
+            // its buffers.
+            let guard = match SbActiveGuard::try_acquire(sb) {
+                Ok(g) => g,
+                Err(_) => continue,
+            };
+
+            // Stage 1: page-cache flush.
+            sync_mount_page_cache(sb);
+
+            // Stage 2: buffer-cache fence.
+            if let Err(e) = sb.ops.sync_fs(sb) {
+                crate::serial_println!("sync: sync_fs failed on fs_id={}: {:?}", sb.fs_id.0, e,);
+            }
+
+            drop(guard);
+        }
+    }
+
+    /// Page-cache flush for a single mount — the stage-1 half of the
+    /// two-stage ordering used by both `sync_all_mounts` and the
+    /// daemon's sweep. Walks every inode the superblock surfaces via
+    /// `for_each_mapped_inode` and flushes each dirty page through
+    /// `writepage`.
+    #[cfg(feature = "page_cache")]
+    fn sync_mount_page_cache(sb: &Arc<SuperBlock>) {
+        use crate::mem::page_cache::{CachePage, PG_DIRTY};
+        use crate::mem::paging;
+        use alloc::vec::Vec;
+        use core::sync::atomic::Ordering;
+
+        let mut inodes: Vec<Arc<crate::fs::vfs::Inode>> = Vec::new();
+        sb.ops.for_each_mapped_inode(&mut |inode| {
+            inodes.push(Arc::clone(inode));
+        });
+
+        for inode in inodes {
+            if sb.draining.load(Ordering::SeqCst) {
+                return;
+            }
+
+            let pc = match inode.mapping.read().as_ref() {
+                Some(pc) => Arc::clone(pc),
+                None => continue,
+            };
+
+            let snapshot: Vec<(u64, Arc<CachePage>)> = pc.snapshot_dirty();
+            if snapshot.is_empty() {
+                continue;
+            }
+
+            let ops = pc.ops();
+            for (pgoff, page) in snapshot {
+                if sb.draining.load(Ordering::SeqCst) {
+                    return;
+                }
+
+                page.begin_writeback();
+
+                let mut buf = [0u8; 4096];
+                // SAFETY: same justification as `sweep_inode_mappings` —
+                // `page.phys` is a valid 4 KiB frame, HHDM-mapped.
+                unsafe {
+                    let hhdm = paging::hhdm_offset();
+                    let src = (hhdm.as_u64() + page.phys) as *const u8;
+                    core::ptr::copy_nonoverlapping(src, buf.as_mut_ptr(), 4096);
+                }
+
+                match ops.writepage(pgoff, &buf) {
+                    Ok(()) => {
+                        pc.clear_page_dirty(pgoff);
+                    }
+                    Err(errno) => {
+                        pc.bump_wb_err();
+                        page.state.fetch_or(PG_DIRTY, Ordering::Release);
+                        crate::serial_println!(
+                            "sync: writepage(ino={} pgoff={}) failed: {}",
+                            inode.ino,
+                            pgoff,
+                            errno,
+                        );
+                    }
+                }
+
+                page.end_writeback();
+            }
+        }
+    }
+
+    /// Compile-out stub when `feature = "page_cache"` is off.
+    #[cfg(not(feature = "page_cache"))]
+    fn sync_mount_page_cache(_sb: &Arc<SuperBlock>) {}
 }
 
 #[cfg(target_os = "none")]
-pub use daemon::{start, WritebackHandle};
+pub use daemon::{start, sync_all_mounts, WritebackHandle};
 
 #[cfg(test)]
 mod tests {

--- a/kernel/tests/syscall_sync.rs
+++ b/kernel/tests/syscall_sync.rs
@@ -1,0 +1,94 @@
+//! Integration test for issue #756: `sync(2)` syscall — writeback
+//! ordering (page cache before `BlockCache::sync_fs`).
+//!
+//! Exercises the `SYS_SYNC` (162) dispatch arm end-to-end:
+//!
+//! - `sync()` returns 0 (Linux ABI: always succeeds).
+//! - `sync()` is idempotent — calling it multiple times is harmless.
+//! - `sync()` returns 0 even when no dirty data exists.
+//!
+//! RFC 0007 §Ordering vs fsync (Workstream D): the two-stage ordering
+//! (page-cache pages flushed first, then `BlockCache::sync_fs` fences
+//! the rest) is structurally encoded in `writeback::sync_all_mounts`;
+//! this test verifies the syscall ABI.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+
+use vibix::arch::x86_64::syscall::syscall_dispatch;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+const SYS_SYNC: u64 = 162;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    vibix::task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("sync_returns_zero", &(sync_returns_zero as fn())),
+        ("sync_idempotent", &(sync_idempotent as fn())),
+        (
+            "sync_no_dirty_data_still_zero",
+            &(sync_no_dirty_data_still_zero as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("syscall_sync: {}", name);
+        t.run();
+    }
+}
+
+fn do_sync() -> i64 {
+    unsafe { syscall_dispatch(core::ptr::null_mut(), SYS_SYNC, 0, 0, 0, 0, 0, 0) }
+}
+
+// --- Tests ----------------------------------------------------------
+
+/// `sync(2)` always returns 0, matching Linux semantics. The mount
+/// table contains the boot-time tarfs rootfs; `sync_all_mounts`
+/// iterates it, calls `SuperOps::sync_fs` (a no-op for tarfs), and
+/// returns — no dirty data, no errors, result is 0.
+fn sync_returns_zero() {
+    let ret = do_sync();
+    assert_eq!(ret, 0, "sync() must return 0, got {}", ret);
+}
+
+/// Calling `sync()` twice in a row is harmless. The second call has
+/// nothing to flush and returns 0.
+fn sync_idempotent() {
+    let ret1 = do_sync();
+    let ret2 = do_sync();
+    assert_eq!(ret1, 0, "first sync() must return 0");
+    assert_eq!(ret2, 0, "second sync() must return 0");
+}
+
+/// Even when no mount has any dirty data, `sync(2)` returns 0. This
+/// pins the "infallible" contract from Linux's `sync(2)` manpage.
+fn sync_no_dirty_data_still_zero() {
+    // Issue three syncs back-to-back to ensure the empty-dirty-set
+    // path is exercised thoroughly.
+    for i in 0..3 {
+        let ret = do_sync();
+        assert_eq!(ret, 0, "sync() iteration {} must return 0, got {}", i, ret);
+    }
+}


### PR DESCRIPTION
## Summary
- Reorder the writeback daemon's main loop to flush page-cache dirty pages **first** (via `writepage` with its internal bitmap -> indirect -> data ordering), then fence the buffer cache with `BlockCache::sync_fs` — the two-stage ordering specified by RFC 0007 §Ordering vs fsync.
- Add `sync(2)` syscall (SYS_SYNC = 162) that triggers an immediate two-stage flush across every live mount via `sync_all_mounts()`. Returns 0 per Linux ABI (always succeeds).
- Add `syscall_sync` integration test verifying the syscall returns 0, is idempotent, and handles no-dirty-data gracefully.

Closes #756

## Test plan
- [x] `cargo fmt --all` (no changes)
- [x] `cargo xtask build` (clean)
- [x] `cargo xtask smoke` (all 42 markers present)
- [x] `syscall_sync` integration test: 3/3 pass (sync_returns_zero, sync_idempotent, sync_no_dirty_data_still_zero)
- [x] `block_writeback` integration test: 5/5 pass (writeback_fires_after_interval, join_waits, no_writeback_on_ro, zero_disables, default_cadence)
- [x] `block_writeback_inode_walk` integration test: 2/2 pass
- [x] `syscall_fsync` integration test: 6/6 pass
- [x] `writeback_complete_wq` integration test: 3/3 pass
- [x] Host unit tests: 647/647 pass
- [ ] Known flake: `blocking_sync::rwlock_concurrent_readers` (#791) — not a regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)