### PR TITLE
Add userspace file utilities (stat, cp, mv, rm, mkdir, rmdir, touch) and /bin/uname

### DIFF
--- a/base/cp/Cargo.toml
+++ b/base/cp/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "cp"
+version = "0.1.0"
+edition = "2021"
+authors = ["vibix hackers"]
+license = "MIT OR Apache-2.0"
+
+[[bin]]
+name = "cp"
+path = "src/main.rs"
+
+# Standalone package — not part of the main workspace. Built with
+# `-Z build-std` against the in-repo std fork (see xtask build).
+[workspace]

--- a/base/cp/src/main.rs
+++ b/base/cp/src/main.rs
@@ -1,0 +1,27 @@
+#![feature(restricted_std)]
+
+#[cfg(not(test))]
+mod syscalls;
+
+use std::env;
+use std::fs;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() != 3 {
+        eprintln!("usage: cp <src> <dst>");
+        return ExitCode::from(1);
+    }
+
+    let src = &args[1];
+    let dst = &args[2];
+
+    if let Err(e) = fs::copy(src, dst) {
+        eprintln!("cp: {src} -> {dst}: {e}");
+        return ExitCode::from(1);
+    }
+
+    ExitCode::from(0)
+}

--- a/base/cp/src/syscalls.rs
+++ b/base/cp/src/syscalls.rs
@@ -27,7 +27,7 @@ unsafe fn raw1(nr: u64, a0: u64) -> i64 {
             lateout("r8") _,
             lateout("r9") _,
             lateout("r10") _,
-            options(nostack, preserves_flags),
+            options(nostack),
         );
     }
     ret

--- a/base/cp/src/syscalls.rs
+++ b/base/cp/src/syscalls.rs
@@ -1,0 +1,50 @@
+//! C-ABI syscall shims required by the vibix std fork.
+//!
+//! The in-repo std fork links against POSIX symbols (`close`, etc.) that are
+//! not provided by a system libc on vibix. We supply them here via raw
+//! syscall instructions, mirroring the approach in `base/sh/src/syscalls.rs`.
+
+use core::arch::asm;
+
+const SYS_CLOSE: u64 = 3;
+
+extern "C" {
+    fn __errno_location() -> *mut i32;
+}
+
+#[inline(always)]
+unsafe fn raw1(nr: u64, a0: u64) -> i64 {
+    let ret: i64;
+    unsafe {
+        asm!(
+            "syscall",
+            inlateout("rax") nr => ret,
+            inlateout("rdi") a0 => _,
+            lateout("rcx") _,
+            lateout("r11") _,
+            lateout("rdx") _,
+            lateout("rsi") _,
+            lateout("r8") _,
+            lateout("r9") _,
+            lateout("r10") _,
+            options(nostack, preserves_flags),
+        );
+    }
+    ret
+}
+
+/// Convert raw syscall return to C convention: on error set errno, return -1.
+#[inline]
+unsafe fn cvt(r: i64) -> i64 {
+    if r < 0 {
+        unsafe { *__errno_location() = (-r) as i32 };
+        -1
+    } else {
+        r
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn close(fd: i32) -> i32 {
+    unsafe { cvt(raw1(SYS_CLOSE, fd as u64)) as i32 }
+}

--- a/base/mkdir/Cargo.toml
+++ b/base/mkdir/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "mkdir"
+version = "0.1.0"
+edition = "2021"
+authors = ["vibix hackers"]
+license = "MIT OR Apache-2.0"
+
+[[bin]]
+name = "mkdir"
+path = "src/main.rs"
+
+# Standalone package — not part of the main workspace. Built with
+# `-Z build-std` against the in-repo std fork (see xtask build).
+[workspace]

--- a/base/mkdir/src/main.rs
+++ b/base/mkdir/src/main.rs
@@ -1,0 +1,27 @@
+#![feature(restricted_std)]
+
+#[cfg(not(test))]
+mod syscalls;
+
+use std::env;
+use std::fs;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() <= 1 {
+        eprintln!("mkdir: missing operand");
+        return ExitCode::from(1);
+    }
+
+    let mut status: u8 = 0;
+    for path in &args[1..] {
+        if let Err(e) = fs::create_dir(path) {
+            eprintln!("mkdir: {path}: {e}");
+            status = 1;
+        }
+    }
+
+    ExitCode::from(status)
+}

--- a/base/mkdir/src/syscalls.rs
+++ b/base/mkdir/src/syscalls.rs
@@ -27,7 +27,7 @@ unsafe fn raw1(nr: u64, a0: u64) -> i64 {
             lateout("r8") _,
             lateout("r9") _,
             lateout("r10") _,
-            options(nostack, preserves_flags),
+            options(nostack),
         );
     }
     ret

