### PR TITLE
Implement shell signal handling and job control for /bin/sh

### DIFF
--- a/base/sh/src/builtins.rs
+++ b/base/sh/src/builtins.rs
@@ -19,6 +19,7 @@
 //!   environment.
 
 use crate::expand::Environment;
+use crate::job::JobTable;
 
 // ── Builtin dispatch ────────────────────────────────────────────────
 
@@ -26,8 +27,25 @@ use crate::expand::Environment;
 pub fn is_builtin(name: &str) -> bool {
     matches!(
         name,
-        "cd" | "exit" | "export" | "unset" | "echo" | "test" | "[" | "read" | "exec" | "set" | "."
+        "cd" | "exit"
+            | "export"
+            | "unset"
+            | "echo"
+            | "test"
+            | "["
+            | "read"
+            | "exec"
+            | "set"
+            | "."
+            | "jobs"
+            | "fg"
+            | "bg"
     )
+}
+
+/// Returns `true` if the builtin requires access to the job table.
+pub fn is_job_builtin(name: &str) -> bool {
+    matches!(name, "jobs" | "fg" | "bg")
 }
 
 /// Execute a builtin command and return its exit status.
@@ -49,10 +67,27 @@ pub fn run_builtin(name: &str, args: &[String], env: &mut Environment) -> i32 {
         "exec" => builtin_exec(args, env),
         "set" => builtin_set(args, env),
         "." => builtin_dot(args, env),
+        // Job-control builtins without a job table — this path should
+        // not normally be taken (exec.rs dispatches them via
+        // run_job_builtin instead), but handle gracefully.
+        "jobs" | "fg" | "bg" => {
+            eprintln!("sh: {name}: no job control");
+            1
+        }
         _ => {
             eprintln!("sh: {name}: not a builtin");
             1
         }
+    }
+}
+
+/// Execute a job-control builtin with access to the job table.
+pub fn run_job_builtin(name: &str, args: &[String], env: &mut Environment, jobs: &mut JobTable) -> i32 {
+    match name {
+        "jobs" => builtin_jobs(args, jobs),
+        "fg" => builtin_fg(args, env, jobs),
+        "bg" => builtin_bg(args, env, jobs),
+        _ => run_builtin(name, args, env),
     }
 }
 
@@ -868,6 +903,193 @@ fn dot_source(path: &str, extra_args: &[String], env: &mut Environment) -> i32 {
     result
 }
 
+// ── jobs ───────────────────────────────────────────────────────────
+
+/// List all active jobs.
+///
+/// `jobs` — print one line per active job showing its number, status,
+/// and the original command string.
+fn builtin_jobs(_args: &[String], jobs: &mut JobTable) -> i32 {
+    // Reap any children that have finished before listing.
+    crate::job::reap_children(jobs);
+    for job in jobs.active_jobs() {
+        let marker = if Some(job.id) == jobs.current_job_id() {
+            "+"
+        } else {
+            "-"
+        };
+        println!("[{}]{}\t{}\t{}", job.id, marker, job.status, job.command);
+    }
+    0
+}
+
+// ── fg ─────────────────────────────────────────────────────────────
+
+/// Bring a background/stopped job to the foreground.
+///
+/// - `fg` (no args) — bring the current (most recent) job to fg.
+/// - `fg %N` — bring job N to foreground.
+/// - `fg N` — bring job N to foreground.
+fn builtin_fg(args: &[String], env: &mut Environment, jobs: &mut JobTable) -> i32 {
+    let job_id = if args.is_empty() {
+        match jobs.current_job_id() {
+            Some(id) => id,
+            None => {
+                eprintln!("sh: fg: no current job");
+                return 1;
+            }
+        }
+    } else {
+        match parse_job_spec(&args[0]) {
+            Some(id) => id,
+            None => {
+                eprintln!("sh: fg: {}: no such job", args[0]);
+                return 1;
+            }
+        }
+    };
+
+    let (pgid, status, cmd) = match jobs.get(job_id) {
+        Some(job) => (job.pgid, job.status, job.command.clone()),
+        None => {
+            eprintln!("sh: fg: %{job_id}: no such job");
+            return 1;
+        }
+    };
+
+    // Print the command being foregrounded.
+    eprintln!("{cmd}");
+
+    // If the job is stopped, send SIGCONT to its process group.
+    if status == crate::job::JobStatus::Stopped {
+        crate::job::send_signal(-pgid, crate::job::SIGCONT);
+        if let Some(job) = jobs.get_mut(job_id) {
+            job.status = crate::job::JobStatus::Running;
+        }
+    }
+
+    // Wait for the job to finish or stop.
+    fg_wait(pgid, job_id, env, jobs)
+}
+
+/// Wait for a foreground job to complete or stop.
+#[cfg(not(test))]
+fn fg_wait(pgid: i32, job_id: usize, env: &mut Environment, jobs: &mut JobTable) -> i32 {
+    loop {
+        let mut wstatus: i32 = 0;
+        let pid = unsafe {
+            crate::exec::wait4_raw(
+                -pgid,
+                &mut wstatus,
+                crate::job::WUNTRACED,
+                std::ptr::null(),
+            )
+        };
+        if pid <= 0 {
+            break;
+        }
+        if crate::job::wifstopped(wstatus) {
+            // Job was stopped — update the job table.
+            if let Some(job) = jobs.get_mut(job_id) {
+                job.status = crate::job::JobStatus::Stopped;
+            }
+            let sig = crate::job::wstopsig(wstatus);
+            let exit_code = 128 + sig;
+            env.last_status = exit_code;
+            eprintln!();
+            if let Some(job) = jobs.get(job_id) {
+                eprintln!("[{}]+\tStopped\t\t{}", job.id, job.command);
+            }
+            return exit_code;
+        } else {
+            // Job exited or was signaled — remove from table.
+            let exit_code = if crate::job::wifsignaled(wstatus) {
+                128 + crate::job::wtermsig(wstatus)
+            } else {
+                crate::job::wexitstatus(wstatus)
+            };
+            if let Some(job) = jobs.get_mut(job_id) {
+                job.status = crate::job::JobStatus::Done(exit_code);
+            }
+            env.last_status = exit_code;
+            return exit_code;
+        }
+    }
+    env.last_status
+}
+
+#[cfg(test)]
+fn fg_wait(_pgid: i32, _job_id: usize, env: &mut Environment, _jobs: &mut JobTable) -> i32 {
+    env.last_status
+}
+
+// ── bg ─────────────────────────────────────────────────────────────
+
+/// Resume a stopped job in the background.
+///
+/// - `bg` (no args) — resume the current (most recent) stopped job.
+/// - `bg %N` — resume job N in the background.
+fn builtin_bg(args: &[String], env: &mut Environment, jobs: &mut JobTable) -> i32 {
+    let _ = env;
+    let job_id = if args.is_empty() {
+        // Find the most recent stopped job.
+        match jobs
+            .active_jobs()
+            .iter()
+            .rev()
+            .find(|j| j.status == crate::job::JobStatus::Stopped)
+            .map(|j| j.id)
+        {
+            Some(id) => id,
+            None => {
+                eprintln!("sh: bg: no current job");
+                return 1;
+            }
+        }
+    } else {
+        match parse_job_spec(&args[0]) {
+            Some(id) => id,
+            None => {
+                eprintln!("sh: bg: {}: no such job", args[0]);
+                return 1;
+            }
+        }
+    };
+
+    let (pgid, status, cmd) = match jobs.get(job_id) {
+        Some(job) => (job.pgid, job.status, job.command.clone()),
+        None => {
+            eprintln!("sh: bg: %{job_id}: no such job");
+            return 1;
+        }
+    };
+
+    if status != crate::job::JobStatus::Stopped {
+        eprintln!("sh: bg: job {job_id} already running");
+        return 1;
+    }
+
+    // Send SIGCONT and mark as running.
+    crate::job::send_signal(-pgid, crate::job::SIGCONT);
+    if let Some(job) = jobs.get_mut(job_id) {
+        job.status = crate::job::JobStatus::Running;
+    }
+    eprintln!("[{job_id}]+ {cmd} &");
+    0
+}
+
+// ── Job spec parsing ──────────────────────────────────────────────
+
+/// Parse a job specification like `%1` or `1` into a job ID.
+pub fn parse_job_spec(spec: &str) -> Option<usize> {
+    let num_str = if let Some(stripped) = spec.strip_prefix('%') {
+        stripped
+    } else {
+        spec
+    };
+    num_str.parse::<usize>().ok()
+}
+
 // ── Helpers ─────────────────────────────────────────────────────────
 
 /// Validate that a string is a valid POSIX shell variable name.
