### PR TITLE
fork/exec TLS cloning (#834)

### DIFF
--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -1341,6 +1341,11 @@ pub fn exec_atomic(elf_bytes: &'static [u8]) -> Result<core::convert::Infallible
     crate::task::set_current_fs_base(exec_fs_base);
     unsafe { Msr::new(MSR_FS_BASE).write(exec_fs_base) };
 
+    // Record the TLS region boundaries so fork can deep-copy the TLS
+    // block into the child (#834). exec replaces the entire address
+    // space, so prior TLS region info is stale.
+    crate::task::set_current_tls_region(image.tls_region_start, image.tls_region_pages);
+
     // If the binary has a dynamic interpreter (PT_INTERP), jump to the
     // interpreter's entry point; otherwise jump directly to the binary's entry.
     let effective_entry = image.interp_entry.unwrap_or(image.entry);

--- a/kernel/src/init_process.rs
+++ b/kernel/src/init_process.rs
@@ -36,6 +36,14 @@ static INIT_STACK_PTR: AtomicU64 = AtomicU64::new(0);
 /// install as `MSR_FS_BASE`. Zero means no TLS block was allocated.
 static INIT_FS_BASE: AtomicU64 = AtomicU64::new(0);
 
+/// Page-aligned start VA of the init process's static TLS block.
+/// Set by `launch`; read by `init_ring3_entry` to record on the task
+/// so fork can deep-copy the TLS pages (#834).
+static INIT_TLS_REGION_START: AtomicU64 = AtomicU64::new(0);
+
+/// Number of 4 KiB pages in the init process's static TLS block.
+static INIT_TLS_REGION_PAGES: AtomicU64 = AtomicU64::new(0);
+
 /// Pre-built init AddressSpace (with ELF VMAs and stack VMA).
 /// Consumed by `init_ring3_entry` on first and only use.
 static INIT_ADDRESS_SPACE: Once<Arc<RwLock<AddressSpace>>> = Once::new();
@@ -185,7 +193,10 @@ pub fn launch(bytes: &'static [u8]) -> usize {
     INIT_STACK_PTR.store(initial_rsp, Ordering::Release);
     if let Some(tcb) = image.tcb_addr {
         INIT_FS_BASE.store(tcb, Ordering::Release);
-        serial_println!("init: TLS block allocated, tcb={:#x}", tcb);
+        INIT_TLS_REGION_START.store(image.tls_region_start, Ordering::Release);
+        INIT_TLS_REGION_PAGES.store(image.tls_region_pages, Ordering::Release);
+        serial_println!("init: TLS block allocated, tcb={:#x}, region={:#x}+{}p",
+            tcb, image.tls_region_start, image.tls_region_pages);
     }
     INIT_ADDRESS_SPACE.call_once(|| Arc::new(RwLock::new(aspace)));
 
@@ -254,6 +265,11 @@ fn init_ring3_entry() -> ! {
         unsafe {
             x86_64::registers::model_specific::Msr::new(0xC000_0100).write(fs_base);
         }
+        // Record the TLS region boundaries so fork can deep-copy the
+        // TLS pages into the child (#834).
+        let tls_start = INIT_TLS_REGION_START.load(Ordering::Acquire);
+        let tls_pages = INIT_TLS_REGION_PAGES.load(Ordering::Acquire);
+        crate::task::set_current_tls_region(tls_start, tls_pages);
     }
 
     serial_println!(

--- a/kernel/src/init_process.rs
+++ b/kernel/src/init_process.rs
@@ -195,8 +195,12 @@ pub fn launch(bytes: &'static [u8]) -> usize {
         INIT_FS_BASE.store(tcb, Ordering::Release);
         INIT_TLS_REGION_START.store(image.tls_region_start, Ordering::Release);
         INIT_TLS_REGION_PAGES.store(image.tls_region_pages, Ordering::Release);
-        serial_println!("init: TLS block allocated, tcb={:#x}, region={:#x}+{}p",
-            tcb, image.tls_region_start, image.tls_region_pages);
+        serial_println!(
+            "init: TLS block allocated, tcb={:#x}, region={:#x}+{}p",
+            tcb,
+            image.tls_region_start,
+            image.tls_region_pages
+        );
     }
     INIT_ADDRESS_SPACE.call_once(|| Arc::new(RwLock::new(aspace)));
 

--- a/kernel/src/mem/loader.rs
+++ b/kernel/src/mem/loader.rs
@@ -365,13 +365,8 @@ pub fn load_user_elf_with_vmas(
     // VMA so fork copies it, and the TCB address is recorded for `MSR_FS_BASE`.
     let tls = parsed.tls_info();
     let (tcb_addr, tls_region_start, tls_region_pages) = if let Some(ref info) = tls {
-        let (tcb_va, region_start, page_count) = allocate_tls_block(
-            bytes,
-            info,
-            &mut image_end,
-            _pml4,
-            address_space,
-        )?;
+        let (tcb_va, region_start, page_count) =
+            allocate_tls_block(bytes, info, &mut image_end, _pml4, address_space)?;
         (Some(tcb_va), region_start, page_count)
     } else {
         (None, 0, 0)
@@ -641,8 +636,8 @@ pub fn deep_copy_tls_block(
         //   3. Copies page content (parent's data) via HHDM
         //   4. Re-maps the fresh frame with full write permission
         //   5. Decrements the refcount on the old shared frame
-        let new_frame =
-            paging::cow_copy_and_remap(child_pml4, page, tls_flags).map_err(LoadError::MapFailed)?;
+        let new_frame = paging::cow_copy_and_remap(child_pml4, page, tls_flags)
+            .map_err(LoadError::MapFailed)?;
 
         // Fix up the TCB self-pointer if the TCB falls within this page.
         // The TCB VA is `fs_base`; its self-pointer at offset 0 must

--- a/kernel/src/mem/loader.rs
+++ b/kernel/src/mem/loader.rs
@@ -126,6 +126,13 @@ pub struct LoadedImage {
     /// self-pointer (x86_64 ELF variant II layout). `None` when the
     /// binary has no `PT_TLS` segment.
     pub tcb_addr: Option<u64>,
+    /// Page-aligned start VA of the static TLS block allocated by the
+    /// loader. Zero when no TLS block was allocated. Used by the fork
+    /// path to deep-copy TLS pages (#834).
+    pub tls_region_start: u64,
+    /// Number of 4 KiB pages in the static TLS block. Zero when no TLS
+    /// block was allocated.
+    pub tls_region_pages: u64,
 }
 
 /// Parse `bytes` as an ELF64 image and install its `PT_LOAD` segments
@@ -176,6 +183,8 @@ pub fn load(bytes: &[u8]) -> Result<LoadedImage, LoadError> {
         phdr_entsize: 0,
         tls_info: parsed.tls_info(),
         tcb_addr: None,
+        tls_region_start: 0,
+        tls_region_pages: 0,
     })
 }
 
@@ -252,6 +261,8 @@ pub fn load_user_elf(bytes: &[u8], pml4: PhysFrame<Size4KiB>) -> Result<LoadedIm
         phdr_entsize: parsed.phdr_entsize(),
         tls_info: parsed.tls_info(),
         tcb_addr: None,
+        tls_region_start: 0,
+        tls_region_pages: 0,
     })
 }
 
@@ -353,16 +364,17 @@ pub fn load_user_elf_with_vmas(
     // placed at `image_end` (page-aligned), registered as a writable AnonObject
     // VMA so fork copies it, and the TCB address is recorded for `MSR_FS_BASE`.
     let tls = parsed.tls_info();
-    let tcb_addr = if let Some(ref info) = tls {
-        Some(allocate_tls_block(
+    let (tcb_addr, tls_region_start, tls_region_pages) = if let Some(ref info) = tls {
+        let (tcb_va, region_start, page_count) = allocate_tls_block(
             bytes,
             info,
             &mut image_end,
             _pml4,
             address_space,
-        )?)
+        )?;
+        (Some(tcb_va), region_start, page_count)
     } else {
-        None
+        (None, 0, 0)
     };
 
     let mut image = LoadedImage {
@@ -376,6 +388,8 @@ pub fn load_user_elf_with_vmas(
         phdr_entsize: parsed.phdr_entsize(),
         tls_info: tls,
         tcb_addr,
+        tls_region_start,
+        tls_region_pages,
     };
 
     // Check for a dynamic interpreter (PT_INTERP). If present, resolve
@@ -463,7 +477,9 @@ fn read_interp_from_fs(interp_path: &[u8]) -> Option<alloc::vec::Vec<u8>> {
 /// file; `.tbss` is zero-filled; TCB[0] is set to `&TCB`.
 ///
 /// On success, updates `*image_end` past the TLS pages and returns
-/// the virtual address of the TCB (the value for `MSR_FS_BASE`).
+/// `(tcb_va, region_start, page_count)` — the TCB virtual address
+/// (the value for `MSR_FS_BASE`), the page-aligned start of the TLS
+/// region, and the number of 4 KiB pages it spans.
 #[cfg(target_os = "none")]
 fn allocate_tls_block(
     elf_bytes: &[u8],
@@ -471,7 +487,7 @@ fn allocate_tls_block(
     image_end: &mut u64,
     pml4: PhysFrame<Size4KiB>,
     aspace: &mut super::addrspace::AddressSpace,
-) -> Result<u64, LoadError> {
+) -> Result<(u64, u64, u64), LoadError> {
     use super::vmatree::{Share, Vma};
     use super::vmobject::{AnonObject, VmObject};
 
@@ -563,7 +579,91 @@ fn allocate_tls_block(
     // Advance image_end past the TLS region so the heap starts after it.
     *image_end = region_end;
 
-    Ok(tcb_va)
+    Ok((tcb_va, region_start, page_count))
+}
+
+// --- deep_copy_tls_block: fork TLS deep-copy (#834) -------------------------
+
+/// Deep-copy the parent's TLS block pages into the child's address space
+/// after a CoW fork. The fork path gave the child read-only references to
+/// the parent's TLS frames via CoW. This function replaces every CoW
+/// page in the child's TLS region with a fresh private copy of the
+/// parent's page content, then fixes up the TCB self-pointer in the
+/// child's copy so `%fs:0` still yields the correct TCB address.
+///
+/// The eager deep-copy avoids the CoW page fault that would otherwise
+/// fire on the child's first write to any TLS variable (e.g. `errno`).
+///
+/// `parent_pml4` — the parent's PML4 frame (for reading TLS page content).
+/// `_child_aspace` — the child's address space (reserved for future VMA
+///     cache updates; currently unused because `cow_copy_and_remap` handles
+///     PTE + refcount bookkeeping).
+/// `child_pml4` — the child's PML4 frame (for replacing CoW mappings).
+/// `fs_base` — TCB virtual address (same VA in parent and child).
+/// `tls_region_start` — page-aligned start VA of the TLS block.
+/// `tls_region_pages` — number of 4 KiB pages in the TLS block.
+#[cfg(target_os = "none")]
+pub fn deep_copy_tls_block(
+    parent_pml4: x86_64::structures::paging::PhysFrame<Size4KiB>,
+    _child_aspace: &mut super::addrspace::AddressSpace,
+    child_pml4: x86_64::structures::paging::PhysFrame<Size4KiB>,
+    fs_base: u64,
+    tls_region_start: u64,
+    tls_region_pages: u64,
+) -> Result<(), LoadError> {
+    use x86_64::structures::paging::{Page, PageTableFlags};
+
+    let hhdm = paging::hhdm_offset();
+
+    // Writable + user-accessible + NX — the TLS block is always RW data.
+    let tls_flags = PageTableFlags::PRESENT
+        | PageTableFlags::WRITABLE
+        | PageTableFlags::USER_ACCESSIBLE
+        | PageTableFlags::NO_EXECUTE;
+
+    for i in 0..tls_region_pages {
+        let va = tls_region_start + i * PAGE_SIZE;
+        let page = Page::<Size4KiB>::containing_address(VirtAddr::new(va));
+
+        // Look up the parent's physical frame for this page. If the page
+        // hasn't been faulted in yet (demand-paged), skip — the child
+        // will demand-fault it independently from the VMA.
+        if paging::translate_in_pml4(parent_pml4, VirtAddr::new(va)).is_none() {
+            continue;
+        }
+
+        // The child's PTE for this page is currently a read-only CoW
+        // alias of the parent's frame. Replace it with a fresh frame
+        // containing a copy of the parent's content via
+        // cow_copy_and_remap, which:
+        //   1. Unmaps the child's CoW PTE
+        //   2. Allocates a fresh frame
+        //   3. Copies page content (parent's data) via HHDM
+        //   4. Re-maps the fresh frame with full write permission
+        //   5. Decrements the refcount on the old shared frame
+        let new_frame =
+            paging::cow_copy_and_remap(child_pml4, page, tls_flags).map_err(LoadError::MapFailed)?;
+
+        // Fix up the TCB self-pointer if the TCB falls within this page.
+        // The TCB VA is `fs_base`; its self-pointer at offset 0 must
+        // equal `fs_base`. The cow_copy_and_remap already copied the
+        // parent's content, so the self-pointer is correct (same VA in
+        // parent and child). This write is technically a no-op for fork
+        // (the VA doesn't change), but we do it defensively to ensure
+        // the invariant holds.
+        if fs_base >= va && fs_base < va + PAGE_SIZE {
+            let tcb_offset_in_page = fs_base - va;
+            let dst = hhdm + new_frame.start_address().as_u64() + tcb_offset_in_page;
+            // SAFETY: the frame was just allocated for our exclusive use.
+            // The 8-byte write fits within the page (TCB is 8 bytes and
+            // sits within the region).
+            unsafe {
+                core::ptr::write_unaligned(dst.as_mut_ptr::<u64>(), fs_base);
+            }
+        }
+    }
+
+    Ok(())
 }
 
 // --- register_demand_vmas: file-backed + zero-tail VMA registration -------

--- a/kernel/src/task/sched_core.rs
+++ b/kernel/src/task/sched_core.rs
@@ -213,6 +213,8 @@ pub fn fork_current_task(
         parent_priority,
         parent_affinity,
         parent_fs_base,
+        parent_tls_region_start,
+        parent_tls_region_pages,
         parent_fpu_ptr,
     ) = {
         let mut sched = SCHED.lock();
@@ -244,6 +246,7 @@ pub fn fork_current_task(
         // makes that race benign: the child gets whichever Credential
         // was current at the instant of `read()`.
         let parent_credentials = Arc::clone(&*cur.credentials.read());
+        let (tls_start, tls_pages) = cur.tls_region();
         (
             Arc::clone(&cur.address_space),
             Arc::clone(&cur.fd_table),
@@ -252,6 +255,8 @@ pub fn fork_current_task(
             cur.priority,
             cur.affinity,
             cur.fs_base,
+            tls_start,
+            tls_pages,
             // SAFETY: the parent Task is the currently-running task and stays
             // alive in SCHED for the duration of this syscall. We only read
             // the FPU area during the new_forked call below.
@@ -262,7 +267,7 @@ pub fn fork_current_task(
 
     // CoW-clone the address space (requires AddressSpace write lock).
     crate::fork_trace!("fork-trace: [fork_current_task] → fork_address_space()");
-    let child_aspace = {
+    let mut child_aspace = {
         let mut tlb = crate::mem::tlb::Flusher::new_active();
         let child = parent_address_space.write().fork_address_space(&mut tlb)?;
         tlb.finish();
@@ -273,6 +278,31 @@ pub fn fork_current_task(
         "fork-trace: [fork_current_task] ← fork_address_space() child_cr3={:#x}",
         child_cr3.start_address().as_u64()
     );
+
+    // Deep-copy the parent's TLS block into the child's address space
+    // (#834). The CoW fork above gave the child read-only references to
+    // the parent's TLS frames; this replaces them with fresh private
+    // copies so the child can write to TLS variables (e.g. errno)
+    // without triggering a CoW page fault on the first access.
+    if parent_tls_region_start != 0 && parent_tls_region_pages != 0 {
+        let parent_cr3 = parent_address_space.read().page_table_frame();
+        crate::fork_trace!(
+            "fork-trace: [fork_current_task] → deep_copy_tls_block(start={:#x}, pages={})",
+            parent_tls_region_start,
+            parent_tls_region_pages
+        );
+        crate::mem::loader::deep_copy_tls_block(
+            parent_cr3,
+            &mut child_aspace,
+            child_cr3,
+            parent_fs_base,
+            parent_tls_region_start,
+            parent_tls_region_pages,
+        )
+        .map_err(|_| crate::mem::addrspace::ForkError::OutOfMemory)?;
+        crate::fork_trace!("fork-trace: [fork_current_task] ← deep_copy_tls_block()");
+    }
+
     let child_aspace = Arc::new(RwLock::new(child_aspace));
 
     // Clone the fd table (slot-independent, description-shared).
@@ -290,6 +320,8 @@ pub fn fork_current_task(
             parent_priority,
             parent_affinity,
             parent_fs_base,
+            parent_tls_region_start,
+            parent_tls_region_pages,
             parent_fpu_ptr,
             child_aspace,
             child_cr3,
@@ -657,6 +689,22 @@ pub fn set_current_fs_base(val: u64) {
         .as_mut()
         .expect("set_current_fs_base: no running task")
         .set_fs_base(val);
+}
+
+/// Record the static TLS block boundaries on the currently-running task.
+/// Called by `exec_atomic` and `init_ring3_entry` after the loader
+/// allocates a TLS block, so the fork path can deep-copy the TLS pages
+/// into the child (#834).
+///
+/// # Panics
+/// Panics if called before [`init`] (no running task).
+pub fn set_current_tls_region(start: u64, pages: u64) {
+    SCHED
+        .lock()
+        .current
+        .as_mut()
+        .expect("set_current_tls_region: no running task")
+        .set_tls_region(start, pages);
 }
 
 fn find_priority(sched: &Scheduler, id: usize) -> Option<u8> {

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -247,6 +247,17 @@ pub(super) struct Task {
     /// `fork` copies this from the parent so the child inherits the
     /// parent's TLS pointer.
     pub fs_base: u64,
+
+    /// Page-aligned start VA of the static TLS block allocated by the
+    /// loader (or zero if no TLS block was allocated). Used by the fork
+    /// path to deep-copy the parent's TLS pages into the child's address
+    /// space so the child gets an immediately-private copy without
+    /// waiting for CoW faults (#834).
+    pub tls_region_start: u64,
+    /// Number of 4 KiB pages in the static TLS block (zero when no TLS
+    /// block exists). Together with `tls_region_start` this defines the
+    /// exact VA range the fork path must deep-copy.
+    pub tls_region_pages: u64,
 }
 
 impl Task {
@@ -280,6 +291,8 @@ impl Task {
             credentials: BlockingRwLock::new(Arc::new(Credential::kernel())),
             syscall_stack_top: 0,
             fs_base: 0,
+            tls_region_start: 0,
+            tls_region_pages: 0,
         }
     }
 
@@ -373,6 +386,8 @@ impl Task {
             credentials: BlockingRwLock::new(Arc::new(Credential::kernel())),
             syscall_stack_top: 0, // kernel-only task — no ring-3 syscall stack needed yet
             fs_base: 0,
+            tls_region_start: 0,
+            tls_region_pages: 0,
         }
     }
 
@@ -407,6 +422,20 @@ impl Task {
         self.fs_base = val;
     }
 
+    /// Returns the static TLS block region start VA and page count.
+    /// `(0, 0)` means no TLS block was allocated.
+    pub fn tls_region(&self) -> (u64, u64) {
+        (self.tls_region_start, self.tls_region_pages)
+    }
+
+    /// Records the static TLS block region boundaries. Called after
+    /// `allocate_tls_block` succeeds so fork can deep-copy the TLS
+    /// pages into the child's address space (#834).
+    pub fn set_tls_region(&mut self, start: u64, pages: u64) {
+        self.tls_region_start = start;
+        self.tls_region_pages = pages;
+    }
+
     /// Returns `true` if `addr` falls within this task's guard page.
     ///
     /// Always returns `false` for the bootstrap task (`guard_base == 0`).
@@ -435,6 +464,8 @@ impl Task {
         parent_priority: u8,
         parent_affinity: u64,
         parent_fs_base: u64,
+        parent_tls_region_start: u64,
+        parent_tls_region_pages: u64,
         parent_fpu: *const crate::arch::x86_64::fpu::FpuArea,
         child_address_space: alloc::sync::Arc<spin::RwLock<AddressSpace>>,
         child_cr3: PhysFrame<Size4KiB>,
@@ -549,6 +580,8 @@ impl Task {
             // shared INIT_KERNEL_STACK. Use the top of this task's kernel stack.
             syscall_stack_top: (stack_base + STACK_SIZE) as u64,
             fs_base: parent_fs_base,
+            tls_region_start: parent_tls_region_start,
+            tls_region_pages: parent_tls_region_pages,
         })
     }
 }
@@ -622,5 +655,27 @@ mod fs_base_tests {
             val,
             "fs_base getter must return the value that was set"
         );
+    }
+
+    /// The bootstrap task must start with zero TLS region — no static
+    /// TLS block exists until the ELF loader allocates one.
+    #[test]
+    fn bootstrap_tls_region_is_zero() {
+        let t = Task::bootstrap();
+        let (start, pages) = t.tls_region();
+        assert_eq!(start, 0, "bootstrap task must have tls_region_start=0");
+        assert_eq!(pages, 0, "bootstrap task must have tls_region_pages=0");
+    }
+
+    /// TLS region setter/getter round-trip.
+    #[test]
+    fn tls_region_setter_getter_round_trip() {
+        let mut t = Task::bootstrap();
+        let start = 0x0000_4030_0000u64;
+        let pages = 3u64;
+        t.set_tls_region(start, pages);
+        let (got_start, got_pages) = t.tls_region();
+        assert_eq!(got_start, start, "tls_region_start must round-trip");
+        assert_eq!(got_pages, pages, "tls_region_pages must round-trip");
     }
 }


### PR DESCRIPTION
## Summary

- **Fork path**: after CoW-cloning the address space, eagerly deep-copy the parent's static TLS pages into the child via `cow_copy_and_remap`, giving the child immediately-private TLS frames without waiting for CoW faults on first write (e.g. `errno`). The TCB self-pointer is defensively rewritten in the child's copy.
- **Exec path**: record `tls_region_start`/`tls_region_pages` on the task after the loader allocates the TLS block, so subsequent forks know the TLS region boundaries. The `fs_base`/`MSR_FS_BASE` handling was already correct from PR #841.
- **New Task fields**: `tls_region_start` and `tls_region_pages` track the static TLS block boundaries. Set by `exec_atomic` and `init_ring3_entry`; inherited by fork children; reset to 0 for kernel-only tasks and ELFs without `PT_TLS`.

Closes #834

### Files changed

| File | Change |
|------|--------|
| `kernel/src/task/task.rs` | Add `tls_region_start`/`tls_region_pages` fields, getters/setters, propagation through `new_forked`, unit tests |
| `kernel/src/task/sched_core.rs` | Snapshot TLS region from parent, call `deep_copy_tls_block` after fork, add `set_current_tls_region` public API |
| `kernel/src/mem/loader.rs` | `allocate_tls_block` returns region info; new `deep_copy_tls_block` function; `LoadedImage` gains TLS region fields |
| `kernel/src/arch/x86_64/syscall.rs` | `exec_atomic` records TLS region on task after exec |
| `kernel/src/init_process.rs` | `launch`/`init_ring3_entry` record TLS region on the init task |

## Test plan

- [x] `cargo xtask build` — kernel compiles cleanly (1 pre-existing warning)
- [x] `cargo test --lib -p vibix` — all 714 host unit tests pass
- [x] `cargo test -p simulator --test fast_suite` — simulator fast suite passes
- [ ] CI workflow (kernel build + host tests + simulator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)