### PR TITLE
sched: close fork/clone register-before-schedule race

### DIFF
--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -734,13 +734,13 @@ pub unsafe extern "C" fn syscall_dispatch(
             }
 
             crate::fork_trace!("fork-trace: [syscall:FORK] → fork_current_task()");
-            let child_task_id = match crate::task::fork_current_task(&regs) {
-                Ok(id) => {
+            let (child_task_id, child_task) = match crate::task::fork_current_task(&regs) {
+                Ok(pair) => {
                     crate::fork_trace!(
                         "fork-trace: [syscall:FORK] ← fork_current_task() child_task_id={}",
-                        id
+                        pair.0
                     );
-                    id
+                    pair
                 }
                 Err(_) => {
                     crate::fork_trace!(
@@ -756,7 +756,12 @@ pub unsafe extern "C" fn syscall_dispatch(
             );
             let child_pid = crate::process::register(child_task_id, parent_pid);
             crate::fork_trace!(
-                "fork-trace: [syscall:FORK] ← process::register child_pid={} — returning to user",
+                "fork-trace: [syscall:FORK] ← process::register child_pid={} — making child runnable",
+                child_pid
+            );
+            crate::task::make_child_runnable(child_task);
+            crate::fork_trace!(
+                "fork-trace: [syscall:FORK] child now runnable — returning pid={} to parent",
                 child_pid
             );
             child_pid as i64

--- a/kernel/src/arch/x86_64/syscalls/phase3.rs
+++ b/kernel/src/arch/x86_64/syscalls/phase3.rs
@@ -133,17 +133,16 @@ pub fn sys_clone(
 
     // For CLONE_VM threads: share the parent's address space and fd table
     // (no CoW fork). Use clone_current_as_thread which shares Arc refs.
-    let child_task_id = match crate::task::clone_current_as_thread(&regs, tls) {
-        Ok(id) => id,
+    let (child_task_id, child_task) = match crate::task::clone_current_as_thread(&regs, tls) {
+        Ok(pair) => pair,
         Err(_) => return -12, // ENOMEM
     };
 
-    // Register in the process table. For CLONE_THREAD the child shares
-    // the parent's PID (it's a thread), but gets a unique TID. In vibix's
-    // current model, task_id == TID and we register a process entry so
-    // that current_pid() works for the child. The child's PID == parent's PID.
+    // Register in the process table BEFORE making the child runnable so
+    // that current_pid() returns a valid PID when the child runs (#921).
     let parent_pid = crate::process::current_pid();
     let child_tid = crate::process::register(child_task_id, parent_pid);
+    crate::task::make_child_runnable(child_task);
 
     // CLONE_PARENT_SETTID: write child TID to parent's memory.
     if clone_flags & CLONE_PARENT_SETTID != 0 && parent_tidptr != 0 {

--- a/kernel/src/task/sched_core.rs
+++ b/kernel/src/task/sched_core.rs
@@ -33,8 +33,18 @@ pub use priority::{
 };
 
 use super::scheduler::Scheduler;
+use super::task::Task;
+
+/// Opaque handle for a newly-created child task that has not yet been
+/// placed on the scheduler's ready queue. Returned by [`fork_current_task`]
+/// and [`clone_current_as_thread`]; consumed by [`make_child_runnable`].
+///
+/// This type intentionally hides `Box<Task>` (which is `pub(super)`) so
+/// that callers outside the `task` module can hold and pass it without
+/// accessing `Task` internals.
+pub struct ForkChild(Box<Task>);
 use super::switch::context_switch;
-use super::task::{Task, TaskState};
+use super::task::TaskState;
 
 use crate::arch::x86_64::fpu;
 use crate::serial_println;
@@ -181,8 +191,14 @@ pub fn spawn_and_get_id(entry: fn() -> !) -> usize {
 }
 
 /// Clone the current task's address space and fd table for a fork child,
-/// allocate a new kernel stack, push the child onto the ready queue, and
-/// return the child's task ID.
+/// allocate a new kernel stack, and return the child task (boxed) along
+/// with its task ID — **without** pushing it onto the ready queue.
+///
+/// The caller must call [`make_child_runnable`] to enqueue the child
+/// after performing any bookkeeping (e.g. `process::register`) that must
+/// complete before the child can be scheduled. This two-phase protocol
+/// closes the race window where a child could run and exit before being
+/// registered in the process table (#921).
 ///
 /// `regs` carries the ring-3 register state saved by the SYSCALL entry
 /// before invoking `syscall_dispatch` — full GPR set so the child sees
@@ -191,7 +207,7 @@ pub fn spawn_and_get_id(entry: fn() -> !) -> usize {
 /// (#690).
 pub fn fork_current_task(
     regs: &crate::fork_abi::ForkUserRegs,
-) -> Result<usize, crate::mem::addrspace::ForkError> {
+) -> Result<(usize, ForkChild), crate::mem::addrspace::ForkError> {
     use alloc::sync::Arc;
     use spin::{Mutex, RwLock};
 
@@ -335,29 +351,11 @@ pub fn fork_current_task(
         "fork-trace: [fork_current_task] ← Task::new_forked() child_id={}",
         child_id
     );
-    let child_box = Box::new(child);
-    let new_prio = child_box.priority;
-    crate::fork_trace!("fork-trace: [fork_current_task] → SCHED.lock() for push_ready");
-    let mut sched = SCHED.lock();
     crate::fork_trace!(
-        "fork-trace: [fork_current_task] SCHED locked; push_ready child_id={} prio={}",
-        child_id,
-        new_prio
-    );
-    sched.push_ready(child_box);
-    maybe_preempt_current_for_priority(&mut sched, new_prio);
-    // RFC 0006 / #718: record the fork transition. Parent id read
-    // through the snapshot we already took above; on a successful
-    // fork the child's id is what `Task::new_forked` minted.
-    crate::sched_mock_trace!(SchedMockEvent::TaskForked {
-        parent: sched.current.as_ref().map(|t| t.id).unwrap_or(usize::MAX),
-        child: child_id,
-    });
-    crate::fork_trace!(
-        "fork-trace: [fork_current_task exit] returning child_id={}",
+        "fork-trace: [fork_current_task exit] returning child_id={} (not yet runnable)",
         child_id
     );
-    Ok(child_id)
+    Ok((child_id, ForkChild(Box::new(child))))
 }
 
 /// Create a new thread that shares the parent's address space and fd table.
@@ -368,11 +366,12 @@ pub fn fork_current_task(
 ///
 /// `tls` is the FS base for the new thread (set by CLONE_SETTLS).
 ///
-/// Returns the child task ID on success.
+/// Returns `(child_task_id, Box<Task>)` without enqueueing the child.
+/// The caller must call [`make_child_runnable`] after registration (#921).
 pub fn clone_current_as_thread(
     regs: &crate::fork_abi::ForkUserRegs,
     tls: u64,
-) -> Result<usize, crate::mem::addrspace::ForkError> {
+) -> Result<(usize, ForkChild), crate::mem::addrspace::ForkError> {
     use alloc::sync::Arc;
 
     // Snapshot parent state while holding SCHED.
@@ -427,12 +426,26 @@ pub fn clone_current_as_thread(
         )
     }?;
     let child_id = child.id;
-    let child_box = Box::new(child);
-    let new_prio = child_box.priority;
+    Ok((child_id, ForkChild(Box::new(child))))
+}
+
+/// Enqueue a child task (returned by [`fork_current_task`] or
+/// [`clone_current_as_thread`]) onto the ready queue, making it
+/// schedulable. Must be called only after any required bookkeeping
+/// (e.g. `process::register`) so the child can look itself up in the
+/// process table when it runs (#921).
+pub fn make_child_runnable(child: ForkChild) {
+    let inner = child.0;
+    let _child_id = inner.id;
+    let new_prio = inner.priority;
     let mut sched = SCHED.lock();
-    sched.push_ready(child_box);
+    sched.push_ready(inner);
     maybe_preempt_current_for_priority(&mut sched, new_prio);
-    Ok(child_id)
+    // RFC 0006 / #718: record the fork transition.
+    crate::sched_mock_trace!(SchedMockEvent::TaskForked {
+        parent: sched.current.as_ref().map(|t| t.id).unwrap_or(usize::MAX),
+        child: _child_id,
+    });
 }
 
 /// Voluntarily yield the current timeslice. Resets the slice counter to


### PR DESCRIPTION
Closes #921

## Summary

- **Root cause**: `fork_current_task()` and `clone_current_as_thread()` pushed the child
  onto the scheduler's ready queue *before* returning to the FORK/CLONE handler, which
  then called `process::register()`. If a timer tick preempted the parent in that window,
  the child could run its entire lifecycle (exec → exit) before registration. The child's
  EXIT handler saw `current_pid() == 0` (unregistered), skipped `mark_zombie()` and
  `CHILD_WAIT.notify_all()`, permanently stalling the parent's `wait4()`.

- **Fix**: Both functions now return an opaque `ForkChild` handle without enqueueing. The
  FORK/CLONE handlers call `process::register()` first, then `make_child_runnable()`. This
  guarantees the child's PID is valid from its first scheduled instruction.

- **Scope**: The same race existed in the CLONE (pthread_create) path via `sys_clone` in
  `phase3.rs` — fixed identically.

## Test plan

- [x] `cargo xtask build` — compiles cleanly (1 pre-existing warning)
- [x] `cargo xtask test` — passes (1 pre-existing flaky `rwlock_concurrent_readers` failure unrelated to this change)
- [x] `cargo xtask smoke` — all 43 markers present