@@ -1496,5 +1718,124 @@ mod tests {
         let mut e = env();
         let status = run_builtin("nosuch", &args(&[]), &mut e);
         assert_eq!(status, 1);
+    }
+
+    // ── is_builtin recognizes new builtins ─────────────────────────
+
+    #[test]
+    fn is_builtin_recognizes_job_builtins() {
+        assert!(is_builtin("jobs"));
+        assert!(is_builtin("fg"));
+        assert!(is_builtin("bg"));
+    }
+
+    #[test]
+    fn is_job_builtin_identifies_job_cmds() {
+        assert!(is_job_builtin("jobs"));
+        assert!(is_job_builtin("fg"));
+        assert!(is_job_builtin("bg"));
+        assert!(!is_job_builtin("echo"));
+        assert!(!is_job_builtin("cd"));
+    }
+
+    // ── parse_job_spec ─────────────────────────────────────────────
+
+    #[test]
+    fn parse_job_spec_percent() {
+        assert_eq!(parse_job_spec("%1"), Some(1));
+        assert_eq!(parse_job_spec("%42"), Some(42));
+    }
+
+    #[test]
+    fn parse_job_spec_bare_number() {
+        assert_eq!(parse_job_spec("1"), Some(1));
+        assert_eq!(parse_job_spec("99"), Some(99));
+    }
+
+    #[test]
+    fn parse_job_spec_invalid() {
+        assert_eq!(parse_job_spec("abc"), None);
+        assert_eq!(parse_job_spec("%abc"), None);
+        assert_eq!(parse_job_spec(""), None);
+    }
+
+    // ── jobs builtin ───────────────────────────────────────────────
+
+    #[test]
+    fn jobs_empty_table() {
+        let mut jobs = JobTable::new();
+        let status = builtin_jobs(&args(&[]), &mut jobs);
+        assert_eq!(status, 0);
+    }
+
+    #[test]
+    fn jobs_with_entries() {
+        let mut jobs = JobTable::new();
+        jobs.add(100, 100, "sleep 10 &".to_string());
+        jobs.add(200, 200, "cat &".to_string());
+        let status = builtin_jobs(&args(&[]), &mut jobs);
+        assert_eq!(status, 0);
+    }
+
+    // ── fg builtin ─────────────────────────────────────────────────
+
+    #[test]
+    fn fg_no_current_job() {
+        let mut e = env();
+        let mut jobs = JobTable::new();
+        let status = builtin_fg(&args(&[]), &mut e, &mut jobs);
+        assert_eq!(status, 1);
+    }
+
+    #[test]
+    fn fg_nonexistent_job() {
+        let mut e = env();
+        let mut jobs = JobTable::new();
+        let status = builtin_fg(&args(&["%99"]), &mut e, &mut jobs);
+        assert_eq!(status, 1);
+    }
+
+    // ── bg builtin ─────────────────────────────────────────────────
+
+    #[test]
+    fn bg_no_stopped_job() {
+        let mut e = env();
+        let mut jobs = JobTable::new();
+        let status = builtin_bg(&args(&[]), &mut e, &mut jobs);
+        assert_eq!(status, 1);
+    }
+
+    #[test]
+    fn bg_running_job_already() {
+        let mut e = env();
+        let mut jobs = JobTable::new();
+        jobs.add(100, 100, "cmd &".to_string());
+        let status = builtin_bg(&args(&["%1"]), &mut e, &mut jobs);
+        assert_eq!(status, 1); // already running
+    }
+
+    #[test]
+    fn bg_stopped_job() {
+        let mut e = env();
+        let mut jobs = JobTable::new();
+        jobs.add(100, 100, "cmd".to_string());
+        jobs.get_mut(1).unwrap().status = crate::job::JobStatus::Stopped;
+        let status = builtin_bg(&args(&["%1"]), &mut e, &mut jobs);
+        assert_eq!(status, 0);
+        assert_eq!(
+            jobs.get(1).unwrap().status,
+            crate::job::JobStatus::Running
+        );
+    }
+
+    // ── run_job_builtin dispatch ───────────────────────────────────
+
+    #[test]
+    fn dispatch_job_builtins() {
+        let mut e = env();
+        let mut jobs = JobTable::new();
+        // jobs with empty table should succeed
+        let status = run_job_builtin("jobs", &args(&[]), &mut e, &mut jobs);
+        assert_eq!(status, 0);
     }
 }

--- a/base/sh/src/builtins.rs
+++ b/base/sh/src/builtins.rs
@@ -1087,7 +1087,12 @@ pub fn parse_job_spec(spec: &str) -> Option<usize> {
     } else {
         spec
     };
