### PR TITLE
Pin mapped files independently of open_count for orphan finalization

### DIFF
--- a/kernel/src/fs/ext2/inode.rs
+++ b/kernel/src/fs/ext2/inode.rs
@@ -177,9 +177,9 @@ pub struct Ext2Inode {
     /// Driver-side outstanding-opens refcount. Bumped by
     /// [`FileOps::open`] (one per successful `OpenFile::new`) and
     /// decremented by [`FileOps::release`] (one per `OpenFile::Drop`).
-    /// When [`unlinked`](Self::unlinked) is set and this count
-    /// transitions from one to zero, the `release` hook calls
-    /// [`super::orphan_finalize::finalize`] directly to drive the
+    /// When [`unlinked`](Self::unlinked) is set and **both** this count
+    /// and [`map_count`](Self::map_count) are zero, the `release` hook
+    /// calls [`super::orphan_finalize::finalize`] directly to drive the
     /// RFC 0004 §Final-close sequence — bypassing the VFS
     /// `gc_queue`/`evict_inode` indirection that would otherwise be
     /// blocked by the orphan-list `Arc<Inode>` pin (chicken-and-egg:
@@ -188,6 +188,15 @@ pub struct Ext2Inode {
     /// trigger eviction). See issue #638 / RFC 0004 §Wiring the
     /// production trigger.
     pub open_count: AtomicU32,
+    /// Outstanding mmap refcount. Bumped by [`FileOps::mmap`] (one per
+    /// `FileObject` constructed) and decremented by
+    /// [`Ext2MmapGuard::drop`] (one per `FileObject` dropped). This
+    /// pins the inode against orphan finalization independently of
+    /// `open_count` — a `FileObject` can outlive its originating
+    /// `OpenFile`, so `unlink() + mmap() + close()` must not trigger
+    /// finalize while a mapping can still fault through the cache.
+    /// See issue #811.
+    pub map_count: AtomicU32,
 }
 
 impl Ext2Inode {
@@ -199,6 +208,63 @@ impl Ext2Inode {
             block_map: BlockingRwLock::new(None),
             unlinked: AtomicBool::new(false),
             open_count: AtomicU32::new(0),
+            map_count: AtomicU32::new(0),
+        }
+    }
+
+    /// Try to run orphan finalization if both `open_count` and
+    /// `map_count` have reached zero and the inode is unlinked.
+    /// Called from [`Self::release`] and from [`Ext2MmapGuard::drop`].
+    fn try_finalize_orphan(&self) {
+        if self.open_count.load(Ordering::SeqCst) != 0 {
+            return;
+        }
+        if self.map_count.load(Ordering::SeqCst) != 0 {
+            return;
+        }
+        if !self.unlinked.load(Ordering::SeqCst) {
+            return;
+        }
+        let Some(super_arc) = self.super_ref.upgrade() else {
+            // Mount is mid-teardown; the orphan-list pin will be
+            // released when the per-super state drops, and any leaked
+            // on-disk state is recovered by mount-replay on the next
+            // boot.
+            return;
+        };
+        if let Err(e) = super::orphan_finalize::finalize(&super_arc, self.ino) {
+            crate::kwarn!(
+                "ext2: finalize ino {}: errno={}, leaving pin for replay",
+                self.ino,
+                e,
+            );
+        }
+    }
+}
+
+/// Guard that pins an ext2 inode's `map_count` for the lifetime of a
+/// `FileObject`. When this guard is dropped (via the `FileObject`'s
+/// `_mmap_guard` field), `map_count` is decremented and orphan
+/// finalization is attempted if both counts have reached zero. See
+/// issue #811.
+pub struct Ext2MmapGuard {
+    ext2_inode: alloc::sync::Arc<Ext2Inode>,
+}
+
+impl Ext2MmapGuard {
+    /// Create a new guard, bumping `map_count` by one.
+    pub fn new(ext2_inode: alloc::sync::Arc<Ext2Inode>) -> Self {
+        ext2_inode.map_count.fetch_add(1, Ordering::SeqCst);
+        Self { ext2_inode }
+    }
+}
+
+impl Drop for Ext2MmapGuard {
+    fn drop(&mut self) {
+        let prev = self.ext2_inode.map_count.fetch_sub(1, Ordering::SeqCst);
+        debug_assert!(prev > 0, "Ext2MmapGuard::drop: map_count underflow");
+        if prev == 1 {
+            self.ext2_inode.try_finalize_orphan();
         }
     }
 }