--- a/base/mkdir/src/syscalls.rs
+++ b/base/mkdir/src/syscalls.rs
@@ -1,0 +1,50 @@
+//! C-ABI syscall shims required by the vibix std fork.
+//!
+//! The in-repo std fork links against POSIX symbols (`close`, etc.) that are
+//! not provided by a system libc on vibix. We supply them here via raw
+//! syscall instructions, mirroring the approach in `base/sh/src/syscalls.rs`.
+
+use core::arch::asm;
+
+const SYS_CLOSE: u64 = 3;
+
+extern "C" {
+    fn __errno_location() -> *mut i32;
+}
+
+#[inline(always)]
+unsafe fn raw1(nr: u64, a0: u64) -> i64 {
+    let ret: i64;
+    unsafe {
+        asm!(
+            "syscall",
+            inlateout("rax") nr => ret,
+            inlateout("rdi") a0 => _,
+            lateout("rcx") _,
+            lateout("r11") _,
+            lateout("rdx") _,
+            lateout("rsi") _,
+            lateout("r8") _,
+            lateout("r9") _,
+            lateout("r10") _,
+            options(nostack, preserves_flags),
+        );
+    }
+    ret
+}
+
+/// Convert raw syscall return to C convention: on error set errno, return -1.
+#[inline]
+unsafe fn cvt(r: i64) -> i64 {
+    if r < 0 {
+        unsafe { *__errno_location() = (-r) as i32 };
+        -1
+    } else {
+        r
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn close(fd: i32) -> i32 {
+    unsafe { cvt(raw1(SYS_CLOSE, fd as u64)) as i32 }
+}

--- a/base/mv/Cargo.toml
+++ b/base/mv/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "mv"
+version = "0.1.0"
+edition = "2021"
+authors = ["vibix hackers"]
+license = "MIT OR Apache-2.0"
+
+[[bin]]
+name = "mv"
+path = "src/main.rs"
+
+# Standalone package — not part of the main workspace. Built with
+# `-Z build-std` against the in-repo std fork (see xtask build).
+[workspace]

--- a/base/mv/src/main.rs
+++ b/base/mv/src/main.rs
@@ -1,0 +1,27 @@
+#![feature(restricted_std)]
+
+#[cfg(not(test))]
+mod syscalls;
+
+use std::env;
+use std::fs;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() != 3 {
+        eprintln!("usage: mv <src> <dst>");
+        return ExitCode::from(1);
+    }
+
+    let src = &args[1];
+    let dst = &args[2];
+
+    if let Err(e) = fs::rename(src, dst) {
+        eprintln!("mv: {src} -> {dst}: {e}");
+        return ExitCode::from(1);
+    }
+
+    ExitCode::from(0)
+}

--- a/base/mv/src/syscalls.rs
+++ b/base/mv/src/syscalls.rs
@@ -27,7 +27,7 @@ unsafe fn raw1(nr: u64, a0: u64) -> i64 {
             lateout("r8") _,
             lateout("r9") _,
             lateout("r10") _,
-            options(nostack, preserves_flags),
+            options(nostack),
         );
     }
     ret