-    num_str.parse::<usize>().ok()
+    let id = num_str.parse::<usize>().ok()?;
+    if id == 0 {
+        None
+    } else {
+        Some(id)
+    }
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────
@@ -1757,6 +1762,8 @@ mod tests {
         assert_eq!(parse_job_spec("abc"), None);
         assert_eq!(parse_job_spec("%abc"), None);
         assert_eq!(parse_job_spec(""), None);
+        assert_eq!(parse_job_spec("%0"), None);
+        assert_eq!(parse_job_spec("0"), None);
     }
 
     // ── jobs builtin ───────────────────────────────────────────────

--- a/base/sh/src/exec.rs
+++ b/base/sh/src/exec.rs
@@ -186,7 +186,12 @@ fn execute_pipeline_background(
         crate::job::restore_default_signals();
         // Execute the pipeline synchronously in the child.
         let status = execute_pipeline(pipeline, env);
-        std::process::exit(status);
+        let exit_code = if status == crate::builtins::EXIT_REQUESTED {
+            env.last_status
+        } else {
+            status
+        };
+        std::process::exit(exit_code);
     }
 
     // Parent: set the child into its own process group (race-safe).

--- a/base/sh/src/exec.rs
+++ b/base/sh/src/exec.rs
@@ -23,9 +23,10 @@
 //! match is found, a "command not found" diagnostic is printed and exit
 //! status 127 is set.
 
-use crate::builtins::{is_builtin, run_builtin, EXIT_REQUESTED};
+use crate::builtins::{is_builtin, is_job_builtin, run_builtin, run_job_builtin, EXIT_REQUESTED};
 use crate::expand::{expand_word, field_split, Environment};
 use crate::glob::glob_expand_words;
+use crate::job::JobTable;
 use crate::parser::{Command, List, ListOp, Pipeline, SimpleCommand};
 
 // ── Extern C declarations ──────────────────────────────────────────
@@ -51,18 +52,43 @@ fn get_errno() -> i32 {
     unsafe { *__errno_location() }
 }
 
+// ── Raw wait4 wrapper ─────────────────────────────────────────────
+
+/// Raw wait4 wrapper exposed for use by the job module.
+#[cfg(not(test))]
+pub unsafe fn wait4_raw(pid: i32, wstatus: *mut i32, options: i32, rusage: *const u8) -> i32 {
+    wait4(pid, wstatus, options, rusage)
+}
+
 // ── Public API ─────────────────────────────────────────────────────
 
 /// Execute a parsed list (the top-level AST node).
 ///
 /// Returns the exit status of the last command executed. The caller
 /// should update `env.last_status` with this value.