@@ -473,10 +539,10 @@ impl FileOps for Ext2Inode {
     }
 
     /// Decrement the outstanding-opens refcount. If the count
-    /// transitions from one to zero AND the inode is unlinked
-    /// (i.e. on the per-mount [`OrphanList`]), drive the RFC 0004
-    /// §Final-close sequence synchronously via
-    /// [`super::orphan_finalize::finalize`].
+    /// transitions from one to zero AND [`map_count`](Self::map_count)
+    /// is also zero AND the inode is unlinked (i.e. on the per-mount
+    /// [`OrphanList`]), drive the RFC 0004 §Final-close sequence
+    /// synchronously via [`super::orphan_finalize::finalize`].
     ///
     /// This is the in-kernel production trigger for orphan-finalize
     /// (issue #638). The VFS `gc_queue` / `evict_inode` indirection
@@ -501,29 +567,10 @@ impl FileOps for Ext2Inode {
         if prev != 1 {
             return;
         }
-        // Last close. If the inode is unlinked, run finalize. The
-        // `unlinked` atomic is set by `unlink::push_on_orphan_list`'s
-        // caller before the orphan-list pin is installed, so reading
-        // `true` here is sufficient evidence that the orphan_list
-        // entry exists (or will be observed by `finalize`'s ENOENT
-        // path otherwise — idempotent).
-        if !self.unlinked.load(Ordering::SeqCst) {
-            return;
-        }
-        let Some(super_arc) = self.super_ref.upgrade() else {
-            // Mount is mid-teardown; the orphan-list pin will be
-            // released when the per-super state drops, and any leaked
-            // on-disk state is recovered by mount-replay on the next
-            // boot.
-            return;
-        };
-        if let Err(e) = super::orphan_finalize::finalize(&super_arc, self.ino) {
-            crate::kwarn!(
-                "ext2: open_count→0 finalize ino {}: errno={}, leaving pin for replay",
-                self.ino,
-                e,
-            );
-        }
+        // Last close — but mappings may still be live. Defer orphan
+        // finalization until every `FileObject` derived from this
+        // inode has been dropped (map_count reaches zero). Issue #811.
+        self.try_finalize_orphan();
     }
 
     /// Build a [`FileObject`] (RFC 0007 §FileObject) for an `mmap(2)`
@@ -638,13 +685,28 @@ impl FileOps for Ext2Inode {
             })
             .unwrap_or(false);
 
-        let fo = crate::mem::file_object::FileObject::new(
+        // Build an mmap guard that pins `map_count` for the lifetime
+        // of the returned `FileObject`. This prevents orphan finalization
+        // from running while the mapping can still page-fault through the
+        // cache — issue #811.
+        let guard = {
+            let super_ref = self.super_ref.upgrade().ok_or(EIO)?;
+            let ecache = super_ref.ext2_inode_cache.lock();
+            let ext2_arc = ecache
+                .get(&self.ino)
+                .and_then(alloc::sync::Weak::upgrade)
+                .ok_or(EIO)?;
+            Ext2MmapGuard::new(ext2_arc)
+        };
+
+        let fo = crate::mem::file_object::FileObject::new_with_guard(
             cache,
             file_offset_pages,
             len_pages,
             share,
             open_mode,
             exec_allowed,
+            Some(alloc::boxed::Box::new(guard)),
         );
         Ok(fo as alloc::sync::Arc<dyn crate::mem::vmobject::VmObject>)
     }