--- a/base/mv/src/syscalls.rs
+++ b/base/mv/src/syscalls.rs
@@ -1,0 +1,50 @@
+//! C-ABI syscall shims required by the vibix std fork.
+//!
+//! The in-repo std fork links against POSIX symbols (`close`, etc.) that are
+//! not provided by a system libc on vibix. We supply them here via raw
+//! syscall instructions, mirroring the approach in `base/sh/src/syscalls.rs`.
+
+use core::arch::asm;
+
+const SYS_CLOSE: u64 = 3;
+
+extern "C" {
+    fn __errno_location() -> *mut i32;
+}
+
+#[inline(always)]
+unsafe fn raw1(nr: u64, a0: u64) -> i64 {
+    let ret: i64;
+    unsafe {
+        asm!(
+            "syscall",
+            inlateout("rax") nr => ret,
+            inlateout("rdi") a0 => _,
+            lateout("rcx") _,
+            lateout("r11") _,
+            lateout("rdx") _,
+            lateout("rsi") _,
+            lateout("r8") _,
+            lateout("r9") _,
+            lateout("r10") _,
+            options(nostack, preserves_flags),
+        );
+    }
+    ret
+}
+
+/// Convert raw syscall return to C convention: on error set errno, return -1.
+#[inline]
+unsafe fn cvt(r: i64) -> i64 {
+    if r < 0 {
+        unsafe { *__errno_location() = (-r) as i32 };
+        -1
+    } else {
+        r
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn close(fd: i32) -> i32 {
+    unsafe { cvt(raw1(SYS_CLOSE, fd as u64)) as i32 }
+}

--- a/base/rm/Cargo.toml
+++ b/base/rm/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rm"
+version = "0.1.0"
+edition = "2021"
+authors = ["vibix hackers"]
+license = "MIT OR Apache-2.0"
+
+[[bin]]
+name = "rm"
+path = "src/main.rs"
+
+# Standalone package — not part of the main workspace. Built with
+# `-Z build-std` against the in-repo std fork (see xtask build).
+[workspace]

--- a/base/rm/src/main.rs
+++ b/base/rm/src/main.rs
@@ -1,0 +1,27 @@
+#![feature(restricted_std)]
+
+#[cfg(not(test))]
+mod syscalls;
+
+use std::env;
+use std::fs;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() <= 1 {
+        eprintln!("rm: missing operand");
+        return ExitCode::from(1);
+    }
+
+    let mut status: u8 = 0;
+    for path in &args[1..] {
+        if let Err(e) = fs::remove_file(path) {
+            eprintln!("rm: {path}: {e}");
+            status = 1;
+        }
+    }
+
+    ExitCode::from(status)
+}

--- a/base/rm/src/syscalls.rs
+++ b/base/rm/src/syscalls.rs
@@ -27,7 +27,7 @@ unsafe fn raw1(nr: u64, a0: u64) -> i64 {
             lateout("r8") _,
             lateout("r9") _,
             lateout("r10") _,
-            options(nostack, preserves_flags),
+            options(nostack),
         );
     }
     ret

--- a/base/rm/src/syscalls.rs
+++ b/base/rm/src/syscalls.rs
@@ -1,0 +1,50 @@
+//! C-ABI syscall shims required by the vibix std fork.
+//!
+//! The in-repo std fork links against POSIX symbols (`close`, etc.) that are
+//! not provided by a system libc on vibix. We supply them here via raw
+//! syscall instructions, mirroring the approach in `base/sh/src/syscalls.rs`.
+
+use core::arch::asm;
+
+const SYS_CLOSE: u64 = 3;
+
+extern "C" {
+    fn __errno_location() -> *mut i32;
+}
+
+#[inline(always)]
+unsafe fn raw1(nr: u64, a0: u64) -> i64 {
+    let ret: i64;
+    unsafe {
+        asm!(
+            "syscall",
+            inlateout("rax") nr => ret,
+            inlateout("rdi") a0 => _,
+            lateout("rcx") _,
+            lateout("r11") _,
+            lateout("rdx") _,
+            lateout("rsi") _,
+            lateout("r8") _,
+            lateout("r9") _,
+            lateout("r10") _,
+            options(nostack, preserves_flags),
+        );
+    }
+    ret
+}
+
+/// Convert raw syscall return to C convention: on error set errno, return -1.
+#[inline]
+unsafe fn cvt(r: i64) -> i64 {
+    if r < 0 {
+        unsafe { *__errno_location() = (-r) as i32 };
+        -1
+    } else {
+        r
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn close(fd: i32) -> i32 {
+    unsafe { cvt(raw1(SYS_CLOSE, fd as u64)) as i32 }
+}

--- a/base/rmdir/Cargo.toml
+++ b/base/rmdir/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rmdir"
+version = "0.1.0"
+edition = "2021"
+authors = ["vibix hackers"]
+license = "MIT OR Apache-2.0"
+
+[[bin]]
+name = "rmdir"
+path = "src/main.rs"
+
+# Standalone package — not part of the main workspace. Built with
+# `-Z build-std` against the in-repo std fork (see xtask build).
+[workspace]

--- a/base/rmdir/src/main.rs
+++ b/base/rmdir/src/main.rs
@@ -1,0 +1,27 @@
+#![feature(restricted_std)]
+
+#[cfg(not(test))]
+mod syscalls;
+
+use std::env;
+use std::fs;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() <= 1 {
+        eprintln!("rmdir: missing operand");
+        return ExitCode::from(1);
+    }
+
+    let mut status: u8 = 0;
+    for path in &args[1..] {
+        if let Err(e) = fs::remove_dir(path) {
+            eprintln!("rmdir: {path}: {e}");
+            status = 1;
+        }
+    }
+
+    ExitCode::from(status)
+}

--- a/base/rmdir/src/syscalls.rs
+++ b/base/rmdir/src/syscalls.rs
@@ -27,7 +27,7 @@ unsafe fn raw1(nr: u64, a0: u64) -> i64 {
             lateout("r8") _,
             lateout("r9") _,
             lateout("r10") _,
-            options(nostack, preserves_flags),
+            options(nostack),
         );
     }
     ret

