### PR TITLE
task: add per-task fs_base field to Task struct (#829)

### DIFF
--- a/kernel/src/task/sched_core.rs
+++ b/kernel/src/task/sched_core.rs
@@ -149,6 +149,7 @@ pub fn fork_current_task(
         parent_credentials,
         parent_priority,
         parent_affinity,
+        parent_fs_base,
         parent_fpu_ptr,
     ) = {
         let mut sched = SCHED.lock();
@@ -187,6 +188,7 @@ pub fn fork_current_task(
             parent_credentials,
             cur.priority,
             cur.affinity,
+            cur.fs_base,
             // SAFETY: the parent Task is the currently-running task and stays
             // alive in SCHED for the duration of this syscall. We only read
             // the FPU area during the new_forked call below.
@@ -224,6 +226,7 @@ pub fn fork_current_task(
             regs,
             parent_priority,
             parent_affinity,
+            parent_fs_base,
             parent_fpu_ptr,
             child_aspace,
             child_cr3,

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -237,6 +237,16 @@ pub(super) struct Task {
     /// this value whenever they switch into this task so that ring-3
     /// syscalls land on the right per-task stack.
     pub syscall_stack_top: u64,
+
+    /// Userspace FS segment base address (`MSR_FS_BASE` value).
+    ///
+    /// Written by `arch_prctl(ARCH_SET_FS)` and restored into
+    /// `MSR_FS_BASE` on every context switch into this task. Zero
+    /// until userspace requests a TLS area via `arch_prctl`.
+    ///
+    /// `fork` copies this from the parent so the child inherits the
+    /// parent's TLS pointer.
+    pub fs_base: u64,
 }
 
 impl Task {
@@ -269,6 +279,7 @@ impl Task {
             cwd: None,
             credentials: BlockingRwLock::new(Arc::new(Credential::kernel())),
             syscall_stack_top: 0,
+            fs_base: 0,
         }
     }
 
@@ -361,6 +372,7 @@ impl Task {
             cwd: None,
             credentials: BlockingRwLock::new(Arc::new(Credential::kernel())),
             syscall_stack_top: 0, // kernel-only task — no ring-3 syscall stack needed yet
+            fs_base: 0,
         }
     }
 
@@ -383,6 +395,16 @@ impl Task {
         } else {
             STACK_SIZE / 4096
         }
+    }
+
+    /// Returns the userspace FS segment base address (`MSR_FS_BASE`).
+    pub fn fs_base(&self) -> u64 {
+        self.fs_base
+    }
+
+    /// Sets the userspace FS segment base address (`MSR_FS_BASE`).
+    pub fn set_fs_base(&mut self, val: u64) {
+        self.fs_base = val;
     }
 
     /// Returns `true` if `addr` falls within this task's guard page.
@@ -412,6 +434,7 @@ impl Task {
         regs: &ForkUserRegs,
         parent_priority: u8,
         parent_affinity: u64,
+        parent_fs_base: u64,
         parent_fpu: *const crate::arch::x86_64::fpu::FpuArea,
         child_address_space: alloc::sync::Arc<spin::RwLock<AddressSpace>>,
         child_cr3: PhysFrame<Size4KiB>,
@@ -525,6 +548,7 @@ impl Task {
             // so it doesn't clobber the parent's saved SYSCALL context on the
             // shared INIT_KERNEL_STACK. Use the top of this task's kernel stack.
             syscall_stack_top: (stack_base + STACK_SIZE) as u64,
+            fs_base: parent_fs_base,
         })
     }
 }
@@ -571,6 +595,32 @@ mod stack_slot_tests {
             (a - TASK_STACKS_VA_BASE) % TASK_SLOT_SIZE,
             0,
             "bump-allocated slot must be slot-aligned"
+        );
+    }
+}
+
+#[cfg(test)]
+mod fs_base_tests {
+    use super::*;
+
+    /// The bootstrap task must start with `fs_base == 0` — no
+    /// userspace TLS is configured until `arch_prctl(ARCH_SET_FS)`.
+    #[test]
+    fn bootstrap_fs_base_is_zero() {
+        let t = Task::bootstrap();
+        assert_eq!(t.fs_base(), 0, "bootstrap task must have fs_base=0");
+    }
+
+    /// Setter/getter round-trip: write an arbitrary value, read it back.
+    #[test]
+    fn fs_base_setter_getter_round_trip() {
+        let mut t = Task::bootstrap();
+        let val: u64 = 0x0000_7FFF_DEAD_BEE0;
+        t.set_fs_base(val);
+        assert_eq!(
+            t.fs_base(),
+            val,
+            "fs_base getter must return the value that was set"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Add `fs_base: u64` field to `Task` struct in `kernel/src/task/task.rs`, initialized to 0 for all construction paths (bootstrap, new_with_priority, new_forked)
- Expose `fs_base()` getter and `set_fs_base()` setter methods for use by context switch and arch_prctl sibling issues
- Copy `fs_base` from parent in `fork_current_task` → `Task::new_forked` so forked children inherit the parent's TLS pointer
- Add bare-metal unit tests: zero-init assertion and setter/getter round-trip

Part of epic #827 (static TLS support).

Closes #829

## Test plan
- [x] `cargo fmt --all` — no formatting changes needed
- [x] `cargo xtask build` — compiles cleanly (only pre-existing dead_code warnings for `is_guard_hit` plus the new accessors, which will be consumed by sibling issues)
- [x] `cargo xtask test` — all tests pass; only failure is the known flake `blocking_sync::rwlock_concurrent_readers` (#791), not a regression