### PR TITLE
Add userspace /bin/cat and /bin/ls

### DIFF
--- a/base/cat/Cargo.toml
+++ b/base/cat/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "cat"
+version = "0.1.0"
+edition = "2021"
+authors = ["vibix hackers"]
+license = "MIT OR Apache-2.0"
+
+[[bin]]
+name = "cat"
+path = "src/main.rs"
+
+# Standalone package — not part of the main workspace. Built with
+# `-Z build-std` against the in-repo std fork (see xtask build).
+[workspace]

--- a/base/cat/src/main.rs
+++ b/base/cat/src/main.rs
@@ -1,0 +1,64 @@
+#![feature(restricted_std)]
+
+#[cfg(not(test))]
+mod syscalls;
+
+use std::env;
+use std::fs::File;
+use std::io::{self, Read, Write};
+use std::process;
+
+fn cat_reader<R: Read>(mut reader: R, stdout: &mut io::StdoutLock<'_>) -> io::Result<()> {
+    let mut buf = [0u8; 4096];
+    loop {
+        let n = reader.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        stdout.write_all(&buf[..n])?;
+    }
+    Ok(())
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let stdout = io::stdout();
+    let mut stdout = stdout.lock();
+    let mut status = 0;
+
+    if args.len() <= 1 {
+        // No arguments: read stdin to stdout.
+        let stdin = io::stdin();
+        let stdin = stdin.lock();
+        if let Err(e) = cat_reader(stdin, &mut stdout) {
+            eprintln!("cat: {e}");
+            process::exit(1);
+        }
+    } else {
+        for path in &args[1..] {
+            if path == "-" {
+                let stdin = io::stdin();
+                let stdin = stdin.lock();
+                if let Err(e) = cat_reader(stdin, &mut stdout) {
+                    eprintln!("cat: -: {e}");
+                    status = 1;
+                }
+            } else {
+                match File::open(path) {
+                    Ok(file) => {
+                        if let Err(e) = cat_reader(file, &mut stdout) {
+                            eprintln!("cat: {path}: {e}");
+                            status = 1;
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("cat: {path}: {e}");
+                        status = 1;
+                    }
+                }
+            }
+        }
+    }
+
+    process::exit(status);
+}

--- a/base/cat/src/main.rs
+++ b/base/cat/src/main.rs
@@ -6,7 +6,7 @@ mod syscalls;
 use std::env;
 use std::fs::File;
 use std::io::{self, Read, Write};
-use std::process;
+use std::process::ExitCode;
 
 fn cat_reader<R: Read>(mut reader: R, stdout: &mut io::StdoutLock<'_>) -> io::Result<()> {
     let mut buf = [0u8; 4096];
@@ -20,11 +20,11 @@ fn cat_reader<R: Read>(mut reader: R, stdout: &mut io::StdoutLock<'_>) -> io::Re
     Ok(())
 }
 
-fn main() {
+fn main() -> ExitCode {
     let args: Vec<String> = env::args().collect();
     let stdout = io::stdout();
     let mut stdout = stdout.lock();
-    let mut status = 0;
+    let mut status: u8 = 0;
 
     if args.len() <= 1 {
         // No arguments: read stdin to stdout.
@@ -32,7 +32,7 @@ fn main() {
         let stdin = stdin.lock();
         if let Err(e) = cat_reader(stdin, &mut stdout) {
             eprintln!("cat: {e}");
-            process::exit(1);
+            return ExitCode::from(1);
         }
     } else {
         for path in &args[1..] {
@@ -60,5 +60,5 @@ fn main() {
         }
     }
 
-    process::exit(status);
+    ExitCode::from(status)
 }

--- a/base/cat/src/syscalls.rs
+++ b/base/cat/src/syscalls.rs
@@ -1,0 +1,50 @@
+//! C-ABI syscall shims required by the vibix std fork.
+//!
+//! The in-repo std fork links against POSIX symbols (`close`, etc.) that are
+//! not provided by a system libc on vibix. We supply them here via raw
+//! syscall instructions, mirroring the approach in `base/sh/src/syscalls.rs`.
+
+use core::arch::asm;
+
+const SYS_CLOSE: u64 = 3;
+
+extern "C" {
+    fn __errno_location() -> *mut i32;
+}
+
+#[inline(always)]
+unsafe fn raw1(nr: u64, a0: u64) -> i64 {
+    let ret: i64;
+    unsafe {
+        asm!(
+            "syscall",
+            inlateout("rax") nr => ret,
+            inlateout("rdi") a0 => _,
+            lateout("rcx") _,
+            lateout("r11") _,
+            lateout("rdx") _,
+            lateout("rsi") _,
+            lateout("r8") _,
+            lateout("r9") _,
+            lateout("r10") _,
+            options(nostack, preserves_flags),
+        );
+    }
+    ret
+}
+
+/// Convert raw syscall return to C convention: on error set errno, return -1.
+#[inline]
+unsafe fn cvt(r: i64) -> i64 {
+    if r < 0 {
+        unsafe { *__errno_location() = (-r) as i32 };
+        -1
+    } else {
+        r
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn close(fd: i32) -> i32 {
+    unsafe { cvt(raw1(SYS_CLOSE, fd as u64)) as i32 }
+}

--- a/base/ls/Cargo.toml
+++ b/base/ls/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ls"
+version = "0.1.0"
+edition = "2021"
+authors = ["vibix hackers"]
+license = "MIT OR Apache-2.0"
+
+[[bin]]
+name = "ls"
+path = "src/main.rs"
+
+# Standalone package — not part of the main workspace. Built with
+# `-Z build-std` against the in-repo std fork (see xtask build).
+[workspace]

--- a/base/ls/src/main.rs
+++ b/base/ls/src/main.rs
@@ -5,9 +5,9 @@ mod syscalls;
 
 use std::env;
 use std::fs;
-use std::process;
+use std::process::ExitCode;
 
-fn list_dir(path: &str) -> i32 {
+fn list_dir(path: &str) -> u8 {
     let entries = match fs::read_dir(path) {
         Ok(entries) => entries,
         Err(e) => {
@@ -21,10 +21,7 @@ fn list_dir(path: &str) -> i32 {
         match entry {
             Ok(entry) => {
                 let name = entry.file_name().to_string_lossy().into_owned();
-                let is_dir = entry
-                    .file_type()
-                    .map(|ft| ft.is_dir())
-                    .unwrap_or(false);
+                let is_dir = entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false);
                 names.push((name, is_dir));
             }
             Err(e) => {
@@ -47,9 +44,9 @@ fn list_dir(path: &str) -> i32 {
     0
 }
 
-fn main() {
+fn main() -> ExitCode {
     let args: Vec<String> = env::args().collect();
-    let mut status = 0;
+    let mut status: u8 = 0;
 
     if args.len() <= 1 {
         status = list_dir(".");
@@ -69,5 +66,5 @@ fn main() {
         }
     }
 
-    process::exit(status);
+    ExitCode::from(status)
 }

--- a/base/ls/src/main.rs
+++ b/base/ls/src/main.rs
@@ -1,0 +1,73 @@
+#![feature(restricted_std)]
+
+#[cfg(not(test))]
+mod syscalls;
+
+use std::env;
+use std::fs;
+use std::process;
+
+fn list_dir(path: &str) -> i32 {
+    let entries = match fs::read_dir(path) {
+        Ok(entries) => entries,
+        Err(e) => {
+            eprintln!("ls: {path}: {e}");
+            return 1;
+        }
+    };
+
+    let mut names: Vec<(String, bool)> = Vec::new();
+    for entry in entries {
+        match entry {
+            Ok(entry) => {
+                let name = entry.file_name().to_string_lossy().into_owned();
+                let is_dir = entry
+                    .file_type()
+                    .map(|ft| ft.is_dir())
+                    .unwrap_or(false);
+                names.push((name, is_dir));
+            }
+            Err(e) => {
+                eprintln!("ls: {path}: {e}");
+                return 1;
+            }
+        }
+    }
+
+    names.sort_by(|a, b| a.0.cmp(&b.0));
+
+    for (name, is_dir) in &names {
+        if *is_dir {
+            println!("{name}/");
+        } else {
+            println!("{name}");
+        }
+    }
+
+    0
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let mut status = 0;
+
+    if args.len() <= 1 {
+        status = list_dir(".");
+    } else {
+        let show_header = args.len() > 2;
+        for (i, path) in args[1..].iter().enumerate() {
+            if show_header {
+                if i > 0 {
+                    println!();
+                }
+                println!("{path}:");
+            }
+            let s = list_dir(path);
+            if s != 0 {
+                status = s;
+            }
+        }
+    }
+
+    process::exit(status);
+}

--- a/base/ls/src/syscalls.rs
+++ b/base/ls/src/syscalls.rs
@@ -1,0 +1,50 @@
+//! C-ABI syscall shims required by the vibix std fork.
+//!
+//! The in-repo std fork links against POSIX symbols (`close`, etc.) that are
+//! not provided by a system libc on vibix. We supply them here via raw
+//! syscall instructions, mirroring the approach in `base/sh/src/syscalls.rs`.
+
+use core::arch::asm;
+
+const SYS_CLOSE: u64 = 3;
+
+extern "C" {
+    fn __errno_location() -> *mut i32;
+}
+
+#[inline(always)]
+unsafe fn raw1(nr: u64, a0: u64) -> i64 {
+    let ret: i64;
+    unsafe {
+        asm!(
+            "syscall",
+            inlateout("rax") nr => ret,
+            inlateout("rdi") a0 => _,
+            lateout("rcx") _,
+            lateout("r11") _,
+            lateout("rdx") _,
+            lateout("rsi") _,
+            lateout("r8") _,
+            lateout("r9") _,
+            lateout("r10") _,
+            options(nostack, preserves_flags),
+        );
+    }
+    ret
+}
+
+/// Convert raw syscall return to C convention: on error set errno, return -1.
+#[inline]
+unsafe fn cvt(r: i64) -> i64 {
+    if r < 0 {
+        unsafe { *__errno_location() = (-r) as i32 };
+        -1
+    } else {
+        r
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn close(fd: i32) -> i32 {
+    unsafe { cvt(raw1(SYS_CLOSE, fd as u64)) as i32 }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -843,6 +843,92 @@ fn build_userspace_sh() -> R<PathBuf> {
     Ok(bin)
 }
 
+/// Build the `/bin/cat` binary — concatenate files to stdout.
+///
+/// Uses the same out-of-tree `-Z build-std` approach as `build_userspace_sh`.
+/// The crate lives in `base/cat/` (base system program).
+fn build_userspace_cat() -> R<PathBuf> {
+    let ws = workspace_root();
+    let target_spec = ws.join(VIBIX_USERSPACE_TARGET);
+    let manifest = ws.join("base/cat/Cargo.toml");
+    let library_root = ws.join("library");
+
+    let target_dir = ws.join("target");
+    let mut cmd = Command::new("cargo");
+    cmd.current_dir(&ws)
+        .env("__CARGO_TESTS_ONLY_SRC_ROOT", &library_root)
+        .args(["build", "--manifest-path"])
+        .arg(&manifest)
+        .arg("--target-dir")
+        .arg(&target_dir)
+        .args([
+            "-Z",
+            "build-std=std,core,alloc,panic_abort",
+            "-Z",
+            "build-std-features=compiler-builtins-mem",
+            "-Z",
+            "unstable-options",
+            "-Z",
+            "json-target-spec",
+            "--target",
+        ])
+        .arg(&target_spec);
+    check(cmd.status()?)?;
+
+    let bin = target_dir
+        .join("x86_64-unknown-vibix")
+        .join("debug")
+        .join("cat");
+    if !bin.exists() {
+        return Err(format!("cat binary missing at {} after build", bin.display()).into());
+    }
+    strip_debug(&bin)?;
+    Ok(bin)
+}
+
+/// Build the `/bin/ls` binary — list directory contents.
+///
+/// Uses the same out-of-tree `-Z build-std` approach as `build_userspace_sh`.
+/// The crate lives in `base/ls/` (base system program).
+fn build_userspace_ls() -> R<PathBuf> {
+    let ws = workspace_root();
+    let target_spec = ws.join(VIBIX_USERSPACE_TARGET);
+    let manifest = ws.join("base/ls/Cargo.toml");
+    let library_root = ws.join("library");
+
+    let target_dir = ws.join("target");
+    let mut cmd = Command::new("cargo");
+    cmd.current_dir(&ws)
+        .env("__CARGO_TESTS_ONLY_SRC_ROOT", &library_root)
+        .args(["build", "--manifest-path"])
+        .arg(&manifest)
+        .arg("--target-dir")
+        .arg(&target_dir)
+        .args([
+            "-Z",
+            "build-std=std,core,alloc,panic_abort",
+            "-Z",
+            "build-std-features=compiler-builtins-mem",
+            "-Z",
+            "unstable-options",
+            "-Z",
+            "json-target-spec",
+            "--target",
+        ])
+        .arg(&target_spec);
+    check(cmd.status()?)?;
+
+    let bin = target_dir
+        .join("x86_64-unknown-vibix")
+        .join("debug")
+        .join("ls");
+    if !bin.exists() {
+        return Err(format!("ls binary missing at {} after build", bin.display()).into());
+    }
+    strip_debug(&bin)?;
+    Ok(bin)
+}
+
 /// Generate a minimal stub dynamic-linker ELF for the #764 integration test.
 ///
 /// Produces an ET_DYN ELF64 with a single page-aligned PT_LOAD segment.
@@ -1722,7 +1808,13 @@ fn run_with_root(opts: &BuildOpts, root_flag: Option<&str>, cmdline_extras: &[&s
         Some("ext2") => {
             let init_bin = build_userspace_init()?;
             let sh_bin = build_userspace_sh()?;
-            let extras: Vec<(&Path, &str)> = vec![(&sh_bin, "/bin/sh")];
+            let cat_bin = build_userspace_cat()?;
+            let ls_bin = build_userspace_ls()?;
+            let extras: Vec<(&Path, &str)> = vec![
+                (&sh_bin, "/bin/sh"),
+                (&cat_bin, "/bin/cat"),
+                (&ls_bin, "/bin/ls"),
+            ];
             let img =
                 ext2_image::build_with_extras(&workspace_root(), Some(&init_bin), &extras, true)?;
             println!("→ root=ext2: booting {}", img.display());
@@ -1738,7 +1830,13 @@ fn run_with_root(opts: &BuildOpts, root_flag: Option<&str>, cmdline_extras: &[&s
         None => {
             let init_bin = build_userspace_init()?;
             let sh_bin = build_userspace_sh()?;
-            let extras: Vec<(&Path, &str)> = vec![(&sh_bin, "/bin/sh")];
+            let cat_bin = build_userspace_cat()?;
+            let ls_bin = build_userspace_ls()?;
+            let extras: Vec<(&Path, &str)> = vec![
+                (&sh_bin, "/bin/sh"),
+                (&cat_bin, "/bin/cat"),
+                (&ls_bin, "/bin/ls"),
+            ];
             let img =
                 ext2_image::build_with_extras(&workspace_root(), Some(&init_bin), &extras, true)?;
             (img, Vec::new())
@@ -2079,7 +2177,13 @@ fn smoke(opts: &BuildOpts) -> R<()> {
     let kernel = build(opts)?;
     let userspace_init = build_userspace_init()?;
     let sh_bin = build_userspace_sh()?;
-    let extras: Vec<(&Path, &str)> = vec![(&sh_bin, "/bin/sh")];
+    let cat_bin = build_userspace_cat()?;
+    let ls_bin = build_userspace_ls()?;
+    let extras: Vec<(&Path, &str)> = vec![
+        (&sh_bin, "/bin/sh"),
+        (&cat_bin, "/bin/cat"),
+        (&ls_bin, "/bin/ls"),
+    ];
     let disk =
         ext2_image::build_with_extras(&workspace_root(), Some(&userspace_init), &extras, true)?;
     let iso = workspace_root().join("target").join("vibix.iso");
@@ -2857,9 +2961,15 @@ fn sh_test(opts: &BuildOpts) -> R<()> {
     let kernel = build(opts)?;
     let init_bin = build_userspace_init()?;
     let sh_bin = build_userspace_sh()?;
+    let cat_bin = build_userspace_cat()?;
+    let ls_bin = build_userspace_ls()?;
 
-    // Install init as /init and sh as /bin/sh in the ext2 rootfs image.
-    let extras: Vec<(&Path, &str)> = vec![(&sh_bin, "/bin/sh")];
+    // Install init as /init and sh/cat/ls as /bin/* in the ext2 rootfs image.
+    let extras: Vec<(&Path, &str)> = vec![
+        (&sh_bin, "/bin/sh"),
+        (&cat_bin, "/bin/cat"),
+        (&ls_bin, "/bin/ls"),
+    ];
     let disk = ext2_image::build_with_extras(&workspace_root(), Some(&init_bin), &extras, true)?;
     let iso = workspace_root().join("target").join("vibix-sh.iso");
     make_iso_with_cmdline(&kernel, &iso, "iso_sh", "root=/dev/vda")?;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -800,14 +800,16 @@ fn build_userspace_std_hello() -> R<PathBuf> {
     Ok(bin)
 }
 
-/// Build the `/bin/sh` binary — the vibix POSIX shell.
+/// Build a standalone base-system binary (e.g. sh, cat, ls) using the
+/// out-of-tree `-Z build-std` approach with the in-repo std fork.
 ///
-/// Uses the same out-of-tree `-Z build-std` approach as `std_hello`.
-/// The crate lives in `base/sh/` (base system program, not a test).
-fn build_userspace_sh() -> R<PathBuf> {
+/// `manifest_rel` is the manifest path relative to the workspace root
+/// (e.g. `"base/sh/Cargo.toml"`). `bin_name` is the expected output
+/// binary name under `target/x86_64-unknown-vibix/debug/`.
+fn build_userspace_std_bin(manifest_rel: &str, bin_name: &str) -> R<PathBuf> {
     let ws = workspace_root();
     let target_spec = ws.join(VIBIX_USERSPACE_TARGET);
-    let manifest = ws.join("base/sh/Cargo.toml");
+    let manifest = ws.join(manifest_rel);
     let library_root = ws.join("library");
 
     let target_dir = ws.join("target");
@@ -835,98 +837,27 @@ fn build_userspace_sh() -> R<PathBuf> {
     let bin = target_dir
         .join("x86_64-unknown-vibix")
         .join("debug")
-        .join("sh");
+        .join(bin_name);
     if !bin.exists() {
-        return Err(format!("sh binary missing at {} after build", bin.display()).into());
+        return Err(format!("{bin_name} binary missing at {} after build", bin.display()).into());
     }
     strip_debug(&bin)?;
     Ok(bin)
+}
+
+/// Build the `/bin/sh` binary — the vibix POSIX shell.
+fn build_userspace_sh() -> R<PathBuf> {
+    build_userspace_std_bin("base/sh/Cargo.toml", "sh")
 }
 
 /// Build the `/bin/cat` binary — concatenate files to stdout.
-///
-/// Uses the same out-of-tree `-Z build-std` approach as `build_userspace_sh`.
-/// The crate lives in `base/cat/` (base system program).
 fn build_userspace_cat() -> R<PathBuf> {
-    let ws = workspace_root();
-    let target_spec = ws.join(VIBIX_USERSPACE_TARGET);
-    let manifest = ws.join("base/cat/Cargo.toml");
-    let library_root = ws.join("library");
-
-    let target_dir = ws.join("target");
-    let mut cmd = Command::new("cargo");
-    cmd.current_dir(&ws)
-        .env("__CARGO_TESTS_ONLY_SRC_ROOT", &library_root)
-        .args(["build", "--manifest-path"])
-        .arg(&manifest)
-        .arg("--target-dir")
-        .arg(&target_dir)
-        .args([
-            "-Z",
-            "build-std=std,core,alloc,panic_abort",
-            "-Z",
-            "build-std-features=compiler-builtins-mem",
-            "-Z",
-            "unstable-options",
-            "-Z",
-            "json-target-spec",
-            "--target",
-        ])
-        .arg(&target_spec);
-    check(cmd.status()?)?;
-
-    let bin = target_dir
-        .join("x86_64-unknown-vibix")
-        .join("debug")
-        .join("cat");
-    if !bin.exists() {
-        return Err(format!("cat binary missing at {} after build", bin.display()).into());
-    }
-    strip_debug(&bin)?;
-    Ok(bin)
+    build_userspace_std_bin("base/cat/Cargo.toml", "cat")
 }
 
 /// Build the `/bin/ls` binary — list directory contents.
-///
-/// Uses the same out-of-tree `-Z build-std` approach as `build_userspace_sh`.
-/// The crate lives in `base/ls/` (base system program).
 fn build_userspace_ls() -> R<PathBuf> {
-    let ws = workspace_root();
-    let target_spec = ws.join(VIBIX_USERSPACE_TARGET);
-    let manifest = ws.join("base/ls/Cargo.toml");
-    let library_root = ws.join("library");
-
-    let target_dir = ws.join("target");
-    let mut cmd = Command::new("cargo");
-    cmd.current_dir(&ws)
-        .env("__CARGO_TESTS_ONLY_SRC_ROOT", &library_root)
-        .args(["build", "--manifest-path"])
-        .arg(&manifest)
-        .arg("--target-dir")
-        .arg(&target_dir)
-        .args([
-            "-Z",
-            "build-std=std,core,alloc,panic_abort",
-            "-Z",
-            "build-std-features=compiler-builtins-mem",
-            "-Z",
-            "unstable-options",
-            "-Z",
-            "json-target-spec",
-            "--target",
-        ])
-        .arg(&target_spec);
-    check(cmd.status()?)?;
-
-    let bin = target_dir
-        .join("x86_64-unknown-vibix")
-        .join("debug")
-        .join("ls");
-    if !bin.exists() {
-        return Err(format!("ls binary missing at {} after build", bin.display()).into());
-    }
-    strip_debug(&bin)?;
-    Ok(bin)
+    build_userspace_std_bin("base/ls/Cargo.toml", "ls")
 }
 
 /// Generate a minimal stub dynamic-linker ELF for the #764 integration test.


### PR DESCRIPTION
Closes #902
Closes #903

## Summary
- Add `base/cat/` — a minimal `cat` implementation that reads files from argv to stdout, or copies stdin to stdout when no args are given. Handles errors (file not found prints to stderr, exits 1).
- Add `base/ls/` — a minimal `ls` implementation that lists directory entries sorted alphabetically, one per line, with `/` suffix for directories. Supports multiple path args with headers; defaults to `.` when no args given.
- Both crates follow the established `base/sh/` pattern: standalone packages with `#![feature(restricted_std)]`, built out-of-tree with `-Z build-std` against the in-repo std fork.
- Both include a minimal `syscalls.rs` module providing the `close` C-ABI shim needed by the std PAL's `OwnedFd::drop`.
- Wire both binaries into the ext2 rootfs image via xtask (`build_userspace_cat()` / `build_userspace_ls()`), installed alongside `/bin/sh` in all code paths that assemble the rootfs.

## Test plan
- [x] `cargo xtask build` — full kernel build succeeds
- [x] `cargo fmt --all -- --check` — no formatting issues
- [x] `cargo test -p xtask` — all 71 xtask tests pass
- [x] Both `cat` and `ls` binaries compile successfully for the `x86_64-unknown-vibix` target