### PR TITLE
init_process: write MSR_FS_BASE before ring-3 entry (#833)

### DIFF
--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -1335,7 +1335,11 @@ pub fn exec_atomic(elf_bytes: &'static [u8]) -> Result<core::convert::Infallible
     // Install the FS base for the static TLS block allocated by the loader.
     // exec replaces the entire address space, so any prior arch_prctl(ARCH_SET_FS)
     // value is stale; reset to the new TCB address or 0 if no PT_TLS.
-    crate::task::set_current_fs_base(image.tcb_addr.unwrap_or(0));
+    // We must write both the task struct field AND the hardware MSR so
+    // the first preemption's rdmsr save reads the correct value. (#833)
+    let exec_fs_base = image.tcb_addr.unwrap_or(0);
+    crate::task::set_current_fs_base(exec_fs_base);
+    unsafe { Msr::new(MSR_FS_BASE).write(exec_fs_base) };
 
     // If the binary has a dynamic interpreter (PT_INTERP), jump to the
     // interpreter's entry point; otherwise jump directly to the binary's entry.

--- a/kernel/src/init_process.rs
+++ b/kernel/src/init_process.rs
@@ -241,12 +241,19 @@ fn init_ring3_entry() -> ! {
     // stack so concurrent/parallel syscalls don't clobber each other.
     crate::task::arm_ring3_syscall_stack();
 
-    // Install the FS base for the static TLS block so MSR_FS_BASE is
-    // written on the first context switch into this task. If no PT_TLS
-    // was present, INIT_FS_BASE is 0 and we skip the write.
+    // Install the FS base for the static TLS block. We must both store
+    // the value in the task struct (so the context-switch restore path
+    // sees it) AND write MSR_FS_BASE directly (so the first preemption's
+    // save path reads the correct value instead of 0). Without the
+    // direct MSR write, the save path does `rdmsr(MSR_FS_BASE)` which
+    // returns 0 and overwrites the stored TCB address — breaking TLS on
+    // the first context switch out of this task. See issue #833.
     let fs_base = INIT_FS_BASE.load(Ordering::Acquire);
     if fs_base != 0 {
         crate::task::set_current_fs_base(fs_base);
+        unsafe {
+            x86_64::registers::model_specific::Msr::new(0xC000_0100).write(fs_base);
+        }
     }
 
     serial_println!(


### PR DESCRIPTION
## Summary

- After `set_current_fs_base(fs_base)`, also write `MSR_FS_BASE` (`0xC000_0100`) directly via `wrmsr` in both `init_ring3_entry` and the `exec_atomic` path
- Without this, the context-switch save path reads MSR_FS_BASE (still 0) on the first preemption and overwrites the stored TCB address, silently breaking TLS
- Two-line fix in each of the two call sites (`kernel/src/init_process.rs`, `kernel/src/arch/x86_64/syscall.rs`)

Closes #833

## Test plan

- [x] `cargo xtask build` — compiles cleanly (only pre-existing `dead_code` warning)
- [x] `cargo xtask smoke` — all 42 serial markers pass
- [x] `cargo xtask test` — all tests pass except pre-existing `blocking_sync.rs:796` rwlock flake (documented in issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)