--- a/base/rmdir/src/syscalls.rs
+++ b/base/rmdir/src/syscalls.rs
@@ -1,0 +1,50 @@
+//! C-ABI syscall shims required by the vibix std fork.
+//!
+//! The in-repo std fork links against POSIX symbols (`close`, etc.) that are
+//! not provided by a system libc on vibix. We supply them here via raw
+//! syscall instructions, mirroring the approach in `base/sh/src/syscalls.rs`.
+
+use core::arch::asm;
+
+const SYS_CLOSE: u64 = 3;
+
+extern "C" {
+    fn __errno_location() -> *mut i32;
+}
+
+#[inline(always)]
+unsafe fn raw1(nr: u64, a0: u64) -> i64 {
+    let ret: i64;
+    unsafe {
+        asm!(
+            "syscall",
+            inlateout("rax") nr => ret,
+            inlateout("rdi") a0 => _,
+            lateout("rcx") _,
+            lateout("r11") _,
+            lateout("rdx") _,
+            lateout("rsi") _,
+            lateout("r8") _,
+            lateout("r9") _,
+            lateout("r10") _,
+            options(nostack, preserves_flags),
+        );
+    }
+    ret
+}
+
+/// Convert raw syscall return to C convention: on error set errno, return -1.
+#[inline]
+unsafe fn cvt(r: i64) -> i64 {
+    if r < 0 {
+        unsafe { *__errno_location() = (-r) as i32 };
+        -1
+    } else {
+        r
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn close(fd: i32) -> i32 {
+    unsafe { cvt(raw1(SYS_CLOSE, fd as u64)) as i32 }
+}

--- a/base/stat/Cargo.toml
+++ b/base/stat/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stat"
+version = "0.1.0"
+edition = "2021"
+authors = ["vibix hackers"]
+license = "MIT OR Apache-2.0"
+
+[[bin]]
+name = "stat"
+path = "src/main.rs"
+
+# Standalone package — not part of the main workspace. Built with
+# `-Z build-std` against the in-repo std fork (see xtask build).
+[workspace]

--- a/base/stat/src/main.rs
+++ b/base/stat/src/main.rs
@@ -1,0 +1,53 @@
+#![feature(restricted_std)]
+
+#[cfg(not(test))]
+mod syscalls;
+
+use std::env;
+use std::fs;
+use std::process::ExitCode;
+
+fn stat_path(path: &str) -> u8 {
+    let meta = match fs::symlink_metadata(path) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("stat: {path}: {e}");
+            return 1;
+        }
+    };
+
+    let file_type = if meta.is_dir() {
+        "directory"
+    } else if meta.is_symlink() {
+        "symbolic link"
+    } else {
+        "regular file"
+    };
+
+    println!("  File: {path}");
+    println!("  Size: {}", meta.len());
+    println!(" Type: {file_type}");
+    println!("Inode: unknown");
+    println!("Links: unknown");
+
+    0
+}
+
+fn main() -> ExitCode {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() <= 1 {
+        eprintln!("stat: missing operand");
+        return ExitCode::from(1);
+    }
+
+    let mut status: u8 = 0;
+    for path in &args[1..] {
+        let s = stat_path(path);
+        if s != 0 {
+            status = s;
+        }
+    }
+
+    ExitCode::from(status)
+}

--- a/base/stat/src/main.rs
+++ b/base/stat/src/main.rs
@@ -5,6 +5,7 @@ mod syscalls;
 
 use std::env;
 use std::fs;
+use std::os::unix::fs::MetadataExt;
 use std::process::ExitCode;
 
 fn stat_path(path: &str) -> u8 {
@@ -26,9 +27,10 @@ fn stat_path(path: &str) -> u8 {
 
     println!("  File: {path}");
     println!("  Size: {}", meta.len());
-    println!(" Type: {file_type}");
-    println!("Inode: unknown");
-    println!("Links: unknown");
+    println!("  Type: {file_type}");
+    println!("  Mode: {:o}", meta.mode());
+    println!(" Inode: {}", meta.ino());
+    println!(" Links: {}", meta.nlink());
 
     0
 }

--- a/base/stat/src/syscalls.rs
+++ b/base/stat/src/syscalls.rs
@@ -27,7 +27,7 @@ unsafe fn raw1(nr: u64, a0: u64) -> i64 {
             lateout("r8") _,
             lateout("r9") _,
             lateout("r10") _,
-            options(nostack, preserves_flags),
+            options(nostack),
         );
     }
     ret

