### PR TITLE
mem: allocate static TLS block (TCB + .tdata + .tbss) for ELF processes (#830)

### DIFF
--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -1332,6 +1332,11 @@ pub fn exec_atomic(elf_bytes: &'static [u8]) -> Result<core::convert::Infallible
         &random_bytes,
     );
 
+    // Install the FS base for the static TLS block allocated by the loader.
+    // exec replaces the entire address space, so any prior arch_prctl(ARCH_SET_FS)
+    // value is stale; reset to the new TCB address or 0 if no PT_TLS.
+    crate::task::set_current_fs_base(image.tcb_addr.unwrap_or(0));
+
     // If the binary has a dynamic interpreter (PT_INTERP), jump to the
     // interpreter's entry point; otherwise jump directly to the binary's entry.
     let effective_entry = image.interp_entry.unwrap_or(image.entry);

--- a/kernel/src/init_process.rs
+++ b/kernel/src/init_process.rs
@@ -31,6 +31,11 @@ static INIT_ENTRY: AtomicU64 = AtomicU64::new(0);
 /// the stack frame. Set by `launch`; read by `init_ring3_entry`.
 static INIT_STACK_PTR: AtomicU64 = AtomicU64::new(0);
 
+/// TCB address for the initial static TLS block. Set by `launch` when
+/// the loaded ELF has a PT_TLS segment; read by `init_ring3_entry` to
+/// install as `MSR_FS_BASE`. Zero means no TLS block was allocated.
+static INIT_FS_BASE: AtomicU64 = AtomicU64::new(0);
+
 /// Pre-built init AddressSpace (with ELF VMAs and stack VMA).
 /// Consumed by `init_ring3_entry` on first and only use.
 static INIT_ADDRESS_SPACE: Once<Arc<RwLock<AddressSpace>>> = Once::new();
@@ -178,6 +183,10 @@ pub fn launch(bytes: &'static [u8]) -> usize {
     }
     INIT_ENTRY.store(effective_entry.as_u64(), Ordering::Release);
     INIT_STACK_PTR.store(initial_rsp, Ordering::Release);
+    if let Some(tcb) = image.tcb_addr {
+        INIT_FS_BASE.store(tcb, Ordering::Release);
+        serial_println!("init: TLS block allocated, tcb={:#x}", tcb);
+    }
     INIT_ADDRESS_SPACE.call_once(|| Arc::new(RwLock::new(aspace)));
 
     // 5. Spawn the kernel task that will drop to ring-3 and register it
@@ -231,6 +240,14 @@ fn init_ring3_entry() -> ! {
     // multi-process correctness: each user-space task needs its own SYSCALL
     // stack so concurrent/parallel syscalls don't clobber each other.
     crate::task::arm_ring3_syscall_stack();
+
+    // Install the FS base for the static TLS block so MSR_FS_BASE is
+    // written on the first context switch into this task. If no PT_TLS
+    // was present, INIT_FS_BASE is 0 and we skip the write.
+    let fs_base = INIT_FS_BASE.load(Ordering::Acquire);
+    if fs_base != 0 {
+        crate::task::set_current_fs_base(fs_base);
+    }
 
     serial_println!(
         "init: entering ring-3 entry={:#x} rsp={:#x}",

--- a/kernel/src/lntab.rs
+++ b/kernel/src/lntab.rs
@@ -41,7 +41,7 @@ const VERSION: u8 = 1;
 /// lands around ~990 KiB today while the largest test ELF needs
 /// ~1.15 MiB. 2.5 MiB gives both headroom. If it overflows, xtask
 /// aborts with a clear "bump LNTAB_BYTES" error.
-pub const LNTAB_BYTES: usize = 2 * 1024 * 1024 + 512 * 1024;
+pub const LNTAB_BYTES: usize = 3 * 1024 * 1024;
 
 /// Fixed-size reservation patched in place by xtask after linking. The
 /// explicit non-zero magic in the first four bytes forces LLVM to emit

--- a/kernel/src/mem/elf.rs
+++ b/kernel/src/mem/elf.rs
@@ -95,6 +95,38 @@ pub struct TlsInfo {
     pub align: u64,
 }
 
+/// Size of the Thread Control Block (TCB) for x86_64 ELF variant II TLS.
+/// Contains a single self-pointer (`%fs:0 == &TCB`).
+pub const TCB_SIZE: u64 = 8;
+
+const PAGE_SIZE_ELF: u64 = 4096;
+
+/// Compute the TLS block layout for the given [`TlsInfo`] per x86_64
+/// variant II conventions. Returns `(tdata_offset, tcb_va, total_pages)`
+/// where:
+///
+/// - `tdata_offset` is the byte offset of the `.tdata` start relative
+///   to `region_start`.
+/// - `tcb_va` is the virtual address of the TCB (the value for
+///   `MSR_FS_BASE`).
+/// - `total_pages` is the number of 4 KiB pages the region occupies.
+///
+/// `region_start` is the page-aligned base where the TLS region begins.
+///
+/// Layout (low to high):
+/// ```text
+/// [padding] [.tdata (tdata_size)] [.tbss (total_size - tdata_size)] [TCB (8 bytes)]
+///            ^--- aligned to p_align                                  ^--- fs_base
+/// ```
+pub fn compute_tls_layout(region_start: u64, info: &TlsInfo) -> (u64, u64, u64) {
+    let align = if info.align < 2 { 1 } else { info.align };
+    let tdata_start = (region_start + align - 1) & !(align - 1);
+    let tcb_va = tdata_start + info.total_size;
+    let region_end = (tcb_va + TCB_SIZE + PAGE_SIZE_ELF - 1) & !(PAGE_SIZE_ELF - 1);
+    let total_pages = (region_end - region_start) / PAGE_SIZE_ELF;
+    (tdata_start - region_start, tcb_va, total_pages)
+}
+
 /// Parsed ELF64 image metadata for segment walking.
 #[derive(Clone, Copy)]
 pub(crate) struct ParsedElf<'a> {
@@ -779,5 +811,171 @@ mod tests {
         let tls = parsed.tls_info().unwrap();
         assert_eq!(tls.tdata_size, size);
         assert_eq!(tls.total_size, size);
+    }
+
+    // --- TLS block layout tests (compute_tls_layout) -----------------------
+
+    const PAGE_SZ: u64 = 4096;
+
+    /// Verify basic layout: tdata_offset is aligned, TCB sits right after
+    /// the TLS data, and total_pages covers the whole region.
+    #[test]
+    fn compute_tls_layout_basic() {
+        let info = super::TlsInfo {
+            file_offset: 0,
+            tdata_size: 64,
+            total_size: 128,
+            align: 16,
+        };
+        let region_start = 0x403000u64; // page-aligned
+        let (tdata_off, tcb_va, total_pages) = super::compute_tls_layout(region_start, &info);
+
+        // tdata starts at an aligned offset within the region.
+        let tdata_start = region_start + tdata_off;
+        assert_eq!(
+            tdata_start % 16,
+            0,
+            "tdata_start must be aligned to p_align"
+        );
+
+        // TCB is right after the total TLS data area.
+        assert_eq!(tcb_va, tdata_start + info.total_size);
+
+        // Region covers at least tcb_va + TCB_SIZE.
+        let region_end = region_start + total_pages * PAGE_SZ;
+        assert!(
+            region_end >= tcb_va + super::TCB_SIZE,
+            "region must cover TCB"
+        );
+        // Region end is page-aligned.
+        assert_eq!(region_end % PAGE_SZ, 0);
+    }
+
+    /// When region_start is already aligned, tdata_offset should be 0.
+    #[test]
+    fn compute_tls_layout_already_aligned() {
+        let info = super::TlsInfo {
+            file_offset: 0,
+            tdata_size: 32,
+            total_size: 32,
+            align: 8,
+        };
+        // 0x404000 is already 8-byte aligned.
+        let (tdata_off, tcb_va, _) = super::compute_tls_layout(0x404000, &info);
+        assert_eq!(tdata_off, 0, "no padding needed when already aligned");
+        assert_eq!(tcb_va, 0x404000 + 32);
+    }
+
+    /// Alignment of 0 or 1 means no alignment constraint — treated as 1.
+    #[test]
+    fn compute_tls_layout_trivial_align() {
+        let info_align0 = super::TlsInfo {
+            file_offset: 0,
+            tdata_size: 10,
+            total_size: 20,
+            align: 0,
+        };
+        let info_align1 = super::TlsInfo {
+            file_offset: 0,
+            tdata_size: 10,
+            total_size: 20,
+            align: 1,
+        };
+        let base = 0x405000u64;
+        let (off0, tcb0, pages0) = super::compute_tls_layout(base, &info_align0);
+        let (off1, tcb1, pages1) = super::compute_tls_layout(base, &info_align1);
+        assert_eq!(off0, off1);
+        assert_eq!(tcb0, tcb1);
+        assert_eq!(pages0, pages1);
+        // With align=1, no padding is needed.
+        assert_eq!(off0, 0);
+    }
+
+    /// Large alignment (64-byte). A page-aligned region_start is already
+    /// 64-aligned, so no padding is needed.
+    #[test]
+    fn compute_tls_layout_large_align() {
+        let info = super::TlsInfo {
+            file_offset: 0,
+            tdata_size: 100,
+            total_size: 256,
+            align: 64,
+        };
+        let base = 0x403000u64;
+        let (tdata_off, tcb_va, _) = super::compute_tls_layout(base, &info);
+        let tdata_start = base + tdata_off;
+        assert_eq!(tdata_start % 64, 0);
+        assert_eq!(tcb_va, tdata_start + 256);
+    }
+
+    /// Verify that the TCB self-pointer layout is correct by simulating
+    /// the allocation on a local buffer.
+    #[test]
+    fn tls_block_layout_self_pointer() {
+        let tdata_content = [0xAAu8; 48];
+        let info = super::TlsInfo {
+            file_offset: 0,
+            tdata_size: 48,
+            total_size: 80, // 48 .tdata + 32 .tbss
+            align: 16,
+        };
+
+        let region_start = 0x500000u64;
+        let (tdata_off, tcb_va, total_pages) = super::compute_tls_layout(region_start, &info);
+
+        // Simulate filling a buffer.
+        let buf_size = (total_pages * PAGE_SZ) as usize;
+        let mut buf = vec![0u8; buf_size];
+
+        // Copy .tdata content.
+        let tdata_off_usize = tdata_off as usize;
+        buf[tdata_off_usize..tdata_off_usize + tdata_content.len()]
+            .copy_from_slice(&tdata_content);
+
+        // Write TCB self-pointer.
+        let tcb_offset_in_buf = (tcb_va - region_start) as usize;
+        let ptr_bytes = tcb_va.to_le_bytes();
+        buf[tcb_offset_in_buf..tcb_offset_in_buf + 8].copy_from_slice(&ptr_bytes);
+
+        // Verify .tdata was copied.
+        assert_eq!(
+            &buf[tdata_off_usize..tdata_off_usize + 48],
+            &[0xAA; 48]
+        );
+
+        // Verify .tbss is zero.
+        let tbss_start = tdata_off_usize + 48;
+        let tbss_end = tbss_start + 32;
+        assert!(
+            buf[tbss_start..tbss_end].iter().all(|&b| b == 0),
+            ".tbss region must be zero-filled"
+        );
+
+        // Verify TCB self-pointer: reading 8 bytes at tcb offset gives tcb_va.
+        let self_ptr = u64::from_le_bytes(
+            buf[tcb_offset_in_buf..tcb_offset_in_buf + 8]
+                .try_into()
+                .unwrap(),
+        );
+        assert_eq!(self_ptr, tcb_va, "TCB[0] must be a self-pointer");
+    }
+
+    /// Zero-size TLS: tdata_size=0, total_size=0 should still produce a
+    /// valid TCB (just the self-pointer, no TLS data).
+    #[test]
+    fn compute_tls_layout_zero_size() {
+        let info = super::TlsInfo {
+            file_offset: 0,
+            tdata_size: 0,
+            total_size: 0,
+            align: 1,
+        };
+        let base = 0x406000u64;
+        let (tdata_off, tcb_va, total_pages) = super::compute_tls_layout(base, &info);
+        assert_eq!(tdata_off, 0);
+        assert_eq!(tcb_va, base); // TCB right at region_start
+        assert!(total_pages >= 1, "need at least one page for the TCB");
+        let region_end = base + total_pages * PAGE_SZ;
+        assert!(region_end >= tcb_va + super::TCB_SIZE);
     }
 }

--- a/kernel/src/mem/elf.rs
+++ b/kernel/src/mem/elf.rs
@@ -929,8 +929,7 @@ mod tests {
 
         // Copy .tdata content.
         let tdata_off_usize = tdata_off as usize;
-        buf[tdata_off_usize..tdata_off_usize + tdata_content.len()]
-            .copy_from_slice(&tdata_content);
+        buf[tdata_off_usize..tdata_off_usize + tdata_content.len()].copy_from_slice(&tdata_content);
 
         // Write TCB self-pointer.
         let tcb_offset_in_buf = (tcb_va - region_start) as usize;
@@ -938,10 +937,7 @@ mod tests {
         buf[tcb_offset_in_buf..tcb_offset_in_buf + 8].copy_from_slice(&ptr_bytes);
 
         // Verify .tdata was copied.
-        assert_eq!(
-            &buf[tdata_off_usize..tdata_off_usize + 48],
-            &[0xAA; 48]
-        );
+        assert_eq!(&buf[tdata_off_usize..tdata_off_usize + 48], &[0xAA; 48]);
 
         // Verify .tbss is zero.
         let tbss_start = tdata_off_usize + 48;

--- a/kernel/src/mem/loader.rs
+++ b/kernel/src/mem/loader.rs
@@ -120,6 +120,12 @@ pub struct LoadedImage {
     /// Static TLS segment layout extracted from PT_TLS, if present.
     /// Used to allocate the initial TLS block for the process.
     pub tls_info: Option<TlsInfo>,
+    /// Virtual address of the TCB (Thread Control Block) allocated for
+    /// the initial static TLS block. This is the value that should be
+    /// written to `MSR_FS_BASE` so that `%fs:0` yields the TCB
+    /// self-pointer (x86_64 ELF variant II layout). `None` when the
+    /// binary has no `PT_TLS` segment.
+    pub tcb_addr: Option<u64>,
 }
 
 /// Parse `bytes` as an ELF64 image and install its `PT_LOAD` segments
@@ -169,6 +175,7 @@ pub fn load(bytes: &[u8]) -> Result<LoadedImage, LoadError> {
         phdr_count: 0,
         phdr_entsize: 0,
         tls_info: parsed.tls_info(),
+        tcb_addr: None,
     })
 }
 
@@ -244,6 +251,7 @@ pub fn load_user_elf(bytes: &[u8], pml4: PhysFrame<Size4KiB>) -> Result<LoadedIm
         phdr_count: parsed.phdr_count(),
         phdr_entsize: parsed.phdr_entsize(),
         tls_info: parsed.tls_info(),
+        tcb_addr: None,
     })
 }
 
