### PR TITLE
Implement path-aware execve() syscall

### DIFF
--- a/base/init/src/main.rs
+++ b/base/init/src/main.rs
@@ -37,7 +37,7 @@
 //! |--------|---------|--------------|--------------|---------|---------|
 //! |      1 | write   | fd           | buf ptr      | len     | —       |
 //! |     57 | fork    | —            | —            | —       | —       |
-//! |     59 | execve  | path (0=ok)  | argv (0=ok)  | envp    | —       |
+//! |     59 | execve  | path         | argv (0=ok)  | envp    | —       |
 //! |     60 | exit    | status       | —            | —       | —       |
 //! |     61 | wait4   | pid          | *wstatus     | options | *rusage |
 //!
@@ -53,9 +53,10 @@
 //! rax=0; the parent gets the child PID.
 //!
 //! ### execve() invariants
-//! The kernel ignores path/argv/envp (rdi/rsi/rdx) for now: it loads the
-//! second Limine ramdisk module unconditionally.  If no second module is
-//! present, execve returns -ENOEXEC.  On success, the call never returns.
+//! The kernel resolves `path` via VFS (with a Limine-module basename
+//! fallback for boot-time binaries), copies `argv` and `envp` from
+//! userspace, and atomically replaces the calling process's image.
+//! On success the call never returns; on failure it returns a negative errno.
 //!
 //! ### wait4() invariants
 //! Blocks on a WaitQueue until a zombie child is reaped.  wstatus is a
@@ -99,6 +100,10 @@ const POST_WRITE_MSG: &[u8] = b"init: post-write marker\n";
 /// from the wait4 condvar park.
 const WAIT4_RETURN_MSG: &[u8] = b"init: wait4-return\n";
 
+/// Path to the hello binary. The kernel resolves this via VFS first,
+/// then falls back to Limine boot modules (basename match).
+const HELLO_PATH: &[u8] = b"/boot/userspace_hello.elf\0";
+
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
     // Pre-write diagnostic marker — see #478. Emitted on fd=2 so it
