### PR TITLE
syscall: implement arch_prctl (ARCH_SET_FS / ARCH_GET_FS)

### DIFF
--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -60,6 +60,7 @@ const MSR_EFER: u32 = 0xC000_0080;
 const MSR_STAR: u32 = 0xC000_0081;
 const MSR_LSTAR: u32 = 0xC000_0082;
 const MSR_FMASK: u32 = 0xC000_0084;
+const MSR_FS_BASE: u32 = 0xC000_0100;
 
 /// EFER.SCE — enables SYSCALL/SYSRET.
 const EFER_SCE: u64 = 1 << 0;
@@ -1170,6 +1171,44 @@ pub unsafe extern "C" fn syscall_dispatch(
         // Workstream B wave 1); list bounded at NGROUPS_MAX=32.
         SETGROUPS => super::syscalls::creds::sys_setgroups(a0 as i32, a1),
 
+        // arch_prctl(code, addr) — x86_64 TLS base manipulation.
+        // Issue #832 (epic #827: x86_64 static TLS).
+        // ARCH_SET_FS (0x1002): set FS base for TLS; validates canonical
+        //   user-range address, stores in task, writes MSR_FS_BASE.
+        // ARCH_GET_FS (0x1003): read FS base from task into userspace ptr.
+        ARCH_PRCTL => {
+            const ARCH_SET_FS: u64 = 0x1002;
+            const ARCH_GET_FS: u64 = 0x1003;
+            match a0 {
+                ARCH_SET_FS => {
+                    let addr = a1;
+                    // Reject non-canonical or kernel-half addresses.
+                    if addr >= crate::mem::addrspace::USER_VA_END {
+                        crate::fs::EPERM
+                    } else {
+                        // Store in current task's fs_base field.
+                        crate::task::set_current_fs_base(addr);
+                        // Write the hardware MSR so %fs-relative accesses
+                        // resolve to the new base immediately on return.
+                        unsafe { Msr::new(MSR_FS_BASE).write(addr) };
+                        0
+                    }
+                }
+                ARCH_GET_FS => {
+                    let out_ptr = a1 as usize;
+                    if let Err(e) = uaccess::check_user_range(out_ptr, 8) {
+                        return e.as_errno();
+                    }
+                    let val = crate::task::current_fs_base();
+                    match unsafe { uaccess::copy_to_user(out_ptr, &val.to_ne_bytes()) } {
+                        Ok(()) => 0,
+                        Err(e) => e.as_errno(),
+                    }
+                }
+                _ => crate::fs::EINVAL,
+            }
+        }
+
         _ => -38i64, // ENOSYS
     };
     // RFC 0006 / #718: syscall exit emit point. Records the same
@@ -1979,6 +2018,7 @@ pub mod syscall_nr {
     pub const SETRESGID: u64 = 119;
     pub const GETGROUPS: u64 = 115;
     pub const SETGROUPS: u64 = 116;
+    pub const ARCH_PRCTL: u64 = 158;
 }
 
 #[cfg(test)]
@@ -2110,5 +2150,8 @@ mod tests {
         assert_eq!(syscall_nr::MOUNT, 165, "SYS_mount must be 165");
         // Umount plumbing (issue #576, RFC 0004 Workstream F)
         assert_eq!(syscall_nr::UMOUNT2, 166, "SYS_umount2 must be 166");
+
+        // TLS (issue #832, epic #827)
+        assert_eq!(syscall_nr::ARCH_PRCTL, 158, "SYS_arch_prctl must be 158");
     }
 }

--- a/kernel/src/task/sched_core.rs
+++ b/kernel/src/task/sched_core.rs
@@ -559,6 +559,40 @@ pub fn current_syscall_stack_top() -> u64 {
         .unwrap_or(0)
 }
 
+/// Return the `fs_base` value of the currently-running task (the FS
+/// segment base used for TLS). Called by `arch_prctl(ARCH_GET_FS)`.
+///
+/// Briefly locks the scheduler, reads the `u64`, and releases.
+///
+/// # Panics
+/// Panics if called before [`init`] (no running task).
+pub fn current_fs_base() -> u64 {
+    SCHED
+        .lock()
+        .current
+        .as_ref()
+        .expect("current_fs_base: no running task")
+        .fs_base()
+}
+
+/// Set the `fs_base` value of the currently-running task.
+/// Called by `arch_prctl(ARCH_SET_FS)` after address validation.
+///
+/// Briefly locks the scheduler, writes the `u64`, and releases.
+/// The caller is responsible for also writing `MSR_FS_BASE` so that
+/// the hardware segment base matches.
+///
+/// # Panics
+/// Panics if called before [`init`] (no running task).
+pub fn set_current_fs_base(val: u64) {
+    SCHED
+        .lock()
+        .current
+        .as_mut()
+        .expect("set_current_fs_base: no running task")
+        .set_fs_base(val);
+}
+
 fn find_priority(sched: &Scheduler, id: usize) -> Option<u8> {
     if let Some(cur) = sched.current.as_ref() {
         if cur.id == id {


### PR DESCRIPTION
## Summary
- Adds syscall 158 (`SYS_arch_prctl`) to the dispatch table — the standard Linux x86_64 interface for TLS base initialization (epic #827, issue #832)
- `ARCH_SET_FS` (0x1002): validates address is in the user canonical half, stores in `Task::fs_base`, writes `MSR_FS_BASE`
- `ARCH_GET_FS` (0x1003): reads `Task::fs_base` and copies the `u64` to the userspace pointer via `copy_to_user`
- Unknown subcodes return `-EINVAL`; kernel-range addresses return `-EPERM`
- Adds `current_fs_base()` / `set_current_fs_base()` scheduler helpers following the existing `SCHED`-lock accessor pattern

Builds on PR #838 which added the `fs_base` field to `Task`.

## Test plan
- [x] `cargo xtask build` — compiles cleanly (only pre-existing `is_guard_hit` warning)
- [x] `cargo xtask test` — all 708 host unit tests pass; QEMU integration tests pass except the pre-existing `blocking_sync.rs:796` rwlock flake (listed in issue as ignorable)
- [x] Syscall number regression test updated (`syscall_numbers_match_linux_x86_64_abi` now asserts `ARCH_PRCTL == 158`)
- [ ] QEMU round-trip integration test (ARCH_SET_FS then ARCH_GET_FS) deferred to issue #833 when userspace TLS initialization is wired up

Closes #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)