@@ -339,7 +347,17 @@ pub fn load_user_elf_with_vmas(
 
     // Register file-backed + zero-tail VMAs for the main binary's PT_LOAD
     // segments. Returns `(segment_count, page_aligned_image_end)`.
-    let (segments, image_end) = register_demand_vmas(bytes, parsed, 0, address_space)?;
+    let (segments, mut image_end) = register_demand_vmas(bytes, parsed, 0, address_space)?;
+
+    // Allocate the static TLS block when PT_TLS is present. The block is
+    // placed at `image_end` (page-aligned), registered as a writable AnonObject
+    // VMA so fork copies it, and the TCB address is recorded for `MSR_FS_BASE`.
+    let tls = parsed.tls_info();
+    let tcb_addr = if let Some(ref info) = tls {
+        Some(allocate_tls_block(bytes, info, &mut image_end, _pml4, address_space)?)
+    } else {
+        None
+    };
 
     let mut image = LoadedImage {
         entry,
@@ -350,7 +368,8 @@ pub fn load_user_elf_with_vmas(
         phdr_vaddr: parsed.phdr_vaddr(),
         phdr_count: parsed.phdr_count(),
         phdr_entsize: parsed.phdr_entsize(),
-        tls_info: parsed.tls_info(),
+        tls_info: tls,
+        tcb_addr,
     };
 
     // Check for a dynamic interpreter (PT_INTERP). If present, resolve
@@ -419,6 +438,131 @@ fn read_interp_from_fs(interp_path: &[u8]) -> Option<alloc::vec::Vec<u8>> {
         Ok(bytes) if !bytes.is_empty() => Some(bytes),
         _ => None,
     }
+}
+
+// --- allocate_tls_block: static TLS block allocation (x86_64 variant II) ---
+
+/// Allocate a static TLS block in the userspace address space per the
+/// x86_64 ELF variant II layout:
+///
+/// ```text
+/// low addr                                                      high addr
+/// [.tdata copy | .tbss zeroes] [TCB (8 bytes, self-pointer)]
+///  ^--- aligned to p_align      ^--- fs_base (thread pointer)
+/// ```
+///
+/// The block is placed at `*image_end` (page-aligned), mapped eagerly
+/// into `pml4`, and registered as an `AnonObject`-backed VMA so
+/// `fork` copies it. `.tdata` template bytes are copied from the ELF
+/// file; `.tbss` is zero-filled; TCB[0] is set to `&TCB`.
+///
+/// On success, updates `*image_end` past the TLS pages and returns
+/// the virtual address of the TCB (the value for `MSR_FS_BASE`).
+#[cfg(target_os = "none")]
+fn allocate_tls_block(
+    elf_bytes: &[u8],
+    info: &TlsInfo,
+    image_end: &mut u64,
+    pml4: PhysFrame<Size4KiB>,
+    aspace: &mut super::addrspace::AddressSpace,
+) -> Result<u64, LoadError> {
+    use super::vmatree::{Share, Vma};
+    use super::vmobject::{AnonObject, VmObject};
+
+    let region_start = *image_end;
+    let (tdata_off, tcb_va, page_count) = elf::compute_tls_layout(region_start, info);
+    let tdata_start = region_start + tdata_off;
+    let region_end = region_start + page_count * PAGE_SIZE;
+
+    // Map the pages eagerly into the user PML4 and fill them.
+    let tls_flags = PageTableFlags::PRESENT
+        | PageTableFlags::WRITABLE
+        | PageTableFlags::USER_ACCESSIBLE
+        | PageTableFlags::NO_EXECUTE;
+
+    let hhdm = paging::hhdm_offset();
+    let anon = AnonObject::new(Some(page_count as usize));
+
+    for i in 0..page_count {
+        let va = VirtAddr::new(region_start + i * PAGE_SIZE);
+        let page = Page::<Size4KiB>::containing_address(va);
+        let frame = paging::map_in_pml4(pml4, page, tls_flags)
+            .map_err(LoadError::MapFailed)?;
+
+        // Record the frame in the AnonObject so fork can find it.
+        anon.insert_existing_frame(i as usize, frame.start_address().as_u64())
+            .expect("TLS: freshly-mapped frame cannot be saturated");
+
+        // Zero-fill is already done by map_in_pml4 (zeroed frames), but
+        // we need to copy .tdata content into the right offset.
+        let page_base_va = region_start + i * PAGE_SIZE;
+        let page_end_va = page_base_va + PAGE_SIZE;
+
+        // Copy .tdata bytes that overlap this page.
+        let tdata_end = tdata_start + info.tdata_size;
+        if tdata_end > page_base_va && tdata_start < page_end_va {
+            let src_start = if tdata_start > page_base_va {
+                0u64
+            } else {
+                page_base_va - tdata_start
+            };
+            let dst_offset = if tdata_start > page_base_va {
+                tdata_start - page_base_va
+            } else {
+                0
+            };
+            let copy_end = core::cmp::min(tdata_end, page_end_va);
+            let copy_start_in_page = if tdata_start > page_base_va {
+                tdata_start - page_base_va
+            } else {
+                0
+            };
+            let n = (copy_end - (page_base_va + copy_start_in_page)) as usize;
+            if n > 0 {
+                let elf_src = &elf_bytes[(info.file_offset + src_start) as usize
+                    ..(info.file_offset + src_start) as usize + n];
+                let dst = hhdm + frame.start_address().as_u64() + dst_offset;
+                // SAFETY: frame was just allocated and mapped; HHDM gives
+                // writable access. `n` is bounded by PAGE_SIZE.
+                unsafe {
+                    core::ptr::copy_nonoverlapping(
+                        elf_src.as_ptr(),
+                        dst.as_mut_ptr::<u8>(),
+                        n,
+                    );
+                }
+            }
+        }
+
+        // Write the TCB self-pointer if the TCB falls within this page.
+        if tcb_va >= page_base_va && tcb_va < page_end_va {
+            let tcb_offset_in_page = tcb_va - page_base_va;
+            let dst = hhdm + frame.start_address().as_u64() + tcb_offset_in_page;
+            // SAFETY: TCB is 8 bytes; offset+8 is within the page because
+            // region_end is page-aligned and TCB_SIZE=8 fits within a page
+            // boundary (tcb_va + 8 <= region_end).
+            unsafe {
+                core::ptr::write_unaligned(dst.as_mut_ptr::<u64>(), tcb_va);
+            }
+        }
+    }
+
+    // Register the TLS region as a private AnonObject VMA so fork copies it.
+    let vma = Vma::new(
+        region_start as usize,
+        region_end as usize,
+        0x3, // PROT_READ|WRITE
+        tls_flags.bits(),
+        Share::Private,
+        anon as Arc<dyn VmObject>,
+        0,
+    );
+    aspace.insert(vma);
+
+    // Advance image_end past the TLS region so the heap starts after it.
+    *image_end = region_end;
+
+    Ok(tcb_va)
 }
 
 // --- register_demand_vmas: file-backed + zero-tail VMA registration -------

--- a/kernel/src/mem/loader.rs
+++ b/kernel/src/mem/loader.rs
@@ -354,7 +354,13 @@ pub fn load_user_elf_with_vmas(
     // VMA so fork copies it, and the TCB address is recorded for `MSR_FS_BASE`.
     let tls = parsed.tls_info();
     let tcb_addr = if let Some(ref info) = tls {
-        Some(allocate_tls_block(bytes, info, &mut image_end, _pml4, address_space)?)
+        Some(allocate_tls_block(
+            bytes,
+            info,
+            &mut image_end,
+            _pml4,
+            address_space,
+        )?)
     } else {
         None
     };
@@ -486,8 +492,7 @@ fn allocate_tls_block(
     for i in 0..page_count {
         let va = VirtAddr::new(region_start + i * PAGE_SIZE);
         let page = Page::<Size4KiB>::containing_address(va);
-        let frame = paging::map_in_pml4(pml4, page, tls_flags)
-            .map_err(LoadError::MapFailed)?;
+        let frame = paging::map_in_pml4(pml4, page, tls_flags).map_err(LoadError::MapFailed)?;
 
         // Record the frame in the AnonObject so fork can find it.
         anon.insert_existing_frame(i as usize, frame.start_address().as_u64())
@@ -525,11 +530,7 @@ fn allocate_tls_block(
                 // SAFETY: frame was just allocated and mapped; HHDM gives
                 // writable access. `n` is bounded by PAGE_SIZE.
                 unsafe {
-                    core::ptr::copy_nonoverlapping(
-                        elf_src.as_ptr(),
-                        dst.as_mut_ptr::<u8>(),
-                        n,
-                    );
+                    core::ptr::copy_nonoverlapping(elf_src.as_ptr(), dst.as_mut_ptr::<u8>(), n);
                 }
             }
         }

--- a/kernel/src/task/sched_core.rs
+++ b/kernel/src/task/sched_core.rs
@@ -609,7 +609,10 @@ pub fn current_fs_base() -> u64 {
 }
 
 /// Set the `fs_base` value of the currently-running task.
-/// Called by `arch_prctl(ARCH_SET_FS)` after address validation.
+/// Called by `arch_prctl(ARCH_SET_FS)` after address validation, and by
+/// the init process launcher and `exec_atomic` after allocating a static
+/// TLS block so the TCB address is propagated to the context-switch path
+/// that restores `MSR_FS_BASE`.
 ///
 /// Briefly locks the scheduler, writes the `u64`, and releases.
 /// The caller is responsible for also writing `MSR_FS_BASE` so that


### PR DESCRIPTION
## Summary

- Allocate the x86_64 variant II static TLS block (`[.tdata | .tbss] [TCB]`) when `PT_TLS` is present in the loaded ELF image
- Store the TCB address in `LoadedImage.tcb_addr` and propagate it as `MSR_FS_BASE` for the init process and on `execve`
- Add `compute_tls_layout()` to `elf.rs` with 6 host unit tests covering alignment, self-pointer layout, zero-size TLS, and trivial alignment

## Details

**Layout** (x86_64 ELF variant II):
```
low addr                                                      high addr
[.tdata copy | .tbss zeroes] [TCB (8 bytes, self-pointer)]
 ^--- aligned to p_align      ^--- fs_base (thread pointer)
```

**Files changed:**
- `kernel/src/mem/elf.rs` — `compute_tls_layout()`, `TCB_SIZE` constant, 6 new tests
- `kernel/src/mem/loader.rs` — `allocate_tls_block()` (maps pages, copies .tdata, writes TCB self-pointer, registers AnonObject VMA for fork), `tcb_addr` field on `LoadedImage`
- `kernel/src/init_process.rs` — `INIT_FS_BASE` static, set on launch, read in `init_ring3_entry`
- `kernel/src/arch/x86_64/syscall.rs` — `exec_atomic` sets `fs_base` from `image.tcb_addr`
- `kernel/src/task/sched_core.rs` — `set_current_fs_base()` public helper
- `kernel/src/lntab.rs` — bump `LNTAB_BYTES` from 2.5 MiB to 3 MiB

Closes #830

## Test plan

- [x] 6 new host unit tests for `compute_tls_layout` (alignment, self-pointer, zero-size, trivial-align)
- [x] 714 host unit tests pass (`cargo test -p vibix --lib`)
- [x] Kernel builds for `x86_64-unknown-none` (`cargo xtask build`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)