--- a/base/stat/src/syscalls.rs
+++ b/base/stat/src/syscalls.rs
@@ -1,0 +1,50 @@
+//! C-ABI syscall shims required by the vibix std fork.
+//!
+//! The in-repo std fork links against POSIX symbols (`close`, etc.) that are
+//! not provided by a system libc on vibix. We supply them here via raw
+//! syscall instructions, mirroring the approach in `base/sh/src/syscalls.rs`.
+
+use core::arch::asm;
+
+const SYS_CLOSE: u64 = 3;
+
+extern "C" {
+    fn __errno_location() -> *mut i32;
+}
+
+#[inline(always)]
+unsafe fn raw1(nr: u64, a0: u64) -> i64 {
+    let ret: i64;
+    unsafe {
+        asm!(
+            "syscall",
+            inlateout("rax") nr => ret,
+            inlateout("rdi") a0 => _,
+            lateout("rcx") _,
+            lateout("r11") _,
+            lateout("rdx") _,
+            lateout("rsi") _,
+            lateout("r8") _,
+            lateout("r9") _,
+            lateout("r10") _,
+            options(nostack, preserves_flags),
+        );
+    }
+    ret
+}
+
+/// Convert raw syscall return to C convention: on error set errno, return -1.
+#[inline]
+unsafe fn cvt(r: i64) -> i64 {
+    if r < 0 {
+        unsafe { *__errno_location() = (-r) as i32 };
+        -1
+    } else {
+        r
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn close(fd: i32) -> i32 {
+    unsafe { cvt(raw1(SYS_CLOSE, fd as u64)) as i32 }
+}

--- a/base/touch/Cargo.toml
+++ b/base/touch/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "touch"
+version = "0.1.0"
+edition = "2021"
+authors = ["vibix hackers"]
+license = "MIT OR Apache-2.0"
+
+[[bin]]
+name = "touch"
+path = "src/main.rs"
+
+# Standalone package — not part of the main workspace. Built with
+# `-Z build-std` against the in-repo std fork (see xtask build).
+[workspace]

--- a/base/touch/src/main.rs
+++ b/base/touch/src/main.rs
@@ -1,0 +1,27 @@
+#![feature(restricted_std)]
+
+#[cfg(not(test))]
+mod syscalls;
+
+use std::env;
+use std::fs::OpenOptions;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() <= 1 {
+        eprintln!("touch: missing operand");
+        return ExitCode::from(1);
+    }
+
+    let mut status: u8 = 0;
+    for path in &args[1..] {
+        if let Err(e) = OpenOptions::new().create(true).write(true).open(path) {
+            eprintln!("touch: {path}: {e}");
+            status = 1;
+        }
+    }
+
+    ExitCode::from(status)
+}

--- a/base/touch/src/syscalls.rs
+++ b/base/touch/src/syscalls.rs
@@ -27,7 +27,7 @@ unsafe fn raw1(nr: u64, a0: u64) -> i64 {
             lateout("r8") _,
             lateout("r9") _,
             lateout("r10") _,
-            options(nostack, preserves_flags),
+            options(nostack),
         );
     }
     ret