@@ -131,15 +136,16 @@ pub extern "C" fn _start() -> ! {
     }
 
     if fork_ret == 0 {
-        // Child: exec the hello binary (execve ignores path/argv/envp,
-        // loads userspace_hello.elf from the ramdisk module).
+        // Child: exec the hello binary. The kernel resolves the path via
+        // VFS (or Limine-module basename fallback), copies argv/envp from
+        // userspace, and atomically replaces this process's image.
         unsafe {
             core::arch::asm!(
                 "syscall",
                 inlateout("rax") 59u64 => _,   // execve
-                inlateout("rdi") 0u64 => _,    // path (ignored)
-                inlateout("rsi") 0u64 => _,    // argv (ignored)
-                inlateout("rdx") 0u64 => _,    // envp (ignored)
+                inlateout("rdi") HELLO_PATH.as_ptr() as u64 => _,  // path
+                inlateout("rsi") 0u64 => _,    // argv (NULL = empty)
+                inlateout("rdx") 0u64 => _,    // envp (NULL = empty)
                 lateout("rcx") _,
                 lateout("r8") _,
                 lateout("r9") _,

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -581,3 +581,7 @@ harness = false
 [[test]]
 name = "tls_context_switch"
 harness = false
+
+[[test]]
+name = "execve_path_resolve"
+harness = false

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -1512,12 +1512,14 @@ unsafe fn sys_execve(
     argv_uva: u64,
     envp_uva: u64,
 ) -> Result<core::convert::Infallible, i64> {
-    use alloc::vec::Vec;
     use crate::fs::vfs::path_walk::PATH_MAX;
+    use alloc::vec::Vec;
 
     // 1. Copy path from userspace.
     let mut path_buf: Vec<u8> = Vec::new();
-    path_buf.try_reserve_exact(PATH_MAX + 1).map_err(|_| crate::fs::ENOMEM)?;
+    path_buf
+        .try_reserve_exact(PATH_MAX + 1)
+        .map_err(|_| crate::fs::ENOMEM)?;
     path_buf.resize(PATH_MAX + 1, 0u8);
     let n = copy_path_from_user(path_uva as usize, &mut path_buf)?;
     path_buf.truncate(n);
@@ -1533,16 +1535,10 @@ unsafe fn sys_execve(
 
     // 4. Copy argv and envp from userspace.
     let mut arg_budget = EXECVE_MAX_ARG_BYTES;
-    let argv_vecs = copy_string_array_from_user(
-        argv_uva as usize,
-        EXECVE_MAX_ARGS,
-        &mut arg_budget,
-    )?;
-    let envp_vecs = copy_string_array_from_user(
-        envp_uva as usize,
-        EXECVE_MAX_ARGS,
-        &mut arg_budget,
-    )?;
+    let argv_vecs =
+        copy_string_array_from_user(argv_uva as usize, EXECVE_MAX_ARGS, &mut arg_budget)?;
+    let envp_vecs =
+        copy_string_array_from_user(envp_uva as usize, EXECVE_MAX_ARGS, &mut arg_budget)?;
 
     // Build &[&[u8]] slices for the stack writer. Each inner slice
     // includes the trailing NUL byte (required by the SysV ABI — argv

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -762,17 +762,12 @@ pub unsafe extern "C" fn syscall_dispatch(
             child_pid as i64
         }
 
-        // execve(path, argv, envp) — path and argv/envp are ignored; the
-        // kernel loads the `userspace_hello.elf` ramdisk module into a
-        // freshly-staged address space and atomically swaps it in on
-        // success. On failure the old address space is preserved so the
-        // caller continues running and observes the `-ENOEXEC` return.
+        // execve(path, argv, envp) — resolve the named binary from the
+        // VFS (or fall back to a Limine boot module), copy argv/envp from
+        // userspace, and atomically replace the calling process's image.
         EXECVE => {
-            let elf_bytes = match crate::mem::userspace_hello_elf_bytes() {
-                Some(b) => b,
-                None => return -8, // ENOEXEC — hello module not present
-            };
-            match exec_atomic(elf_bytes) {
+            // SAFETY: `a0` is a user pointer to a NUL-terminated path.
+            match unsafe { sys_execve(a0, a1, a2) } {
                 Ok(never) => match never {},
                 Err(e) => e,
             }
@@ -1298,6 +1293,21 @@ pub unsafe extern "C" fn syscall_dispatch(
 /// bounded by ELF size; tracked separately as a follow-up.)
 #[cfg(target_os = "none")]
 pub fn exec_atomic(elf_bytes: &'static [u8]) -> Result<core::convert::Infallible, i64> {
+    exec_atomic_with_args(elf_bytes, &[], &[])
+}
+
+/// Atomic execve body with argv/envp: stage the new image into a fresh
+/// `AddressSpace` and only commit it once the load has fully succeeded.
+///
+/// `argv` and `envp` are slices of NUL-terminated byte strings that will
+/// be placed on the new process's stack in the standard System V AMD64
+/// layout.
+#[cfg(target_os = "none")]
+pub fn exec_atomic_with_args(
+    elf_bytes: &'static [u8],
+    argv: &[&[u8]],
+    envp: &[&[u8]],
+) -> Result<core::convert::Infallible, i64> {
     use crate::mem::addrspace::AddressSpace;
     use crate::mem::vmatree::{Share, Vma};
     use crate::mem::vmobject::{AnonObject, VmObject};
@@ -1385,11 +1395,13 @@ pub fn exec_atomic(elf_bytes: &'static [u8]) -> Result<core::convert::Infallible
         phdr_count: image.phdr_count as u64,
         phdr_entsize: image.phdr_entsize as u64,
     };
-    let initial_rsp = crate::mem::auxv::write_initial_stack(
+    let initial_rsp = crate::mem::auxv::write_initial_stack_with_args(
         stack_phys,
         crate::init_process::USER_STACK_PAGE_VA,
         &auxv_params,
         &random_bytes,
+        argv,
+        envp,
     );
 
     // Install the FS base for the static TLS block allocated by the loader.
@@ -1411,6 +1423,176 @@ pub fn exec_atomic(elf_bytes: &'static [u8]) -> Result<core::convert::Infallible
     let effective_entry = image.interp_entry.unwrap_or(image.entry);
     // Never returns.
     unsafe { jump_to_ring3(effective_entry.as_u64(), initial_rsp) }
+}
+
+// -----------------------------------------------------------------------
+// sys_execve: path-aware execve(2) implementation
+// -----------------------------------------------------------------------
+
+/// Maximum number of argv/envp entries copied from userspace. This is a
+/// practical limit for early vibix; a future implementation can raise it
+/// once multi-page stacks are supported.
+const EXECVE_MAX_ARGS: usize = 64;
+
+/// Maximum total byte size of all argv + envp string data. Capped to
+/// fit within a single 4 KiB stack page alongside auxv/pointers.
+const EXECVE_MAX_ARG_BYTES: usize = 2048;
+
+/// Copy a NULL-terminated pointer array from userspace, reading each
+/// pointed-to NUL-terminated string. Returns a `Vec` of `Vec<u8>` where
+/// each inner Vec includes the trailing NUL byte. `max_count` caps the
+/// number of entries; `remaining_bytes` is decremented for each string's
+/// length and an error is returned if the total exceeds the budget.
+#[cfg(target_os = "none")]
+unsafe fn copy_string_array_from_user(
+    array_uva: usize,
+    max_count: usize,
+    remaining_bytes: &mut usize,
+) -> Result<alloc::vec::Vec<alloc::vec::Vec<u8>>, i64> {
+    use alloc::vec::Vec;
+
+    if array_uva == 0 {
+        return Ok(Vec::new());
+    }
+
+    let mut result = Vec::new();
+    for i in 0..max_count {
+        // Read the i-th pointer from the array.
+        let mut ptr_val = 0u64;
+        let ptr_bytes = core::slice::from_raw_parts_mut(
+            &mut ptr_val as *mut u64 as *mut u8,
+            core::mem::size_of::<u64>(),
+        );
+        if let Err(e) = uaccess::copy_from_user(ptr_bytes, array_uva + i * 8) {
+            return Err(e.as_errno());
+        }
+        if ptr_val == 0 {
+            break; // NULL terminator
+        }
+
+        // Copy the NUL-terminated string from the pointer.
+        let mut s = Vec::new();
+        let str_uva = ptr_val as usize;
+        for j in 0..(*remaining_bytes + 1) {
+            let mut byte = 0u8;
+            if let Err(e) = uaccess::copy_from_user(core::slice::from_mut(&mut byte), str_uva + j) {
+                return Err(e.as_errno());
+            }
+            s.push(byte);
+            if byte == 0 {
+                break;
+            }
+            if j >= *remaining_bytes {
+                return Err(crate::fs::EINVAL); // E2BIG equivalent
+            }
+        }
+        let len = s.len();
+        if len > *remaining_bytes {
+            return Err(crate::fs::EINVAL);
+        }
+        *remaining_bytes -= len;
+        result.push(s);
+    }
+    Ok(result)
+}
+
+/// Path-aware `execve(path, argv, envp)` implementation.
+///
+/// 1. Copies the path string from userspace.
+/// 2. Resolves the binary via VFS (with Limine module fallback).
+/// 3. Copies argv/envp string arrays from userspace.
+/// 4. Delegates to `exec_atomic_with_args` which atomically replaces
+///    the calling process's address space.
+///
+/// Returns `Err(errno)` on failure; on success, never returns (the new
+/// image takes over).
+#[cfg(target_os = "none")]
+unsafe fn sys_execve(
+    path_uva: u64,
+    argv_uva: u64,
+    envp_uva: u64,
+) -> Result<core::convert::Infallible, i64> {
+    use alloc::vec::Vec;
+    use crate::fs::vfs::path_walk::PATH_MAX;
+
+    // 1. Copy path from userspace.
+    let mut path_buf: Vec<u8> = Vec::new();
+    path_buf.try_reserve_exact(PATH_MAX + 1).map_err(|_| crate::fs::ENOMEM)?;
+    path_buf.resize(PATH_MAX + 1, 0u8);
+    let n = copy_path_from_user(path_uva as usize, &mut path_buf)?;
+    path_buf.truncate(n);
+
+    // 2. Resolve the binary. Try the VFS first; fall back to Limine
+    //    modules for boot-time binaries before the FS is fully mounted.
+    let elf_bytes: &'static [u8] = resolve_execve_binary(&path_buf)?;
+
+    // 3. Validate it looks like an ELF before copying args (fast reject).
+    if elf_bytes.len() < 4 || &elf_bytes[..4] != b"\x7fELF" {
+        return Err(crate::fs::ENOEXEC);
+    }
+
+    // 4. Copy argv and envp from userspace.
+    let mut arg_budget = EXECVE_MAX_ARG_BYTES;
+    let argv_vecs = copy_string_array_from_user(
+        argv_uva as usize,
+        EXECVE_MAX_ARGS,
+        &mut arg_budget,
+    )?;
+    let envp_vecs = copy_string_array_from_user(
+        envp_uva as usize,
+        EXECVE_MAX_ARGS,
+        &mut arg_budget,
+    )?;
+
+    // Build &[&[u8]] slices for the stack writer. Each inner slice
+    // includes the trailing NUL byte (required by the SysV ABI — argv
+    // strings must be NUL-terminated in the new stack).
+    let argv_refs: Vec<&[u8]> = argv_vecs.iter().map(|v| v.as_slice()).collect();
+    let envp_refs: Vec<&[u8]> = envp_vecs.iter().map(|v| v.as_slice()).collect();
+
+    exec_atomic_with_args(elf_bytes, &argv_refs, &envp_refs)
+}
+
+/// Resolve the execve binary path to a `&'static [u8]` ELF slice.
+///
+/// Resolution order:
+/// 1. VFS path walk (normal path once the filesystem is mounted).
+/// 2. Limine boot modules (basename suffix match) — works during early
+///    bootstrap before the VFS root is available.
+///
+/// The returned slice has `'static` lifetime because:
+/// - VFS path: the `Vec<u8>` from `read_all` is leaked (bounded by
+///   file size; same pattern as `read_interp_from_fs`).
+/// - Limine module: already `'static` (lives in boot memory).
+#[cfg(target_os = "none")]
+pub fn resolve_execve_binary(path: &[u8]) -> Result<&'static [u8], i64> {
+    // Try VFS first.
+    if crate::fs::vfs::root().is_some() {
+        match crate::shell::vfs_helpers::read_all(path) {
+            Ok(bytes) if !bytes.is_empty() => {
+                // Leak the Vec to get &'static [u8]. The leaked memory
+                // is bounded by the file size and lives as long as the
+                // process (the demand-paged loader reads from it on
+                // page faults).
+                return Ok(&*bytes.leak());
+            }
+            Ok(_) => {} // empty file — fall through to module lookup
+            Err(e) if e == crate::fs::ENOENT => {} // not found in VFS — try modules
+            Err(e) => return Err(e), // other VFS error — propagate
+        }
+    }
+
+    // Fall back to Limine boot modules (basename match).
+    let basename = path
+        .iter()
+        .rposition(|&b| b == b'/')
+        .map(|slash| &path[slash + 1..])
+        .unwrap_or(path);
+    if let Some(module_bytes) = crate::mem::elf::module_bytes_for_path(basename) {
+        return Ok(module_bytes);
+    }
+
+    Err(crate::fs::ENOENT)
 }
 
 /// Public wrapper around `copy_path_from_user` for use by the VFS

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -224,6 +224,7 @@ pub const ENOENT: i64 = -2;
 pub const EINTR: i64 = -4;
 pub const EIO: i64 = -5;
 pub const ENXIO: i64 = -6;
+pub const ENOEXEC: i64 = -8;
 pub const EBADF: i64 = -9;
 pub const EAGAIN: i64 = -11;
 pub const ENOMEM: i64 = -12;

--- a/kernel/src/mem/auxv.rs
+++ b/kernel/src/mem/auxv.rs
@@ -77,7 +77,14 @@ pub fn write_initial_stack(
     params: &AuxvParams,
     random_bytes: &[u8; 16],
 ) -> u64 {
-    write_initial_stack_with_args(stack_phys, stack_page_user_va, params, random_bytes, &[], &[])
+    write_initial_stack_with_args(
+        stack_phys,
+        stack_page_user_va,
+        params,
+        random_bytes,
+        &[],
+        &[],
+    )
 }
 
 /// Write the System V AMD64 initial stack layout with argv and envp.

--- a/kernel/src/mem/auxv.rs
+++ b/kernel/src/mem/auxv.rs
@@ -77,6 +77,38 @@ pub fn write_initial_stack(
     params: &AuxvParams,
     random_bytes: &[u8; 16],
 ) -> u64 {
+    write_initial_stack_with_args(stack_phys, stack_page_user_va, params, random_bytes, &[], &[])
+}
+
+/// Write the System V AMD64 initial stack layout with argv and envp.
+///
+/// `argv` and `envp` are slices of NUL-terminated byte strings. Their
+/// contents are placed at the top of the stack page (below the AT_RANDOM
+/// seed), and pointer arrays are built pointing into those copies.
+///
+/// Layout (high to low):
+/// ```text
+/// [16-byte AT_RANDOM seed]
+/// [envp string data, NUL-terminated each]
+/// [argv string data, NUL-terminated each]
+/// [padding to 8-byte alignment]
+/// auxv pairs (AT_NULL ... AT_PHDR)
+/// envp[n] = NULL
+/// envp[n-1] ... envp[0]
+/// argv[argc] = NULL
+/// argv[argc-1] ... argv[0]
+/// argc
+/// <- initial RSP
+/// ```
+#[cfg(target_os = "none")]
+pub fn write_initial_stack_with_args(
+    stack_phys: u64,
+    stack_page_user_va: u64,
+    params: &AuxvParams,
+    random_bytes: &[u8; 16],
+    argv: &[&[u8]],
+    envp: &[&[u8]],
+) -> u64 {
     use super::paging;
 
     // Map the physical frame into kernel VA space via HHDM.
@@ -84,7 +116,8 @@ pub fn write_initial_stack(
     let frame_base: *mut u8 = (hhdm.as_u64() + stack_phys) as *mut u8;
 
     // We build the layout top-down within the 4096-byte page.
-    // `offset` counts bytes from the *top* of the frame.
+    // `offset` counts bytes from the *start* of the frame (i.e. `offset`
+    // is in [0, STACK_PAGE_SIZE]; we write downward from STACK_PAGE_SIZE).
     let mut offset: usize = STACK_PAGE_SIZE as usize;
 
     // Helper: write a u64 word top-down.
@@ -98,7 +131,6 @@ pub fn write_initial_stack(
     };
 
     // 1. Place the 16 AT_RANDOM bytes at the very top of the frame.
-    //    Their user-space VA is the top of the page minus 16.
     let random_va = stack_page_user_va + STACK_PAGE_SIZE - 16;
     // SAFETY: frame_base + (PAGE_SIZE - 16) is within the same 4KiB frame.
     unsafe {
@@ -110,12 +142,41 @@ pub fn write_initial_stack(
     }
     offset -= 16;
 
-    // 2. Build auxv pairs (tag, value) top-down.
-    //    Written high→low: AT_NULL first (highest), then AT_PAGESZ, ..., AT_PHDR last.
-    //    The loader reads low→high: AT_PHDR, AT_PHENT, ..., AT_PAGESZ, AT_NULL.
-    //    Both orderings are valid per the ABI (auxv is an unordered array
-    //    terminated by AT_NULL).
+    // 2. Place argv and envp string data at the top (below AT_RANDOM).
+    //    Each string is NUL-terminated in the caller's data; we copy
+    //    including the NUL. Record user-VA of each string start.
+    //
+    //    We use a fixed-size array to avoid heap allocation. The limit
+    //    of 64 args + 64 env vars is generous for early vibix userspace.
+    const MAX_STRINGS: usize = 64;
+    let mut argv_vas = [0u64; MAX_STRINGS];
+    let mut envp_vas = [0u64; MAX_STRINGS];
 
+    // Copy envp strings first (higher addresses), then argv.
+    for (i, env) in envp.iter().enumerate().take(MAX_STRINGS) {
+        let len = env.len();
+        offset -= len;
+        // SAFETY: `offset` is within the frame and `len` fits.
+        unsafe {
+            core::ptr::copy_nonoverlapping(env.as_ptr(), frame_base.add(offset), len);
+        }
+        envp_vas[i] = stack_page_user_va + offset as u64;
+    }
+
+    for (i, arg) in argv.iter().enumerate().take(MAX_STRINGS) {
+        let len = arg.len();
+        offset -= len;
+        // SAFETY: same as above.
+        unsafe {
+            core::ptr::copy_nonoverlapping(arg.as_ptr(), frame_base.add(offset), len);
+        }
+        argv_vas[i] = stack_page_user_va + offset as u64;
+    }
+
+    // Align offset down to 8 bytes for the pointer/auxv array.
+    offset &= !7;
+
+    // 3. Build auxv pairs (tag, value) top-down.
     push_u64(0, &mut offset); // AT_NULL value
     push_u64(AT_NULL, &mut offset);
 
@@ -140,18 +201,25 @@ pub fn write_initial_stack(
     push_u64(params.phdr_vaddr, &mut offset);
     push_u64(AT_PHDR, &mut offset);
 
-    // 3. envp terminator (NULL pointer)
+    // 4. envp pointer array (NULL-terminated).
     push_u64(0, &mut offset);
+    let envp_count = envp.len().min(MAX_STRINGS);
+    for i in (0..envp_count).rev() {
+        push_u64(envp_vas[i], &mut offset);
+    }
 
-    // 4. argv terminator (NULL pointer)
+    // 5. argv pointer array (NULL-terminated).
     push_u64(0, &mut offset);
+    let argc = argv.len().min(MAX_STRINGS);
+    for i in (0..argc).rev() {
+        push_u64(argv_vas[i], &mut offset);
+    }
 
-    // 5. argc = 0
-    push_u64(0, &mut offset);
+    // 6. argc
+    push_u64(argc as u64, &mut offset);
 
     // Sanity: ensure we haven't overflowed into the random-seed region at the
-    // top of the frame. The random bytes occupy the top 16 bytes, and all
-    // auxv/envp/argv/argc words were written below them.
+    // top of the frame.
     assert!(
         offset + 16 <= STACK_PAGE_SIZE as usize,
         "auxv: initial stack layout exceeds page boundary"
@@ -254,5 +322,213 @@ mod tests {
         }
         assert!(found_pagesz, "AT_PAGESZ not found in auxv");
         assert!(found_null, "AT_NULL terminator not found in auxv");
+    }
+
+    /// Build the SysV AMD64 initial stack layout with argv/envp into a
+    /// caller-supplied buffer. Mirrors `write_initial_stack_with_args`
+    /// but without HHDM / kernel-paging dependency.
+    fn build_layout_with_args_into_buf(
+        buf: &mut [u8; 4096],
+        stack_page_user_va: u64,
+        params: &AuxvParams,
+        random_bytes: &[u8; 16],
+        argv: &[&[u8]],
+        envp: &[&[u8]],
+    ) -> usize {
+        let mut offset: usize = 4096;
+
+        let push = |val: u64, buf: &mut [u8; 4096], offset: &mut usize| {
+            *offset -= 8;
+            buf[*offset..*offset + 8].copy_from_slice(&val.to_le_bytes());
+        };
+
+        // Random bytes at the top.
+        let random_va = stack_page_user_va + STACK_PAGE_SIZE - 16;
+        buf[4096 - 16..4096].copy_from_slice(random_bytes);
+        offset -= 16;
+
+        // String data (envp first, then argv — higher to lower).
+        const MAX_STRINGS: usize = 64;
+        let mut argv_vas = [0u64; MAX_STRINGS];
+        let mut envp_vas = [0u64; MAX_STRINGS];
+
+        for (i, env) in envp.iter().enumerate().take(MAX_STRINGS) {
+            offset -= env.len();
+            buf[offset..offset + env.len()].copy_from_slice(env);
+            envp_vas[i] = stack_page_user_va + offset as u64;
+        }
+        for (i, arg) in argv.iter().enumerate().take(MAX_STRINGS) {
+            offset -= arg.len();
+            buf[offset..offset + arg.len()].copy_from_slice(arg);
+            argv_vas[i] = stack_page_user_va + offset as u64;
+        }
+
+        // Align to 8.
+        offset &= !7;
+
+        // Auxv.
+        push(0, buf, &mut offset);
+        push(AT_NULL, buf, &mut offset);
+        push(STACK_PAGE_SIZE, buf, &mut offset);
+        push(AT_PAGESZ, buf, &mut offset);
+        push(random_va, buf, &mut offset);
+        push(AT_RANDOM, buf, &mut offset);
+        push(params.entry, buf, &mut offset);
+        push(AT_ENTRY, buf, &mut offset);
+        push(params.interp_base, buf, &mut offset);
+        push(AT_BASE, buf, &mut offset);
+        push(params.phdr_count, buf, &mut offset);
+        push(AT_PHNUM, buf, &mut offset);
+        push(params.phdr_entsize, buf, &mut offset);
+        push(AT_PHENT, buf, &mut offset);
+        push(params.phdr_vaddr, buf, &mut offset);
+        push(AT_PHDR, buf, &mut offset);
+
+        // envp pointers.
+        push(0, buf, &mut offset);
+        let envp_count = envp.len().min(MAX_STRINGS);
+        for i in (0..envp_count).rev() {
+            push(envp_vas[i], buf, &mut offset);
+        }
+
+        // argv pointers.
+        push(0, buf, &mut offset);
+        let argc = argv.len().min(MAX_STRINGS);
+        for i in (0..argc).rev() {
+            push(argv_vas[i], buf, &mut offset);
+        }
+
+        // argc.
+        push(argc as u64, buf, &mut offset);
+
+        offset
+    }
+
+    #[test]
+    fn initial_stack_layout_with_args_is_correct() {
+        let mut page = [0u8; 4096];
+        let random_bytes = [0xBBu8; 16];
+        let stack_page_user_va: u64 = 0x7FFF_F000;
+        let params = AuxvParams {
+            entry: 0x400080,
+            interp_base: 0,
+            phdr_vaddr: 0x400040,
+            phdr_count: 2,
+            phdr_entsize: 56,
+        };
+
+        // argv: ["/bin/hello\0", "world\0"]
+        // envp: ["HOME=/\0"]
+        let argv: &[&[u8]] = &[b"/bin/hello\0", b"world\0"];
+        let envp: &[&[u8]] = &[b"HOME=/\0"];
+
+        let rsp_offset = build_layout_with_args_into_buf(
+            &mut page,
+            stack_page_user_va,
+            &params,
+            &random_bytes,
+            argv,
+            envp,
+        );
+
+        // argc == 2
+        let argc = u64::from_le_bytes(page[rsp_offset..rsp_offset + 8].try_into().unwrap());
+        assert_eq!(argc, 2, "argc must be 2");
+
+        // argv[0] pointer — must be non-null.
+        let argv0_ptr =
+            u64::from_le_bytes(page[rsp_offset + 8..rsp_offset + 16].try_into().unwrap());
+        assert_ne!(argv0_ptr, 0, "argv[0] must be non-null");
+
+        // argv[1] pointer — must be non-null.
+        let argv1_ptr =
+            u64::from_le_bytes(page[rsp_offset + 16..rsp_offset + 24].try_into().unwrap());
+        assert_ne!(argv1_ptr, 0, "argv[1] must be non-null");
+
+        // argv[2] (terminator) — must be NULL.
+        let argv_null =
+            u64::from_le_bytes(page[rsp_offset + 24..rsp_offset + 32].try_into().unwrap());
+        assert_eq!(argv_null, 0, "argv terminator must be NULL");
+
+        // envp[0] pointer — must be non-null.
+        let envp0_ptr =
+            u64::from_le_bytes(page[rsp_offset + 32..rsp_offset + 40].try_into().unwrap());
+        assert_ne!(envp0_ptr, 0, "envp[0] must be non-null");
+
+        // envp[1] (terminator) — must be NULL.
+        let envp_null =
+            u64::from_le_bytes(page[rsp_offset + 40..rsp_offset + 48].try_into().unwrap());
+        assert_eq!(envp_null, 0, "envp terminator must be NULL");
+
+        // Verify argv[0] string content by reading from the string data area.
+        let argv0_page_offset = (argv0_ptr - stack_page_user_va) as usize;
+        assert_eq!(
+            &page[argv0_page_offset..argv0_page_offset + 11],
+            b"/bin/hello\0",
+            "argv[0] string must be '/bin/hello\\0'"
+        );
+
+        // Verify envp[0] string content.
+        let envp0_page_offset = (envp0_ptr - stack_page_user_va) as usize;
+        assert_eq!(
+            &page[envp0_page_offset..envp0_page_offset + 7],
+            b"HOME=/\0",
+            "envp[0] string must be 'HOME=/\\0'"
+        );
+
+        // Walk auxv to find AT_PAGESZ (from envp_null + 8 onward).
+        let auxv_start = rsp_offset + 48;
+        let mut found_pagesz = false;
+        let mut found_entry = false;
+        let mut i = auxv_start;
+        while i + 16 <= 4096 {
+            let tag = u64::from_le_bytes(page[i..i + 8].try_into().unwrap());
+            let val = u64::from_le_bytes(page[i + 8..i + 16].try_into().unwrap());
+            if tag == AT_NULL {
+                break;
+            }
+            if tag == AT_PAGESZ {
+                assert_eq!(val, 4096);
+                found_pagesz = true;
+            }
+            if tag == AT_ENTRY {
+                assert_eq!(val, 0x400080);
+                found_entry = true;
+            }
+            i += 16;
+        }
+        assert!(found_pagesz, "AT_PAGESZ not found");
+        assert!(found_entry, "AT_ENTRY not found");
+    }
+
+    #[test]
+    fn initial_stack_with_no_args_matches_legacy() {
+        // write_initial_stack (no args) should produce the same layout as
+        // write_initial_stack_with_args with empty argv/envp.
+        let mut page_legacy = [0u8; 4096];
+        let mut page_new = [0u8; 4096];
+        let random_bytes = [0xCCu8; 16];
+        let stack_page_user_va: u64 = 0x7FFF_F000;
+        let params = AuxvParams {
+            entry: 0x400080,
+            interp_base: 0,
+            phdr_vaddr: 0x400040,
+            phdr_count: 3,
+            phdr_entsize: 56,
+        };
+
+        let off_legacy =
+            build_layout_into_buf(&mut page_legacy, stack_page_user_va, &params, &random_bytes);
+        let off_new = build_layout_with_args_into_buf(
+            &mut page_new,
+            stack_page_user_va,
+            &params,
+            &random_bytes,
+            &[],
+            &[],
+        );
+
+        assert_eq!(off_legacy, off_new, "RSP offset must match");
+        assert_eq!(page_legacy, page_new, "page content must match");
     }
 }

--- a/kernel/tests/execve_path_resolve.rs
+++ b/kernel/tests/execve_path_resolve.rs
@@ -73,19 +73,15 @@ fn resolve_limine_module_finds_hello_elf() {
     let bytes = resolve_execve_binary(b"/boot/userspace_hello.elf")
         .expect("resolve should find userspace_hello.elf via Limine module");
     assert!(bytes.len() > 4, "module bytes must be non-trivial");
-    assert_eq!(
-        &bytes[..4],
-        b"\x7fELF",
-        "first 4 bytes must be ELF magic"
-    );
+    assert_eq!(&bytes[..4], b"\x7fELF", "first 4 bytes must be ELF magic");
 }
 
 /// `/etc/hostname` exists in the rootfs tarball. `resolve_execve_binary`
 /// should find it via VFS and return its raw content (which is not ELF —
 /// the caller validates ELF separately).
 fn resolve_vfs_file_returns_bytes() {
-    let bytes = resolve_execve_binary(b"/etc/hostname")
-        .expect("resolve should find /etc/hostname via VFS");
+    let bytes =
+        resolve_execve_binary(b"/etc/hostname").expect("resolve should find /etc/hostname via VFS");
     // The rootfs hostname file contains "vibix\n".
     assert_eq!(bytes, b"vibix\n", "hostname file should contain 'vibix\\n'");
 }

--- a/kernel/tests/execve_path_resolve.rs
+++ b/kernel/tests/execve_path_resolve.rs
@@ -1,0 +1,91 @@
+//! Integration test for #884: path-aware execve() syscall.
+//!
+//! Validates that `resolve_execve_binary`:
+//!
+//! 1. Returns `ENOENT` for a path that does not exist anywhere (neither
+//!    in the VFS nor as a Limine boot module).
+//! 2. Resolves `/boot/userspace_hello.elf` via the Limine module
+//!    fallback path, returning a non-empty ELF slice whose first four
+//!    bytes are the ELF magic.
+//! 3. Resolves an absolute path for a VFS-resident file (e.g.
+//!    `/etc/hostname`) — this file exists in the rootfs tarball and is
+//!    NOT an ELF, but `resolve_execve_binary` should still return its
+//!    bytes (the ELF validation happens in the caller, not in resolve).
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
+
+use vibix::arch::x86_64::syscall::resolve_execve_binary;
+use vibix::{
+    exit_qemu, serial_println,
+    test_harness::{test_panic_handler, Testable},
+    QemuExitCode,
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vibix::init();
+    x86_64::instructions::interrupts::enable();
+    run_tests();
+    exit_qemu(QemuExitCode::Success);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+fn run_tests() {
+    let tests: &[(&str, &dyn Testable)] = &[
+        (
+            "resolve_nonexistent_returns_enoent",
+            &(resolve_nonexistent_returns_enoent as fn()),
+        ),
+        (
+            "resolve_limine_module_finds_hello_elf",
+            &(resolve_limine_module_finds_hello_elf as fn()),
+        ),
+        (
+            "resolve_vfs_file_returns_bytes",
+            &(resolve_vfs_file_returns_bytes as fn()),
+        ),
+    ];
+    serial_println!("running {} tests", tests.len());
+    for (name, t) in tests {
+        serial_println!("test {name}");
+        t.run();
+    }
+}
+
+/// A path that matches no VFS entry and no Limine module must yield ENOENT.
+fn resolve_nonexistent_returns_enoent() {
+    let result = resolve_execve_binary(b"/nonexistent/binary");
+    assert_eq!(result.unwrap_err(), -2, "expected ENOENT (-2)");
+}
+
+/// `/boot/userspace_hello.elf` is loaded as a Limine boot module. The
+/// basename `userspace_hello.elf` should match via `module_bytes_for_path`.
+fn resolve_limine_module_finds_hello_elf() {
+    let bytes = resolve_execve_binary(b"/boot/userspace_hello.elf")
+        .expect("resolve should find userspace_hello.elf via Limine module");
+    assert!(bytes.len() > 4, "module bytes must be non-trivial");
+    assert_eq!(
+        &bytes[..4],
+        b"\x7fELF",
+        "first 4 bytes must be ELF magic"
+    );
+}
+
+/// `/etc/hostname` exists in the rootfs tarball. `resolve_execve_binary`
+/// should find it via VFS and return its raw content (which is not ELF —
+/// the caller validates ELF separately).
+fn resolve_vfs_file_returns_bytes() {
+    let bytes = resolve_execve_binary(b"/etc/hostname")
+        .expect("resolve should find /etc/hostname via VFS");
+    // The rootfs hostname file contains "vibix\n".
+    assert_eq!(bytes, b"vibix\n", "hostname file should contain 'vibix\\n'");
+}

--- a/tests/userspace/repro_fork/src/main.rs
+++ b/tests/userspace/repro_fork/src/main.rs
@@ -97,6 +97,10 @@ const SYS_WRITE: u64 = 1;
 const SYS_FORK: u64 = 57;
 const SYS_EXECVE: u64 = 59;
 const SYS_EXIT: u64 = 60;
+
+/// Path to the hello binary. The kernel resolves this via VFS first,
+/// then falls back to Limine boot modules (basename match).
+const HELLO_PATH: &[u8] = b"/boot/userspace_hello.elf\0";
 const SYS_WAIT4: u64 = 61;
 
 const STDOUT: u64 = 1;
@@ -152,7 +156,7 @@ pub extern "C" fn _start() -> ! {
                 core::arch::asm!(
                     "syscall",
                     inlateout("rax") SYS_EXECVE => _,
-                    inlateout("rdi") 0u64 => _,
+                    inlateout("rdi") HELLO_PATH.as_ptr() as u64 => _,
                     inlateout("rsi") 0u64 => _,
                     inlateout("rdx") 0u64 => _,
                     lateout("rcx") _,


### PR DESCRIPTION
Closes #884

## Summary
- Replace the hardcoded EXECVE handler (which always loaded `userspace_hello.elf`) with a full path-aware implementation that copies the path from userspace, resolves the binary via VFS (with Limine module fallback), and loads argv/envp onto the new process stack per the SysV AMD64 ABI
- Add `exec_atomic_with_args` and `write_initial_stack_with_args` to support argc/argv/envp in the initial stack layout; the existing `exec_atomic` remains backward-compatible (delegates with empty args)
- Add `resolve_execve_binary` which tries VFS path walk first, then falls back to Limine boot modules for early-bootstrap binaries
- Handle `ENOENT` (file not found), `ENOEXEC` (not valid ELF), and `ENOMEM` errors
- Add `ENOEXEC` (`-8`) to the errno constants in `kernel/src/fs/mod.rs`

## Test plan
- [x] `cargo xtask build` — compiles cleanly
- [x] Host unit tests (`cargo test -p vibix --lib -- auxv`) — 3 auxv tests pass, including new `initial_stack_layout_with_args_is_correct` and `initial_stack_with_no_args_matches_legacy`
- [x] New integration test `execve_path_resolve` — validates `resolve_execve_binary` returns ENOENT for non-existent paths, finds Limine modules by basename, and reads VFS files
- [x] Existing integration test `execve_atomic` — still passes (backward compat via `exec_atomic`)
- [x] Known pre-existing flake: `blocking_sync` rwlock test (#791)