### PR TITLE
arch: enable CR4.FSGSBASE for fast userspace TLS access (#836)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -573,3 +573,7 @@ required-features = ["page_cache"]
 [[test]]
 name = "dynlinker_stub"
 harness = false
+
+[[test]]
+name = "fsgsbase"
+harness = false

--- a/kernel/src/arch/x86_64/mod.rs
+++ b/kernel/src/arch/x86_64/mod.rs
@@ -12,6 +12,52 @@ pub mod syscall;
 pub mod syscalls;
 pub mod uaccess;
 
+use core::sync::atomic::{AtomicBool, Ordering};
+
+/// `true` after [`enable_fsgsbase`] has set `CR4.FSGSBASE` on this CPU.
+/// Checked by the context-switch fast path in `sched_core.rs` to choose
+/// between `rdfsbase`/`wrfsbase` (fast, user-visible) and
+/// `rdmsr`/`wrmsr` (slow, always-available fallback).
+static FSGSBASE_ON: AtomicBool = AtomicBool::new(false);
+
+/// Return `true` if `CR4.FSGSBASE` was successfully enabled at boot.
+///
+/// Lock-free: reads a `Relaxed` `AtomicBool` populated once by
+/// [`enable_fsgsbase`] during `arch::init()`.
+#[inline]
+pub fn fsgsbase_enabled() -> bool {
+    FSGSBASE_ON.load(Ordering::Relaxed)
+}
+
+/// Enable the FSGSBASE CPU feature (CR4 bit 16) so that userspace can
+/// use `wrfsbase`/`rdfsbase` directly and the kernel context-switch
+/// path can use the faster non-serialising instructions instead of
+/// `rdmsr`/`wrmsr`.
+///
+/// Checks CPUID leaf 7 sub-leaf 0 EBX bit 0 (already cached by
+/// `cpu::init()`). If the CPU does not advertise FSGSBASE the function
+/// is a no-op and the fallback MSR path remains in effect.
+fn enable_fsgsbase() {
+    use crate::cpu::{self, Feature};
+    use x86_64::registers::control::{Cr4, Cr4Flags};
+
+    if !cpu::has(Feature::Fsgsbase) {
+        crate::serial_println!("fsgsbase: unavailable");
+        return;
+    }
+
+    // SAFETY: We only set CR4.FSGSBASE after confirming the CPU
+    // supports it via CPUID. No other CR4 bits are touched.
+    unsafe {
+        Cr4::update(|f| {
+            f.insert(Cr4Flags::FSGSBASE);
+        });
+    }
+
+    FSGSBASE_ON.store(true, Ordering::Relaxed);
+    crate::serial_println!("fsgsbase: CR4.FSGSBASE enabled");
+}
+
 /// Bring up arch-specific interrupt plumbing that doesn't depend on
 /// the kernel mapper. Interrupts stay disabled throughout.
 pub fn init() {
@@ -21,6 +67,10 @@ pub fn init() {
     // outside a `stac`/`clac` bracket. Must precede `syscall::init` so
     // the first SYSCALL fires with enforcement already live.
     uaccess::enable_smep_smap();
+    // Enable CR4.FSGSBASE so userspace can use wrfsbase/rdfsbase for
+    // fast TLS access, and the kernel context switch can use the
+    // faster non-serialising instructions (#836).
+    enable_fsgsbase();
     // FPU init needs CR0/CR4 writes but no heap, so it fits here —
     // ahead of task::init() which spawns the first saving task.
     fpu::init();

--- a/kernel/src/task/sched_core.rs
+++ b/kernel/src/task/sched_core.rs
@@ -48,19 +48,40 @@ use x86_64::registers::model_specific::Msr;
 /// area after a context switch.
 const MSR_FS_BASE: u32 = 0xC000_0100;
 
-/// Save the current CPU's `MSR_FS_BASE` into `task.fs_base`.
+/// Save the current CPU's FS base into `task.fs_base`.
+///
+/// When `CR4.FSGSBASE` is enabled (#836) this uses the `rdfsbase`
+/// instruction — a non-serialising, ~1-cycle read — instead of the
+/// `rdmsr` path (~20-40 cycles, serialising). The fast-path flag is
+/// cached in [`crate::arch::x86_64::fsgsbase_enabled`] and checked at
+/// each call; it never changes after early boot so the branch predicts
+/// perfectly.
 ///
 /// # Safety
 /// Must be called with IRQs disabled (or from an ISR) so no concurrent
-/// context switch can race the MSR read.
+/// context switch can race the read.
 #[inline(always)]
 unsafe fn save_fs_base(task: &mut Task) {
-    task.fs_base = Msr::new(MSR_FS_BASE).read();
+    if crate::arch::x86_64::fsgsbase_enabled() {
+        // SAFETY: CR4.FSGSBASE is set, so `rdfsbase` is legal.
+        let val: u64;
+        core::arch::asm!(
+            "rdfsbase {}",
+            out(reg) val,
+            options(nomem, nostack, preserves_flags),
+        );
+        task.fs_base = val;
+    } else {
+        task.fs_base = Msr::new(MSR_FS_BASE).read();
+    }
 }
 
-/// Restore `task.fs_base` into the CPU's `MSR_FS_BASE`. Skips the
+/// Restore `task.fs_base` into the CPU's FS base register. Skips the
 /// write when `fs_base == 0` (kernel tasks with no userspace TLS) as
-/// an optimisation — `wrmsr` is an expensive serialising instruction.
+/// an optimisation.
+///
+/// When `CR4.FSGSBASE` is enabled (#836) this uses `wrfsbase` instead
+/// of the serialising `wrmsr`.
 ///
 /// # Safety
 /// Must be called with IRQs disabled so the restored value is not
@@ -69,7 +90,16 @@ unsafe fn save_fs_base(task: &mut Task) {
 unsafe fn restore_fs_base(task: &Task) {
     let val = task.fs_base;
     if val != 0 {
-        Msr::new(MSR_FS_BASE).write(val);
+        if crate::arch::x86_64::fsgsbase_enabled() {
+            // SAFETY: CR4.FSGSBASE is set, so `wrfsbase` is legal.
+            core::arch::asm!(
+                "wrfsbase {}",
+                in(reg) val,
+                options(nomem, nostack, preserves_flags),
+            );
+        } else {
+            Msr::new(MSR_FS_BASE).write(val);
+        }
     }
 }
 

--- a/kernel/tests/fsgsbase.rs
+++ b/kernel/tests/fsgsbase.rs
@@ -1,0 +1,223 @@
+//! Integration test for #836: CR4.FSGSBASE is enabled at boot and the
+//! `rdfsbase`/`wrfsbase` instructions are usable from ring 0.
+//!
+//! Verifies:
+//! 1. CR4 bit 16 (FSGSBASE) is set after `vibix::init()`.
+//! 2. A `wrfsbase` / `rdfsbase` round-trip returns the written value.
+//! 3. The context-switch helpers preserve FS base across a preemption
+//!    window (same pattern as `fpu_context_switch`).
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use vibix::{
+    exit_qemu, serial_println, task,
+    test_harness::{test_panic_handler, Testable},
+    time, QemuExitCode,
+};
+use x86_64::registers::control::{Cr4, Cr4Flags};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    task::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        ("cr4_fsgsbase_bit_set", &(cr4_fsgsbase_bit_set as fn())),
+        (
+            "wrfsbase_rdfsbase_roundtrip",
+            &(wrfsbase_rdfsbase_roundtrip as fn()),
+        ),
+        (
+            "fs_base_preserved_across_preemption",
+            &(fs_base_preserved_across_preemption as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+/// CR4.FSGSBASE (bit 16) must be set after boot.
+fn cr4_fsgsbase_bit_set() {
+    let flags = Cr4::read();
+    assert!(
+        flags.contains(Cr4Flags::FSGSBASE),
+        "CR4.FSGSBASE not set — enable_fsgsbase() did not run or CPU lacks support"
+    );
+}
+
+/// Write a non-zero value via `wrfsbase`, read it back via `rdfsbase`,
+/// then restore the original value. Without CR4.FSGSBASE these
+/// instructions would #UD.
+fn wrfsbase_rdfsbase_roundtrip() {
+    // Save the current FS base so we can restore it.
+    let original: u64;
+    unsafe {
+        core::arch::asm!(
+            "rdfsbase {}",
+            out(reg) original,
+            options(nomem, nostack, preserves_flags),
+        );
+    }
+
+    let test_val: u64 = 0xDEAD_BEEF_CAFE_0836;
+    unsafe {
+        core::arch::asm!(
+            "wrfsbase {}",
+            in(reg) test_val,
+            options(nomem, nostack, preserves_flags),
+        );
+    }
+
+    let readback: u64;
+    unsafe {
+        core::arch::asm!(
+            "rdfsbase {}",
+            out(reg) readback,
+            options(nomem, nostack, preserves_flags),
+        );
+    }
+
+    assert_eq!(
+        readback, test_val,
+        "rdfsbase returned {readback:#x}, expected {test_val:#x}"
+    );
+
+    // Restore original FS base.
+    unsafe {
+        core::arch::asm!(
+            "wrfsbase {}",
+            in(reg) original,
+            options(nomem, nostack, preserves_flags),
+        );
+    }
+}
+
+// ----- preemption-survival test -----
+
+const PATTERN_A: u64 = 0xAAAA_BBBB_CCCC_0001;
+const PATTERN_B: u64 = 0x1111_2222_3333_0002;
+
+static A_ITERS: AtomicUsize = AtomicUsize::new(0);
+static B_ITERS: AtomicUsize = AtomicUsize::new(0);
+static A_FAIL: AtomicBool = AtomicBool::new(false);
+static B_FAIL: AtomicBool = AtomicBool::new(false);
+
+fn worker_a() -> ! {
+    // Set FS base to our pattern.
+    unsafe {
+        core::arch::asm!(
+            "wrfsbase {}",
+            in(reg) PATTERN_A,
+            options(nomem, nostack, preserves_flags),
+        );
+    }
+
+    loop {
+        let val: u64;
+        unsafe {
+            core::arch::asm!(
+                "rdfsbase {}",
+                out(reg) val,
+                options(nomem, nostack, preserves_flags),
+            );
+        }
+        if val != PATTERN_A {
+            A_FAIL.store(true, Ordering::Relaxed);
+        }
+        A_ITERS.fetch_add(1, Ordering::Relaxed);
+        // Reload to keep the test honest after a real failure — we want
+        // subsequent iterations to also flag corruption, not silently pass.
+        unsafe {
+            core::arch::asm!(
+                "wrfsbase {}",
+                in(reg) PATTERN_A,
+                options(nomem, nostack, preserves_flags),
+            );
+        }
+        core::hint::spin_loop();
+    }
+}
+
+fn worker_b() -> ! {
+    unsafe {
+        core::arch::asm!(
+            "wrfsbase {}",
+            in(reg) PATTERN_B,
+            options(nomem, nostack, preserves_flags),
+        );
+    }
+
+    loop {
+        let val: u64;
+        unsafe {
+            core::arch::asm!(
+                "rdfsbase {}",
+                out(reg) val,
+                options(nomem, nostack, preserves_flags),
+            );
+        }
+        if val != PATTERN_B {
+            B_FAIL.store(true, Ordering::Relaxed);
+        }
+        B_ITERS.fetch_add(1, Ordering::Relaxed);
+        unsafe {
+            core::arch::asm!(
+                "wrfsbase {}",
+                in(reg) PATTERN_B,
+                options(nomem, nostack, preserves_flags),
+            );
+        }
+        core::hint::spin_loop();
+    }
+}
+
+/// Spawn two tasks that each set FS base to a unique pattern and spin
+/// verifying it. Without proper save/restore in the context-switch
+/// path, one task's pattern would clobber the other's within a single
+/// preemption tick.
+fn fs_base_preserved_across_preemption() {
+    A_ITERS.store(0, Ordering::SeqCst);
+    B_ITERS.store(0, Ordering::SeqCst);
+    A_FAIL.store(false, Ordering::SeqCst);
+    B_FAIL.store(false, Ordering::SeqCst);
+
+    task::spawn(worker_a);
+    task::spawn(worker_b);
+
+    // 200 ms = 20 PIT ticks at 100 Hz. The two 10 ms slices interleave
+    // ~10 times each over this window; without FS base save/restore the
+    // first preemption would already corrupt one task's pattern.
+    let start = time::uptime_ms();
+    while time::uptime_ms() < start + 200 {
+        x86_64::instructions::hlt();
+    }
+
+    let a = A_ITERS.load(Ordering::Relaxed);
+    let b = B_ITERS.load(Ordering::Relaxed);
+    let af = A_FAIL.load(Ordering::Relaxed);
+    let bf = B_FAIL.load(Ordering::Relaxed);
+    serial_println!("fsgsbase test: a_iters={a} b_iters={b} a_fail={af} b_fail={bf}");
+    assert!(a > 0, "worker_a never ran (a={a})");
+    assert!(b > 0, "worker_b never ran (b={b})");
+    assert!(!af, "worker_a saw FS base corruption");
+    assert!(!bf, "worker_b saw FS base corruption");
+}


### PR DESCRIPTION
## Summary
- Enable CR4.FSGSBASE (bit 16) during early boot after CPUID feature detection confirms support, so userspace can use `wrfsbase`/`rdfsbase` directly for fast TLS access
- Upgrade context-switch `save_fs_base`/`restore_fs_base` from `rdmsr`/`wrmsr` (~20-40 cycles, serialising) to `rdfsbase`/`wrfsbase` (~1 cycle, non-serialising) when FSGSBASE is enabled
- Add `fsgsbase` integration test: CR4 bit verification, wrfsbase/rdfsbase round-trip, and FS base preservation across preemptive context switches

## Test plan
- [x] New `fsgsbase` integration test passes (3 sub-tests: CR4 bit set, round-trip, preemption survival)
- [x] `cargo xtask smoke` passes (all 42 markers present)
- [x] Host unit tests pass (714/714)
- [x] rdmsr/wrmsr fallback path preserved for CPUs without FSGSBASE support

Closes #836

🤖 Generated with [Claude Code](https://claude.com/claude-code)