--- a/kernel/src/mem/file_object.rs
+++ b/kernel/src/mem/file_object.rs
@@ -162,7 +162,15 @@ impl FileObject {
         open_mode: u32,
         exec_allowed: bool,
     ) -> Arc<Self> {
-        Self::new_with_guard(cache, file_offset_pages, len_pages, share, open_mode, exec_allowed, None)
+        Self::new_with_guard(
+            cache,
+            file_offset_pages,
+            len_pages,
+            share,
+            open_mode,
+            exec_allowed,
+            None,
+        )
     }
 
     /// Like [`Self::new`], but accepts an optional mmap guard that is

--- a/kernel/src/mem/file_object.rs
+++ b/kernel/src/mem/file_object.rs
@@ -49,6 +49,7 @@
 //!   They construct an `Arc<FileObject>` with the same fields this
 //!   module defines; nothing here depends on those drivers.
 
+use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
 use alloc::sync::Arc;
 
@@ -127,6 +128,14 @@ pub struct FileObject {
     /// Population is deferred to #739/#746 — the CoW resolver wiring;
     /// this module exposes only the storage and a query helper.
     private_frames: BlockingMutex<BTreeMap<u64, u64>>,
+
+    /// Optional guard dropped when this `FileObject` is dropped.
+    /// Used by filesystem drivers (e.g. ext2) to pin the inode against
+    /// orphan finalization while a mapping derived from it is still
+    /// alive. The guard's `Drop` impl decrements the driver's
+    /// `map_count` and, if appropriate, triggers deferred orphan
+    /// finalization. See issue #811.
+    _mmap_guard: Option<Box<dyn Send + Sync>>,
 }
 
 impl FileObject {
@@ -153,6 +162,22 @@ impl FileObject {
         open_mode: u32,
         exec_allowed: bool,
     ) -> Arc<Self> {
+        Self::new_with_guard(cache, file_offset_pages, len_pages, share, open_mode, exec_allowed, None)
+    }
+
+    /// Like [`Self::new`], but accepts an optional mmap guard that is
+    /// dropped when this `FileObject` is dropped. Filesystem drivers
+    /// use this to pin the inode against orphan finalization while a
+    /// mapping exists. See issue #811.
+    pub fn new_with_guard(
+        cache: Arc<PageCache>,
+        file_offset_pages: u64,
+        len_pages: usize,
+        share: Share,
+        open_mode: u32,
+        exec_allowed: bool,
+        mmap_guard: Option<Box<dyn Send + Sync>>,
+    ) -> Arc<Self> {
         // Validate the file-page window: `file_offset_pages + len_pages`
         // must not wrap. Lookups below combine the two via `pgoff_of`,
         // and a wrapped sum would index unrelated cache entries instead
@@ -173,6 +198,7 @@ impl FileObject {
             open_mode,
             exec_allowed,
             private_frames: BlockingMutex::new(BTreeMap::new()),
+            _mmap_guard: mmap_guard,
         })
     }
 
@@ -299,6 +325,12 @@ impl FileObject {
             // same reason as open_mode.
             exec_allowed: self.exec_allowed,
             private_frames: BlockingMutex::new(BTreeMap::new()),
+            // The clone is a post-fork private copy; the originating
+            // process's open_count (bumped at fork via dup_fd) covers
+            // orphan-finalization deferral. No separate mmap guard
+            // needed — the parent's guard (or the child's own
+            // open_count) prevents premature finalization.
+            _mmap_guard: None,
         })
     }
 }

--- a/kernel/tests/ext2_create.rs
+++ b/kernel/tests/ext2_create.rs
@@ -187,6 +187,7 @@ fn make_ext2_inode_from_disk(
         block_map: BlockingRwLock::new(None),
         unlinked: AtomicBool::new(false),
         open_count: AtomicU32::new(0),
+        map_count: AtomicU32::new(0),
     }
 }
 

