### PR TITLE
Add framebuffer TTY driver for console output

### DIFF
--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -667,8 +667,12 @@ impl FileBackend for SerialBackend {
         if let Some(rc) = crate::tty::tty_check_tostop(&tty, caller) {
             return Err(rc);
         }
-        crate::serial::write_bytes(buf);
-        Ok(buf.len())
+        // Write through the console TTY's driver so output reaches both
+        // the serial port (CI smoke markers) and the framebuffer (on-screen
+        // display). Previously this called `serial::write_bytes` directly,
+        // bypassing the framebuffer entirely.
+        let n = tty.driver.write(buf);
+        Ok(n)
     }
 
     fn ioctl(&self, cmd: u32, arg: usize) -> Result<i64, i64> {

--- a/kernel/src/tty/framebuffer.rs
+++ b/kernel/src/tty/framebuffer.rs
@@ -1,0 +1,107 @@
+//! Framebuffer TTY driver for console output.
+//!
+//! Issue #897. [`FramebufferDriver`] implements [`TtyDriver`] by feeding
+//! bytes into the framebuffer console's existing ANSI/VT100 terminal
+//! emulator ([`crate::framebuffer::CONSOLE`]). This gives userspace
+//! processes visible output on the display while keeping the full
+//! escape-sequence, scrollback, and alt-screen machinery that the
+//! framebuffer module already provides.
+//!
+//! [`DualDriver`] multiplexes writes to both the serial port (for CI
+//! smoke-test markers) and the framebuffer (for on-screen display).
+
+use crate::tty::TtyDriver;
+
+/// TTY driver that writes to the framebuffer console.
+///
+/// Each byte slice is interpreted as UTF-8 and fed character-by-character
+/// into [`crate::framebuffer::_print`], which acquires the `CONSOLE` lock
+/// and drives the ANSI parser + glyph renderer.
+pub struct FramebufferDriver;
+
+impl TtyDriver for FramebufferDriver {
+    #[cfg(target_os = "none")]
+    fn write(&self, buf: &[u8]) -> usize {
+        // The framebuffer console expects characters via `write_char` /
+        // `write_str`. Convert the byte slice to a &str (lossy: invalid
+        // UTF-8 is replaced with U+FFFD, which the glyph renderer handles
+        // gracefully). Most kernel and userspace output is ASCII or valid
+        // UTF-8 so the fast path hits `from_utf8` without copying.
+        match core::str::from_utf8(buf) {
+            Ok(s) => {
+                crate::framebuffer::_print(format_args!("{}", s));
+            }
+            Err(_) => {
+                // Fallback: write byte-by-byte as individual chars.
+                // Non-UTF-8 bytes become their Latin-1 code points, which
+                // is what a terminal emulator would do.
+                if let Some(console) = crate::framebuffer::CONSOLE.lock().as_mut() {
+                    for &b in buf {
+                        console.write_char(b as char);
+                    }
+                }
+            }
+        }
+        buf.len()
+    }
+
+    #[cfg(not(target_os = "none"))]
+    fn write(&self, buf: &[u8]) -> usize {
+        buf.len()
+    }
+}
+
+/// Multiplexing driver that writes to both serial and framebuffer.
+///
+/// CI smoke tests read serial output for pass/fail markers, so serial
+/// must remain active. The framebuffer provides on-screen console output
+/// for interactive use. This driver writes to serial first (lower
+/// latency, no lock contention with the framebuffer's pixel blitter),
+/// then to the framebuffer.
+pub struct DualDriver;
+
+impl TtyDriver for DualDriver {
+    #[cfg(target_os = "none")]
+    fn write(&self, buf: &[u8]) -> usize {
+        // Serial first — fast, no pixel work.
+        crate::serial::write_bytes(buf);
+        // Then framebuffer.
+        match core::str::from_utf8(buf) {
+            Ok(s) => {
+                crate::framebuffer::_print(format_args!("{}", s));
+            }
+            Err(_) => {
+                if let Some(console) = crate::framebuffer::CONSOLE.lock().as_mut() {
+                    for &b in buf {
+                        console.write_char(b as char);
+                    }
+                }
+            }
+        }
+        buf.len()
+    }
+
+    #[cfg(not(target_os = "none"))]
+    fn write(&self, buf: &[u8]) -> usize {
+        buf.len()
+    }
+}
+
+#[cfg(all(test, not(target_os = "none")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn framebuffer_driver_write_reports_all_bytes() {
+        let d = FramebufferDriver;
+        assert_eq!(d.write(b""), 0);
+        assert_eq!(d.write(b"hello"), 5);
+    }
+
+    #[test]
+    fn dual_driver_write_reports_all_bytes() {
+        let d = DualDriver;
+        assert_eq!(d.write(b""), 0);
+        assert_eq!(d.write(b"hello world"), 11);
+    }
+}

--- a/kernel/src/tty/mod.rs
+++ b/kernel/src/tty/mod.rs
@@ -13,6 +13,7 @@
 //!
 //! See `docs/RFC/0003-pipes-poll-tty.md` for the design rationale.
 
+pub mod framebuffer;
 pub mod ntty;
 pub mod ps2;
 pub mod ring;
@@ -257,8 +258,16 @@ impl Default for Tty {
 /// A real multi-tty world (pty, serial[N], vt[N]) arrives with #374/#403 —
 /// until then every legacy `/dev/*` open refers to the same `Arc<Tty>` so
 /// session/pgrp identity is shared across fds as POSIX expects.
+///
+/// The driver is [`framebuffer::DualDriver`], which writes to both serial
+/// (for CI smoke markers) and the framebuffer (for on-screen display).
 #[cfg(target_os = "none")]
-pub static CONSOLE_TTY: Lazy<Arc<Tty>> = Lazy::new(|| Arc::new(Tty::new()));
+pub static CONSOLE_TTY: Lazy<Arc<Tty>> = Lazy::new(|| {
+    Arc::new(Tty::with_driver(
+        Arc::new(framebuffer::DualDriver),
+        Arc::new(PassthroughLdisc::new()) as Arc<dyn LineDiscipline>,
+    ))
+});
 
 /// Return the shared console tty.
 #[cfg(target_os = "none")]


### PR DESCRIPTION
Closes #897

## Summary
- Introduce `FramebufferDriver` and `DualDriver` in `kernel/src/tty/framebuffer.rs` -- `DualDriver` writes to both serial and framebuffer so CI smoke markers remain visible while userspace output appears on screen
- Wire `CONSOLE_TTY` to use `DualDriver` instead of `NullDriver`, giving the system-wide console tty a real output path to the framebuffer
- Route `SerialBackend::write()` through the console TTY's driver (`tty.driver.write(buf)`) instead of calling `serial::write_bytes()` directly, so all userspace writes flow through the TTY layer

## Test plan
- [x] `cargo xtask build` -- compiles cleanly
- [x] `cargo xtask smoke` -- all 43 markers present
- [x] `cargo fmt --all -- --check` -- no formatting issues
- [x] `cargo xtask test` -- host unit tests pass; only pre-existing flaky `rwlock_concurrent_readers` failure in `blocking_sync` (timing-dependent, unrelated)