--- a/base/touch/src/syscalls.rs
+++ b/base/touch/src/syscalls.rs
@@ -1,0 +1,50 @@
+//! C-ABI syscall shims required by the vibix std fork.
+//!
+//! The in-repo std fork links against POSIX symbols (`close`, etc.) that are
+//! not provided by a system libc on vibix. We supply them here via raw
+//! syscall instructions, mirroring the approach in `base/sh/src/syscalls.rs`.
+
+use core::arch::asm;
+
+const SYS_CLOSE: u64 = 3;
+
+extern "C" {
+    fn __errno_location() -> *mut i32;
+}
+
+#[inline(always)]
+unsafe fn raw1(nr: u64, a0: u64) -> i64 {
+    let ret: i64;
+    unsafe {
+        asm!(
+            "syscall",
+            inlateout("rax") nr => ret,
+            inlateout("rdi") a0 => _,
+            lateout("rcx") _,
+            lateout("r11") _,
+            lateout("rdx") _,
+            lateout("rsi") _,
+            lateout("r8") _,
+            lateout("r9") _,
+            lateout("r10") _,
+            options(nostack, preserves_flags),
+        );
+    }
+    ret
+}
+
+/// Convert raw syscall return to C convention: on error set errno, return -1.
+#[inline]
+unsafe fn cvt(r: i64) -> i64 {
+    if r < 0 {
+        unsafe { *__errno_location() = (-r) as i32 };
+        -1
+    } else {
+        r
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn close(fd: i32) -> i32 {
+    unsafe { cvt(raw1(SYS_CLOSE, fd as u64)) as i32 }
+}

--- a/base/uname/Cargo.toml
+++ b/base/uname/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "uname"
+version = "0.1.0"
+edition = "2021"
+authors = ["vibix hackers"]
+license = "MIT OR Apache-2.0"
+
+[[bin]]
+name = "uname"
+path = "src/main.rs"
+
+# Standalone package — not part of the main workspace. Built with
+# `-Z build-std` against the in-repo std fork (see xtask build).
+[workspace]

--- a/base/uname/src/main.rs
+++ b/base/uname/src/main.rs
@@ -9,12 +9,17 @@ use std::process::ExitCode;
 fn main() -> ExitCode {
     let args: Vec<String> = env::args().collect();
 
-    let all = args.iter().any(|a| a == "-a");
-
-    if all {
-        println!("vibix vibix 0.1.0 x86_64");
-    } else {
-        println!("vibix");
+    match args.len() {
+        1 => {
+            println!("vibix");
+        }
+        2 if args[1] == "-a" => {
+            println!("vibix vibix 0.1.0 x86_64");
+        }
+        _ => {
+            eprintln!("usage: uname [-a]");
+            return ExitCode::from(1);
+        }
     }
 
     ExitCode::from(0)

--- a/base/uname/src/main.rs
+++ b/base/uname/src/main.rs
@@ -1,0 +1,21 @@
+#![feature(restricted_std)]
+
+#[cfg(not(test))]
+mod syscalls;
+
+use std::env;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = env::args().collect();
+
+    let all = args.iter().any(|a| a == "-a");
+
+    if all {
+        println!("vibix vibix 0.1.0 x86_64");
+    } else {
+        println!("vibix");
+    }
+
+    ExitCode::from(0)
+}

--- a/base/uname/src/syscalls.rs
+++ b/base/uname/src/syscalls.rs
@@ -27,7 +27,7 @@ unsafe fn raw1(nr: u64, a0: u64) -> i64 {
             lateout("r8") _,
             lateout("r9") _,
             lateout("r10") _,
-            options(nostack, preserves_flags),
+            options(nostack),
         );
     }
     ret

--- a/base/uname/src/syscalls.rs
+++ b/base/uname/src/syscalls.rs
@@ -1,0 +1,50 @@
+//! C-ABI syscall shims required by the vibix std fork.
+//!
+//! The in-repo std fork links against POSIX symbols (`close`, etc.) that are
+//! not provided by a system libc on vibix. We supply them here via raw
+//! syscall instructions, mirroring the approach in `base/sh/src/syscalls.rs`.
+
+use core::arch::asm;
+
+const SYS_CLOSE: u64 = 3;
+
+extern "C" {
+    fn __errno_location() -> *mut i32;
+}
+
+#[inline(always)]
+unsafe fn raw1(nr: u64, a0: u64) -> i64 {
+    let ret: i64;
+    unsafe {
+        asm!(
+            "syscall",
+            inlateout("rax") nr => ret,
+            inlateout("rdi") a0 => _,
+            lateout("rcx") _,
+            lateout("r11") _,
+            lateout("rdx") _,
+            lateout("rsi") _,
+            lateout("r8") _,
+            lateout("r9") _,
+            lateout("r10") _,
+            options(nostack, preserves_flags),
+        );
+    }
+    ret
+}
+
+/// Convert raw syscall return to C convention: on error set errno, return -1.
+#[inline]
+unsafe fn cvt(r: i64) -> i64 {
+    if r < 0 {
+        unsafe { *__errno_location() = (-r) as i32 };
+        -1
+    } else {
+        r
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn close(fd: i32) -> i32 {
+    unsafe { cvt(raw1(SYS_CLOSE, fd as u64)) as i32 }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -860,6 +860,46 @@ fn build_userspace_ls() -> R<PathBuf> {
     build_userspace_std_bin("base/ls/Cargo.toml", "ls")
 }
 
+/// Build the `/bin/stat` binary — display file status.
+fn build_userspace_stat() -> R<PathBuf> {
+    build_userspace_std_bin("base/stat/Cargo.toml", "stat")
+}
+
+/// Build the `/bin/cp` binary — copy files.
+fn build_userspace_cp() -> R<PathBuf> {
+    build_userspace_std_bin("base/cp/Cargo.toml", "cp")
+}
+
+/// Build the `/bin/mv` binary — move/rename files.
+fn build_userspace_mv() -> R<PathBuf> {
+    build_userspace_std_bin("base/mv/Cargo.toml", "mv")
+}
+
+/// Build the `/bin/rm` binary — remove files.
+fn build_userspace_rm() -> R<PathBuf> {
+    build_userspace_std_bin("base/rm/Cargo.toml", "rm")
+}
+
+/// Build the `/bin/mkdir` binary — create directories.
+fn build_userspace_mkdir() -> R<PathBuf> {
+    build_userspace_std_bin("base/mkdir/Cargo.toml", "mkdir")
+}
+
+/// Build the `/bin/rmdir` binary — remove empty directories.
+fn build_userspace_rmdir() -> R<PathBuf> {
+    build_userspace_std_bin("base/rmdir/Cargo.toml", "rmdir")
+}
+
+/// Build the `/bin/touch` binary — create empty files.
+fn build_userspace_touch() -> R<PathBuf> {
+    build_userspace_std_bin("base/touch/Cargo.toml", "touch")
+}
+
+/// Build the `/bin/uname` binary — print system information.
+fn build_userspace_uname() -> R<PathBuf> {
+    build_userspace_std_bin("base/uname/Cargo.toml", "uname")
+}
+
 /// Generate a minimal stub dynamic-linker ELF for the #764 integration test.
 ///
 /// Produces an ET_DYN ELF64 with a single page-aligned PT_LOAD segment.
@@ -1741,10 +1781,26 @@ fn run_with_root(opts: &BuildOpts, root_flag: Option<&str>, cmdline_extras: &[&s
             let sh_bin = build_userspace_sh()?;
             let cat_bin = build_userspace_cat()?;
             let ls_bin = build_userspace_ls()?;
+            let stat_bin = build_userspace_stat()?;
+            let cp_bin = build_userspace_cp()?;
+            let mv_bin = build_userspace_mv()?;
+            let rm_bin = build_userspace_rm()?;
+            let mkdir_bin = build_userspace_mkdir()?;
+            let rmdir_bin = build_userspace_rmdir()?;
+            let touch_bin = build_userspace_touch()?;
+            let uname_bin = build_userspace_uname()?;
             let extras: Vec<(&Path, &str)> = vec![
                 (&sh_bin, "/bin/sh"),
                 (&cat_bin, "/bin/cat"),
                 (&ls_bin, "/bin/ls"),
+                (&stat_bin, "/bin/stat"),
+                (&cp_bin, "/bin/cp"),
+                (&mv_bin, "/bin/mv"),
+                (&rm_bin, "/bin/rm"),
+                (&mkdir_bin, "/bin/mkdir"),
+                (&rmdir_bin, "/bin/rmdir"),
+                (&touch_bin, "/bin/touch"),
+                (&uname_bin, "/bin/uname"),
             ];
             let img =
                 ext2_image::build_with_extras(&workspace_root(), Some(&init_bin), &extras, true)?;
@@ -1763,10 +1819,26 @@ fn run_with_root(opts: &BuildOpts, root_flag: Option<&str>, cmdline_extras: &[&s
             let sh_bin = build_userspace_sh()?;
             let cat_bin = build_userspace_cat()?;
             let ls_bin = build_userspace_ls()?;
+            let stat_bin = build_userspace_stat()?;
+            let cp_bin = build_userspace_cp()?;
+            let mv_bin = build_userspace_mv()?;
+            let rm_bin = build_userspace_rm()?;
+            let mkdir_bin = build_userspace_mkdir()?;
+            let rmdir_bin = build_userspace_rmdir()?;
+            let touch_bin = build_userspace_touch()?;
+            let uname_bin = build_userspace_uname()?;
             let extras: Vec<(&Path, &str)> = vec![
                 (&sh_bin, "/bin/sh"),
                 (&cat_bin, "/bin/cat"),
                 (&ls_bin, "/bin/ls"),
+                (&stat_bin, "/bin/stat"),
+                (&cp_bin, "/bin/cp"),
+                (&mv_bin, "/bin/mv"),
+                (&rm_bin, "/bin/rm"),
+                (&mkdir_bin, "/bin/mkdir"),
+                (&rmdir_bin, "/bin/rmdir"),
+                (&touch_bin, "/bin/touch"),
+                (&uname_bin, "/bin/uname"),
             ];
             let img =
                 ext2_image::build_with_extras(&workspace_root(), Some(&init_bin), &extras, true)?;
@@ -2110,10 +2182,26 @@ fn smoke(opts: &BuildOpts) -> R<()> {
     let sh_bin = build_userspace_sh()?;
     let cat_bin = build_userspace_cat()?;
     let ls_bin = build_userspace_ls()?;
+    let stat_bin = build_userspace_stat()?;
+    let cp_bin = build_userspace_cp()?;
+    let mv_bin = build_userspace_mv()?;
+    let rm_bin = build_userspace_rm()?;
+    let mkdir_bin = build_userspace_mkdir()?;
+    let rmdir_bin = build_userspace_rmdir()?;
+    let touch_bin = build_userspace_touch()?;
+    let uname_bin = build_userspace_uname()?;
     let extras: Vec<(&Path, &str)> = vec![
         (&sh_bin, "/bin/sh"),
         (&cat_bin, "/bin/cat"),
         (&ls_bin, "/bin/ls"),
+        (&stat_bin, "/bin/stat"),
+        (&cp_bin, "/bin/cp"),
+        (&mv_bin, "/bin/mv"),
+        (&rm_bin, "/bin/rm"),
+        (&mkdir_bin, "/bin/mkdir"),
+        (&rmdir_bin, "/bin/rmdir"),
+        (&touch_bin, "/bin/touch"),
+        (&uname_bin, "/bin/uname"),
     ];
     let disk =
         ext2_image::build_with_extras(&workspace_root(), Some(&userspace_init), &extras, true)?;
@@ -2894,12 +2982,28 @@ fn sh_test(opts: &BuildOpts) -> R<()> {
     let sh_bin = build_userspace_sh()?;
     let cat_bin = build_userspace_cat()?;
     let ls_bin = build_userspace_ls()?;
+    let stat_bin = build_userspace_stat()?;
+    let cp_bin = build_userspace_cp()?;
+    let mv_bin = build_userspace_mv()?;
+    let rm_bin = build_userspace_rm()?;
+    let mkdir_bin = build_userspace_mkdir()?;
+    let rmdir_bin = build_userspace_rmdir()?;
+    let touch_bin = build_userspace_touch()?;
+    let uname_bin = build_userspace_uname()?;
 
-    // Install init as /init and sh/cat/ls as /bin/* in the ext2 rootfs image.
+    // Install init as /init and sh/cat/ls/etc. as /bin/* in the ext2 rootfs image.
     let extras: Vec<(&Path, &str)> = vec![
         (&sh_bin, "/bin/sh"),
         (&cat_bin, "/bin/cat"),
         (&ls_bin, "/bin/ls"),
+        (&stat_bin, "/bin/stat"),
+        (&cp_bin, "/bin/cp"),
+        (&mv_bin, "/bin/mv"),
+        (&rm_bin, "/bin/rm"),
+        (&mkdir_bin, "/bin/mkdir"),
+        (&rmdir_bin, "/bin/rmdir"),
+        (&touch_bin, "/bin/touch"),
+        (&uname_bin, "/bin/uname"),
     ];
     let disk = ext2_image::build_with_extras(&workspace_root(), Some(&init_bin), &extras, true)?;
     let iso = workspace_root().join("target").join("vibix-sh.iso");


### PR DESCRIPTION
Closes #904
Closes #905

## Summary
- Add eight new base system programs following the cat/ls pattern from PR #909: `stat`, `cp`, `mv`, `rm`, `mkdir`, `rmdir`, `touch`, and `uname`
- Each is a standalone crate in `base/<name>/` with its own `syscalls.rs` shim, built via the `build_userspace_std_bin()` helper
- All binaries are wired into the ext2 rootfs across all four extras assembly sites (run ext2, run default, smoke, sh_test)
- Updated ext2 image hash

### Utilities
| Utility | Description | std API |
|---------|-------------|---------|
| `stat`  | Print file type and size for paths | `fs::symlink_metadata()` |
| `cp`    | Copy a file (`cp <src> <dst>`) | `fs::copy()` |
| `mv`    | Move/rename a file (`mv <src> <dst>`) | `fs::rename()` |
| `rm`    | Remove files (`rm <path>...`) | `fs::remove_file()` |
| `mkdir` | Create directories (`mkdir <path>...`) | `fs::create_dir()` |
| `rmdir` | Remove empty directories (`rmdir <path>...`) | `fs::remove_dir()` |
| `touch` | Create empty files if not exist | `OpenOptions::new().create(true).write(true).open()` |
| `uname` | Print system info; `-a` for full | Hardcoded (no syscall yet) |

## Test plan
- [x] `cargo xtask build` — passes
- [x] `cargo xtask smoke` — all 43 markers present
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo xtask ext2-image` — hash updated and verified