### PR TITLE
Gate kernel shell behind shell=kernel boot flag

### DIFF
--- a/kernel/src/boot_cmdline.rs
+++ b/kernel/src/boot_cmdline.rs
@@ -178,6 +178,28 @@ pub fn parse(cmdline: &[u8]) -> RootArgs {
     out
 }
 
+/// Returns `true` when the cmdline contains `shell=kernel`.
+///
+/// When present the kernel spawns the built-in interactive shell task;
+/// otherwise the shell is skipped so serial/keyboard input is available
+/// for userspace `/bin/sh`.
+pub fn shell_kernel(cmdline: &[u8]) -> bool {
+    let mut i = 0;
+    while i < cmdline.len() {
+        while i < cmdline.len() && is_ws(cmdline[i]) {
+            i += 1;
+        }
+        let start = i;
+        while i < cmdline.len() && !is_ws(cmdline[i]) {
+            i += 1;
+        }
+        if &cmdline[start..i] == b"shell=kernel" {
+            return true;
+        }
+    }
+    false
+}
+
 fn strip_prefix<'a>(token: &'a [u8], prefix: &[u8]) -> Option<&'a [u8]> {
     if token.len() >= prefix.len() && &token[..prefix.len()] == prefix {
         Some(&token[prefix.len()..])
@@ -360,6 +382,22 @@ mod tests {
         // `rootflags_extra=ro` must not be read as `rootflags=`.
         let r = parse(b"rootflags_extra=ro");
         assert_eq!(r.explicit_ro, None);
+    }
+
+    #[test]
+    fn shell_kernel_present() {
+        assert!(shell_kernel(b"shell=kernel"));
+        assert!(shell_kernel(b"root=/dev/vda shell=kernel"));
+        assert!(shell_kernel(b"shell=kernel writeback_secs=5"));
+        assert!(shell_kernel(b"root=ext2 shell=kernel rootflags=ro"));
+    }
+
+    #[test]
+    fn shell_kernel_absent() {
+        assert!(!shell_kernel(b""));
+        assert!(!shell_kernel(b"root=/dev/vda"));
+        assert!(!shell_kernel(b"shell=user"));
+        assert!(!shell_kernel(b"xshell=kernel"));
     }
 
     #[test]

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -70,7 +70,7 @@ pub extern "C" fn _start() -> ! {
     // ext2 instead of falling back to the auto-probe (issue #631).
     // Defaults to `RootArgs::auto()` when no cmdline is delivered, which
     // preserves the pre-#577 behaviour of "try ext2 → tarfs → ramfs".
-    let root_args = if let Some(cmdline_resp) = vibix::boot::KERNEL_CMDLINE_REQUEST.get_response() {
+    let (root_args, kernel_shell) = if let Some(cmdline_resp) = vibix::boot::KERNEL_CMDLINE_REQUEST.get_response() {
         let bytes = cmdline_resp.cmdline().to_bytes();
         if !bytes.is_empty() {
             serial_println!(
@@ -103,10 +103,11 @@ pub extern "C" fn _start() -> ! {
             );
         }
 
-        root_args
+        let kernel_shell = vibix::boot_cmdline::shell_kernel(bytes);
+        (root_args, kernel_shell)
     } else {
         serial_println!("cmdline: not provided by bootloader");
-        vibix::boot_cmdline::RootArgs::auto()
+        (vibix::boot_cmdline::RootArgs::auto(), false)
     };
 
     vibix::arch::init_apic(rsdp_ptr, hhdm_offset);
@@ -248,7 +249,19 @@ pub extern "C" fn _start() -> ! {
     }
 
     vibix::task::init();
-    vibix::task::spawn(vibix::shell::run);
+
+    // Print the boot banner unconditionally — smoke tests assert on the
+    // `banner: vibix <version>` marker. Previously the banner was emitted
+    // inside `shell::run`, but now that the kernel shell is optional we
+    // print it from `_start` so it fires on every boot.
+    vibix::shell::banner::print_banner();
+
+    if kernel_shell {
+        serial_println!("kernel shell: enabled via shell=kernel");
+        vibix::task::spawn(vibix::shell::run);
+    } else {
+        serial_println!("kernel shell: disabled (pass shell=kernel to enable)");
+    }
     vibix::task::spawn(cursor_blink_task);
 
     // Launch PID 1: load the init ELF into a user-space address space

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -70,45 +70,46 @@ pub extern "C" fn _start() -> ! {
     // ext2 instead of falling back to the auto-probe (issue #631).
     // Defaults to `RootArgs::auto()` when no cmdline is delivered, which
     // preserves the pre-#577 behaviour of "try ext2 → tarfs → ramfs".
-    let (root_args, kernel_shell) = if let Some(cmdline_resp) = vibix::boot::KERNEL_CMDLINE_REQUEST.get_response() {
-        let bytes = cmdline_resp.cmdline().to_bytes();
-        if !bytes.is_empty() {
+    let (root_args, kernel_shell) =
+        if let Some(cmdline_resp) = vibix::boot::KERNEL_CMDLINE_REQUEST.get_response() {
+            let bytes = cmdline_resp.cmdline().to_bytes();
+            if !bytes.is_empty() {
+                serial_println!(
+                    "cmdline: {:?}",
+                    core::str::from_utf8(bytes).unwrap_or("<non-utf8>")
+                );
+            }
+            let root_args = vibix::boot_cmdline::parse(bytes);
             serial_println!(
-                "cmdline: {:?}",
-                core::str::from_utf8(bytes).unwrap_or("<non-utf8>")
+                "rootfs: source={:?} flags={:#x} explicit_ro={:?}",
+                root_args.source,
+                root_args.mount_flags.0,
+                root_args.explicit_ro,
             );
-        }
-        let root_args = vibix::boot_cmdline::parse(bytes);
-        serial_println!(
-            "rootfs: source={:?} flags={:#x} explicit_ro={:?}",
-            root_args.source,
-            root_args.mount_flags.0,
-            root_args.explicit_ro,
-        );
 
-        if vibix::block::writeback::parse_cmdline(bytes) {
-            serial_println!(
-                "writeback: cadence configured to {} s ({})",
-                vibix::block::writeback::configured_secs(),
-                if vibix::block::writeback::is_disabled() {
-                    "disabled"
-                } else {
-                    "enabled"
-                },
-            );
+            if vibix::block::writeback::parse_cmdline(bytes) {
+                serial_println!(
+                    "writeback: cadence configured to {} s ({})",
+                    vibix::block::writeback::configured_secs(),
+                    if vibix::block::writeback::is_disabled() {
+                        "disabled"
+                    } else {
+                        "enabled"
+                    },
+                );
+            } else {
+                serial_println!(
+                    "writeback: using default cadence ({} s)",
+                    vibix::block::writeback::DEFAULT_INTERVAL_SECS,
+                );
+            }
+
+            let kernel_shell = vibix::boot_cmdline::shell_kernel(bytes);
+            (root_args, kernel_shell)
         } else {
-            serial_println!(
-                "writeback: using default cadence ({} s)",
-                vibix::block::writeback::DEFAULT_INTERVAL_SECS,
-            );
-        }
-
-        let kernel_shell = vibix::boot_cmdline::shell_kernel(bytes);
-        (root_args, kernel_shell)
-    } else {
-        serial_println!("cmdline: not provided by bootloader");
-        (vibix::boot_cmdline::RootArgs::auto(), false)
-    };
+            serial_println!("cmdline: not provided by bootloader");
+            (vibix::boot_cmdline::RootArgs::auto(), false)
+        };
 
     vibix::arch::init_apic(rsdp_ptr, hhdm_offset);
     match vibix::hpet::init() {

--- a/kernel/src/shell/mod.rs
+++ b/kernel/src/shell/mod.rs
@@ -39,7 +39,8 @@ mod kernel_side {
     pub fn run() -> ! {
         serial_println!("shell: prompt online");
         SHELL_ONLINE.store(true, Ordering::SeqCst);
-        super::banner::print_banner();
+        // Banner is now printed unconditionally from `_start` so smoke
+        // tests see it even when the kernel shell is not spawned.
         prompt();
 
         let mut editor = LineEditor::new();


### PR DESCRIPTION
Closes #896

## Summary
- Add `boot_cmdline::shell_kernel()` to detect the `shell=kernel` cmdline token
- Conditionally spawn the kernel shell task in `_start` — only when `shell=kernel` is present
- Move the boot banner print from `shell::run` to `_start` so the smoke marker fires on every boot
- When the shell is disabled, log `kernel shell: disabled (pass shell=kernel to enable)`

## Test plan
- [x] `cargo xtask build` — compiles cleanly
- [x] `cargo xtask test-unit` — `shell_kernel_present` and `shell_kernel_absent` tests pass
- [x] `cargo xtask smoke` — all 43 markers present (banner fires without shell)
- [x] `cargo xtask test` — integration tests pass (blocking_sync flake is pre-existing)