### PR TITLE
Implement stdin read for vibix PAL (fix /bin/sh exit loop)

### DIFF
--- a/base/vibix_abi/src/stdio.rs
+++ b/base/vibix_abi/src/stdio.rs
@@ -9,7 +9,11 @@ use crate::syscall;
 /// `writev` syscall number (Linux x86_64).
 const SYS_WRITEV: u64 = 20;
 
+/// `read` syscall number (Linux x86_64).
+const SYS_READ: u64 = 0;
+
 /// Standard file descriptors.
+const STDIN_FD: u64 = 0;
 const STDOUT_FD: u64 = 1;
 const STDERR_FD: u64 = 2;
 
@@ -30,6 +34,19 @@ pub fn write_stdout(buf: &[u8]) -> i64 {
 /// errno on failure.
 pub fn write_stderr(buf: &[u8]) -> i64 {
     writev(STDERR_FD, buf)
+}
+
+/// Read from stdin into `buf`. Returns the number of bytes read, or a negative
+/// errno on failure. Returns 0 on EOF.
+pub fn read_stdin(buf: &mut [u8]) -> i64 {
+    unsafe {
+        syscall::syscall3(
+            SYS_READ,
+            STDIN_FD,
+            buf.as_mut_ptr() as u64,
+            buf.len() as u64,
+        )
+    }
 }
 
 /// Issue a `writev` syscall with a single iovec entry.

--- a/library/std/src/sys/stdio/vibix.rs
+++ b/library/std/src/sys/stdio/vibix.rs
@@ -13,13 +13,34 @@ impl Stdin {
 }
 
 impl io::Read for Stdin {
-    fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
-        // Stdin reading not yet implemented.
-        Ok(0)
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let ret = vibix_abi::stdio::read_stdin(buf);
+        if ret < 0 {
+            Err(io::Error::from_raw_os_error(-ret as i32))
+        } else {
+            Ok(ret as usize)
+        }
     }
 
-    fn read_vectored(&mut self, _bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
-        Ok(0)
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
+        let mut total = 0;
+        for buf in bufs {
+            if buf.is_empty() {
+                continue;
+            }
+            let ret = vibix_abi::stdio::read_stdin(buf);
+            if ret < 0 {
+                if total > 0 {
+                    return Ok(total);
+                }
+                return Err(io::Error::from_raw_os_error(-ret as i32));
+            }
+            total += ret as usize;
+            if ret == 0 || (ret as usize) < buf.len() {
+                break;
+            }
+        }
+        Ok(total)
     }
 
     #[inline]


### PR DESCRIPTION
## Summary

- The std fork's vibix `Stdin::read()` returned `Ok(0)` (immediate EOF), causing `/bin/sh` to exit its interactive read loop immediately after launch. Init respawned it in a tight loop.
- Added `vibix_abi::stdio::read_stdin()` which issues a `read(2)` syscall on fd 0
- Wired `Stdin::read()` and `read_vectored()` through it, connecting to the kernel's blocking N_TTY read path (landed in PR #917)

This is the missing link between the kernel's blocking TTY reads and userspace std — without it, `std::io::stdin()` never reaches the syscall layer.

Fixes the /bin/sh respawn loop reported after epic #895.

## Test plan
- [x] `cargo xtask build` succeeds
- [x] `cargo xtask smoke` passes (all 43 markers)
- [x] `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)