--- a/kernel/tests/ext2_dir_ops.rs
+++ b/kernel/tests/ext2_dir_ops.rs
@@ -185,6 +185,7 @@ fn make_ext2_inode_from_stat(
         block_map: BlockingRwLock::new(None),
         unlinked: AtomicBool::new(false),
         open_count: AtomicU32::new(0),
+        map_count: AtomicU32::new(0),
     }
 }
 

--- a/kernel/tests/ext2_link.rs
+++ b/kernel/tests/ext2_link.rs
@@ -198,6 +198,7 @@ fn make_ext2_inode_from_disk(
         block_map: BlockingRwLock::new(None),
         unlinked: AtomicBool::new(false),
         open_count: AtomicU32::new(0),
+        map_count: AtomicU32::new(0),
     }
 }
 

--- a/kernel/tests/ext2_malformed_dir.rs
+++ b/kernel/tests/ext2_malformed_dir.rs
@@ -174,6 +174,7 @@ fn make_ext2_inode_from_stat(
         block_map: BlockingRwLock::new(None),
         unlinked: AtomicBool::new(false),
         open_count: AtomicU32::new(0),
+        map_count: AtomicU32::new(0),
     }
 }
 

--- a/kernel/tests/ext2_mmap.rs
+++ b/kernel/tests/ext2_mmap.rs
@@ -215,6 +215,11 @@ fn mmap_returns_file_object_against_lazy_page_cache() {
     assert_eq!(obj1.len_pages(), Some(1));
     assert_eq!(obj2.len_pages(), Some(1));
 
+    // Drop mapped objects before the open file / inode / superblock so
+    // the mmap guard's map_count decrement fires while the mount is
+    // still live. Issue #811.
+    drop(obj1);
+    drop(obj2);
     drop(of);
     drop(inode);
     sb.ops.unmount();

--- a/kernel/tests/ext2_rename.rs
+++ b/kernel/tests/ext2_rename.rs
@@ -200,6 +200,7 @@ fn ext2_from_disk(
         block_map: BlockingRwLock::new(None),
         unlinked: AtomicBool::new(false),
         open_count: AtomicU32::new(0),
+        map_count: AtomicU32::new(0),
     }
 }
 

--- a/kernel/tests/ext2_setattr.rs
+++ b/kernel/tests/ext2_setattr.rs
@@ -510,6 +510,7 @@ fn ext2_inode_from_disk(super_arc: &Arc<Ext2Super>, ino: u32) -> Ext2Inode {
         block_map: BlockingRwLock::new(None),
         unlinked: AtomicBool::new(false),
         open_count: AtomicU32::new(0),
+        map_count: AtomicU32::new(0),
     }
 }
 


### PR DESCRIPTION
Closes #811

## Summary
- Adds a `map_count` atomic to `Ext2Inode` that tracks outstanding `FileObject` mappings independently of `open_count`, preventing `orphan_finalize::finalize()` from running while a mapping can still fault through the page cache.
- Introduces `Ext2MmapGuard` — a drop guard stored in `FileObject._mmap_guard` that bumps `map_count` on construction and decrements it on drop. Both `release` (open_count -> 0) and `Ext2MmapGuard::drop` (map_count -> 0) call `try_finalize_orphan`, which only runs finalize when both counters are zero and the inode is unlinked.
- Fixes `mmap_returns_file_object_against_lazy_page_cache` test to drop mapped objects before the `OpenFile`/inode/superblock to prevent use-after-unmount.

## Test plan
- [x] `cargo xtask build` — compiles cleanly
- [x] `cargo xtask test` — all tests pass (only known-flaky `rwlock_concurrent_readers` fails, pre-existing on main)
- [x] `cargo xtask smoke` — all 43 markers present