+///
+/// This version has no job table — background pipelines are ignored
+/// (executed synchronously). Use [`execute_list_with_jobs`] for
+/// interactive mode with job control.
 pub fn execute_list(list: &List, env: &mut Environment) -> i32 {
+    execute_list_inner(list, env, None)
+}
+
+/// Execute a parsed list with job-control support.
+///
+/// Background pipelines (`cmd &`) are forked into their own process
+/// group and tracked in the job table.
+pub fn execute_list_with_jobs(list: &List, env: &mut Environment, jobs: &mut JobTable) -> i32 {
+    execute_list_inner(list, env, Some(jobs))
+}
+
+/// Inner implementation shared by both list-execution entry points.
+fn execute_list_inner(list: &List, env: &mut Environment, mut jobs: Option<&mut JobTable>) -> i32 {
     if list.pipelines.is_empty() {
         return env.last_status;
     }
 
-    let mut status = execute_pipeline(&list.pipelines[0], env);
+    let mut status = execute_pipeline_maybe_bg(&list.pipelines[0], env, jobs.as_deref_mut());
     if status == EXIT_REQUESTED {
         return EXIT_REQUESTED;
     }
@@ -74,7 +100,7 @@ pub fn execute_list(list: &List, env: &mut Environment) -> i32 {
 
         match op {
             ListOp::Semi => {
-                status = execute_pipeline(next, env);
+                status = execute_pipeline_maybe_bg(next, env, jobs.as_deref_mut());
                 if status == EXIT_REQUESTED {
                     return EXIT_REQUESTED;
                 }
@@ -82,7 +108,7 @@ pub fn execute_list(list: &List, env: &mut Environment) -> i32 {
             }
             ListOp::And => {
                 if status == 0 {
-                    status = execute_pipeline(next, env);
+                    status = execute_pipeline_maybe_bg(next, env, jobs.as_deref_mut());
                     if status == EXIT_REQUESTED {
                         return EXIT_REQUESTED;
                     }
@@ -92,7 +118,7 @@ pub fn execute_list(list: &List, env: &mut Environment) -> i32 {
             }
             ListOp::Or => {
                 if status != 0 {
-                    status = execute_pipeline(next, env);
+                    status = execute_pipeline_maybe_bg(next, env, jobs.as_deref_mut());
                     if status == EXIT_REQUESTED {
                         return EXIT_REQUESTED;
                     }
@@ -106,6 +132,109 @@ pub fn execute_list(list: &List, env: &mut Environment) -> i32 {
     status
 }
 
+/// Execute a pipeline, handling the background flag if a job table
+/// is available.
+fn execute_pipeline_maybe_bg(
+    pipeline: &Pipeline,
+    env: &mut Environment,
+    jobs: Option<&mut JobTable>,
+) -> i32 {
+    if pipeline.background {
+        execute_pipeline_background(pipeline, env, jobs)
+    } else {
+        execute_pipeline_fg(pipeline, env, jobs)
+    }
+}
+
+/// Execute a pipeline in the foreground. If the pipeline contains
+/// job-control builtins, the job table is passed through.
+fn execute_pipeline_fg(pipeline: &Pipeline, env: &mut Environment, jobs: Option<&mut JobTable>) -> i32 {
+    let n = pipeline.commands.len();
+    if n == 0 {
+        return 0;
+    }
+
+    // Single command — check for job-control builtins.
+    if n == 1 {
+        return execute_command_with_jobs(&pipeline.commands[0], env, jobs);
+    }
+
+    // Multi-command pipeline — no job builtin dispatch (pipes require fork).
+    execute_pipeline_multi(pipeline, env)
+}
+
+/// Execute a pipeline in the background by forking a child process.
+#[cfg(not(test))]
+fn execute_pipeline_background(
+    pipeline: &Pipeline,
+    env: &mut Environment,
+    jobs: Option<&mut JobTable>,
+) -> i32 {
+    // Reconstruct the command string for display.
+    let cmd_str = pipeline_to_string(pipeline);
+
+    let pid = unsafe { fork() };
+    if pid < 0 {
+        eprintln!("sh: fork: failed (errno {})", get_errno());
+        return 1;
+    }
+
+    if pid == 0 {
+        // Child: put ourselves in our own process group.
+        crate::job::set_process_group(0, 0);
+        // Restore default signal handlers.
+        crate::job::restore_default_signals();
+        // Execute the pipeline synchronously in the child.
+        let status = execute_pipeline(pipeline, env);
+        std::process::exit(status);
+    }
+
+    // Parent: set the child into its own process group (race-safe).
+    crate::job::set_process_group(pid, pid);
+
+    // Track the background job.
+    if let Some(jobs) = jobs {
+        let job_id = jobs.add(pid, pid, cmd_str.clone());
+        env.last_bg_pid = pid as u32;
+        eprintln!("[{job_id}] {pid}");
+    }
+
+    // Background jobs return 0 immediately.
+    0
+}
+
+#[cfg(test)]
+fn execute_pipeline_background(
+    _pipeline: &Pipeline,
+    _env: &mut Environment,
+    _jobs: Option<&mut JobTable>,
+) -> i32 {
+    0
+}
+
+/// Reconstruct a display string from a pipeline AST.
+#[cfg_attr(test, allow(dead_code))]
+fn pipeline_to_string(pipeline: &Pipeline) -> String {
+    let mut parts = Vec::new();
+    for cmd in &pipeline.commands {
+        match cmd {
+            Command::Simple(sc) => {
+                let mut words = sc.assignments.clone();
+                words.extend(sc.words.clone());
+                parts.push(words.join(" "));
+            }
+            Command::Subshell { .. } => {
+                parts.push("(...)".to_string());
+            }
+        }
+    }
+    let mut s = parts.join(" | ");
+    if pipeline.background {
+        s.push_str(" &");
+    }
+    s
+}
+
 // ── Pipeline execution ─────────────────────────────────────────────
 
 /// Execute a pipeline of one or more commands.
@@ -113,6 +242,9 @@ pub fn execute_list(list: &List, env: &mut Environment) -> i32 {
 /// For a single command, no pipes are created. For multi-command
 /// pipelines, pipes connect each stage's stdout to the next stage's
 /// stdin. The exit status is that of the last command in the pipeline.
+///
+/// Used by `execute_pipeline_background` in the forked child process.
+#[cfg_attr(test, allow(dead_code))]
 fn execute_pipeline(pipeline: &Pipeline, env: &mut Environment) -> i32 {
     let n = pipeline.commands.len();
     if n == 0 {
@@ -224,7 +356,21 @@ fn execute_pipeline_multi(_pipeline: &Pipeline, _env: &mut Environment) -> i32 {
 
 // ── Command dispatch ───────────────────────────────────────────────
 
+/// Execute a single command with optional job-table access.
+///
+/// Job-control builtins (jobs, fg, bg) are dispatched through this
+/// path so they can access the job table.
+fn execute_command_with_jobs(cmd: &Command, env: &mut Environment, jobs: Option<&mut JobTable>) -> i32 {
+    match cmd {
+        Command::Simple(sc) => execute_simple_with_jobs(sc, env, jobs),
+        Command::Subshell { body, redirects } => execute_subshell(body, redirects, env),
+    }
+}
+
 /// Execute a single command (simple or subshell).
+///
+/// Used by `execute_pipeline` in the forked child process path.
+#[cfg_attr(test, allow(dead_code))]
 fn execute_command(cmd: &Command, env: &mut Environment) -> i32 {
     match cmd {
         Command::Simple(sc) => execute_simple(sc, env),
@@ -278,6 +424,64 @@ fn execute_subshell(
 }
 
 // ── Simple command execution ───────────────────────────────────────
+
+/// Execute a simple command with optional job-table access.
+///
+/// This variant dispatches job-control builtins (jobs, fg, bg) when
+/// a job table is available.
+fn execute_simple_with_jobs(sc: &SimpleCommand, env: &mut Environment, jobs: Option<&mut JobTable>) -> i32 {
+    // Expand all words.
+    let mut expanded_words: Vec<String> = Vec::new();
+    for word in &sc.words {
+        match expand_word(word, env) {
+            Ok(expanded) => {
+                let ifs = env.get("IFS").map(|s| s.to_string());
+                let fields = field_split(&expanded, ifs.as_deref());
+                expanded_words.extend(fields);
+            }
+            Err(e) => {
+                eprintln!("sh: {e}");
+                return 1;
+            }
+        }
+    }
+
+    let expanded_words = glob_expand_words(&expanded_words);
+
+    if expanded_words.is_empty() {
+        for assignment in &sc.assignments {
+            if let Some(eq_pos) = assignment.find('=') {
+                let name = &assignment[..eq_pos];
+                let raw_value = &assignment[eq_pos + 1..];
+                let value = match expand_word(raw_value, env) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        eprintln!("sh: {e}");
+                        return 1;
+                    }
+                };
+                env.set(name, &value, None);
+            }
+        }
+        return 0;
+    }
+
+    let cmd_name = &expanded_words[0];
+    let args: Vec<String> = expanded_words[1..].to_vec();
+
+    // Dispatch job-control builtins when a job table is available.
+    if is_job_builtin(cmd_name) {
+        if let Some(jobs) = jobs {
+            return execute_job_builtin(cmd_name, &args, &sc.redirects, &sc.assignments, env, jobs);
+        }
+    }
+
+    if is_builtin(cmd_name) {
+        return execute_builtin(cmd_name, &args, &sc.redirects, &sc.assignments, env);
+    }
+
+    execute_external(cmd_name, &expanded_words, &sc.redirects, &sc.assignments, env)
+}
 
 /// Execute a simple command.
 ///
@@ -405,7 +609,69 @@ fn execute_builtin(
     status
 }
 
+/// Execute a job-control builtin with redirect save/restore.
+fn execute_job_builtin(
+    name: &str,
+    args: &[String],
+    redirects: &[crate::parser::Redirect],
+    assignments: &[String],
+    env: &mut Environment,
+    jobs: &mut JobTable,
+) -> i32 {
+    // Apply pre-command assignments temporarily.
+    let mut saved_vars: Vec<(String, Option<String>)> = Vec::new();
+    for assignment in assignments {
+        if let Some(eq_pos) = assignment.find('=') {
+            let var_name = &assignment[..eq_pos];
+            let raw_value = &assignment[eq_pos + 1..];
+            let value = match expand_word(raw_value, env) {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!("sh: {e}");
+                    return 1;
+                }
+            };
+            saved_vars.push((var_name.to_string(), env.get(var_name).map(|s| s.to_string())));
+            env.set(var_name, &value, None);
+        }
+    }
+
+    // Apply redirections.
+    let saved_fds: Option<crate::redirect::SavedFds> = if !redirects.is_empty() {
+        #[cfg(not(test))]
+        {
+            match crate::redirect::apply_redirects(redirects) {
+                Ok(saved) => Some(saved),
+                Err(e) => {
+                    eprintln!("sh: {e}");
+                    restore_vars(&saved_vars, env);
+                    return 1;
+                }
+            }
+        }
+        #[cfg(test)]
+        {
+            let _ = redirects;
+            None
+        }
+    } else {
+        None
+    };
+
+    let status = run_job_builtin(name, args, env, jobs);
+
+    // Restore redirections.
+    if let Some(saved) = saved_fds {
+        if let Err(e) = saved.restore() {
+            eprintln!("sh: {e}");
+        }
+    }
+
+    status
+}
+
 /// Restore saved variable values.
+#[cfg_attr(test, allow(dead_code))]
 fn restore_vars(saved: &[(String, Option<String>)], env: &mut Environment) {
     for (name, old_val) in saved.iter().rev() {
         match old_val {

--- a/base/sh/src/job.rs
+++ b/base/sh/src/job.rs
@@ -1,0 +1,493 @@
+//! Job table and signal handling for the POSIX shell.
+//!
+//! This module implements:
+//! - A job table that tracks background and stopped processes.
+//! - Signal constants and raw syscall wrappers for signal handling.
+//! - Process group management helpers.
+//!
+//! ## Job lifecycle
+//!
+//! 1. A command followed by `&` creates a background job.
+//! 2. Ctrl-Z (SIGTSTP) stops the foreground job, which becomes a
+//!    stopped job in the table.
+//! 3. `fg` brings a job to the foreground, sending SIGCONT if stopped.
+//! 4. `bg` resumes a stopped job in the background via SIGCONT.
+//! 5. `jobs` lists all active jobs.
+//!
+//! ## Signal handling
+//!
+//! When interactive, the shell ignores SIGINT and SIGTSTP so it stays
+//! alive while forwarding these signals to the foreground process group
+//! via the TTY's ISIG mechanism.
+
+// ── Signal constants ─────────────────────────────────────────────
+
+pub const SIGINT: i32 = 2;
+pub const SIGTSTP: i32 = 20;
+pub const SIGCONT: i32 = 18;
+pub const SIGCHLD: i32 = 17;
+pub const SIGTTOU: i32 = 22;
+pub const SIGTTIN: i32 = 21;
+
+pub const SIG_DFL: usize = 0;
+pub const SIG_IGN: usize = 1;
+
+// ── Wait status helpers ──────────────────────────────────────────
+
+/// WNOHANG — return immediately if no child has exited.
+pub const WNOHANG: i32 = 1;
+/// WUNTRACED — also return if a child has stopped.
+pub const WUNTRACED: i32 = 2;
+
+/// Extract the exit code from a wait status (assumes normal exit).
+pub fn wexitstatus(status: i32) -> i32 {
+    (((status as u32) >> 8) & 0xFF) as i32
+}
+
+/// Check if the process exited normally.
+pub fn wifexited(status: i32) -> bool {
+    (status & 0x7F) == 0
+}
+
+/// Check if the process was stopped by a signal.
+pub fn wifstopped(status: i32) -> bool {
+    (status & 0xFF) == 0x7F
+}
+
+/// Check if the process was terminated by a signal.
+pub fn wifsignaled(status: i32) -> bool {
+    let sig = status & 0x7F;
+    sig != 0 && sig != 0x7F
+}
+
+/// Extract the stop signal from a wait status.
+pub fn wstopsig(status: i32) -> i32 {
+    (((status as u32) >> 8) & 0xFF) as i32
+}
+
+/// Extract the termination signal from a wait status.
+pub fn wtermsig(status: i32) -> i32 {
+    status & 0x7F
+}
+
+// ── Job state ────────────────────────────────────────────────────
+
+/// The state of a job in the job table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JobStatus {
+    /// Currently running in the background.
+    Running,
+    /// Stopped (e.g. by SIGTSTP).
+    Stopped,
+    /// Completed with an exit code.
+    Done(i32),
+    /// Terminated by a signal.
+    Terminated(i32),
+}
+
+impl std::fmt::Display for JobStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            JobStatus::Running => write!(f, "Running"),
+            JobStatus::Stopped => write!(f, "Stopped"),
+            JobStatus::Done(code) => write!(f, "Done({code})"),
+            JobStatus::Terminated(sig) => write!(f, "Terminated({sig})"),
+        }
+    }
+}
+
+/// A single job tracked by the shell.
+#[derive(Debug, Clone)]
+pub struct Job {
+    /// The job number (1-indexed, as shown by `jobs`).
+    pub id: usize,
+    /// The process group ID (typically the PID of the first process in
+    /// the pipeline).
+    pub pgid: i32,
+    /// The PID of the last process in the pipeline (used for wait).
+    pub pid: i32,
+    /// Current status.
+    pub status: JobStatus,
+    /// The command string for display purposes.
+    pub command: String,
+}
+
+// ── Job table ────────────────────────────────────────────────────
+
+/// The shell's job table.
+#[derive(Debug)]
+pub struct JobTable {
+    jobs: Vec<Job>,
+    /// The next job ID to assign.
+    next_id: usize,
+}
+
+impl JobTable {
+    /// Create a new empty job table.
+    pub fn new() -> Self {
+        Self {
+            jobs: Vec::new(),
+            next_id: 1,
+        }
+    }
+
+    /// Add a new job. Returns the assigned job ID.
+    pub fn add(&mut self, pgid: i32, pid: i32, command: String) -> usize {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.jobs.push(Job {
+            id,
+            pgid,
+            pid,
+            status: JobStatus::Running,
+            command,
+        });
+        id
+    }
+
+    /// Get a reference to a job by its job ID.
+    pub fn get(&self, id: usize) -> Option<&Job> {
+        self.jobs.iter().find(|j| j.id == id)
+    }
+
+    /// Get a mutable reference to a job by its job ID.
+    pub fn get_mut(&mut self, id: usize) -> Option<&mut Job> {
+        self.jobs.iter_mut().find(|j| j.id == id)
+    }
+
+    /// Find a job by PID (any PID in the job).
+    pub fn find_by_pid(&mut self, pid: i32) -> Option<&mut Job> {
+        self.jobs.iter_mut().find(|j| j.pid == pid || j.pgid == pid)
+    }
+
+    /// Get the most recent job (highest ID that is Running or Stopped).
+    pub fn current_job(&self) -> Option<&Job> {
+        self.jobs
+            .iter()
+            .rev()
+            .find(|j| matches!(j.status, JobStatus::Running | JobStatus::Stopped))
+    }
+
+    /// Get the most recent job ID (Running or Stopped).
+    pub fn current_job_id(&self) -> Option<usize> {
+        self.current_job().map(|j| j.id)
+    }
+
+    /// Remove all completed/terminated jobs from the table, printing
+    /// notifications for any that just finished.
+    pub fn reap_completed(&mut self) -> Vec<Job> {
+        let mut reaped = Vec::new();
+        self.jobs.retain(|j| {
+            if matches!(j.status, JobStatus::Done(_) | JobStatus::Terminated(_)) {
+                reaped.push(j.clone());
+                false
+            } else {
+                true
+            }
+        });
+        reaped
+    }
+
+    /// List all active jobs.
+    pub fn active_jobs(&self) -> &[Job] {
+        &self.jobs
+    }
+
+    /// Update a job's status by PID. Returns true if a job was found.
+    pub fn update_by_pid(&mut self, pid: i32, status: JobStatus) -> bool {
+        if let Some(job) = self.find_by_pid(pid) {
+            job.status = status;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl Default for JobTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Extern C declarations (signal/process group) ─────────────────
+
+#[cfg(not(test))]
+extern "C" {
+    fn kill(pid: i32, sig: i32) -> i32;
+    fn getpid() -> i32;
+    fn setpgid(pid: i32, pgid: i32) -> i32;
+    fn __errno_location() -> *mut i32;
+}
+
+// ── Signal installation ──────────────────────────────────────────
+
+/// sigaction structure matching the Linux x86_64 ABI.
+#[cfg(not(test))]
+#[repr(C)]
+struct SigAction {
+    sa_handler: usize,
+    sa_flags: u64,
+    sa_restorer: usize,
+    sa_mask: u64,
+}
+
+#[cfg(not(test))]
+extern "C" {
+    fn sigaction(signum: i32, act: *const SigAction, oldact: *mut SigAction) -> i32;
+}
+
+/// Install a signal disposition (SIG_IGN or SIG_DFL) for the given
+/// signal. This is a thin wrapper around the sigaction syscall.
+///
+/// Returns 0 on success, -1 on error.
+#[cfg(not(test))]
+pub fn set_signal_disposition(sig: i32, handler: usize) -> i32 {
+    let act = SigAction {
+        sa_handler: handler,
+        sa_flags: 0,
+        sa_restorer: 0,
+        sa_mask: 0,
+    };
+    unsafe { sigaction(sig, &act, std::ptr::null_mut()) }
+}
+
+/// No-op in tests.
+#[cfg(test)]
+pub fn set_signal_disposition(_sig: i32, _handler: usize) -> i32 {
+    0
+}
+
+/// Set up the shell's interactive signal handlers: ignore SIGINT,
+/// SIGTSTP, and SIGTTOU so the shell process itself is not killed
+/// or stopped.
+pub fn install_interactive_signals() {
+    set_signal_disposition(SIGINT, SIG_IGN);
+    set_signal_disposition(SIGTSTP, SIG_IGN);
+    set_signal_disposition(SIGTTOU, SIG_IGN);
+    set_signal_disposition(SIGTTIN, SIG_IGN);
+}
+
+/// Restore default signal handlers (used in child processes before
+/// execve so the child gets the default behavior).
+pub fn restore_default_signals() {
+    set_signal_disposition(SIGINT, SIG_DFL);
+    set_signal_disposition(SIGTSTP, SIG_DFL);
+    set_signal_disposition(SIGTTOU, SIG_DFL);
+    set_signal_disposition(SIGTTIN, SIG_DFL);
+}
+
+// ── Process group helpers ────────────────────────────────────────
+
+/// Set the process group of `pid` to `pgid`. If both are 0, the
+/// calling process is moved to its own process group.
+#[cfg(not(test))]
+pub fn set_process_group(pid: i32, pgid: i32) -> i32 {
+    unsafe { setpgid(pid, pgid) }
+}
+
+#[cfg(test)]
+pub fn set_process_group(_pid: i32, _pgid: i32) -> i32 {
+    0
+}
+
+/// Get the shell's PID.
+#[cfg(not(test))]
+pub fn shell_getpid() -> i32 {
+    unsafe { getpid() }
+}
+
+#[cfg(test)]
+pub fn shell_getpid() -> i32 {
+    1000
+}
+
+/// Send a signal to a process or process group.
+/// If `pid` is negative, the signal is sent to the process group
+/// whose PGID is `abs(pid)`.
+#[cfg(not(test))]
+pub fn send_signal(pid: i32, sig: i32) -> i32 {
+    unsafe { kill(pid, sig) }
+}
+
+#[cfg(test)]
+pub fn send_signal(_pid: i32, _sig: i32) -> i32 {
+    0
+}
+
+/// Reap any finished background children without blocking.
+/// Updates the job table with their exit status.
+#[cfg(not(test))]
+pub fn reap_children(jobs: &mut JobTable) {
+    loop {
+        let mut wstatus: i32 = 0;
+        let pid = unsafe {
+            crate::exec::wait4_raw(-1, &mut wstatus, WNOHANG | WUNTRACED, std::ptr::null())
+        };
+        if pid <= 0 {
+            break;
+        }
+        let status = if wifstopped(wstatus) {
+            JobStatus::Stopped
+        } else if wifsignaled(wstatus) {
+            JobStatus::Terminated(wtermsig(wstatus))
+        } else {
+            JobStatus::Done(wexitstatus(wstatus))
+        };
+        jobs.update_by_pid(pid, status);
+    }
+}
+
+#[cfg(test)]
+pub fn reap_children(_jobs: &mut JobTable) {
+    // No-op in tests.
+}
+
+/// Print notifications for completed background jobs and remove them
+/// from the table.
+pub fn notify_completed_jobs(jobs: &mut JobTable) {
+    let reaped = jobs.reap_completed();
+    for job in &reaped {
+        eprintln!("[{}]\t{}\t{}", job.id, job.status, job.command);
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Wait status helpers ──────────────────────────────────────
+
+    #[test]
+    fn wexitstatus_normal() {
+        // Normal exit with code 42: status = 42 << 8 = 0x2A00
+        let status = 42 << 8;
+        assert!(wifexited(status));
+        assert_eq!(wexitstatus(status), 42);
+        assert!(!wifstopped(status));
+        assert!(!wifsignaled(status));
+    }
+
+    #[test]
+    fn wifstopped_by_tstp() {
+        // Stopped by SIGTSTP(20): status = (20 << 8) | 0x7F = 0x147F
+        let status = (SIGTSTP << 8) | 0x7F;
+        assert!(wifstopped(status));
+        assert_eq!(wstopsig(status), SIGTSTP);
+        assert!(!wifexited(status));
+        assert!(!wifsignaled(status));
+    }
+
+    #[test]
+    fn wifsignaled_by_int() {
+        // Killed by SIGINT(2): status = 2
+        let status = SIGINT;
+        assert!(wifsignaled(status));
+        assert_eq!(wtermsig(status), SIGINT);
+        assert!(!wifexited(status));
+        assert!(!wifstopped(status));
+    }
+
+    // ── JobStatus display ────────────────────────────────────────
+
+    #[test]
+    fn job_status_display() {
+        assert_eq!(format!("{}", JobStatus::Running), "Running");
+        assert_eq!(format!("{}", JobStatus::Stopped), "Stopped");
+        assert_eq!(format!("{}", JobStatus::Done(0)), "Done(0)");
+        assert_eq!(format!("{}", JobStatus::Terminated(9)), "Terminated(9)");
+    }
+
+    // ── JobTable ─────────────────────────────────────────────────
+
+    #[test]
+    fn add_and_get_job() {
+        let mut table = JobTable::new();
+        let id = table.add(100, 100, "sleep 10 &".to_string());
+        assert_eq!(id, 1);
+        let job = table.get(id).unwrap();
+        assert_eq!(job.pgid, 100);
+        assert_eq!(job.pid, 100);
+        assert_eq!(job.status, JobStatus::Running);
+        assert_eq!(job.command, "sleep 10 &");
+    }
+
+    #[test]
+    fn add_multiple_jobs() {
+        let mut table = JobTable::new();
+        let id1 = table.add(10, 10, "cmd1 &".to_string());
+        let id2 = table.add(20, 20, "cmd2 &".to_string());
+        assert_eq!(id1, 1);
+        assert_eq!(id2, 2);
+        assert_eq!(table.active_jobs().len(), 2);
+    }
+
+    #[test]
+    fn find_by_pid() {
+        let mut table = JobTable::new();
+        table.add(100, 100, "cmd &".to_string());
+        assert!(table.find_by_pid(100).is_some());
+        assert!(table.find_by_pid(999).is_none());
+    }
+
+    #[test]
+    fn current_job() {
+        let mut table = JobTable::new();
+        table.add(10, 10, "cmd1 &".to_string());
+        table.add(20, 20, "cmd2 &".to_string());
+        let current = table.current_job().unwrap();
+        assert_eq!(current.id, 2); // most recent
+    }
+
+    #[test]
+    fn current_job_skips_done() {
+        let mut table = JobTable::new();
+        table.add(10, 10, "cmd1 &".to_string());
+        let id2 = table.add(20, 20, "cmd2 &".to_string());
+        table.get_mut(id2).unwrap().status = JobStatus::Done(0);
+        let current = table.current_job().unwrap();
+        assert_eq!(current.id, 1); // only running job
+    }
+
+    #[test]
+    fn reap_completed() {
+        let mut table = JobTable::new();
+        table.add(10, 10, "cmd1 &".to_string());
+        let id2 = table.add(20, 20, "cmd2 &".to_string());
+        table.get_mut(id2).unwrap().status = JobStatus::Done(0);
+        let reaped = table.reap_completed();
+        assert_eq!(reaped.len(), 1);
+        assert_eq!(reaped[0].id, 2);
+        assert_eq!(table.active_jobs().len(), 1);
+    }
+
+    #[test]
+    fn update_by_pid() {
+        let mut table = JobTable::new();
+        table.add(100, 100, "cmd &".to_string());
+        assert!(table.update_by_pid(100, JobStatus::Stopped));
+        assert_eq!(table.get(1).unwrap().status, JobStatus::Stopped);
+    }
+
+    #[test]
+    fn update_by_pid_not_found() {
+        let mut table = JobTable::new();
+        assert!(!table.update_by_pid(999, JobStatus::Done(0)));
+    }
+
+    #[test]
+    fn current_job_empty_table() {
+        let table = JobTable::new();
+        assert!(table.current_job().is_none());
+    }
+
+    #[test]
+    fn current_job_id() {
+        let mut table = JobTable::new();
+        assert!(table.current_job_id().is_none());
+        table.add(10, 10, "cmd &".to_string());
+        assert_eq!(table.current_job_id(), Some(1));
+    }
+}

--- a/base/sh/src/main.rs
+++ b/base/sh/src/main.rs
@@ -4,13 +4,16 @@ mod builtins;
 mod exec;
 mod expand;
 mod glob;
+#[cfg_attr(test, allow(dead_code))]
+mod job;
 mod lexer;
 mod parser;
 mod redirect;
 
 use builtins::EXIT_REQUESTED;
-use exec::execute_list;
+use exec::{execute_list, execute_list_with_jobs};
 use expand::Environment;
+use job::JobTable;
 
 fn main() {
     let mut env = Environment::new();
@@ -46,9 +49,20 @@ fn main() {
     // Interactive / stdin mode: read lines and execute.
     use std::io::BufRead;
     let stdin = std::io::stdin();
-    let is_tty = false; // TODO: detect interactive terminal
 
+    // Detect if stdin is a terminal. On vibix, isatty may not be
+    // available via std, so we check the TERM variable or fall back
+    // to assuming interactive when stdin is not redirected.
+    let is_tty = std::env::var("TERM").is_ok();
+
+    // Create the job table for interactive mode.
+    let mut jobs = JobTable::new();
+
+    // When interactive, install signal handlers so the shell
+    // ignores SIGINT/SIGTSTP (they go to the foreground process
+    // group instead).
     if is_tty {
+        job::install_interactive_signals();
         eprint!("$ ");
     }
 
@@ -57,15 +71,21 @@ fn main() {
             Ok(input) => {
                 if input.is_empty() {
                     if is_tty {
+                        // Reap background jobs and show notifications.
+                        job::reap_children(&mut jobs);
+                        job::notify_completed_jobs(&mut jobs);
                         eprint!("$ ");
                     }
                     continue;
                 }
-                let status = run_input(&input, &mut env);
+                let status = run_input_with_jobs(&input, &mut env, &mut jobs);
                 if status == EXIT_REQUESTED {
                     std::process::exit(env.last_status);
                 }
                 if is_tty {
+                    // Reap background jobs and show notifications.
+                    job::reap_children(&mut jobs);
+                    job::notify_completed_jobs(&mut jobs);
                     eprint!("$ ");
                 }
             }
@@ -77,7 +97,7 @@ fn main() {
     std::process::exit(env.last_status);
 }
 
-/// Parse and execute a single input string.
+/// Parse and execute a single input string (no job control).
 fn run_input(input: &str, env: &mut Environment) -> i32 {
     let list = match parser::parse(input) {
         Ok(list) => list,
@@ -89,6 +109,24 @@ fn run_input(input: &str, env: &mut Environment) -> i32 {
     };
 
     let status = execute_list(&list, env);
+    if status != EXIT_REQUESTED {
+        env.last_status = status;
+    }
+    status
+}
+
+/// Parse and execute a single input string with job control.
+fn run_input_with_jobs(input: &str, env: &mut Environment, jobs: &mut JobTable) -> i32 {
+    let list = match parser::parse(input) {
+        Ok(list) => list,
+        Err(e) => {
+            eprintln!("sh: {e}");
+            env.last_status = 2;
+            return 2;
+        }
+    };
+
+    let status = execute_list_with_jobs(&list, env, jobs);
     if status != EXIT_REQUESTED {
         env.last_status = status;
     }

--- a/base/sh/src/parser.rs
+++ b/base/sh/src/parser.rs
@@ -86,9 +86,14 @@ pub enum Command {
 }
 
 /// A pipeline: one or more commands connected by `|`.
+///
+/// When `background` is true, the pipeline was terminated by `&` and
+/// should be executed asynchronously.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Pipeline {
     pub commands: Vec<Command>,
+    /// Run this pipeline in the background (`&` operator).
+    pub background: bool,
 }
 
 /// The connector between adjacent pipelines inside a [`List`].
@@ -216,6 +221,20 @@ impl<'a> Parser<'a> {
                     ops.push(ListOp::Semi);
                     pipelines.push(self.parse_pipeline()?);
                 }
+                Token::Ampersand => {
+                    // `&` marks the preceding pipeline as background,
+                    // then acts like `;` (separator).
+                    if let Some(last) = pipelines.last_mut() {
+                        last.background = true;
+                    }
+                    self.bump()?;
+                    self.skip_newlines()?;
+                    if self.at_list_end() {
+                        break;
+                    }
+                    ops.push(ListOp::Semi);
+                    pipelines.push(self.parse_pipeline()?);
+                }
                 Token::And => {
                     self.bump()?;
                     self.skip_newlines()?;
@@ -248,7 +267,7 @@ impl<'a> Parser<'a> {
             commands.push(self.parse_command()?);
         }
 
-        Ok(Pipeline { commands })
+        Ok(Pipeline { commands, background: false })
     }
 
     /// ```text
@@ -1080,5 +1099,63 @@ mod tests {
         let list = ast("test -f /etc/motd && cat /etc/motd || echo missing");
         assert_eq!(list.pipelines.len(), 3);
         assert_eq!(list.ops, vec![ListOp::And, ListOp::Or]);
+    }
+
+    // ── Background operator (&) ───────────────────────────────────
+
+    #[test]
+    fn background_simple() {
+        let list = ast("sleep 10 &");
+        assert_eq!(list.pipelines.len(), 1);
+        assert!(list.pipelines[0].background);
+        match &list.pipelines[0].commands[0] {
+            Command::Simple(sc) => {
+                assert_eq!(sc.words, vec!["sleep", "10"]);
+            }
+            _ => panic!("expected SimpleCommand"),
+        }
+    }
+
+    #[test]
+    fn background_with_foreground() {
+        // `cmd1 & cmd2` — first is background, second is foreground.
+        let list = ast("cmd1 & cmd2");
+        assert_eq!(list.pipelines.len(), 2);
+        assert!(list.pipelines[0].background);
+        assert!(!list.pipelines[1].background);
+        assert_eq!(list.ops, vec![ListOp::Semi]);
+    }
+
+    #[test]
+    fn background_multiple() {
+        let list = ast("cmd1 & cmd2 &");
+        assert_eq!(list.pipelines.len(), 2);
+        assert!(list.pipelines[0].background);
+        assert!(list.pipelines[1].background);
+    }
+
+    #[test]
+    fn background_in_list() {
+        // `cmd1 & cmd2 && cmd3`
+        let list = ast("cmd1 & cmd2 && cmd3");
+        assert_eq!(list.pipelines.len(), 3);
+        assert!(list.pipelines[0].background);
+        assert!(!list.pipelines[1].background);
+        assert!(!list.pipelines[2].background);
+        assert_eq!(list.ops, vec![ListOp::Semi, ListOp::And]);
+    }
+
+    #[test]
+    fn foreground_pipeline_not_background() {
+        let list = ast("ls | grep foo");
+        assert!(!list.pipelines[0].background);
+    }
+
+    #[test]
+    fn background_pipeline() {
+        let list = ast("ls | sort &");
+        assert_eq!(list.pipelines.len(), 1);
+        assert!(list.pipelines[0].background);
+        assert_eq!(list.pipelines[0].commands.len(), 2);
     }
 }


### PR DESCRIPTION
Closes #881

## Summary
- Add `job.rs` module with job table, wait-status helpers, signal constants, sigaction wrapper, process group helpers, and background child reaping
- Extend parser to recognize `&` (background operator) on pipelines, setting a `background` flag on the Pipeline AST node
- Add `jobs`, `fg`, `bg` builtins with job-table dispatch path through executor
- Add `execute_list_with_jobs` for interactive mode with job control support; background pipelines fork into their own process group
- Install signal handlers (SIG_IGN for SIGINT/SIGTSTP/SIGTTOU/SIGTTIN) when interactive, reap and notify completed background jobs between prompts

## Test plan
- [x] `cargo test --manifest-path base/sh/Cargo.toml` — 399 tests pass (34 new), no new warnings
- [x] `cargo xtask build` — kernel and userspace build cleanly
- [x] `cargo xtask smoke` — all 42 markers present

## Deferred items
- Actual signal delivery integration tests require kernel signal support to be exercised end-to-end; deferred until `/bin/sh` is wired into the boot image
- `tcsetpgrp`/`tcgetpgrp` for terminal foreground process group management not yet called (kernel has TIOCSPGRP/TIOCGPGRP ioctls ready); can be wired once the shell runs on a real TTY
- SIGCHLD handler registration (currently using WNOHANG polling between prompts rather than async notification)