### PR TITLE
block: per-cache wb_err errseq counter for sticky EIO (#758)

### DIFF
--- a/kernel/src/fs/vfs/inode.rs
+++ b/kernel/src/fs/vfs/inode.rs
@@ -118,18 +118,27 @@ pub struct Inode {
 impl Inode {
     /// Read the inode's page-cache `wb_err` errseq counter.
     ///
-    /// Forward-compat seam for RFC 0007: once issue #745 lands an
-    /// `Option<Arc<PageCache>>` `mapping` field on `Inode`, this
-    /// becomes `self.mapping.as_ref().map(|m| m.wb_err()).unwrap_or(0)`.
-    /// Until then, no inode has a mapping and the counter is
-    /// universally zero — `fsync(2)` therefore never surfaces a
-    /// sticky `EIO`, which is correct because there is no writeback
-    /// daemon yet to bump the counter (#755).
+    /// When the `page_cache` feature is active *and* a
+    /// [`PageCache`] has been lazily installed via
+    /// [`Inode::page_cache_or_create`], delegates to
+    /// [`PageCache::wb_err`]. Otherwise returns 0 — an inode
+    /// without a page cache has had no writeback, so no writeback
+    /// error.
     ///
-    /// Defining the accessor now means the syscall layer can already
-    /// consume the errseq value via `OpenFile::wb_err_snapshot`
-    /// without rewriting any plumbing when the mapping field lands.
+    /// The accessor is the bridge between `OpenFile::do_fsync`
+    /// (which reads `inode.wb_err()`) and the writeback daemon
+    /// (which calls `PageCache::bump_wb_err` on every `writepage`
+    /// failure). Together they implement the RFC 0007 §`wb_err`
+    /// errseq "consume once per witness" pattern: `fsync` surfaces
+    /// a sticky `EIO` exactly once per open file description when
+    /// the counter has advanced since that description's snapshot.
     pub fn wb_err(&self) -> u32 {
+        #[cfg(feature = "page_cache")]
+        {
+            if let Some(pc) = self.mapping.read().as_ref() {
+                return pc.wb_err();
+            }
+        }
         0
     }
 

--- a/kernel/src/fs/vfs/open_file.rs
+++ b/kernel/src/fs/vfs/open_file.rs
@@ -450,4 +450,90 @@ mod tests {
         // Same path for fdatasync.
         assert_eq!(of.do_fsync(true), Err(crate::fs::EIO));
     }
+
+    /// RFC 0007 §`wb_err` errseq: simulated `writepage` failure bumps
+    /// the `PageCache::wb_err` counter, `Inode::wb_err()` delegates to
+    /// the mapping, and `do_fsync` surfaces a sticky `EIO` exactly
+    /// once per open file description. A second `do_fsync` on the same
+    /// fd observes a clean state (consume-once-per-witness). A second
+    /// fd opened against the same inode also sees the error exactly
+    /// once, independently of the first fd's snapshot.
+    #[cfg(feature = "page_cache")]
+    #[test]
+    fn wb_err_errseq_sticky_eio_once_per_fd() {
+        use core::sync::atomic::Ordering;
+
+        let sb = Arc::new(SuperBlock::new(
+            FsId(10),
+            Arc::new(StubSuper),
+            "stub",
+            512,
+            SbFlags::default(),
+        ));
+        let inode = Arc::new(Inode::new(
+            1,
+            Arc::downgrade(&sb),
+            Arc::new(StubInode),
+            Arc::new(StubFile),
+            InodeKind::Reg,
+            InodeMeta::default(),
+        ));
+
+        // Install aops so page_cache_or_create succeeds, then get a
+        // handle to the PageCache so we can simulate writeback errors.
+        inode.set_aops(crate::mem::aops::tests::fresh_ops());
+        let pc = inode.page_cache_or_create().expect("aops installed");
+
+        // Baseline: no writeback errors yet. wb_err is 0 and inode
+        // delegates to the mapping.
+        assert_eq!(pc.wb_err(), 0);
+        assert_eq!(inode.wb_err(), 0);
+
+        // Open fd1 — snapshots wb_err=0.
+        let dentry1 = Dentry::new_root(inode.clone());
+        let file_ops1: Arc<dyn FileOps> = Arc::new(StubFile);
+        let guard1 = SbActiveGuard::try_acquire(&sb).expect("guard");
+        let fd1 = OpenFile::new(dentry1, inode.clone(), file_ops1, sb.clone(), 0, guard1);
+        assert_eq!(fd1.wb_err_snapshot.load(Ordering::Acquire), 0);
+
+        // fsync on fd1 before any error — clean.
+        assert_eq!(fd1.do_fsync(false), Ok(()));
+
+        // Simulate a writepage failure (writeback daemon would call
+        // this on every writepage Err).
+        pc.bump_wb_err();
+        assert_eq!(pc.wb_err(), 1);
+        assert_eq!(inode.wb_err(), 1);
+
+        // fd1.do_fsync must now return EIO — counter advanced.
+        assert_eq!(fd1.do_fsync(false), Err(crate::fs::EIO));
+
+        // fd1.do_fsync again — snapshot caught up, must be Ok.
+        assert_eq!(fd1.do_fsync(false), Ok(()));
+        assert_eq!(fd1.wb_err_snapshot.load(Ordering::Acquire), 1);
+
+        // Open fd2 *after* the error — snapshots wb_err=1.
+        let dentry2 = Dentry::new_root(inode.clone());
+        let file_ops2: Arc<dyn FileOps> = Arc::new(StubFile);
+        let guard2 = SbActiveGuard::try_acquire(&sb).expect("guard");
+        let fd2 = OpenFile::new(dentry2, inode.clone(), file_ops2, sb.clone(), 0, guard2);
+        // Snapshot matches current counter — no pending error.
+        assert_eq!(fd2.wb_err_snapshot.load(Ordering::Acquire), 1);
+        assert_eq!(fd2.do_fsync(false), Ok(()));
+
+        // Simulate a second writepage failure.
+        pc.bump_wb_err();
+        assert_eq!(inode.wb_err(), 2);
+
+        // Both fds see EIO exactly once.
+        assert_eq!(fd1.do_fsync(false), Err(crate::fs::EIO));
+        assert_eq!(fd1.do_fsync(false), Ok(()));
+        assert_eq!(fd2.do_fsync(false), Err(crate::fs::EIO));
+        assert_eq!(fd2.do_fsync(false), Ok(()));
+
+        // fdatasync exercises the same errseq path.
+        pc.bump_wb_err();
+        assert_eq!(fd1.do_fsync(true), Err(crate::fs::EIO));
+        assert_eq!(fd1.do_fsync(true), Ok(()));
+    }
 }

--- a/kernel/src/mem/page_cache.rs
+++ b/kernel/src/mem/page_cache.rs
@@ -1515,6 +1515,74 @@ mod tests {
         assert_eq!(cache.wb_err(), 3);
     }
 
+    /// RFC 0007 §`wb_err` errseq end-to-end: simulates the
+    /// `writepage` Err → `bump_wb_err` → fsync snapshot comparison
+    /// chain. Two independent "file descriptions" (modelled as
+    /// separate `AtomicU32` snapshots — the same shape as
+    /// `OpenFile::wb_err_snapshot`) each observe the sticky EIO
+    /// exactly once per advance, consuming it on read.
+    ///
+    /// This exercises the pattern at the `PageCache` layer so it
+    /// runs as a host unit test even though `OpenFile` (VFS module)
+    /// is only compiled for `target_os = "none"`.
+    #[test]
+    fn wb_err_errseq_sticky_eio_once_per_snapshot() {
+        use core::sync::atomic::AtomicU32;
+
+        let cache = fresh_cache();
+
+        // Two "file descriptions" snapshot wb_err at open time.
+        let fd1_snapshot = AtomicU32::new(cache.wb_err());
+        let fd2_snapshot = AtomicU32::new(cache.wb_err());
+
+        // Helper: compare-and-advance a snapshot, return true if
+        // the counter advanced (i.e. fsync would return EIO).
+        let check_and_consume = |snap: &AtomicU32| -> bool {
+            let current = cache.wb_err();
+            let seen = snap.load(Ordering::Acquire);
+            let advanced = seen != current;
+            if advanced {
+                snap.store(current, Ordering::Release);
+            }
+            advanced
+        };
+
+        // No error yet — both fds clean.
+        assert!(!check_and_consume(&fd1_snapshot));
+        assert!(!check_and_consume(&fd2_snapshot));
+
+        // Simulate a writepage failure.
+        cache.bump_wb_err();
+
+        // Both fds see EIO exactly once.
+        assert!(check_and_consume(&fd1_snapshot));
+        assert!(!check_and_consume(&fd1_snapshot)); // consumed
+        assert!(check_and_consume(&fd2_snapshot));
+        assert!(!check_and_consume(&fd2_snapshot)); // consumed
+
+        // A second failure — both see EIO again, once each.
+        cache.bump_wb_err();
+        assert!(check_and_consume(&fd1_snapshot));
+        assert!(!check_and_consume(&fd1_snapshot));
+        assert!(check_and_consume(&fd2_snapshot));
+        assert!(!check_and_consume(&fd2_snapshot));
+
+        // Open a third fd *after* two failures (snapshot=2).
+        let fd3_snapshot = AtomicU32::new(cache.wb_err());
+        // fd3 is up to date — no pending error.
+        assert!(!check_and_consume(&fd3_snapshot));
+
+        // Third failure.
+        cache.bump_wb_err();
+        // All three see it once.
+        assert!(check_and_consume(&fd1_snapshot));
+        assert!(check_and_consume(&fd2_snapshot));
+        assert!(check_and_consume(&fd3_snapshot));
+        assert!(!check_and_consume(&fd1_snapshot));
+        assert!(!check_and_consume(&fd2_snapshot));
+        assert!(!check_and_consume(&fd3_snapshot));
+    }
+
     #[test]
     fn i_size_round_trips() {
         let cache = fresh_cache();


### PR DESCRIPTION
## Summary
- Wire `Inode::wb_err()` to delegate to `PageCache::wb_err()` via the `mapping` field when `cfg(feature = "page_cache")` is active, completing the errseq chain from writeback daemon -> PageCache -> Inode -> OpenFile::do_fsync -> sticky EIO.
- Add host unit test exercising the errseq snapshot pattern end-to-end (bump_wb_err -> per-fd snapshot comparison -> EIO once per witness per advance).
- Add VFS-level test (target_os = "none" only) covering the full `Inode::wb_err -> OpenFile::do_fsync` chain with multiple fds against the same inode.

This is the final connection in the RFC 0007 §`wb_err` errseq pipeline: `PageCache::wb_err` (landed in #799), `OpenFile::wb_err_snapshot` + `do_fsync` errseq logic (landed in #815), and the writeback daemon's `bump_wb_err` call (landed in #813) were all already in place. The only missing piece was `Inode::wb_err()` returning a hardcoded 0 instead of delegating to the inode's mapping.

Closes #758

## Test plan
- [x] `cargo test --lib --features page_cache -p vibix wb_err_errseq_sticky_eio` — host unit test passes (errseq pattern at PageCache layer)
- [x] `cargo test --lib --features page_cache -p vibix` — all 668 host tests pass
- [x] `cargo xtask build` — kernel builds clean
- [x] `cargo xtask test` — all tests pass (only known flake `rwlock_concurrent_readers` #791)

🤖 Generated with [Claude Code](https://claude.com/claude-code)